### PR TITLE
TFP-2491 (andre forsøk): Fjernet regelen om at vedtaksresultatet skal…

### DIFF
--- a/behandlingsprosess/src/main/java/no/nav/foreldrepenger/behandling/steg/vedtak/BehandlingVedtakTjeneste.java
+++ b/behandlingsprosess/src/main/java/no/nav/foreldrepenger/behandling/steg/vedtak/BehandlingVedtakTjeneste.java
@@ -1,14 +1,10 @@
 package no.nav.foreldrepenger.behandling.steg.vedtak;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.util.Optional;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
-import no.nav.foreldrepenger.behandling.BehandlingReferanse;
-import no.nav.foreldrepenger.behandling.Skjæringstidspunkt;
 import no.nav.foreldrepenger.behandling.es.UtledVedtakResultatTypeES;
 import no.nav.foreldrepenger.behandling.fp.UtledVedtakResultatType;
 import no.nav.foreldrepenger.behandling.impl.FinnAnsvarligSaksbehandler;
@@ -20,9 +16,7 @@ import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRe
 import no.nav.foreldrepenger.behandlingslager.behandling.vedtak.BehandlingVedtak;
 import no.nav.foreldrepenger.behandlingslager.behandling.vedtak.BehandlingVedtakRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.vedtak.VedtakResultatType;
-import no.nav.foreldrepenger.domene.uttak.OpphørUttakTjeneste;
 import no.nav.foreldrepenger.domene.vedtak.impl.BehandlingVedtakEventPubliserer;
-import no.nav.foreldrepenger.skjæringstidspunkt.SkjæringstidspunktTjeneste;
 import no.nav.vedtak.util.FPDateUtil;
 
 @ApplicationScoped
@@ -30,8 +24,6 @@ public class BehandlingVedtakTjeneste {
 
     private BehandlingVedtakEventPubliserer behandlingVedtakEventPubliserer;
     private BehandlingVedtakRepository behandlingVedtakRepository;
-    private OpphørUttakTjeneste opphørUttakTjeneste;
-    private SkjæringstidspunktTjeneste skjæringstidspunktTjeneste;
 
     BehandlingVedtakTjeneste() {
         // for CDI proxy
@@ -39,11 +31,9 @@ public class BehandlingVedtakTjeneste {
 
     @Inject
     public BehandlingVedtakTjeneste(BehandlingVedtakEventPubliserer behandlingVedtakEventPubliserer,
-                                    BehandlingRepositoryProvider repositoryProvider, OpphørUttakTjeneste opphørUttakTjeneste, SkjæringstidspunktTjeneste skjæringstidspunktTjeneste) {
+                                    BehandlingRepositoryProvider repositoryProvider) {
         this.behandlingVedtakEventPubliserer = behandlingVedtakEventPubliserer;
         this.behandlingVedtakRepository = repositoryProvider.getBehandlingVedtakRepository();
-        this.opphørUttakTjeneste = opphørUttakTjeneste;
-        this.skjæringstidspunktTjeneste = skjæringstidspunktTjeneste;
     }
 
     public void opprettBehandlingVedtak(BehandlingskontrollKontekst kontekst, Behandling behandling) {
@@ -52,16 +42,7 @@ public class BehandlingVedtakTjeneste {
         if (behandling.getFagsakYtelseType().gjelderEngangsstønad()) {
             vedtakResultatType = UtledVedtakResultatTypeES.utled(behandling);
         } else {
-            Optional<LocalDate> opphørsdato = Optional.empty();
-            Optional<LocalDate> skjæringstidspunkt = Optional.empty();
-            if (behandling.erRevurdering()) {
-                Skjæringstidspunkt skjæringstidspunkter = skjæringstidspunktTjeneste.getSkjæringstidspunkter(behandling.getId());
-                var ref = BehandlingReferanse.fra(behandling, skjæringstidspunkter);
-                opphørsdato = opphørUttakTjeneste.getOpphørsdato(ref, behandling.getBehandlingsresultat());
-
-                skjæringstidspunkt = skjæringstidspunkter.getSkjæringstidspunktHvisUtledet();
-            }
-            vedtakResultatType = UtledVedtakResultatType.utled(behandling, opphørsdato, skjæringstidspunkt);
+            vedtakResultatType = UtledVedtakResultatType.utled(behandling);
         }
         String ansvarligSaksbehandler = FinnAnsvarligSaksbehandler.finn(behandling);
         LocalDateTime vedtakstidspunkt = FPDateUtil.nå();

--- a/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/vedtak/es/FatteVedtakStegImplTest.java
+++ b/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/vedtak/es/FatteVedtakStegImplTest.java
@@ -24,7 +24,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
-import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
@@ -79,8 +78,6 @@ import no.nav.foreldrepenger.domene.abakus.AbakusInMemoryInntektArbeidYtelseTjen
 import no.nav.foreldrepenger.domene.arbeidsforhold.InntektArbeidYtelseTjeneste;
 import no.nav.foreldrepenger.domene.person.tps.TpsTjeneste;
 import no.nav.foreldrepenger.domene.personopplysning.PersonopplysningTjeneste;
-import no.nav.foreldrepenger.domene.uttak.OpphørUttakTjeneste;
-import no.nav.foreldrepenger.domene.uttak.UttakRepositoryProvider;
 import no.nav.foreldrepenger.domene.vedtak.VedtakTjeneste;
 import no.nav.foreldrepenger.domene.vedtak.es.BeregningsgrunnlagXmlTjenesteImpl;
 import no.nav.foreldrepenger.domene.vedtak.es.BeregningsresultatXmlTjenesteImpl;
@@ -97,7 +94,6 @@ import no.nav.foreldrepenger.domene.vedtak.xml.PersonopplysningXmlFelles;
 import no.nav.foreldrepenger.domene.vedtak.xml.VedtakXmlTjeneste;
 import no.nav.foreldrepenger.domene.vedtak.xml.VilkårsgrunnlagXmlTjeneste;
 import no.nav.foreldrepenger.domene.vedtak.xml.YtelseXmlTjeneste;
-import no.nav.foreldrepenger.familiehendelse.FamilieHendelseTjeneste;
 import no.nav.foreldrepenger.kompletthet.KompletthetsjekkerProvider;
 import no.nav.foreldrepenger.produksjonsstyring.oppgavebehandling.OppgaveTjeneste;
 import no.nav.foreldrepenger.produksjonsstyring.totrinn.TotrinnTjeneste;
@@ -147,9 +143,6 @@ public class FatteVedtakStegImplTest {
 
     private InntektArbeidYtelseTjeneste iayTjeneste = new AbakusInMemoryInntektArbeidYtelseTjeneste();
 
-    @Mock
-    private FamilieHendelseTjeneste familieHendelseTjeneste;
-
     private BehandlingVedtakTjeneste behandlingVedtakTjeneste;
 
     private KompletthetsjekkerProvider kompletthetssjekkerProvider = mock(KompletthetsjekkerProvider.class);
@@ -187,8 +180,7 @@ public class FatteVedtakStegImplTest {
 
         BehandlingVedtakEventPubliserer behandlingVedtakEventPubliserer = mock(BehandlingVedtakEventPubliserer.class);
 
-        OpphørUttakTjeneste opphørUttakTjeneste = new OpphørUttakTjeneste(new UttakRepositoryProvider(repositoryProvider.getEntityManager()));
-        behandlingVedtakTjeneste = new BehandlingVedtakTjeneste(behandlingVedtakEventPubliserer, repositoryProvider, opphørUttakTjeneste, skjæringstidspunktTjeneste);
+        behandlingVedtakTjeneste = new BehandlingVedtakTjeneste(behandlingVedtakEventPubliserer, repositoryProvider);
         FatteVedtakTjeneste fvtei = new FatteVedtakTjeneste(vedtakRepository, fpSakVedtakXmlTjeneste, vedtakTjeneste,
             oppgaveTjeneste, totrinnTjeneste, behandlingVedtakTjeneste);
         var simuler = new SimulerInntrekkSjekkeTjeneste(null, null, null, null);

--- a/domenetjenester/behandling/src/main/java/no/nav/foreldrepenger/behandling/fp/UtledVedtakResultatType.java
+++ b/domenetjenester/behandling/src/main/java/no/nav/foreldrepenger/behandling/fp/UtledVedtakResultatType.java
@@ -1,8 +1,6 @@
 package no.nav.foreldrepenger.behandling.fp;
 
-import java.time.LocalDate;
 import java.util.Objects;
-import java.util.Optional;
 
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingResultatType;
@@ -14,8 +12,7 @@ public class UtledVedtakResultatType {
         // hide public contructor
     }
 
-    public static VedtakResultatType utled(Behandling behandling, BehandlingResultatType behandlingResultatType, Optional<LocalDate> opphørsdato,
-                                           Optional<LocalDate> skjæringstidspunkt) {
+    public static VedtakResultatType utled(Behandling behandling, BehandlingResultatType behandlingResultatType) {
         Objects.requireNonNull(behandling, "behandling");
         Objects.requireNonNull(behandlingResultatType);
 
@@ -37,18 +34,16 @@ public class UtledVedtakResultatType {
         if (BehandlingResultatType.INGEN_ENDRING.equals(behandlingResultatType)) {
             Behandling originalBehandling = behandling.getOriginalBehandling()
                 .orElseThrow(() -> new IllegalStateException("Kan ikke ha resultat INGEN ENDRING uten å ha en original behandling"));
-            return utled(originalBehandling, Optional.empty(), skjæringstidspunkt);
+            return utled(originalBehandling);
         }
         if (BehandlingResultatType.OPPHØR.equals(behandlingResultatType)) {
-            if (opphørsdato.isPresent() && skjæringstidspunkt.isPresent() && opphørsdato.get().isAfter(skjæringstidspunkt.get())) {
-                return VedtakResultatType.INNVILGET;
-            }
+            return VedtakResultatType.OPPHØR;
         }
         return VedtakResultatType.AVSLAG;
     }
 
-    public static VedtakResultatType utled(Behandling behandling, Optional<LocalDate> opphørsdato, Optional<LocalDate> skjæringstidspunkt) {
+    public static VedtakResultatType utled(Behandling behandling) {
         BehandlingResultatType behandlingResultatType = behandling.getBehandlingsresultat().getBehandlingResultatType();
-        return utled(behandling, behandlingResultatType, opphørsdato, skjæringstidspunkt);
+        return utled(behandling, behandlingResultatType);
     }
 }

--- a/domenetjenester/behandling/src/test/java/no/nav/foreldrepenger/behandling/es/UtledVedtakResultatTypeTest.java
+++ b/domenetjenester/behandling/src/test/java/no/nav/foreldrepenger/behandling/es/UtledVedtakResultatTypeTest.java
@@ -2,8 +2,6 @@ package no.nav.foreldrepenger.behandling.es;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.util.Optional;
-
 import org.junit.Before;
 import org.junit.Test;
 
@@ -32,7 +30,7 @@ public class UtledVedtakResultatTypeTest {
         Behandling behandling = scenarioKlage.lagMocked();
 
         // Act
-        VedtakResultatType vedtakResultatType = UtledVedtakResultatType.utled(behandling, Optional.empty(), Optional.empty());
+        VedtakResultatType vedtakResultatType = UtledVedtakResultatType.utled(behandling);
 
         // Assert
         assertThat(vedtakResultatType).isEqualTo(VedtakResultatType.VEDTAK_I_KLAGEBEHANDLING);
@@ -45,7 +43,7 @@ public class UtledVedtakResultatTypeTest {
         Behandling behandling = scenarioKlage.lagMocked();
 
         // Act
-        VedtakResultatType vedtakResultatType = UtledVedtakResultatType.utled(behandling, Optional.empty(), Optional.empty());
+        VedtakResultatType vedtakResultatType = UtledVedtakResultatType.utled(behandling);
 
         // Assert
         assertThat(vedtakResultatType).isEqualTo(VedtakResultatType.VEDTAK_I_INNSYNBEHANDLING);
@@ -58,7 +56,7 @@ public class UtledVedtakResultatTypeTest {
         Behandling behandling = scenarioFørstegang.lagMocked();
 
         // Act
-        VedtakResultatType vedtakResultatType = UtledVedtakResultatType.utled(behandling, Optional.empty(), Optional.empty());
+        VedtakResultatType vedtakResultatType = UtledVedtakResultatType.utled(behandling);
 
         // Assert
         assertThat(vedtakResultatType).isEqualTo(VedtakResultatType.AVSLAG);
@@ -71,7 +69,7 @@ public class UtledVedtakResultatTypeTest {
         Behandling behandling = scenarioFørstegang.lagMocked();
 
         // Act
-        VedtakResultatType vedtakResultatType = UtledVedtakResultatType.utled(behandling, Optional.empty(), Optional.empty());
+        VedtakResultatType vedtakResultatType = UtledVedtakResultatType.utled(behandling);
 
         // Assert
         assertThat(vedtakResultatType).isEqualTo(VedtakResultatType.INNVILGET);

--- a/domenetjenester/behandling/src/test/java/no/nav/foreldrepenger/behandling/fp/UtledVedtakResultatTypeTest.java
+++ b/domenetjenester/behandling/src/test/java/no/nav/foreldrepenger/behandling/fp/UtledVedtakResultatTypeTest.java
@@ -2,9 +2,6 @@ package no.nav.foreldrepenger.behandling.fp;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.time.LocalDate;
-import java.util.Optional;
-
 import org.junit.Before;
 import org.junit.Test;
 
@@ -22,8 +19,6 @@ import no.nav.foreldrepenger.behandlingslager.testutilities.behandling.ScenarioM
 
 public class UtledVedtakResultatTypeTest {
 
-    private final LocalDate SKJÆRINGSTIDSPUNKT = LocalDate.now();
-
     private ScenarioMorSøkerForeldrepenger scenarioFørstegang;
 
     @Before
@@ -38,7 +33,7 @@ public class UtledVedtakResultatTypeTest {
         Behandling behandling = scenarioKlage.lagMocked();
 
         // Act
-        VedtakResultatType vedtakResultatType = UtledVedtakResultatType.utled(behandling, Optional.empty(), Optional.empty());
+        VedtakResultatType vedtakResultatType = UtledVedtakResultatType.utled(behandling);
 
         // Assert
         assertThat(vedtakResultatType).isEqualTo(VedtakResultatType.VEDTAK_I_KLAGEBEHANDLING);
@@ -51,7 +46,7 @@ public class UtledVedtakResultatTypeTest {
         Behandling behandling = scenarioAnke.lagMocked();
 
         // Act
-        VedtakResultatType vedtakResultatType = UtledVedtakResultatType.utled(behandling, Optional.empty(), Optional.empty());
+        VedtakResultatType vedtakResultatType = UtledVedtakResultatType.utled(behandling);
 
         // Assert
         assertThat(vedtakResultatType).isEqualTo(VedtakResultatType.VEDTAK_I_ANKEBEHANDLING);
@@ -64,7 +59,7 @@ public class UtledVedtakResultatTypeTest {
         Behandling behandling = scenarioKlage.lagMocked();
 
         // Act
-        VedtakResultatType vedtakResultatType = UtledVedtakResultatType.utled(behandling, Optional.empty(), Optional.empty());
+        VedtakResultatType vedtakResultatType = UtledVedtakResultatType.utled(behandling);
 
         // Assert
         assertThat(vedtakResultatType).isEqualTo(VedtakResultatType.VEDTAK_I_INNSYNBEHANDLING);
@@ -77,7 +72,7 @@ public class UtledVedtakResultatTypeTest {
         Behandling behandling = scenarioFørstegang.lagMocked();
 
         // Act
-        VedtakResultatType vedtakResultatType = UtledVedtakResultatType.utled(behandling, Optional.empty(), Optional.empty());
+        VedtakResultatType vedtakResultatType = UtledVedtakResultatType.utled(behandling);
 
         // Assert
         assertThat(vedtakResultatType).isEqualTo(VedtakResultatType.AVSLAG);
@@ -90,7 +85,7 @@ public class UtledVedtakResultatTypeTest {
         Behandling behandling = scenarioFørstegang.lagMocked();
 
         // Act
-        VedtakResultatType vedtakResultatType = UtledVedtakResultatType.utled(behandling, Optional.empty(), Optional.empty());
+        VedtakResultatType vedtakResultatType = UtledVedtakResultatType.utled(behandling);
 
         // Assert
         assertThat(vedtakResultatType).isEqualTo(VedtakResultatType.INNVILGET);
@@ -103,7 +98,7 @@ public class UtledVedtakResultatTypeTest {
         Behandling behandling = scenarioFørstegang.lagMocked();
 
         // Act
-        VedtakResultatType vedtakResultatType = UtledVedtakResultatType.utled(behandling, Optional.empty(), Optional.empty());
+        VedtakResultatType vedtakResultatType = UtledVedtakResultatType.utled(behandling);
 
         // Assert
         assertThat(vedtakResultatType).isEqualTo(VedtakResultatType.INNVILGET);
@@ -118,10 +113,10 @@ public class UtledVedtakResultatTypeTest {
         // Arrange
         scenarioFørstegang.medBehandlingsresultat(Behandlingsresultat.builder().medBehandlingResultatType(BehandlingResultatType.AVSLÅTT));
         Behandling behandling1 = scenarioFørstegang.lagMocked();
-        Behandling behandling2 = lagRevurdering(behandling1, BehandlingResultatType.INGEN_ENDRING);
+        Behandling behandling2 = lagRevurdering(behandling1);
 
         // Act
-        VedtakResultatType vedtakResultatType = UtledVedtakResultatType.utled(behandling2, Optional.empty(), Optional.empty());
+        VedtakResultatType vedtakResultatType = UtledVedtakResultatType.utled(behandling2);
 
         // Assert
         assertThat(vedtakResultatType).isEqualTo(VedtakResultatType.AVSLAG);
@@ -137,49 +132,23 @@ public class UtledVedtakResultatTypeTest {
         // Arrange
         scenarioFørstegang.medBehandlingsresultat(Behandlingsresultat.builder().medBehandlingResultatType(BehandlingResultatType.INNVILGET));
         Behandling behandling1 = scenarioFørstegang.lagMocked();
-        Behandling behandling2 = lagRevurdering(behandling1, BehandlingResultatType.INGEN_ENDRING);
-        Behandling behandling3 = lagRevurdering(behandling2, BehandlingResultatType.INGEN_ENDRING);
+        Behandling behandling2 = lagRevurdering(behandling1);
+        Behandling behandling3 = lagRevurdering(behandling2);
 
         // Act
-        VedtakResultatType vedtakResultatType = UtledVedtakResultatType.utled(behandling3, Optional.empty(), Optional.empty());
+        VedtakResultatType vedtakResultatType = UtledVedtakResultatType.utled(behandling3);
 
         // Assert
         assertThat(vedtakResultatType).isEqualTo(VedtakResultatType.INNVILGET);
     }
 
-    @Test
-    public void vedtakResultatTypeSettesTilINNVILGETForOpphørMedDatoEtterSkjæringstidspunkt() {
-        // Arrange
-        scenarioFørstegang.medBehandlingsresultat(Behandlingsresultat.builder().medBehandlingResultatType(BehandlingResultatType.OPPHØR));
-        Behandling behandling = scenarioFørstegang.lagMocked();
-
-        // Act
-        VedtakResultatType vedtakResultatType = UtledVedtakResultatType.utled(behandling, Optional.of(SKJÆRINGSTIDSPUNKT.plusDays(1)), Optional.of(SKJÆRINGSTIDSPUNKT));
-
-        // Assert
-        assertThat(vedtakResultatType).isEqualTo(VedtakResultatType.INNVILGET);
-    }
-
-    @Test
-    public void vedtakResultatTypeSettesTilAVSLAGForOpphørMedDatoLikSkjæringstidspunkt() {
-        // Arrange
-        scenarioFørstegang.medBehandlingsresultat(Behandlingsresultat.builder().medBehandlingResultatType(BehandlingResultatType.OPPHØR));
-        Behandling behandling = scenarioFørstegang.lagMocked();
-
-        // Act
-        VedtakResultatType vedtakResultatType = UtledVedtakResultatType.utled(behandling, Optional.of(SKJÆRINGSTIDSPUNKT), Optional.of(SKJÆRINGSTIDSPUNKT));
-
-        // Assert
-        assertThat(vedtakResultatType).isEqualTo(VedtakResultatType.AVSLAG);
-    }
-
-    private Behandling lagRevurdering(Behandling tidligereBehandling, BehandlingResultatType behandlingResultatType) {
+    private Behandling lagRevurdering(Behandling tidligereBehandling) {
         BehandlingÅrsak.Builder årsakBuilder = BehandlingÅrsak.builder(BehandlingÅrsakType.RE_ENDRET_INNTEKTSMELDING)
             .medOriginalBehandling(tidligereBehandling);
         Behandling revurdering = Behandling.fraTidligereBehandling(tidligereBehandling, BehandlingType.REVURDERING)
             .medBehandlingÅrsak(årsakBuilder)
             .build();
-        Behandlingsresultat.builder().medBehandlingResultatType(behandlingResultatType).buildFor(revurdering);
+        Behandlingsresultat.builder().medBehandlingResultatType(BehandlingResultatType.INGEN_ENDRING).buildFor(revurdering);
         return revurdering;
     }
 }

--- a/domenetjenester/dokumentbestiller/src/main/java/no/nav/foreldrepenger/dokumentbestiller/vedtak/VedtaksbrevUtleder.java
+++ b/domenetjenester/dokumentbestiller/src/main/java/no/nav/foreldrepenger/dokumentbestiller/vedtak/VedtaksbrevUtleder.java
@@ -31,7 +31,8 @@ public class VedtaksbrevUtleder {
     }
 
     static boolean erAvlåttEllerOpphørt(BehandlingVedtak behandlingVedtak) {
-        return VedtakResultatType.AVSLAG.equals(behandlingVedtak.getVedtakResultatType());
+        return VedtakResultatType.AVSLAG.equals(behandlingVedtak.getVedtakResultatType())
+            || VedtakResultatType.OPPHØR.equals(behandlingVedtak.getVedtakResultatType());
     }
 
     static boolean erKlageBehandling(BehandlingVedtak behandlingVedtak) {


### PR DESCRIPTION
… være INNVILGET ved behandlingsresultat OPPHØR, dersom opphørsdatoen er etter skjæringstidspunktet. Nå vil alltid vedtaksresultatet settes til OPPHØR ved behandlingsresultat OPPHØR.