### PR TITLE
TFP-2889 velg enhet fra PO-grunnlag isf TPS-alle-relasjoner

### DIFF
--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/aktør/OrganisasjonsEnhet.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/aktør/OrganisasjonsEnhet.java
@@ -21,7 +21,7 @@ public class OrganisasjonsEnhet {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         OrganisasjonsEnhet that = (OrganisasjonsEnhet) o;
-        return enhetId.equals(that.enhetId);
+        return Objects.equals(enhetId, that.enhetId);
     }
 
     @Override

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/Behandling.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/Behandling.java
@@ -60,7 +60,6 @@ import no.nav.foreldrepenger.domene.typer.AktørId;
 import no.nav.foreldrepenger.domene.typer.Saksnummer;
 import no.nav.vedtak.feil.FeilFactory;
 import no.nav.vedtak.felles.jpa.converters.BooleanToStringConverter;
-import no.nav.vedtak.util.FPDateUtil;
 
 @SqlResultSetMappings(value = {
         @SqlResultSetMapping(name = "PipDataResult", classes = {
@@ -372,7 +371,7 @@ public class Behandling extends BaseEntitet {
     public void avsluttBehandling() {
         lukkBehandlingStegStatuser(this.behandlingStegTilstander, BehandlingStegStatus.UTFØRT);
         this.status = BehandlingStatus.AVSLUTTET;
-        this.avsluttetDato = FPDateUtil.nå();
+        this.avsluttetDato = LocalDateTime.now();
     }
 
     private void lukkBehandlingStegStatuser(Collection<BehandlingStegTilstand> stegTilstander, BehandlingStegStatus sluttStatusForSteg) {
@@ -843,7 +842,7 @@ public class Behandling extends BaseEntitet {
         private String behandlendeEnhetNavn;
         private String behandlendeEnhetÅrsak;
 
-        private LocalDate behandlingstidFrist = FPDateUtil.iDag().plusWeeks(6);
+        private LocalDate behandlingstidFrist = LocalDate.now().plusWeeks(6);
 
         private BehandlingÅrsak.Builder behandlingÅrsakBuilder;
 
@@ -921,9 +920,6 @@ public class Behandling extends BaseEntitet {
 
             if (forrigeBehandling != null) {
                 behandling = new Behandling(forrigeBehandling.getFagsak(), behandlingType);
-                behandling.behandlendeEnhet = forrigeBehandling.behandlendeEnhet;
-                behandling.behandlendeEnhetNavn = forrigeBehandling.behandlendeEnhetNavn;
-                behandling.behandlendeEnhetÅrsak = forrigeBehandling.behandlendeEnhetÅrsak;
                 if (behandlingstidFrist != null) {
                     behandling.behandlingstidFrist = behandlingstidFrist;
                 } else {
@@ -931,13 +927,20 @@ public class Behandling extends BaseEntitet {
                 }
             } else {
                 behandling = new Behandling(fagsak, behandlingType);
-                behandling.behandlendeEnhet = behandlendeEnhet;
-                behandling.behandlendeEnhetNavn = behandlendeEnhetNavn;
-                behandling.behandlendeEnhetÅrsak = behandlendeEnhetÅrsak;
                 behandling.behandlingstidFrist = behandlingstidFrist;
             }
 
-            behandling.opprettetDato = FPDateUtil.nå();
+            if (behandlendeEnhet != null) {
+                behandling.behandlendeEnhet = behandlendeEnhet;
+                behandling.behandlendeEnhetNavn = behandlendeEnhetNavn;
+                behandling.behandlendeEnhetÅrsak = behandlendeEnhetÅrsak;
+            } else if (forrigeBehandling != null) {
+                behandling.behandlendeEnhet = forrigeBehandling.behandlendeEnhet;
+                behandling.behandlendeEnhetNavn = forrigeBehandling.behandlendeEnhetNavn;
+                behandling.behandlendeEnhetÅrsak = forrigeBehandling.behandlendeEnhetÅrsak;
+            }
+
+            behandling.opprettetDato = LocalDateTime.now();
             if (opprettetDato != null) {
                 behandling.opprettetDato = opprettetDato;
             }

--- a/behandlingsprosess/src/main/java/no/nav/foreldrepenger/behandling/steg/innhentsaksopplysninger/InnhentRegisteropplysningerResterendeOppgaverStegImpl.java
+++ b/behandlingsprosess/src/main/java/no/nav/foreldrepenger/behandling/steg/innhentsaksopplysninger/InnhentRegisteropplysningerResterendeOppgaverStegImpl.java
@@ -25,6 +25,7 @@ import no.nav.foreldrepenger.behandlingskontroll.FagsakYtelseTypeRef;
 import no.nav.foreldrepenger.behandlingslager.aktør.PersonstatusType;
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
 import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.AksjonspunktDefinisjon;
+import no.nav.foreldrepenger.behandlingslager.behandling.historikk.HistorikkAktør;
 import no.nav.foreldrepenger.behandlingslager.behandling.personopplysning.PersonopplysningEntitet;
 import no.nav.foreldrepenger.behandlingslager.behandling.personopplysning.PersonopplysningerAggregat;
 import no.nav.foreldrepenger.behandlingslager.behandling.personopplysning.PersonstatusEntitet;
@@ -34,6 +35,7 @@ import no.nav.foreldrepenger.domene.personopplysning.PersonopplysningTjeneste;
 import no.nav.foreldrepenger.familiehendelse.FamilieHendelseTjeneste;
 import no.nav.foreldrepenger.kompletthet.KompletthetResultat;
 import no.nav.foreldrepenger.mottak.kompletthettjeneste.KompletthetModell;
+import no.nav.foreldrepenger.produksjonsstyring.behandlingenhet.BehandlendeEnhetTjeneste;
 import no.nav.foreldrepenger.skjæringstidspunkt.SkjæringstidspunktTjeneste;
 import no.nav.vedtak.util.FPDateUtil;
 
@@ -50,6 +52,7 @@ public class InnhentRegisteropplysningerResterendeOppgaverStegImpl implements Be
     private FamilieHendelseTjeneste familieHendelseTjeneste;
     private SkjæringstidspunktTjeneste skjæringstidspunktTjeneste;
     private KompletthetModell kompletthetModell;
+    private BehandlendeEnhetTjeneste enhetTjeneste;
 
     InnhentRegisteropplysningerResterendeOppgaverStegImpl() {
         // for CDI proxy
@@ -60,6 +63,7 @@ public class InnhentRegisteropplysningerResterendeOppgaverStegImpl implements Be
                                                                    FagsakTjeneste fagsakTjeneste,
                                                                    PersonopplysningTjeneste personopplysningTjeneste,
                                                                    FamilieHendelseTjeneste familieHendelseTjeneste,
+                                                                   BehandlendeEnhetTjeneste enhetTjeneste,
                                                                    KompletthetModell kompletthetModell,
                                                                    SkjæringstidspunktTjeneste skjæringstidspunktTjeneste) {
 
@@ -69,6 +73,7 @@ public class InnhentRegisteropplysningerResterendeOppgaverStegImpl implements Be
         this.familieHendelseTjeneste = familieHendelseTjeneste;
         this.skjæringstidspunktTjeneste = skjæringstidspunktTjeneste;
         this.kompletthetModell = kompletthetModell;
+        this.enhetTjeneste = enhetTjeneste;
     }
 
     @Override
@@ -90,6 +95,9 @@ public class InnhentRegisteropplysningerResterendeOppgaverStegImpl implements Be
         PersonopplysningerAggregat personopplysninger = personopplysningTjeneste.hentPersonopplysninger(ref);
 
         fagsakTjeneste.oppdaterFagsak(behandling, personopplysninger, barnSøktStønadFor);
+
+        enhetTjeneste.sjekkEnhetEtterEndring(behandling)
+            .ifPresent(e -> enhetTjeneste.oppdaterBehandlendeEnhet(behandling, e, HistorikkAktør.VEDTAKSLØSNINGEN, "Personopplysning"));
 
         return BehandleStegResultat.utførtMedAksjonspunkter(sjekkPersonstatus(ref));
 

--- a/behandlingsprosess/src/main/java/no/nav/foreldrepenger/behandling/steg/klage/KlageNfpSteg.java
+++ b/behandlingsprosess/src/main/java/no/nav/foreldrepenger/behandling/steg/klage/KlageNfpSteg.java
@@ -18,7 +18,6 @@ import no.nav.foreldrepenger.behandlingskontroll.FagsakYtelseTypeRef;
 import no.nav.foreldrepenger.behandlingslager.aktør.OrganisasjonsEnhet;
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingStegType;
-import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingType;
 import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.AksjonspunktDefinisjon;
 import no.nav.foreldrepenger.behandlingslager.behandling.historikk.HistorikkAktør;
 import no.nav.foreldrepenger.behandlingslager.behandling.klage.KlageRepository;
@@ -41,7 +40,7 @@ public class KlageNfpSteg implements BehandlingSteg {
     }
 
     @Inject
-    public KlageNfpSteg(BehandlingRepository behandlingRepository, 
+    public KlageNfpSteg(BehandlingRepository behandlingRepository,
                         KlageRepository klageRepository,
                         BehandlendeEnhetTjeneste behandlendeEnhetTjeneste) {
         this.behandlingRepository = behandlingRepository;
@@ -68,13 +67,10 @@ public class KlageNfpSteg implements BehandlingSteg {
     private void endreAnsvarligEnhetTilNFPVedTilbakeføringOgLagreHistorikkinnslag(BehandlingskontrollKontekst kontekst) {
 
         Behandling behandling = behandlingRepository.hentBehandling(kontekst.getBehandlingId());
-        Behandling sisteFørstegangsbehandling = behandlingRepository.hentSisteBehandlingAvBehandlingTypeForFagsakId(kontekst.getFagsakId(),
-            BehandlingType.FØRSTEGANGSSØKNAD).orElseThrow(() -> new IllegalStateException("Fant ingen behandling som passet for saksnummer: "
-            + behandling.getFagsak().getSaksnummer()));
-        if (behandling.getBehandlendeEnhet() != null && behandling.getBehandlendeEnhet().equals(sisteFørstegangsbehandling.getBehandlendeEnhet())) {
+        if (behandling.getBehandlendeEnhet() != null && !behandlendeEnhetTjeneste.getKlageInstans().getEnhetId().equals(behandling.getBehandlendeEnhet())) {
             return;
         }
-        OrganisasjonsEnhet tilEnhet = behandlendeEnhetTjeneste.sjekkEnhetVedNyAvledetBehandling(sisteFørstegangsbehandling).orElse(sisteFørstegangsbehandling.getBehandlendeOrganisasjonsEnhet());
+        OrganisasjonsEnhet tilEnhet = behandlendeEnhetTjeneste.finnBehandlendeEnhetFor(behandling.getFagsak());
         behandlendeEnhetTjeneste.oppdaterBehandlendeEnhet(behandling, tilEnhet, HistorikkAktør.VEDTAKSLØSNINGEN, "");
     }
 }

--- a/behandlingsprosess/src/main/java/no/nav/foreldrepenger/behandling/steg/mottatteopplysninger/es/TilknyttFagsakStegImpl.java
+++ b/behandlingsprosess/src/main/java/no/nav/foreldrepenger/behandling/steg/mottatteopplysninger/es/TilknyttFagsakStegImpl.java
@@ -53,7 +53,7 @@ public class TilknyttFagsakStegImpl implements TilknyttFagsakSteg {
     }
 
     private void oppdaterEnhetMedAnnenPart(Behandling behandling) {
-        behandlendeEnhetTjeneste.endretBehandlendeEnhetFraOppgittAnnenPart(behandling).ifPresent(organisasjonsEnhet ->
-            behandlendeEnhetTjeneste.oppdaterBehandlendeEnhet(behandling, organisasjonsEnhet, HistorikkAktør.VEDTAKSLØSNINGEN, "Annen part"));
+        behandlendeEnhetTjeneste.sjekkEnhetEtterEndring(behandling)
+            .ifPresent(enhet -> behandlendeEnhetTjeneste.oppdaterBehandlendeEnhet(behandling, enhet, HistorikkAktør.VEDTAKSLØSNINGEN, "Annen part"));
     }
 }

--- a/behandlingsprosess/src/main/java/no/nav/foreldrepenger/behandling/steg/mottatteopplysninger/fp/TilknyttFagsakStegImpl.java
+++ b/behandlingsprosess/src/main/java/no/nav/foreldrepenger/behandling/steg/mottatteopplysninger/fp/TilknyttFagsakStegImpl.java
@@ -122,8 +122,8 @@ public class TilknyttFagsakStegImpl implements TilknyttFagsakSteg {
     }
 
     private void oppdaterEnhetMedAnnenPart(Behandling behandling) {
-        behandlendeEnhetTjeneste.endretBehandlendeEnhetFraOppgittAnnenPart(behandling).ifPresent(organisasjonsEnhet -> behandlendeEnhetTjeneste
-            .oppdaterBehandlendeEnhet(behandling, organisasjonsEnhet, HistorikkAktør.VEDTAKSLØSNINGEN, "Annen part"));
+        behandlendeEnhetTjeneste.sjekkEnhetEtterEndring(behandling)
+            .ifPresent(enhet -> behandlendeEnhetTjeneste.oppdaterBehandlendeEnhet(behandling, enhet, HistorikkAktør.VEDTAKSLØSNINGEN, "Annen part"));
     }
 
     private void kobleSakerOppdaterEnhetVedBehov(Behandling behandling) {

--- a/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/klage/KlageNfpStegTest.java
+++ b/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/klage/KlageNfpStegTest.java
@@ -7,8 +7,6 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.util.Optional;
-
 import org.junit.Before;
 import org.junit.Test;
 
@@ -22,6 +20,7 @@ import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.Aksjonspun
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingLås;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepositoryProvider;
+import no.nav.foreldrepenger.behandlingslager.fagsak.Fagsak;
 import no.nav.foreldrepenger.behandlingslager.testutilities.behandling.ScenarioKlageEngangsstønad;
 import no.nav.foreldrepenger.behandlingslager.testutilities.behandling.ScenarioMorSøkerEngangsstønad;
 import no.nav.foreldrepenger.produksjonsstyring.behandlingenhet.BehandlendeEnhetTjeneste;
@@ -36,7 +35,7 @@ public class KlageNfpStegTest {
     public void setUp() {
         behandlendeEnhetTjeneste = mock(BehandlendeEnhetTjeneste.class);
         BehandlingRepository behandlingRepositoryMock = mock(BehandlingRepository.class);
-        when(behandlendeEnhetTjeneste.sjekkEnhetVedNyAvledetBehandling(any(Behandling.class))).thenReturn(Optional.of(enhet));
+        when(behandlendeEnhetTjeneste.finnBehandlendeEnhetFor(any(Fagsak.class))).thenReturn(enhet);
 
         steg = new KlageNfpSteg(behandlingRepositoryMock, null, behandlendeEnhetTjeneste);
     }

--- a/domenetjenester/behandling-klage/src/main/java/no/nav/foreldrepenger/behandling/klage/KlageTjeneste.java
+++ b/domenetjenester/behandling-klage/src/main/java/no/nav/foreldrepenger/behandling/klage/KlageTjeneste.java
@@ -1,5 +1,6 @@
 package no.nav.foreldrepenger.behandling.klage;
 
+import java.time.LocalDate;
 import java.util.Optional;
 
 import javax.enterprise.context.ApplicationScoped;
@@ -16,7 +17,6 @@ import no.nav.foreldrepenger.behandlingsprosess.prosessering.task.StartBehandlin
 import no.nav.foreldrepenger.produksjonsstyring.behandlingenhet.BehandlendeEnhetTjeneste;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTaskData;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTaskRepository;
-import no.nav.vedtak.util.FPDateUtil;
 
 @ApplicationScoped
 public class KlageTjeneste {
@@ -50,16 +50,15 @@ public class KlageTjeneste {
     public Optional<Behandling> opprettKlageBehandling(Fagsak fagsak) {
         Optional<Behandling> behandlingKlagenGjelder = behandlingRepository.hentSisteYtelsesBehandlingForFagsakId(fagsak.getId());
 
-        if (!behandlingKlagenGjelder.isPresent()) {
+        if (behandlingKlagenGjelder.isEmpty()) {
             return Optional.empty();
         }
         BehandlingType behandlingTypeKlage = BehandlingType.KLAGE;
-        OrganisasjonsEnhet enhetKlage = behandlendeEnhetTjeneste.sjekkEnhetVedNyAvledetBehandling(
-            behandlingKlagenGjelder.get()).orElse(behandlingKlagenGjelder.get().getBehandlendeOrganisasjonsEnhet());
+        OrganisasjonsEnhet enhetKlage = behandlendeEnhetTjeneste.finnBehandlendeEnhetFor(fagsak);
 
         Behandling klageBehandling = behandlingskontrollTjeneste.opprettNyBehandling(fagsak, behandlingTypeKlage,
             (beh) -> {
-                beh.setBehandlingstidFrist(FPDateUtil.iDag().plusWeeks(behandlingTypeKlage.getBehandlingstidFristUker()));
+                beh.setBehandlingstidFrist(LocalDate.now().plusWeeks(behandlingTypeKlage.getBehandlingstidFristUker()));
                 beh.setBehandlendeEnhet(enhetKlage);
             });
 

--- a/domenetjenester/behandling-prosessering/src/main/java/no/nav/foreldrepenger/behandlingsprosess/prosessering/task/GjenopptaBehandlingTask.java
+++ b/domenetjenester/behandling-prosessering/src/main/java/no/nav/foreldrepenger/behandlingsprosess/prosessering/task/GjenopptaBehandlingTask.java
@@ -59,13 +59,13 @@ public class GjenopptaBehandlingTask implements ProsessTaskHandler {
             behandlingskontrollTjeneste.taBehandlingAvVentSetAlleAutopunktUtført(behandling, kontekst);
         }
 
-        behandlendeEnhetTjeneste.sjekkEnhetVedGjenopptak(behandling).ifPresent(organisasjonsEnhet -> {
-            behandlendeEnhetTjeneste.oppdaterBehandlendeEnhet(behandling, organisasjonsEnhet, HistorikkAktør.VEDTAKSLØSNINGEN, "");
-        });
-
         if (behandling.erYtelseBehandling() && behandlingskontrollTjeneste.erStegPassert(behandling, BehandlingStegType.INNHENT_REGISTEROPP)) {
             registerdataOppdaterer.oppdaterRegisteropplysningerOgReposisjonerBehandlingVedEndringer(behandling);
         }
+
+        behandlendeEnhetTjeneste.sjekkEnhetEtterEndring(behandling)
+            .ifPresent(enhet -> behandlendeEnhetTjeneste.oppdaterBehandlendeEnhet(behandling, enhet, HistorikkAktør.VEDTAKSLØSNINGEN, ""));
+
         behandlingskontrollTjeneste.prosesserBehandling(kontekst);
     }
 }

--- a/domenetjenester/behandling-prosessering/src/test/java/no/nav/foreldrepenger/behandlingsprosess/prosessering/GjenopptaBehandlingTaskTest.java
+++ b/domenetjenester/behandling-prosessering/src/test/java/no/nav/foreldrepenger/behandlingsprosess/prosessering/GjenopptaBehandlingTaskTest.java
@@ -19,11 +19,11 @@ import no.nav.foreldrepenger.behandlingslager.aktør.OrganisasjonsEnhet;
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingLås;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepository;
+import no.nav.foreldrepenger.behandlingslager.testutilities.behandling.ScenarioMorSøkerEngangsstønad;
 import no.nav.foreldrepenger.behandlingsprosess.prosessering.task.GjenopptaBehandlingTask;
 import no.nav.foreldrepenger.domene.registerinnhenting.RegisterdataEndringshåndterer;
 import no.nav.foreldrepenger.domene.typer.AktørId;
 import no.nav.foreldrepenger.produksjonsstyring.behandlingenhet.BehandlendeEnhetTjeneste;
-import no.nav.foreldrepenger.behandlingslager.testutilities.behandling.ScenarioMorSøkerEngangsstønad;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTaskData;
 
 public class GjenopptaBehandlingTaskTest {
@@ -55,7 +55,7 @@ public class GjenopptaBehandlingTaskTest {
         Behandling behandling = scenario.lagMocked();
         behandling.setBehandlendeEnhet(organisasjonsEnhet);
         when(mockBehandlingRepository.hentBehandling(any(Long.class))).thenReturn(behandling);
-        when(mockEnhetsTjeneste.sjekkEnhetVedGjenopptak(any())).thenReturn(Optional.empty());
+        when(mockEnhetsTjeneste.sjekkEnhetEtterEndring(any())).thenReturn(Optional.empty());
 
         ProsessTaskData prosessTaskData = new ProsessTaskData(GjenopptaBehandlingTask.TASKTYPE);
         prosessTaskData.setBehandling(0L, behandlingId, AktørId.dummy().getId());
@@ -82,7 +82,7 @@ public class GjenopptaBehandlingTaskTest {
         when(mockBehandlingRepository.lagre(any(Behandling.class), any())).thenReturn(0L);
         when(mockBehandlingskontrollTjeneste.initBehandlingskontroll(Mockito.anyLong())).thenReturn(kontekst);
         when(kontekst.getSkriveLås()).thenReturn(lås);
-        when(mockEnhetsTjeneste.sjekkEnhetVedGjenopptak(any())).thenReturn(Optional.of(enhet));
+        when(mockEnhetsTjeneste.sjekkEnhetEtterEndring(any())).thenReturn(Optional.of(enhet));
 
         ProsessTaskData prosessTaskData = new ProsessTaskData(GjenopptaBehandlingTask.TASKTYPE);
         prosessTaskData.setBehandling(0L, behandlingId, "0");

--- a/domenetjenester/behandling-revurdering/src/main/java/no/nav/foreldrepenger/behandling/revurdering/RevurderingTjeneste.java
+++ b/domenetjenester/behandling-revurdering/src/main/java/no/nav/foreldrepenger/behandling/revurdering/RevurderingTjeneste.java
@@ -1,7 +1,5 @@
 package no.nav.foreldrepenger.behandling.revurdering;
 
-import java.util.Optional;
-
 import no.nav.foreldrepenger.behandlingslager.aktør.OrganisasjonsEnhet;
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingÅrsakType;
@@ -9,9 +7,9 @@ import no.nav.foreldrepenger.behandlingslager.fagsak.Fagsak;
 
 public interface RevurderingTjeneste {
 
-    Behandling opprettManuellRevurdering(Fagsak fagsak, BehandlingÅrsakType revurderingsÅrsak, Optional<OrganisasjonsEnhet> enhet);
+    Behandling opprettManuellRevurdering(Fagsak fagsak, BehandlingÅrsakType revurderingsÅrsak, OrganisasjonsEnhet enhet);
 
-    Behandling opprettAutomatiskRevurdering(Fagsak fagsak, BehandlingÅrsakType revurderingsÅrsak, Optional<OrganisasjonsEnhet> enhet);
+    Behandling opprettAutomatiskRevurdering(Fagsak fagsak, BehandlingÅrsakType revurderingsÅrsak, OrganisasjonsEnhet enhet);
 
     void kopierAlleGrunnlagFraTidligereBehandling(Behandling original, Behandling ny);
 

--- a/domenetjenester/behandling-revurdering/src/main/java/no/nav/foreldrepenger/behandling/revurdering/RevurderingTjenesteFelles.java
+++ b/domenetjenester/behandling-revurdering/src/main/java/no/nav/foreldrepenger/behandling/revurdering/RevurderingTjenesteFelles.java
@@ -3,7 +3,6 @@ package no.nav.foreldrepenger.behandling.revurdering;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 import javax.enterprise.context.ApplicationScoped;
@@ -53,7 +52,7 @@ public class RevurderingTjenesteFelles {
     }
 
     public Behandling opprettRevurderingsbehandling(BehandlingÅrsakType revurderingÅrsakType, Behandling opprinneligBehandling, boolean manueltOpprettet,
-                                                    Optional<OrganisasjonsEnhet> enhet) {
+                                                    OrganisasjonsEnhet enhet) {
         BehandlingType behandlingType = BehandlingType.REVURDERING;
         BehandlingÅrsak.Builder revurderingÅrsak = BehandlingÅrsak.builder(revurderingÅrsakType)
             .medOriginalBehandling(opprinneligBehandling)
@@ -63,9 +62,9 @@ public class RevurderingTjenesteFelles {
                 .orElseThrow(() -> new IllegalStateException("Berørt behandling må ha en tilhørende avlsuttet behandling for medforelder - skal ikke skje")); // NOSONAR
         }
         Behandling revurdering = Behandling.fraTidligereBehandling(opprinneligBehandling, behandlingType)
+            .medBehandlendeEnhet(enhet)
             .medBehandlingstidFrist(LocalDate.now().plusWeeks(behandlingType.getBehandlingstidFristUker()))
             .medBehandlingÅrsak(revurderingÅrsak).build();
-        enhet.ifPresent(revurdering::setBehandlendeEnhet);
         revurderingHistorikk.opprettHistorikkinnslagOmRevurdering(revurdering, revurderingÅrsakType, manueltOpprettet);
         return revurdering;
     }

--- a/domenetjenester/behandling-revurdering/src/main/java/no/nav/foreldrepenger/behandling/revurdering/etterkontroll/task/AutomatiskEtterkontrollTask.java
+++ b/domenetjenester/behandling-revurdering/src/main/java/no/nav/foreldrepenger/behandling/revurdering/etterkontroll/task/AutomatiskEtterkontrollTask.java
@@ -206,7 +206,7 @@ public class AutomatiskEtterkontrollTask extends FagsakProsessTask {
 
     private Behandling opprettRevurdering(Behandling behandlingForRevurdering, RevurderingTjeneste revurderingTjeneste, BehandlingÅrsakType behandlingÅrsakType) {
         Behandling revurdering;
-        Optional<OrganisasjonsEnhet> enhet = behandlendeEnhetTjeneste.sjekkEnhetVedNyAvledetBehandling(behandlingForRevurdering.getFagsak());
+        OrganisasjonsEnhet enhet = behandlendeEnhetTjeneste.finnBehandlendeEnhetFor(behandlingForRevurdering.getFagsak());
 
         revurdering = revurderingTjeneste.opprettAutomatiskRevurdering(behandlingForRevurdering.getFagsak(), behandlingÅrsakType, enhet);
 

--- a/domenetjenester/behandling-revurdering/src/main/java/no/nav/foreldrepenger/behandling/revurdering/ytelse/es/RevurderingTjenesteImpl.java
+++ b/domenetjenester/behandling-revurdering/src/main/java/no/nav/foreldrepenger/behandling/revurdering/ytelse/es/RevurderingTjenesteImpl.java
@@ -64,16 +64,16 @@ public class RevurderingTjenesteImpl implements RevurderingTjeneste {
     }
 
     @Override
-    public Behandling opprettManuellRevurdering(Fagsak fagsak, BehandlingÅrsakType revurderingsÅrsak, Optional<OrganisasjonsEnhet> enhet) {
+    public Behandling opprettManuellRevurdering(Fagsak fagsak, BehandlingÅrsakType revurderingsÅrsak, OrganisasjonsEnhet enhet) {
         return opprettRevurdering(fagsak, revurderingsÅrsak, true, enhet);
     }
 
     @Override
-    public Behandling opprettAutomatiskRevurdering(Fagsak fagsak, BehandlingÅrsakType revurderingsÅrsak, Optional<OrganisasjonsEnhet> enhet) {
+    public Behandling opprettAutomatiskRevurdering(Fagsak fagsak, BehandlingÅrsakType revurderingsÅrsak, OrganisasjonsEnhet enhet) {
         return opprettRevurdering(fagsak, revurderingsÅrsak, false, enhet);
     }
 
-    private Behandling opprettRevurdering(Fagsak fagsak, BehandlingÅrsakType revurderingÅrsakType, boolean manueltOpprettet, Optional<OrganisasjonsEnhet> enhet) {
+    private Behandling opprettRevurdering(Fagsak fagsak, BehandlingÅrsakType revurderingÅrsakType, boolean manueltOpprettet, OrganisasjonsEnhet enhet) {
         Optional<Behandling> opprinneligBehandlingOptional = behandlingRepository.finnSisteAvsluttedeIkkeHenlagteBehandling(fagsak.getId());
         if (!opprinneligBehandlingOptional.isPresent()) {
             throw RevurderingFeil.FACTORY.tjenesteFinnerIkkeBehandlingForRevurdering(fagsak.getId()).toException();

--- a/domenetjenester/behandling-revurdering/src/main/java/no/nav/foreldrepenger/behandling/revurdering/ytelse/fp/RevurderingTjenesteImpl.java
+++ b/domenetjenester/behandling-revurdering/src/main/java/no/nav/foreldrepenger/behandling/revurdering/ytelse/fp/RevurderingTjenesteImpl.java
@@ -70,7 +70,7 @@ public class RevurderingTjenesteImpl implements RevurderingTjeneste {
     }
 
     @Override
-    public Behandling opprettManuellRevurdering(Fagsak fagsak, BehandlingÅrsakType revurderingsÅrsak, Optional<OrganisasjonsEnhet> enhet) {
+    public Behandling opprettManuellRevurdering(Fagsak fagsak, BehandlingÅrsakType revurderingsÅrsak, OrganisasjonsEnhet enhet) {
         Behandling behandling = opprettRevurdering(fagsak, revurderingsÅrsak, true, enhet);
         BehandlingskontrollKontekst kontekst = behandlingskontrollTjeneste.initBehandlingskontroll(behandling);
         behandlingskontrollTjeneste.lagreAksjonspunkterFunnet(kontekst, List.of(AksjonspunktDefinisjon.KONTROLL_AV_MANUELT_OPPRETTET_REVURDERINGSBEHANDLING));
@@ -78,11 +78,11 @@ public class RevurderingTjenesteImpl implements RevurderingTjeneste {
     }
 
     @Override
-    public Behandling opprettAutomatiskRevurdering(Fagsak fagsak, BehandlingÅrsakType revurderingsÅrsak, Optional<OrganisasjonsEnhet> enhet) {
+    public Behandling opprettAutomatiskRevurdering(Fagsak fagsak, BehandlingÅrsakType revurderingsÅrsak, OrganisasjonsEnhet enhet) {
         return opprettRevurdering(fagsak, revurderingsÅrsak, false, enhet);
     }
 
-    private Behandling opprettRevurdering(Fagsak fagsak, BehandlingÅrsakType revurderingsÅrsak, boolean manueltOpprettet, Optional<OrganisasjonsEnhet> enhet) {
+    private Behandling opprettRevurdering(Fagsak fagsak, BehandlingÅrsakType revurderingsÅrsak, boolean manueltOpprettet, OrganisasjonsEnhet enhet) {
         Behandling origBehandling = behandlingRepository.finnSisteAvsluttedeIkkeHenlagteBehandling(fagsak.getId())
             .orElseThrow(() -> RevurderingFeil.FACTORY.tjenesteFinnerIkkeBehandlingForRevurdering(fagsak.getId()).toException());
 

--- a/domenetjenester/behandling-revurdering/src/main/java/no/nav/foreldrepenger/behandling/revurdering/ytelse/svp/RevurderingTjenesteImpl.java
+++ b/domenetjenester/behandling-revurdering/src/main/java/no/nav/foreldrepenger/behandling/revurdering/ytelse/svp/RevurderingTjenesteImpl.java
@@ -1,7 +1,5 @@
 package no.nav.foreldrepenger.behandling.revurdering.ytelse.svp;
 
-import java.util.Optional;
-
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
@@ -71,16 +69,16 @@ public class RevurderingTjenesteImpl implements RevurderingTjeneste {
     }
 
     @Override
-    public Behandling opprettManuellRevurdering(Fagsak fagsak, BehandlingÅrsakType revurderingsÅrsak, Optional<OrganisasjonsEnhet> enhet) {
+    public Behandling opprettManuellRevurdering(Fagsak fagsak, BehandlingÅrsakType revurderingsÅrsak, OrganisasjonsEnhet enhet) {
         return opprettRevurdering(fagsak, revurderingsÅrsak, true, enhet);
     }
 
     @Override
-    public Behandling opprettAutomatiskRevurdering(Fagsak fagsak, BehandlingÅrsakType revurderingsÅrsak, Optional<OrganisasjonsEnhet> enhet) {
+    public Behandling opprettAutomatiskRevurdering(Fagsak fagsak, BehandlingÅrsakType revurderingsÅrsak, OrganisasjonsEnhet enhet) {
         return opprettRevurdering(fagsak, revurderingsÅrsak, false, enhet);
     }
 
-    private Behandling opprettRevurdering(Fagsak fagsak, BehandlingÅrsakType revurderingsÅrsak, boolean manueltOpprettet, Optional<OrganisasjonsEnhet> enhet) {
+    private Behandling opprettRevurdering(Fagsak fagsak, BehandlingÅrsakType revurderingsÅrsak, boolean manueltOpprettet, OrganisasjonsEnhet enhet) {
         Behandling origBehandling = behandlingRepository.finnSisteAvsluttedeIkkeHenlagteBehandling(fagsak.getId())
             .orElseThrow(() -> RevurderingFeil.FACTORY.tjenesteFinnerIkkeBehandlingForRevurdering(fagsak.getId()).toException());
 

--- a/domenetjenester/behandling-revurdering/src/test/java/no/nav/foreldrepenger/behandling/revurdering/etterkontroll/es/AutomatiskEtterkontrollTaskTest.java
+++ b/domenetjenester/behandling-revurdering/src/test/java/no/nav/foreldrepenger/behandling/revurdering/etterkontroll/es/AutomatiskEtterkontrollTaskTest.java
@@ -27,6 +27,7 @@ import no.nav.foreldrepenger.behandlingskontroll.BehandlingskontrollTjeneste;
 import no.nav.foreldrepenger.behandlingskontroll.FagsakYtelseTypeRef;
 import no.nav.foreldrepenger.behandlingslager.aktør.FødtBarnInfo;
 import no.nav.foreldrepenger.behandlingslager.aktør.NavBrukerKjønn;
+import no.nav.foreldrepenger.behandlingslager.aktør.OrganisasjonsEnhet;
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingResultatType;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingStatus;
@@ -88,7 +89,7 @@ public class AutomatiskEtterkontrollTaskTest {
         tpsFamilieTjenesteMock = mock(TpsFamilieTjeneste.class);
         behandlendeEnhetTjeneste = mock(BehandlendeEnhetTjeneste.class);
         var bkTjeneste = mock(BehandlingskontrollTjeneste.class);
-        when(behandlendeEnhetTjeneste.sjekkEnhetVedNyAvledetBehandling(any(Fagsak.class))).thenReturn(Optional.empty());
+        when(behandlendeEnhetTjeneste.finnBehandlendeEnhetFor(any(Fagsak.class))).thenReturn(new OrganisasjonsEnhet("1234", "Testlokasjon"));
         etterkontrollTjeneste = new EtterkontrollTjeneste(repositoryProvider,prosessTaskRepositoryMock, bkTjeneste);
         this.historikkRepository = mock(HistorikkRepository.class);
 

--- a/domenetjenester/behandling-revurdering/src/test/java/no/nav/foreldrepenger/behandling/revurdering/etterkontroll/fp/AutomatiskEtterkontrollTaskTest.java
+++ b/domenetjenester/behandling-revurdering/src/test/java/no/nav/foreldrepenger/behandling/revurdering/etterkontroll/fp/AutomatiskEtterkontrollTaskTest.java
@@ -31,6 +31,7 @@ import no.nav.foreldrepenger.behandlingskontroll.FagsakYtelseTypeRef;
 import no.nav.foreldrepenger.behandlingslager.aktør.FødtBarnInfo;
 import no.nav.foreldrepenger.behandlingslager.aktør.NavBruker;
 import no.nav.foreldrepenger.behandlingslager.aktør.NavBrukerKjønn;
+import no.nav.foreldrepenger.behandlingslager.aktør.OrganisasjonsEnhet;
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingResultatType;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingStatus;
@@ -125,7 +126,7 @@ public class AutomatiskEtterkontrollTaskTest {
         behandlendeEnhetTjeneste = mock(BehandlendeEnhetTjeneste.class);
         familieHendelseRepositoryMock =  mock(FamilieHendelseRepository.class);
         var bkTjeneste = mock(BehandlingskontrollTjeneste.class);
-        when(behandlendeEnhetTjeneste.sjekkEnhetVedNyAvledetBehandling(any(Fagsak.class))).thenReturn(Optional.empty());
+        when(behandlendeEnhetTjeneste.finnBehandlendeEnhetFor(any(Fagsak.class))).thenReturn(new OrganisasjonsEnhet("1234", "Testlokasjon"));
 
         etterkontrollTjeneste = new EtterkontrollTjeneste( repositoryProvider,prosessTaskRepositoryMock, bkTjeneste);
         this.historikkRepository = mock(HistorikkRepository.class);

--- a/domenetjenester/behandling-revurdering/src/test/java/no/nav/foreldrepenger/behandling/revurdering/felles/ErEndringIBeregningTest.java
+++ b/domenetjenester/behandling-revurdering/src/test/java/no/nav/foreldrepenger/behandling/revurdering/felles/ErEndringIBeregningTest.java
@@ -27,6 +27,7 @@ import no.nav.foreldrepenger.behandling.revurdering.ytelse.fp.RevurderingTjenest
 import no.nav.foreldrepenger.behandlingskontroll.FagsakYtelseTypeRef;
 import no.nav.foreldrepenger.behandlingskontroll.impl.BehandlingskontrollTjenesteImpl;
 import no.nav.foreldrepenger.behandlingskontroll.spi.BehandlingskontrollServiceProvider;
+import no.nav.foreldrepenger.behandlingslager.aktør.OrganisasjonsEnhet;
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingStegType;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingÅrsakType;
@@ -92,7 +93,7 @@ public class ErEndringIBeregningTest {
         RevurderingTjeneste revurderingTjeneste = new RevurderingTjenesteImpl(repositoryProvider, behandlingskontrollTjeneste,
             iayTjeneste, revurderingEndring, revurderingTjenesteFelles, vergeRepository);
         revurdering = revurderingTjeneste
-            .opprettAutomatiskRevurdering(behandlingSomSkalRevurderes.getFagsak(), BehandlingÅrsakType.RE_HENDELSE_FØDSEL, Optional.empty());
+            .opprettAutomatiskRevurdering(behandlingSomSkalRevurderes.getFagsak(), BehandlingÅrsakType.RE_HENDELSE_FØDSEL, new OrganisasjonsEnhet("1234", "Test"));
         VirksomhetEntitet virksomhet = new VirksomhetEntitet.Builder().medOrgnr(KUNSTIG_ORG).medNavn("Virksomheten").oppdatertOpplysningerNå().build();
         repositoryProvider.getVirksomhetRepository().lagre(virksomhet);
         LocalDate endringsdato = LocalDate.now().minusMonths(3);

--- a/domenetjenester/behandling-revurdering/src/test/java/no/nav/foreldrepenger/behandling/revurdering/felles/ErKunEndringIFordelingAvYtelsenTest.java
+++ b/domenetjenester/behandling-revurdering/src/test/java/no/nav/foreldrepenger/behandling/revurdering/felles/ErKunEndringIFordelingAvYtelsenTest.java
@@ -27,6 +27,7 @@ import no.nav.foreldrepenger.behandling.revurdering.ytelse.fp.RevurderingTjenest
 import no.nav.foreldrepenger.behandlingskontroll.FagsakYtelseTypeRef;
 import no.nav.foreldrepenger.behandlingskontroll.impl.BehandlingskontrollTjenesteImpl;
 import no.nav.foreldrepenger.behandlingskontroll.spi.BehandlingskontrollServiceProvider;
+import no.nav.foreldrepenger.behandlingslager.aktør.OrganisasjonsEnhet;
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingResultatType;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingStegType;
@@ -99,7 +100,7 @@ public class ErKunEndringIFordelingAvYtelsenTest {
         var revurderingTjeneste = new RevurderingTjenesteImpl(repositoryProvider, behandlingskontrollTjeneste,
             iayTjeneste, revurderingEndring, revurderingTjenesteFelles, vergeRepository);
         revurdering = revurderingTjeneste
-            .opprettAutomatiskRevurdering(behandlingSomSkalRevurderes.getFagsak(), BehandlingÅrsakType.RE_HENDELSE_FØDSEL, Optional.empty());
+            .opprettAutomatiskRevurdering(behandlingSomSkalRevurderes.getFagsak(), BehandlingÅrsakType.RE_HENDELSE_FØDSEL, new OrganisasjonsEnhet("1234", "Test"));
     }
 
     @Test

--- a/domenetjenester/behandling-revurdering/src/test/java/no/nav/foreldrepenger/behandling/revurdering/felles/ErSisteUttakAvslåttMedÅrsakTest.java
+++ b/domenetjenester/behandling-revurdering/src/test/java/no/nav/foreldrepenger/behandling/revurdering/felles/ErSisteUttakAvslåttMedÅrsakTest.java
@@ -28,6 +28,7 @@ import no.nav.foreldrepenger.behandling.revurdering.ytelse.fp.UttakResultatHolde
 import no.nav.foreldrepenger.behandlingskontroll.FagsakYtelseTypeRef;
 import no.nav.foreldrepenger.behandlingskontroll.impl.BehandlingskontrollTjenesteImpl;
 import no.nav.foreldrepenger.behandlingskontroll.spi.BehandlingskontrollServiceProvider;
+import no.nav.foreldrepenger.behandlingslager.aktør.OrganisasjonsEnhet;
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingStegType;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingÅrsakType;
@@ -102,7 +103,7 @@ public class ErSisteUttakAvslåttMedÅrsakTest {
         var revurderingTjeneste = new RevurderingTjenesteImpl(repositoryProvider, behandlingskontrollTjeneste,
             iayTjeneste, revurderingEndring, revurderingTjenesteFelles, vergeRepository);
         revurdering = revurderingTjeneste
-            .opprettAutomatiskRevurdering(behandlingSomSkalRevurderes.getFagsak(), BehandlingÅrsakType.RE_HENDELSE_FØDSEL, Optional.empty());
+            .opprettAutomatiskRevurdering(behandlingSomSkalRevurderes.getFagsak(), BehandlingÅrsakType.RE_HENDELSE_FØDSEL, new OrganisasjonsEnhet("1234", "Test"));
         LocalDate endringsdato = LocalDate.now().minusMonths(3);
         when(endringsdatoRevurderingUtlederImpl.utledEndringsdato(any())).thenReturn(endringsdato);
     }

--- a/domenetjenester/behandling-revurdering/src/test/java/no/nav/foreldrepenger/behandling/revurdering/felles/OppfyllerIkkeInngangsvilkårPåSkjæringstidsspunktTest.java
+++ b/domenetjenester/behandling-revurdering/src/test/java/no/nav/foreldrepenger/behandling/revurdering/felles/OppfyllerIkkeInngangsvilkårPåSkjæringstidsspunktTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.util.Optional;
 
 import javax.inject.Inject;
 
@@ -20,6 +19,7 @@ import no.nav.foreldrepenger.behandling.revurdering.ytelse.fp.RevurderingTjenest
 import no.nav.foreldrepenger.behandlingskontroll.FagsakYtelseTypeRef;
 import no.nav.foreldrepenger.behandlingskontroll.impl.BehandlingskontrollTjenesteImpl;
 import no.nav.foreldrepenger.behandlingskontroll.spi.BehandlingskontrollServiceProvider;
+import no.nav.foreldrepenger.behandlingslager.aktør.OrganisasjonsEnhet;
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingResultatType;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingStegType;
@@ -80,7 +80,7 @@ public class OppfyllerIkkeInngangsvilkårPåSkjæringstidsspunktTest {
         var revurderingTjeneste = new RevurderingTjenesteImpl(repositoryProvider, behandlingskontrollTjeneste,
             iayTjeneste, revurderingEndring, revurderingTjenesteFelles, vergeRepository);
         revurdering = revurderingTjeneste
-            .opprettAutomatiskRevurdering(behandlingSomSkalRevurderes.getFagsak(), BehandlingÅrsakType.RE_HENDELSE_FØDSEL, Optional.empty());
+            .opprettAutomatiskRevurdering(behandlingSomSkalRevurderes.getFagsak(), BehandlingÅrsakType.RE_HENDELSE_FØDSEL, new OrganisasjonsEnhet("1234", "Test"));
     }
 
     @Test

--- a/domenetjenester/behandling-revurdering/src/test/java/no/nav/foreldrepenger/behandling/revurdering/satsregulering/AutomatiskGrunnbelopReguleringTaskTest.java
+++ b/domenetjenester/behandling-revurdering/src/test/java/no/nav/foreldrepenger/behandling/revurdering/satsregulering/AutomatiskGrunnbelopReguleringTaskTest.java
@@ -1,6 +1,9 @@
 package no.nav.foreldrepenger.behandling.revurdering.satsregulering;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -15,6 +18,7 @@ import org.junit.runner.RunWith;
 
 import no.nav.foreldrepenger.behandling.revurdering.RevurderingTjeneste;
 import no.nav.foreldrepenger.behandlingskontroll.FagsakYtelseTypeRef;
+import no.nav.foreldrepenger.behandlingslager.aktør.OrganisasjonsEnhet;
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingResultatType;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingStatus;
@@ -32,6 +36,7 @@ import no.nav.foreldrepenger.behandlingslager.behandling.vilkår.VilkårUtfallTy
 import no.nav.foreldrepenger.behandlingslager.fagsak.Fagsak;
 import no.nav.foreldrepenger.behandlingslager.testutilities.behandling.ScenarioMorSøkerForeldrepenger;
 import no.nav.foreldrepenger.dbstoette.UnittestRepositoryRule;
+import no.nav.foreldrepenger.produksjonsstyring.behandlingenhet.BehandlendeEnhetTjeneste;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTaskData;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTaskRepository;
 import no.nav.vedtak.felles.testutilities.Whitebox;
@@ -58,11 +63,14 @@ public class AutomatiskGrunnbelopReguleringTaskTest {
     @Inject
     private BehandlingRepositoryProvider repositoryProvider;
 
+    private BehandlendeEnhetTjeneste enhetsTjeneste = mock(BehandlendeEnhetTjeneste.class);
+
 
     @Test
     public void skal_opprette_revurderingsbehandling_med_årsak_når_avsluttet_behandling() {
 
         Behandling behandling = opprettRevurderingsKandidat(BehandlingStatus.AVSLUTTET);
+        when(enhetsTjeneste.finnBehandlendeEnhetFor(any())).thenReturn(new OrganisasjonsEnhet("1234", "Test"));
 
         ProsessTaskData prosessTaskData = new ProsessTaskData(AutomatiskGrunnbelopReguleringTask.TASKTYPE);
         prosessTaskData.setFagsak(behandling.getFagsakId(), behandling.getAktørId().getId());
@@ -89,13 +97,14 @@ public class AutomatiskGrunnbelopReguleringTaskTest {
     }
 
     private void createTask() {
-        task = new AutomatiskGrunnbelopReguleringTask(repositoryProvider, prosessTaskRepositoryMock);
+        task = new AutomatiskGrunnbelopReguleringTask(repositoryProvider, prosessTaskRepositoryMock, enhetsTjeneste);
 
     }
 
     @Test
     public void skal_ikke_opprette_revurdering_dersom_åpen_behandling_på_fagsak() {
         Behandling behandling = opprettRevurderingsKandidat(BehandlingStatus.UTREDES);
+        when(enhetsTjeneste.finnBehandlendeEnhetFor(any())).thenReturn(new OrganisasjonsEnhet("1234", "Test"));
 
         ProsessTaskData prosessTaskData = new ProsessTaskData(AutomatiskGrunnbelopReguleringTask.TASKTYPE);
         prosessTaskData.setFagsak(behandling.getFagsakId(), behandling.getAktørId().getId());

--- a/domenetjenester/behandling-revurdering/src/test/java/no/nav/foreldrepenger/behandling/revurdering/ytelse/es/RevurderingTjenesteImplTest.java
+++ b/domenetjenester/behandling-revurdering/src/test/java/no/nav/foreldrepenger/behandling/revurdering/ytelse/es/RevurderingTjenesteImplTest.java
@@ -3,7 +3,6 @@ package no.nav.foreldrepenger.behandling.revurdering.ytelse.es;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.LocalDateTime;
-import java.util.Optional;
 
 import javax.inject.Inject;
 
@@ -61,7 +60,7 @@ public class RevurderingTjenesteImplTest {
     public void skal_opprette_automatisk_revurdering_basert_på_siste_innvilgede_behandling() {
         final BehandlingskontrollTjenesteImpl behandlingskontrollTjeneste = new BehandlingskontrollTjenesteImpl(serviceProvider);
         revurderingTjeneste = new RevurderingTjenesteImpl(repositoryProvider, behandlingskontrollTjeneste, revurderingEndringES, revurderingTjenesteFelles, vergeRepository);
-        final Behandling revurdering = revurderingTjeneste.opprettAutomatiskRevurdering(behandlingSomSkalRevurderes.getFagsak(), BehandlingÅrsakType.RE_AVVIK_ANTALL_BARN, Optional.empty());
+        final Behandling revurdering = revurderingTjeneste.opprettAutomatiskRevurdering(behandlingSomSkalRevurderes.getFagsak(), BehandlingÅrsakType.RE_AVVIK_ANTALL_BARN, new OrganisasjonsEnhet("1234", "Test"));
 
         assertThat(revurdering.getFagsak()).isEqualTo(behandlingSomSkalRevurderes.getFagsak());
         assertThat(revurdering.getBehandlingÅrsaker().get(0).getBehandlingÅrsakType()).isEqualTo(BehandlingÅrsakType.RE_AVVIK_ANTALL_BARN);
@@ -72,7 +71,7 @@ public class RevurderingTjenesteImplTest {
         OrganisasjonsEnhet enhet = new OrganisasjonsEnhet("4806", "Nye Nav FP");
         final BehandlingskontrollTjenesteImpl behandlingskontrollTjeneste = new BehandlingskontrollTjenesteImpl(serviceProvider);
         revurderingTjeneste = new RevurderingTjenesteImpl(repositoryProvider, behandlingskontrollTjeneste, revurderingEndringES, revurderingTjenesteFelles, vergeRepository);
-        final Behandling revurdering = revurderingTjeneste.opprettManuellRevurdering(behandlingSomSkalRevurderes.getFagsak(), BehandlingÅrsakType.RE_MANGLER_FØDSEL_I_PERIODE, Optional.of(enhet));
+        final Behandling revurdering = revurderingTjeneste.opprettManuellRevurdering(behandlingSomSkalRevurderes.getFagsak(), BehandlingÅrsakType.RE_MANGLER_FØDSEL_I_PERIODE, enhet);
 
         assertThat(revurdering.getFagsak()).isEqualTo(behandlingSomSkalRevurderes.getFagsak());
         assertThat(revurdering.getBehandlingÅrsaker().get(0).getBehandlingÅrsakType()).isEqualTo(BehandlingÅrsakType.RE_MANGLER_FØDSEL_I_PERIODE);

--- a/domenetjenester/behandling-revurdering/src/test/java/no/nav/foreldrepenger/behandling/revurdering/ytelse/fp/ErEndringIUttakFraEndringsdatoTest.java
+++ b/domenetjenester/behandling-revurdering/src/test/java/no/nav/foreldrepenger/behandling/revurdering/ytelse/fp/ErEndringIUttakFraEndringsdatoTest.java
@@ -27,6 +27,7 @@ import no.nav.foreldrepenger.behandling.revurdering.felles.LagBeregningsresultat
 import no.nav.foreldrepenger.behandlingskontroll.FagsakYtelseTypeRef;
 import no.nav.foreldrepenger.behandlingskontroll.impl.BehandlingskontrollTjenesteImpl;
 import no.nav.foreldrepenger.behandlingskontroll.spi.BehandlingskontrollServiceProvider;
+import no.nav.foreldrepenger.behandlingslager.aktør.OrganisasjonsEnhet;
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingStegType;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingÅrsakType;
@@ -105,7 +106,7 @@ public class ErEndringIUttakFraEndringsdatoTest {
         RevurderingTjeneste revurderingTjeneste = new RevurderingTjenesteImpl(repositoryProvider, behandlingskontrollTjeneste,
             iayTjeneste, revurderingEndring, revurderingTjenesteFelles, vergeRepository);
         revurdering = revurderingTjeneste
-            .opprettAutomatiskRevurdering(behandlingSomSkalRevurderes.getFagsak(), BehandlingÅrsakType.RE_HENDELSE_FØDSEL, Optional.empty());
+            .opprettAutomatiskRevurdering(behandlingSomSkalRevurderes.getFagsak(), BehandlingÅrsakType.RE_HENDELSE_FØDSEL, new OrganisasjonsEnhet("1234", "Test"));
         LocalDate endringsdato = LocalDate.now().minusMonths(3);
         when(endringsdatoRevurderingUtlederImpl.utledEndringsdato(any())).thenReturn(endringsdato);
         erEndringIUttakFraEndringsdato = new ErEndringIUttakFraEndringsdatoImpl();

--- a/domenetjenester/behandling-revurdering/src/test/java/no/nav/foreldrepenger/behandling/revurdering/ytelse/fp/RevurderingBehandlingsresultatutlederTest.java
+++ b/domenetjenester/behandling-revurdering/src/test/java/no/nav/foreldrepenger/behandling/revurdering/ytelse/fp/RevurderingBehandlingsresultatutlederTest.java
@@ -9,7 +9,6 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
 
 import javax.inject.Inject;
 import javax.persistence.EntityManager;
@@ -39,6 +38,7 @@ import no.nav.foreldrepenger.behandling.revurdering.ytelse.UttakInputTjeneste;
 import no.nav.foreldrepenger.behandlingskontroll.FagsakYtelseTypeRef;
 import no.nav.foreldrepenger.behandlingskontroll.impl.BehandlingskontrollTjenesteImpl;
 import no.nav.foreldrepenger.behandlingskontroll.spi.BehandlingskontrollServiceProvider;
+import no.nav.foreldrepenger.behandlingslager.aktør.OrganisasjonsEnhet;
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingResultatType;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingStegType;
@@ -170,7 +170,7 @@ public class RevurderingBehandlingsresultatutlederTest {
         revurderingTjeneste = new RevurderingTjenesteImpl(repositoryProvider, behandlingskontrollTjeneste,
             iayTjeneste, revurderingEndring, revurderingTjenesteFelles, vergeRepository);
         revurdering = revurderingTjeneste
-            .opprettAutomatiskRevurdering(behandlingSomSkalRevurderes.getFagsak(), BehandlingÅrsakType.RE_HENDELSE_FØDSEL, Optional.empty());
+            .opprettAutomatiskRevurdering(behandlingSomSkalRevurderes.getFagsak(), BehandlingÅrsakType.RE_HENDELSE_FØDSEL, new OrganisasjonsEnhet("1234", "Test"));
     }
 
     // Case 1
@@ -1164,7 +1164,7 @@ public class RevurderingBehandlingsresultatutlederTest {
 
         // Arrange revurdering 2
         Behandling revurdering2 = revurderingTjeneste
-            .opprettAutomatiskRevurdering(revurdering.getFagsak(), BehandlingÅrsakType.RE_HENDELSE_FØDSEL, Optional.empty());
+            .opprettAutomatiskRevurdering(revurdering.getFagsak(), BehandlingÅrsakType.RE_HENDELSE_FØDSEL, new OrganisasjonsEnhet("1234", "Test"));
         BehandlingLås låsRevurdering2 = behandlingRepository.taSkriveLås(revurdering2);
         VilkårResultat vilkårResultatRevurdering2 = VilkårResultat.builder()
             .leggTilVilkår(VilkårType.FØDSELSVILKÅRET_MOR, VilkårUtfallType.OPPFYLT)

--- a/domenetjenester/behandling-revurdering/src/test/java/no/nav/foreldrepenger/behandling/revurdering/ytelse/fp/RevurderingTjenesteImplTest.java
+++ b/domenetjenester/behandling-revurdering/src/test/java/no/nav/foreldrepenger/behandling/revurdering/ytelse/fp/RevurderingTjenesteImplTest.java
@@ -31,6 +31,7 @@ import no.nav.foreldrepenger.behandlingskontroll.impl.BehandlingskontrollTjenest
 import no.nav.foreldrepenger.behandlingskontroll.spi.BehandlingskontrollServiceProvider;
 import no.nav.foreldrepenger.behandlingslager.aktør.FødtBarnInfo;
 import no.nav.foreldrepenger.behandlingslager.aktør.NavBrukerKjønn;
+import no.nav.foreldrepenger.behandlingslager.aktør.OrganisasjonsEnhet;
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingStegType;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingType;
@@ -154,7 +155,7 @@ public class RevurderingTjenesteImplTest {
 
         // Act
         Behandling revurdering = revurderingTjeneste
-            .opprettAutomatiskRevurdering(behandlingSomSkalRevurderes.getFagsak(), BehandlingÅrsakType.RE_HENDELSE_FØDSEL, Optional.empty());
+            .opprettAutomatiskRevurdering(behandlingSomSkalRevurderes.getFagsak(), BehandlingÅrsakType.RE_HENDELSE_FØDSEL, new OrganisasjonsEnhet("1234", "Test"));
 
         // Assert
         assertThat(revurdering.getFagsak()).isEqualTo(behandlingSomSkalRevurderes.getFagsak());

--- a/domenetjenester/behandling-revurdering/src/test/java/no/nav/foreldrepenger/behandling/revurdering/ytelse/svp/RevurderingBehandlingsresultatutlederTest.java
+++ b/domenetjenester/behandling-revurdering/src/test/java/no/nav/foreldrepenger/behandling/revurdering/ytelse/svp/RevurderingBehandlingsresultatutlederTest.java
@@ -10,7 +10,6 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
 
 import javax.inject.Inject;
 import javax.persistence.EntityManager;
@@ -41,6 +40,7 @@ import no.nav.foreldrepenger.behandling.revurdering.ytelse.fp.RevurderingTjenest
 import no.nav.foreldrepenger.behandlingskontroll.FagsakYtelseTypeRef;
 import no.nav.foreldrepenger.behandlingskontroll.impl.BehandlingskontrollTjenesteImpl;
 import no.nav.foreldrepenger.behandlingskontroll.spi.BehandlingskontrollServiceProvider;
+import no.nav.foreldrepenger.behandlingslager.aktør.OrganisasjonsEnhet;
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingResultatType;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingStegType;
@@ -162,7 +162,7 @@ public class RevurderingBehandlingsresultatutlederTest {
         revurderingTjeneste = new RevurderingTjenesteImpl(repositoryProvider, behandlingskontrollTjeneste,
             iayTjeneste, revurderingEndring, revurderingTjenesteFelles, vergeRepository);
         revurdering = revurderingTjeneste
-            .opprettAutomatiskRevurdering(behandlingSomSkalRevurderes.getFagsak(), BehandlingÅrsakType.RE_HENDELSE_FØDSEL, Optional.empty());
+            .opprettAutomatiskRevurdering(behandlingSomSkalRevurderes.getFagsak(), BehandlingÅrsakType.RE_HENDELSE_FØDSEL, new OrganisasjonsEnhet("1234", "Test"));
     }
 
     // Case 1

--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/Behandlingsoppretter.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/Behandlingsoppretter.java
@@ -94,7 +94,7 @@ public class Behandlingsoppretter {
                 BehandlingÅrsak.builder(behandlingÅrsakType).buildFor(beh);
             }
             beh.setBehandlingstidFrist(LocalDate.now().plusWeeks(behandlingType.getBehandlingstidFristUker()));
-            OrganisasjonsEnhet enhet = finnBehandlendeEnhet(fagsak);
+            OrganisasjonsEnhet enhet = behandlendeEnhetTjeneste.finnBehandlendeEnhetFor(fagsak);
             beh.setBehandlendeEnhet(enhet);
         }); // NOSONAR
     }
@@ -206,10 +206,6 @@ public class Behandlingsoppretter {
             .collect(toList());
     }
 
-
-    private OrganisasjonsEnhet finnBehandlendeEnhet(Fagsak fagsak) {
-        return behandlendeEnhetTjeneste.finnBehandlendeEnhetFor(fagsak);
-    }
 
     public void settSomKøet(Behandling nyKøetBehandling) {
         behandlingskontrollTjeneste.settBehandlingPåVent(nyKøetBehandling, AksjonspunktDefinisjon.AUTO_KØET_BEHANDLING, null, null, Venteårsak.VENT_ÅPEN_BEHANDLING);

--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/dokumentmottak/impl/DokumentmottakerFelles.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/dokumentmottak/impl/DokumentmottakerFelles.java
@@ -129,13 +129,13 @@ public class DokumentmottakerFelles {
     }
 
     private String finnEnhetFraFagsak(Fagsak sak) {
-        OrganisasjonsEnhet organisasjonsEnhet = behandlendeEnhetTjeneste.finnBehandlendeEnhetFraSøker(sak);
+        OrganisasjonsEnhet organisasjonsEnhet = behandlendeEnhetTjeneste.finnBehandlendeEnhetFor(sak);
         return organisasjonsEnhet.getEnhetId();
     }
 
     OrganisasjonsEnhet utledEnhetFraTidligereBehandling(Behandling tidligereBehandling) {
         // Utleder basert på regler rundt sakskompleks og diskresjonskoder. Vil bruke forrige enhet med mindre noen tilsier Kode6 eller opphør av enhet
-        return behandlendeEnhetTjeneste.sjekkEnhetVedNyAvledetBehandling(tidligereBehandling).orElse(tidligereBehandling.getBehandlendeOrganisasjonsEnhet());
+        return behandlendeEnhetTjeneste.finnBehandlendeEnhetFor(tidligereBehandling.getFagsak());
     }
 
     void opprettHistorikkinnslagForBehandlingOppdatertMedNyeOpplysninger(Behandling behandling, BehandlingÅrsakType behandlingÅrsakType) {

--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/dokumentmottak/impl/DokumentmottakerFelles.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/dokumentmottak/impl/DokumentmottakerFelles.java
@@ -118,24 +118,18 @@ public class DokumentmottakerFelles {
             return dokument.getJournalEnhet().get();
         }
         if (behandling == null) {
-            return finnEnhetFraFagsak(sak);
+            return finnEnhetFraFagsak(sak).getEnhetId();
         }
         if (BehandlingType.KLAGE.equals(behandling.getType())) {
             return behandlingRepository.hentSisteYtelsesBehandlingForFagsakId(behandling.getFagsak().getId())
                 .map(Behandling::getBehandlendeEnhet)
-                .orElse(finnEnhetFraFagsak(sak));
+                .orElse(finnEnhetFraFagsak(sak).getEnhetId());
         }
         return behandling.getBehandlendeEnhet();
     }
 
-    private String finnEnhetFraFagsak(Fagsak sak) {
-        OrganisasjonsEnhet organisasjonsEnhet = behandlendeEnhetTjeneste.finnBehandlendeEnhetFor(sak);
-        return organisasjonsEnhet.getEnhetId();
-    }
-
-    OrganisasjonsEnhet utledEnhetFraTidligereBehandling(Behandling tidligereBehandling) {
-        // Utleder basert på regler rundt sakskompleks og diskresjonskoder. Vil bruke forrige enhet med mindre noen tilsier Kode6 eller opphør av enhet
-        return behandlendeEnhetTjeneste.finnBehandlendeEnhetFor(tidligereBehandling.getFagsak());
+    OrganisasjonsEnhet finnEnhetFraFagsak(Fagsak sak) {
+        return behandlendeEnhetTjeneste.finnBehandlendeEnhetFor(sak);
     }
 
     void opprettHistorikkinnslagForBehandlingOppdatertMedNyeOpplysninger(Behandling behandling, BehandlingÅrsakType behandlingÅrsakType) {

--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/dokumentmottak/impl/DokumentmottakerKlage.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/dokumentmottak/impl/DokumentmottakerKlage.java
@@ -77,17 +77,15 @@ class DokumentmottakerKlage implements Dokumentmottaker {
     }
 
     private Optional<Behandling> opprettKlagebehandling(Fagsak fagsak) {
-        Optional<Behandling> forrigeOpt = behandlingRepository.hentSisteYtelsesBehandlingForFagsakId(fagsak.getId());
-        if (!forrigeOpt.isPresent()) { //#K2
+        if (behandlingRepository.hentSisteYtelsesBehandlingForFagsakId(fagsak.getId()).isEmpty()) { //#K2
             Feilene.FACTORY.finnerIkkeEksisterendeBehandling(fagsak.getSaksnummer().toString()).log(logger);
             return Optional.empty();
         }
-        Behandling behandlingKlagenGjelder = forrigeOpt.get();
         BehandlingType behandlingTypeKlage = BehandlingType.KLAGE;
         return Optional.ofNullable(behandlingskontrollTjeneste.opprettNyBehandling(fagsak, behandlingTypeKlage,
             (beh) -> {
                 beh.setBehandlingstidFrist(LocalDate.now().plusWeeks(behandlingTypeKlage.getBehandlingstidFristUker()));
-                beh.setBehandlendeEnhet(dokumentmottakerFelles.utledEnhetFraTidligereBehandling(behandlingKlagenGjelder));
+                beh.setBehandlendeEnhet(dokumentmottakerFelles.finnEnhetFraFagsak(fagsak));
             }));
     }
 

--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/dokumentmottak/impl/DokumentmottakerKlage.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/dokumentmottak/impl/DokumentmottakerKlage.java
@@ -2,6 +2,7 @@ package no.nav.foreldrepenger.mottak.dokumentmottak.impl;
 
 import static no.nav.vedtak.feil.LogLevel.WARN;
 
+import java.time.LocalDate;
 import java.util.Optional;
 
 import javax.enterprise.context.ApplicationScoped;
@@ -26,7 +27,6 @@ import no.nav.vedtak.feil.Feil;
 import no.nav.vedtak.feil.FeilFactory;
 import no.nav.vedtak.feil.deklarasjon.DeklarerteFeil;
 import no.nav.vedtak.feil.deklarasjon.TekniskFeil;
-import no.nav.vedtak.util.FPDateUtil;
 
 @ApplicationScoped
 @FagsakYtelseTypeRef
@@ -86,7 +86,7 @@ class DokumentmottakerKlage implements Dokumentmottaker {
         BehandlingType behandlingTypeKlage = BehandlingType.KLAGE;
         return Optional.ofNullable(behandlingskontrollTjeneste.opprettNyBehandling(fagsak, behandlingTypeKlage,
             (beh) -> {
-                beh.setBehandlingstidFrist(FPDateUtil.iDag().plusWeeks(behandlingTypeKlage.getBehandlingstidFristUker()));
+                beh.setBehandlingstidFrist(LocalDate.now().plusWeeks(behandlingTypeKlage.getBehandlingstidFristUker()));
                 beh.setBehandlendeEnhet(dokumentmottakerFelles.utledEnhetFraTidligereBehandling(behandlingKlagenGjelder));
             }));
     }

--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/vedtak/VurderOpphørAvYtelser.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/vedtak/VurderOpphørAvYtelser.java
@@ -211,7 +211,7 @@ public class VurderOpphørAvYtelser  {
 
     private Behandling opprettRevurdering(Fagsak sakRevurdering, BehandlingÅrsakType behandlingÅrsakType) {
         Behandling revurdering;
-        Optional<OrganisasjonsEnhet> enhet = behandlendeEnhetTjeneste.sjekkEnhetVedNyAvledetBehandling(sakRevurdering);
+        OrganisasjonsEnhet enhet = behandlendeEnhetTjeneste.finnBehandlendeEnhetFor(sakRevurdering);
 
         revurdering = revurderingTjeneste.opprettAutomatiskRevurdering(sakRevurdering, behandlingÅrsakType, enhet);
 

--- a/domenetjenester/mottak/src/test/java/no/nav/foreldrepenger/mottak/dokumentmottak/es/DokumentmottakerSøknadEngangsstønadHåndteringVedAvslåttBehandlingTest.java
+++ b/domenetjenester/mottak/src/test/java/no/nav/foreldrepenger/mottak/dokumentmottak/es/DokumentmottakerSøknadEngangsstønadHåndteringVedAvslåttBehandlingTest.java
@@ -55,8 +55,7 @@ public class DokumentmottakerSøknadEngangsstønadHåndteringVedAvslåttBehandli
         HistorikkinnslagTjeneste mockHist = Mockito.mock(HistorikkinnslagTjeneste.class);
         BehandlendeEnhetTjeneste enhetsTjeneste = mock(BehandlendeEnhetTjeneste.class);
         OrganisasjonsEnhet enhet = new OrganisasjonsEnhet("0312", "enhetNavn");
-        when(enhetsTjeneste.finnBehandlendeEnhetFraSøker(any(Fagsak.class))).thenReturn(enhet);
-        when(enhetsTjeneste.finnBehandlendeEnhetFraSøker(any(Behandling.class))).thenReturn(enhet);
+        when(enhetsTjeneste.finnBehandlendeEnhetFor(any(Fagsak.class))).thenReturn(enhet);
         ProsessTaskRepository taskrepo = mock(ProsessTaskRepository.class);
         DokumentmottakerFelles felles = new DokumentmottakerFelles(repositoryProvider,
             taskrepo,
@@ -98,8 +97,7 @@ public class DokumentmottakerSøknadEngangsstønadHåndteringVedAvslåttBehandli
         HistorikkinnslagTjeneste mockHist = Mockito.mock(HistorikkinnslagTjeneste.class);
         BehandlendeEnhetTjeneste enhetsTjeneste = mock(BehandlendeEnhetTjeneste.class);
         OrganisasjonsEnhet enhet = new OrganisasjonsEnhet("0312", "enhetNavn");
-        when(enhetsTjeneste.finnBehandlendeEnhetFraSøker(any(Fagsak.class))).thenReturn(enhet);
-        when(enhetsTjeneste.finnBehandlendeEnhetFraSøker(any(Behandling.class))).thenReturn(enhet);
+        when(enhetsTjeneste.finnBehandlendeEnhetFor(any(Fagsak.class))).thenReturn(enhet);
         ProsessTaskRepository taskrepo = mock(ProsessTaskRepository.class);
         DokumentmottakerFelles felles = new DokumentmottakerFelles(repositoryProvider,
             taskrepo,

--- a/domenetjenester/mottak/src/test/java/no/nav/foreldrepenger/mottak/dokumentmottak/fp/DokmentmottakerSøknadHåndterÅpenFørstegang.java
+++ b/domenetjenester/mottak/src/test/java/no/nav/foreldrepenger/mottak/dokumentmottak/fp/DokmentmottakerSøknadHåndterÅpenFørstegang.java
@@ -61,8 +61,7 @@ public class DokmentmottakerSøknadHåndterÅpenFørstegang extends Dokumentmott
         HistorikkinnslagTjeneste mockHist = Mockito.mock(HistorikkinnslagTjeneste.class);
         BehandlendeEnhetTjeneste enhetsTjeneste = mock(BehandlendeEnhetTjeneste.class);
         OrganisasjonsEnhet enhet = new OrganisasjonsEnhet("0312", "enhetNavn");
-        when(enhetsTjeneste.finnBehandlendeEnhetFraSøker(any(Fagsak.class))).thenReturn(enhet);
-        when(enhetsTjeneste.finnBehandlendeEnhetFraSøker(any(Behandling.class))).thenReturn(enhet);
+        when(enhetsTjeneste.finnBehandlendeEnhetFor(any(Fagsak.class))).thenReturn(enhet);
         ProsessTaskRepository taskrepo = mock(ProsessTaskRepository.class);
         DokumentmottakerFelles felles = new DokumentmottakerFelles(repositoryProvider,
             taskrepo,

--- a/domenetjenester/mottak/src/test/java/no/nav/foreldrepenger/mottak/dokumentmottak/fp/DokumentmottakerSøknadHåndteringVedAvslåttBehandlingTest.java
+++ b/domenetjenester/mottak/src/test/java/no/nav/foreldrepenger/mottak/dokumentmottak/fp/DokumentmottakerSøknadHåndteringVedAvslåttBehandlingTest.java
@@ -57,8 +57,7 @@ public class DokumentmottakerSøknadHåndteringVedAvslåttBehandlingTest extends
         HistorikkinnslagTjeneste mockHist = Mockito.mock(HistorikkinnslagTjeneste.class);
         BehandlendeEnhetTjeneste enhetsTjeneste = mock(BehandlendeEnhetTjeneste.class);
         OrganisasjonsEnhet enhet = new OrganisasjonsEnhet("0312", "enhetNavn");
-        when(enhetsTjeneste.finnBehandlendeEnhetFraSøker(any(Fagsak.class))).thenReturn(enhet);
-        when(enhetsTjeneste.finnBehandlendeEnhetFraSøker(any(Behandling.class))).thenReturn(enhet);
+        when(enhetsTjeneste.finnBehandlendeEnhetFor(any(Fagsak.class))).thenReturn(enhet);
         ProsessTaskRepository taskrepo = mock(ProsessTaskRepository.class);
         DokumentmottakerFelles felles = new DokumentmottakerFelles(repositoryProvider,
             taskrepo,

--- a/domenetjenester/mottak/src/test/java/no/nav/foreldrepenger/mottak/dokumentmottak/impl/DokumentmottakerEndringssøknadTest.java
+++ b/domenetjenester/mottak/src/test/java/no/nav/foreldrepenger/mottak/dokumentmottak/impl/DokumentmottakerEndringssøknadTest.java
@@ -96,8 +96,7 @@ public class DokumentmottakerEndringssøknadTest {
         MockitoAnnotations.initMocks(this);
 
         OrganisasjonsEnhet enhet = new OrganisasjonsEnhet("0312", "enhetNavn");
-        when(enhetsTjeneste.finnBehandlendeEnhetFraSøker(any(Fagsak.class))).thenReturn(enhet);
-        when(enhetsTjeneste.finnBehandlendeEnhetFraSøker(any(Behandling.class))).thenReturn(enhet);
+        when(enhetsTjeneste.finnBehandlendeEnhetFor(any(Fagsak.class))).thenReturn(enhet);
 
         dokumentmottakerFelles = new DokumentmottakerFelles(repositoryProvider, prosessTaskRepository,
             enhetsTjeneste, historikkinnslagTjeneste, mottatteDokumentTjeneste, behandlingsoppretter);

--- a/domenetjenester/mottak/src/test/java/no/nav/foreldrepenger/mottak/dokumentmottak/impl/DokumentmottakerInntektsmeldingTest.java
+++ b/domenetjenester/mottak/src/test/java/no/nav/foreldrepenger/mottak/dokumentmottak/impl/DokumentmottakerInntektsmeldingTest.java
@@ -104,8 +104,7 @@ public class DokumentmottakerInntektsmeldingTest {
         dokumentmottaker = Mockito.spy(dokumentmottaker);
 
         OrganisasjonsEnhet enhet = new OrganisasjonsEnhet("0312", "enhetNavn");
-        when(behandlendeEnhetTjeneste.finnBehandlendeEnhetFraSøker(any(Fagsak.class))).thenReturn(enhet);
-        when(behandlendeEnhetTjeneste.finnBehandlendeEnhetFraSøker(any(Behandling.class))).thenReturn(enhet);
+        when(behandlendeEnhetTjeneste.finnBehandlendeEnhetFor(any(Fagsak.class))).thenReturn(enhet);
     }
 
     @Test

--- a/domenetjenester/mottak/src/test/java/no/nav/foreldrepenger/mottak/dokumentmottak/impl/DokumentmottakerKlageTest.java
+++ b/domenetjenester/mottak/src/test/java/no/nav/foreldrepenger/mottak/dokumentmottak/impl/DokumentmottakerKlageTest.java
@@ -8,7 +8,6 @@ import static org.mockito.Mockito.when;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.util.Optional;
 import java.util.Properties;
 
 import javax.inject.Inject;
@@ -52,8 +51,6 @@ import no.nav.foreldrepenger.dbstoette.UnittestRepositoryRule;
 import no.nav.foreldrepenger.mottak.Behandlingsoppretter;
 import no.nav.foreldrepenger.mottak.dokumentmottak.HistorikkinnslagTjeneste;
 import no.nav.foreldrepenger.mottak.dokumentmottak.MottatteDokumentTjeneste;
-import no.nav.foreldrepenger.mottak.dokumentmottak.impl.DokumentmottakerFelles;
-import no.nav.foreldrepenger.mottak.dokumentmottak.impl.DokumentmottakerKlage;
 import no.nav.foreldrepenger.produksjonsstyring.behandlingenhet.BehandlendeEnhetTjeneste;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTaskRepository;
 import no.nav.vedtak.felles.testutilities.cdi.CdiRunner;
@@ -101,10 +98,7 @@ public class DokumentmottakerKlageTest {
         historikkinnslagTjeneste = mock(HistorikkinnslagTjeneste.class);
         klageFormkravTjeneste = mock(KlageFormkravTjeneste.class);
         OrganisasjonsEnhet enhet = new OrganisasjonsEnhet("4806", "NAV Drammen");
-        when(behandlendeEnhetTjeneste.sjekkEnhetVedNyAvledetBehandling(any(Behandling.class)))
-            .thenReturn(Optional.of(enhet));
-        when(behandlendeEnhetTjeneste.finnBehandlendeEnhetFraSøker(any(Fagsak.class))).thenReturn(enhet);
-        when(behandlendeEnhetTjeneste.finnBehandlendeEnhetFraSøker(any(Behandling.class))).thenReturn(enhet);
+        when(behandlendeEnhetTjeneste.finnBehandlendeEnhetFor(any(Fagsak.class))).thenReturn(enhet);
 
         BehandlingskontrollTjeneste behandlingskontrollTjeneste = DokumentmottakTestUtil.lagBehandlingskontrollTjenesteMock(serviceProvider);
 

--- a/domenetjenester/mottak/src/test/java/no/nav/foreldrepenger/mottak/dokumentmottak/impl/DokumentmottakerSøknadDefaultTest.java
+++ b/domenetjenester/mottak/src/test/java/no/nav/foreldrepenger/mottak/dokumentmottak/impl/DokumentmottakerSøknadDefaultTest.java
@@ -101,8 +101,7 @@ public class DokumentmottakerSøknadDefaultTest {
 
         BehandlendeEnhetTjeneste enhetsTjeneste = mock(BehandlendeEnhetTjeneste.class);
         OrganisasjonsEnhet enhet = new OrganisasjonsEnhet("0312", "enhetNavn");
-        when(enhetsTjeneste.finnBehandlendeEnhetFraSøker(any(Fagsak.class))).thenReturn(enhet);
-        when(enhetsTjeneste.finnBehandlendeEnhetFraSøker(any(Behandling.class))).thenReturn(enhet);
+        when(enhetsTjeneste.finnBehandlendeEnhetFor(any(Fagsak.class))).thenReturn(enhet);
 
         dokumentmottakerFelles = new DokumentmottakerFelles(repositoryProvider, prosessTaskRepository, enhetsTjeneste,
             historikkinnslagTjeneste, mottatteDokumentTjeneste, behandlingsoppretter);

--- a/domenetjenester/mottak/src/test/java/no/nav/foreldrepenger/mottak/dokumentmottak/impl/DokumentmottakerVedleggTest.java
+++ b/domenetjenester/mottak/src/test/java/no/nav/foreldrepenger/mottak/dokumentmottak/impl/DokumentmottakerVedleggTest.java
@@ -40,9 +40,6 @@ import no.nav.foreldrepenger.domene.typer.Saksnummer;
 import no.nav.foreldrepenger.mottak.Behandlingsoppretter;
 import no.nav.foreldrepenger.mottak.dokumentmottak.HistorikkinnslagTjeneste;
 import no.nav.foreldrepenger.mottak.dokumentmottak.MottatteDokumentTjeneste;
-import no.nav.foreldrepenger.mottak.dokumentmottak.impl.DokumentmottakerFelles;
-import no.nav.foreldrepenger.mottak.dokumentmottak.impl.DokumentmottakerVedlegg;
-import no.nav.foreldrepenger.mottak.dokumentmottak.impl.Kompletthetskontroller;
 import no.nav.foreldrepenger.produksjonsstyring.behandlingenhet.BehandlendeEnhetTjeneste;
 import no.nav.foreldrepenger.produksjonsstyring.oppgavebehandling.task.OpprettOppgaveVurderDokumentTask;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTaskData;
@@ -60,10 +57,10 @@ public class DokumentmottakerVedleggTest {
 
     @Inject
     private Behandlingsoppretter behandlingsoppretter;
-    
+
     @Inject
     private KlageRepository klageRepository;
-    
+
     @Mock
     private ProsessTaskRepository prosessTaskRepository;
     @Mock
@@ -82,8 +79,7 @@ public class DokumentmottakerVedleggTest {
         MockitoAnnotations.initMocks(this);
 
         OrganisasjonsEnhet enhet = new OrganisasjonsEnhet("0312", "enhetNavn");
-        when(behandlendeEnhetTjeneste.finnBehandlendeEnhetFraSøker(any(Fagsak.class))).thenReturn(enhet);
-        when(behandlendeEnhetTjeneste.finnBehandlendeEnhetFraSøker(any(Behandling.class))).thenReturn(enhet);
+        when(behandlendeEnhetTjeneste.finnBehandlendeEnhetFor(any(Fagsak.class))).thenReturn(enhet);
 
         dokumentmottakerFelles = new DokumentmottakerFelles(repositoryProvider, prosessTaskRepository, behandlendeEnhetTjeneste,
             historikkinnslagTjeneste, mottatteDokumentTjeneste, behandlingsoppretter);

--- a/domenetjenester/mottak/src/test/java/no/nav/foreldrepenger/mottak/dokumentmottak/impl/DokumentmottakerYtelsesesrelatertDokumentTest.java
+++ b/domenetjenester/mottak/src/test/java/no/nav/foreldrepenger/mottak/dokumentmottak/impl/DokumentmottakerYtelsesesrelatertDokumentTest.java
@@ -90,8 +90,7 @@ public class DokumentmottakerYtelsesesrelatertDokumentTest {
         dokumentmottaker = Mockito.spy(dokumentmottaker);
 
         OrganisasjonsEnhet enhet = new OrganisasjonsEnhet("0312", "enhetNavn");
-        when(behandlendeEnhetTjeneste.finnBehandlendeEnhetFraSøker(any(Fagsak.class))).thenReturn(enhet);
-        when(behandlendeEnhetTjeneste.finnBehandlendeEnhetFraSøker(any(Behandling.class))).thenReturn(enhet);
+        when(behandlendeEnhetTjeneste.finnBehandlendeEnhetFor(any(Fagsak.class))).thenReturn(enhet);
     }
 
     @Test

--- a/domenetjenester/mottak/src/test/java/no/nav/foreldrepenger/mottak/vedtak/VurderOpphørAvYtelserTest.java
+++ b/domenetjenester/mottak/src/test/java/no/nav/foreldrepenger/mottak/vedtak/VurderOpphørAvYtelserTest.java
@@ -1,6 +1,8 @@
 package no.nav.foreldrepenger.mottak.vedtak;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -19,7 +21,6 @@ import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import no.nav.foreldrepenger.behandling.revurdering.RevurderingTjeneste;
 import no.nav.foreldrepenger.behandlingskontroll.FagsakYtelseTypeRef;
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
@@ -111,9 +112,10 @@ public class VurderOpphørAvYtelserTest {
 
         vurderOpphørAvYtelser.vurderOpphørAvYtelser(fagsakNy.getId(), nyAvsBehandlingMor.getId());
 
-        verify(revurderingTjenesteMock, times(1)).opprettAutomatiskRevurdering(fsavsluttetBehMor, BehandlingÅrsakType.OPPHØR_YTELSE_NYTT_BARN, Optional.empty());
+        verify(revurderingTjenesteMock, times(1)).opprettAutomatiskRevurdering(eq(fsavsluttetBehMor), eq(BehandlingÅrsakType.OPPHØR_YTELSE_NYTT_BARN), any());
         verify(sjekkInfotrygdTjeneste, times(0)).harForeldrepengerInfotrygdSomOverlapper(any(), any());
     }
+
     @Test
     public void opphørSakPåMorOgMedforelderNårNySakOverlapper() {
         Behandling avsluttetBehMor = lagBehandlingMor(FØDSELS_DATO_1, AKTØR_ID_MOR, MEDF_AKTØR_ID);
@@ -133,8 +135,8 @@ public class VurderOpphørAvYtelserTest {
 
         vurderOpphørAvYtelser.vurderOpphørAvYtelser(fagsakNy.getId(),nyAvsBehandlingMor.getId());
 
-        verify(revurderingTjenesteMock, times(1)).opprettAutomatiskRevurdering(fsavsluttetBehMor, BehandlingÅrsakType.OPPHØR_YTELSE_NYTT_BARN, Optional.empty());
-        verify(revurderingTjenesteMock, times(1)).opprettAutomatiskRevurdering(fsavsluttetBehFar, BehandlingÅrsakType.OPPHØR_YTELSE_NYTT_BARN, Optional.empty());
+        verify(revurderingTjenesteMock, times(1)).opprettAutomatiskRevurdering(eq(fsavsluttetBehMor), eq(BehandlingÅrsakType.OPPHØR_YTELSE_NYTT_BARN), any());
+        verify(revurderingTjenesteMock, times(1)).opprettAutomatiskRevurdering(eq(fsavsluttetBehFar), eq(BehandlingÅrsakType.OPPHØR_YTELSE_NYTT_BARN), any());
         verify(sjekkInfotrygdTjeneste, times(1)).harForeldrepengerInfotrygdSomOverlapper(fsavsluttetBehFar.getAktørId(),SKJÆRINGSTIDSPUNKT_OVERLAPPER_BEH_1 );
     }
 
@@ -155,6 +157,7 @@ public class VurderOpphørAvYtelserTest {
         verify(revurderingTjenesteMock, times(0)).opprettAutomatiskRevurdering(any(), any(), any());
         verify(sjekkInfotrygdTjeneste, times(0)).harForeldrepengerInfotrygdSomOverlapper(any(),any() );
     }
+
     @Test
     public void opphørSakPåMedforelderMenIkkeMor() {
         Behandling avsluttetBehMor = lagBehandlingMor(FØDSELS_DATO_1, AKTØR_ID_MOR,MEDF_AKTØR_ID);
@@ -174,10 +177,11 @@ public class VurderOpphørAvYtelserTest {
         Fagsak fsavsluttetBehFar = avslBehFarMedOverlappMor.getFagsak();
 
         vurderOpphørAvYtelser.vurderOpphørAvYtelser(fagsakNy.getId(), nyBehMorSomIkkeOverlapper.getId());
-        verify(revurderingTjenesteMock, times(1)).opprettAutomatiskRevurdering(fsavsluttetBehFar, BehandlingÅrsakType.OPPHØR_YTELSE_NYTT_BARN, Optional.empty());
+        verify(revurderingTjenesteMock, times(1)).opprettAutomatiskRevurdering(eq(fsavsluttetBehFar), eq(BehandlingÅrsakType.OPPHØR_YTELSE_NYTT_BARN), any());
         verify(sjekkInfotrygdTjeneste, times(1)).harForeldrepengerInfotrygdSomOverlapper(fsavsluttetBehFar.getAktørId(),SKJÆRINGSTIDSPUNKT_OVERLAPPER_IKKE_BEH_1 );
 
     }
+
     @Test
     public void opphørSakPåFarNårNySakPåFarOverlapper() {
         Behandling avslBehFar = lagBehandlingFar(FØDSELS_DATO_1, MEDF_AKTØR_ID);
@@ -193,7 +197,7 @@ public class VurderOpphørAvYtelserTest {
         Fagsak fagsakNy = nyBehFar.getFagsak();
 
         vurderOpphørAvYtelser.vurderOpphørAvYtelser(fagsakNy.getId(), nyBehFar.getId());
-        verify(revurderingTjenesteMock, times(1)).opprettAutomatiskRevurdering(fsavsluttetBehFar, BehandlingÅrsakType.OPPHØR_YTELSE_NYTT_BARN, Optional.empty());
+        verify(revurderingTjenesteMock, times(1)).opprettAutomatiskRevurdering(eq(fsavsluttetBehFar), eq(BehandlingÅrsakType.OPPHØR_YTELSE_NYTT_BARN), any());
         verify(sjekkInfotrygdTjeneste, times(1)).harForeldrepengerInfotrygdSomOverlapper(fagsakNy.getAktørId(),SKJÆRINGSTIDSPUNKT_OVERLAPPER_BEH_1 );
     }
 
@@ -210,9 +214,10 @@ public class VurderOpphørAvYtelserTest {
         Fagsak fagsakNy = nyAvsBehandlingMor.getFagsak();
 
         vurderOpphørAvYtelser.vurderOpphørAvYtelser(fagsakNy.getId(), nyAvsBehandlingMor.getId());
-        verify(revurderingTjenesteMock, times(1)).opprettAutomatiskRevurdering(fsavsluttetBehMor, BehandlingÅrsakType.OPPHØR_YTELSE_NYTT_BARN, Optional.empty());
+        verify(revurderingTjenesteMock, times(1)).opprettAutomatiskRevurdering(eq(fsavsluttetBehMor), eq(BehandlingÅrsakType.OPPHØR_YTELSE_NYTT_BARN), any());
         verify(sjekkInfotrygdTjeneste, times(0)).harForeldrepengerInfotrygdSomOverlapper(any(),any() );
     }
+
     @Test
     public void ikkeOpphørSakPåMorNårOpphørErOpprettetAllerede() {
         Behandling avsluttetBehMor = lagBehandlingMor(FØDSELS_DATO_1, AKTØR_ID_MOR, null);
@@ -231,6 +236,7 @@ public class VurderOpphørAvYtelserTest {
         verify(revurderingTjenesteMock, times(0)).opprettAutomatiskRevurdering(any(), any(), any());
         verify(sjekkInfotrygdTjeneste, times(0)).harForeldrepengerInfotrygdSomOverlapper(any(),any() );
     }
+
     @Test
     public void oppretteTaskVurderKonsekvensIngenGjeldendeAktørId() {
         String KEY_GJELDENDE_AKTØR_ID="aktuellAktoerId";

--- a/domenetjenester/produksjonsstyring/src/test/java/no/nav/foreldrepenger/produksjonsstyring/behandlingenhet/EnhetsTjenesteTest.java
+++ b/domenetjenester/produksjonsstyring/src/test/java/no/nav/foreldrepenger/produksjonsstyring/behandlingenhet/EnhetsTjenesteTest.java
@@ -12,6 +12,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -44,15 +45,12 @@ public class EnhetsTjenesteTest {
     private static Personinfo FAR_PINFO;
 
     private static AktørId BARN_AKTØR_ID = AktørId.dummy();
-    private static AktørId ELDRE_BARN_AKTØR_ID = AktørId.dummy();
     private static PersonIdent BARN_IDENT = new PersonIdent(new FiktiveFnr().nesteBarnFnr());
-    private static PersonIdent ELDRE_BARN_IDENT = new PersonIdent(new FiktiveFnr().nesteBarnFnr());
     private static Personinfo BARN_PINFO;
-    private static Personinfo ELDRE_BARN_PINFO;
-    private static LocalDate ELDRE_BARN_FØDT = LocalDate.of(2006,6,6);
     private static LocalDate BARN_FØDT = LocalDate.of(2018,3,3);
 
-    private static Familierelasjon relasjontilEldreBarn = new Familierelasjon(ELDRE_BARN_IDENT, RelasjonsRolleType.BARN, ELDRE_BARN_FØDT, "Vei", true);
+    private static final Set<AktørId> FAMILIE = Set.of(MOR_AKTØR_ID, FAR_AKTØR_ID, BARN_AKTØR_ID);
+
     private static Familierelasjon relasjontilBarn = new Familierelasjon(BARN_IDENT, RelasjonsRolleType.BARN, BARN_FØDT, "Vei", true);
     private static Familierelasjon relasjonEkteFar = new Familierelasjon(FAR_IDENT, RelasjonsRolleType.EKTE, LocalDate.of(1991,11,11), "Vei", true);
 
@@ -60,7 +58,6 @@ public class EnhetsTjenesteTest {
     private static OrganisasjonsEnhet enhetKode6 = new OrganisasjonsEnhet("2103", "NAV Viken");
     private static ArbeidsfordelingResponse respNormal = new ArbeidsfordelingResponse("4802", "NAV Bærum", "Aktiv", "FPY");
     private static ArbeidsfordelingResponse respKode6 = new ArbeidsfordelingResponse("2103", "NAV Viken", "Aktiv", "KO");
-
 
     private static GeografiskTilknytning tilknytningNormal = new GeografiskTilknytning("0219", null);
     private static GeografiskTilknytning tilknytningKode6 = new GeografiskTilknytning("0219", "SPSF");
@@ -83,7 +80,7 @@ public class EnhetsTjenesteTest {
         // Oppsett
         settOppTpsStrukturer(false, false, false, true);
 
-        OrganisasjonsEnhet enhet = enhetsTjeneste.hentEnhetSjekkRegistrerteRelasjoner(MOR_AKTØR_ID, BehandlingTema.ENGANGSSTØNAD);
+        OrganisasjonsEnhet enhet = enhetsTjeneste.hentEnhetSjekkKunAktør(MOR_AKTØR_ID, BehandlingTema.ENGANGSSTØNAD);
 
         assertThat(enhet).isNotNull();
         assertThat(enhet).isEqualTo(enhetNormal);
@@ -94,7 +91,7 @@ public class EnhetsTjenesteTest {
         // Oppsett
         settOppTpsStrukturer(true, false, false, true);
 
-        OrganisasjonsEnhet enhet = enhetsTjeneste.hentEnhetSjekkRegistrerteRelasjoner(MOR_AKTØR_ID, BehandlingTema.ENGANGSSTØNAD);
+        OrganisasjonsEnhet enhet = enhetsTjeneste.hentEnhetSjekkKunAktør(MOR_AKTØR_ID, BehandlingTema.ENGANGSSTØNAD);
 
         assertThat(enhet).isNotNull();
         assertThat(enhet).isEqualTo(enhetKode6);
@@ -105,10 +102,11 @@ public class EnhetsTjenesteTest {
         // Oppsett
         settOppTpsStrukturer(false, true, false, true);
 
-        OrganisasjonsEnhet enhet = enhetsTjeneste.hentEnhetSjekkRegistrerteRelasjoner(MOR_AKTØR_ID, BehandlingTema.ENGANGSSTØNAD);
+        OrganisasjonsEnhet enhet = enhetsTjeneste.hentEnhetSjekkKunAktør(MOR_AKTØR_ID, BehandlingTema.ENGANGSSTØNAD);
+        OrganisasjonsEnhet enhet1 = enhetsTjeneste.oppdaterEnhetSjekkOppgittePersoner(enhet.getEnhetId(), BehandlingTema.ENGANGSSTØNAD, MOR_AKTØR_ID, FAMILIE).orElse(enhet);
 
         assertThat(enhet).isNotNull();
-        assertThat(enhet).isEqualTo(enhetKode6);
+        assertThat(enhet1).isEqualTo(enhetKode6);
     }
 
     @Test
@@ -116,10 +114,11 @@ public class EnhetsTjenesteTest {
         // Oppsett
         settOppTpsStrukturer(false, false, true, true);
 
-        OrganisasjonsEnhet enhet = enhetsTjeneste.hentEnhetSjekkRegistrerteRelasjoner(MOR_AKTØR_ID, BehandlingTema.ENGANGSSTØNAD);
+        OrganisasjonsEnhet enhet = enhetsTjeneste.hentEnhetSjekkKunAktør(MOR_AKTØR_ID, BehandlingTema.ENGANGSSTØNAD);
+        OrganisasjonsEnhet enhet1 = enhetsTjeneste.oppdaterEnhetSjekkOppgittePersoner(enhet.getEnhetId(), BehandlingTema.ENGANGSSTØNAD, MOR_AKTØR_ID, FAMILIE).orElse(enhet);
 
         assertThat(enhet).isNotNull();
-        assertThat(enhet).isEqualTo(enhetKode6);
+        assertThat(enhet1).isEqualTo(enhetKode6);
     }
 
     @Test
@@ -127,7 +126,7 @@ public class EnhetsTjenesteTest {
         // Oppsett
         settOppTpsStrukturer(false, false, true, false);
 
-        Optional<OrganisasjonsEnhet> enhet = enhetsTjeneste.oppdaterEnhetSjekkOppgitte(enhetNormal.getEnhetId(), List.of(FAR_AKTØR_ID));
+        Optional<OrganisasjonsEnhet> enhet = enhetsTjeneste.oppdaterEnhetSjekkOppgittePersoner(enhetNormal.getEnhetId(), BehandlingTema.ENGANGSSTØNAD, MOR_AKTØR_ID, FAMILIE);
 
         assertThat(enhet).isPresent();
         assertThat(enhet).hasValueSatisfying(enhetObj -> assertThat(enhetObj).isEqualTo(enhetKode6));
@@ -138,7 +137,7 @@ public class EnhetsTjenesteTest {
         // Oppsett
         settOppTpsStrukturer(false, false, false, false);
 
-        OrganisasjonsEnhet enhet = enhetsTjeneste.enhetsPresedens(enhetNormal, enhetKode6, false);
+        OrganisasjonsEnhet enhet = enhetsTjeneste.enhetsPresedens(enhetNormal, enhetKode6);
 
         assertThat(enhet).isEqualTo(enhetKode6);
     }
@@ -148,7 +147,7 @@ public class EnhetsTjenesteTest {
         // Oppsett
         settOppTpsStrukturer(true, false, true, false);
 
-        Optional<OrganisasjonsEnhet> enhet = enhetsTjeneste.oppdaterEnhetSjekkOppgitte(enhetKode6.getEnhetId(), List.of(FAR_AKTØR_ID));
+        Optional<OrganisasjonsEnhet> enhet = enhetsTjeneste.oppdaterEnhetSjekkOppgittePersoner(enhetKode6.getEnhetId(), BehandlingTema.ENGANGSSTØNAD, MOR_AKTØR_ID, FAMILIE);
 
         assertThat(enhet).isNotPresent();
     }
@@ -158,7 +157,7 @@ public class EnhetsTjenesteTest {
         // Oppsett
         settOppTpsStrukturer(false, true, false, true);
 
-        Optional<OrganisasjonsEnhet> enhet = enhetsTjeneste.oppdaterEnhetSjekkRegistrerteRelasjoner(enhetNormal.getEnhetId(), BehandlingTema.ENGANGSSTØNAD, MOR_AKTØR_ID, Optional.of(FAR_AKTØR_ID), Collections.emptyList());
+        Optional<OrganisasjonsEnhet> enhet = enhetsTjeneste.oppdaterEnhetSjekkOppgittePersoner(enhetNormal.getEnhetId(), BehandlingTema.ENGANGSSTØNAD, MOR_AKTØR_ID, FAMILIE);
 
         assertThat(enhet).isPresent();
         assertThat(enhet).hasValueSatisfying(enhetObj -> assertThat(enhetObj).isEqualTo(enhetKode6));
@@ -169,14 +168,14 @@ public class EnhetsTjenesteTest {
         // Oppsett
         settOppTpsStrukturer(false, false, true, false);
 
-        Optional<OrganisasjonsEnhet> enhet = enhetsTjeneste.oppdaterEnhetSjekkRegistrerteRelasjoner(enhetNormal.getEnhetId(), BehandlingTema.ENGANGSSTØNAD, MOR_AKTØR_ID, Optional.of(FAR_AKTØR_ID), Collections.emptyList());
+        Optional<OrganisasjonsEnhet> enhet = enhetsTjeneste.oppdaterEnhetSjekkOppgittePersoner(enhetNormal.getEnhetId(), BehandlingTema.ENGANGSSTØNAD, MOR_AKTØR_ID, FAMILIE);
 
         assertThat(enhet).isPresent();
         assertThat(enhet).hasValueSatisfying(enhetObj -> assertThat(enhetObj).isEqualTo(enhetKode6));
     }
 
     private void settOppTpsStrukturer(boolean morKode6, boolean barnKode6, boolean annenPartKode6, boolean foreldreRelatertTps) {
-        HashSet<Familierelasjon> relasjoner = new HashSet<>(List.of(relasjontilEldreBarn, relasjontilBarn));
+        HashSet<Familierelasjon> relasjoner = new HashSet<>(List.of(relasjontilBarn));
         if (foreldreRelatertTps) {
             relasjoner.add(relasjonEkteFar);
         }
@@ -185,25 +184,20 @@ public class EnhetsTjenesteTest {
             .medFamilierelasjon(relasjoner).build();
         FAR_PINFO = new Personinfo.Builder().medAktørId(FAR_AKTØR_ID).medPersonIdent(FAR_IDENT).medNavn("Ola Dunk")
             .medNavBrukerKjønn(NavBrukerKjønn.MANN).medFødselsdato(LocalDate.of(1991,11,11)).medAdresse("Vei").build();
-        ELDRE_BARN_PINFO = new Personinfo.Builder().medAktørId(ELDRE_BARN_AKTØR_ID).medPersonIdent(ELDRE_BARN_IDENT).medFødselsdato(ELDRE_BARN_FØDT)
-            .medNavBrukerKjønn(NavBrukerKjønn.MANN).medNavn("Dunk junior d.e.").medAdresse("Vei").build();
         BARN_PINFO = new Personinfo.Builder().medAktørId(BARN_AKTØR_ID).medPersonIdent(BARN_IDENT).medFødselsdato(BARN_FØDT)
             .medNavBrukerKjønn(NavBrukerKjønn.KVINNE).medNavn("Dunk junior d.y.").medAdresse("Vei").build();
 
         when(tpsTjeneste.hentFnrForAktør(MOR_AKTØR_ID)).thenReturn(MOR_IDENT);
         when(tpsTjeneste.hentFnrForAktør(FAR_AKTØR_ID)).thenReturn(FAR_IDENT);
         when(tpsTjeneste.hentFnrForAktør(BARN_AKTØR_ID)).thenReturn(BARN_IDENT);
-        when(tpsTjeneste.hentFnrForAktør(ELDRE_BARN_AKTØR_ID)).thenReturn(ELDRE_BARN_IDENT);
 
         when(tpsTjeneste.hentBrukerForAktør(MOR_AKTØR_ID)).thenReturn(Optional.of(MOR_PINFO));
         when(tpsTjeneste.hentBrukerForAktør(FAR_AKTØR_ID)).thenReturn(Optional.of(FAR_PINFO));
         when(tpsTjeneste.hentBrukerForAktør(BARN_AKTØR_ID)).thenReturn(Optional.of(BARN_PINFO));
-        when(tpsTjeneste.hentBrukerForAktør(ELDRE_BARN_AKTØR_ID)).thenReturn(Optional.of(ELDRE_BARN_PINFO));
 
         when(tpsTjeneste.hentGeografiskTilknytning(MOR_IDENT)).thenReturn(morKode6 ? tilknytningKode6 : tilknytningNormal);
         when(tpsTjeneste.hentGeografiskTilknytning(FAR_IDENT)).thenReturn(annenPartKode6 ? tilknytningKode6 : tilknytningNormal);
-        when(tpsTjeneste.hentGeografiskTilknytning(ELDRE_BARN_IDENT)).thenReturn(barnKode6 ? tilknytningKode6 : tilknytningNormal);
-        when(tpsTjeneste.hentGeografiskTilknytning(BARN_IDENT)).thenReturn(morKode6 ? tilknytningKode6 : tilknytningNormal);
+        when(tpsTjeneste.hentGeografiskTilknytning(BARN_IDENT)).thenReturn(barnKode6 ? tilknytningKode6 : tilknytningNormal);
 
         doAnswer((Answer<List<ArbeidsfordelingResponse>>) invocation -> {
             ArbeidsfordelingRequest data = (ArbeidsfordelingRequest) invocation.getArguments()[0];

--- a/domenetjenester/vedtak/src/main/java/no/nav/foreldrepenger/domene/vedtak/impl/OpprettProsessTaskIverksettAnke.java
+++ b/domenetjenester/vedtak/src/main/java/no/nav/foreldrepenger/domene/vedtak/impl/OpprettProsessTaskIverksettAnke.java
@@ -7,7 +7,6 @@ import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
-import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingType;
 import no.nav.foreldrepenger.behandlingslager.behandling.anke.AnkeRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.anke.AnkeVurdering;
 import no.nav.foreldrepenger.behandlingslager.behandling.anke.AnkeVurderingResultatEntitet;
@@ -76,8 +75,7 @@ public class OpprettProsessTaskIverksettAnke implements OpprettProsessTaskIverks
         if (vurderingsresultat.isPresent()) {
             AnkeVurdering vurdering = vurderingsresultat.get().getAnkeVurdering();
             if (AnkeVurdering.ANKE_OPPHEVE_OG_HJEMSENDE.equals(vurdering) || AnkeVurdering.ANKE_OMGJOER.equals(vurdering)) {
-                Behandling sisteFørstegangsbehandling = behandlingRepository.hentSisteBehandlingAvBehandlingTypeForFagsakId(behandling.getFagsakId(),
-                    BehandlingType.FØRSTEGANGSSØKNAD).orElse(behandling);
+                Behandling sisteFørstegangsbehandling = behandlingRepository.hentSisteYtelsesBehandlingForFagsakId(behandling.getFagsakId()).orElse(behandling);
                 ProsessTaskData opprettOppgave = new ProsessTaskData(OpprettOppgaveVurderKonsekvensTask.TASKTYPE);
                 opprettOppgave.setProperty(OpprettOppgaveVurderKonsekvensTask.KEY_BEHANDLENDE_ENHET, sisteFørstegangsbehandling.getBehandlendeEnhet());
                 opprettOppgave.setProperty(OpprettOppgaveVurderKonsekvensTask.KEY_BESKRIVELSE, BESKRIVELSESTEKST);

--- a/domenetjenester/vedtak/src/main/java/no/nav/foreldrepenger/domene/vedtak/impl/OpprettProsessTaskIverksettKlage.java
+++ b/domenetjenester/vedtak/src/main/java/no/nav/foreldrepenger/domene/vedtak/impl/OpprettProsessTaskIverksettKlage.java
@@ -7,7 +7,6 @@ import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
-import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingType;
 import no.nav.foreldrepenger.behandlingslager.behandling.klage.KlageRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.klage.KlageVurdering;
 import no.nav.foreldrepenger.behandlingslager.behandling.klage.KlageVurderingResultat;
@@ -77,8 +76,7 @@ public class OpprettProsessTaskIverksettKlage implements OpprettProsessTaskIverk
             KlageVurdering vurdering = vurderingsresultat.get().getKlageVurdering();
             if (KlageVurdering.MEDHOLD_I_KLAGE.equals(vurdering) || KlageVurdering.OPPHEVE_YTELSESVEDTAK.equals(vurdering)
                 || KlageVurdering.HJEMSENDE_UTEN_Å_OPPHEVE.equals(vurdering)) {
-                Behandling sisteFørstegangsbehandling = behandlingRepository.hentSisteBehandlingAvBehandlingTypeForFagsakId(behandling.getFagsakId(),
-                    BehandlingType.FØRSTEGANGSSØKNAD).orElse(behandling);
+                Behandling sisteFørstegangsbehandling = behandlingRepository.hentSisteYtelsesBehandlingForFagsakId(behandling.getFagsakId()).orElse(behandling);
                 ProsessTaskData opprettOppgave = new ProsessTaskData(OpprettOppgaveVurderKonsekvensTask.TASKTYPE);
                 opprettOppgave.setProperty(OpprettOppgaveVurderKonsekvensTask.KEY_BEHANDLENDE_ENHET, sisteFørstegangsbehandling.getBehandlendeEnhet());
                 opprettOppgave.setProperty(OpprettOppgaveVurderKonsekvensTask.KEY_BESKRIVELSE, BESKRIVELSESTEKST);

--- a/domenetjenester/vedtak/src/main/java/no/nav/foreldrepenger/domene/vedtak/innsyn/InnsynTjeneste.java
+++ b/domenetjenester/vedtak/src/main/java/no/nav/foreldrepenger/domene/vedtak/innsyn/InnsynTjeneste.java
@@ -62,7 +62,7 @@ public class InnsynTjeneste {
 
         BehandlingType behandlingType = BehandlingType.INNSYN;
         Behandling nyBehandling = Behandling.nyBehandlingFor(fagsak, behandlingType).build();
-        nyBehandling.setBehandlendeEnhet(behandlendeEnhetTjeneste.finnBehandlendeEnhetFraSøker(nyBehandling));
+        nyBehandling.setBehandlendeEnhet(behandlendeEnhetTjeneste.finnBehandlendeEnhetFor(fagsak));
 
         innsynHistorikkTjeneste.opprettHistorikkinnslag(nyBehandling, SAKSBEHANDLER);
 

--- a/domenetjenester/vedtak/src/test/java/no/nav/foreldrepenger/domene/vedtak/innsyn/InnsynTjenesteImplTest.java
+++ b/domenetjenester/vedtak/src/test/java/no/nav/foreldrepenger/domene/vedtak/innsyn/InnsynTjenesteImplTest.java
@@ -26,6 +26,7 @@ import no.nav.foreldrepenger.behandlingslager.behandling.innsyn.InnsynRepository
 import no.nav.foreldrepenger.behandlingslager.behandling.innsyn.InnsynResultatType;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepositoryProvider;
+import no.nav.foreldrepenger.behandlingslager.fagsak.Fagsak;
 import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakRepository;
 import no.nav.foreldrepenger.behandlingslager.testutilities.behandling.ScenarioMorSøkerEngangsstønad;
 import no.nav.foreldrepenger.dbstoette.UnittestRepositoryRule;
@@ -64,7 +65,7 @@ public class InnsynTjenesteImplTest {
     @Before
     public void oppsett() {
         initMocks(this);
-        when(behandlendeEnhetTjeneste.finnBehandlendeEnhetFraSøker(any(Behandling.class))).thenReturn(new OrganisasjonsEnhet("1234", ""));
+        when(behandlendeEnhetTjeneste.finnBehandlendeEnhetFor(any(Fagsak.class))).thenReturn(new OrganisasjonsEnhet("1234", ""));
 
         innsynTjeneste = new InnsynTjeneste(behandlingKontrollTjeneste, innsynHistorikkTjeneste,
             fagsakRepository,behandlingRepository, behandlingsresultatRepository, innsynRepository, behandlendeEnhetTjeneste);

--- a/nais/dev-fss-q0.json
+++ b/nais/dev-fss-q0.json
@@ -6,8 +6,8 @@
   "fpsakserviceuser": "serviceuser/data/dev/srvengangsstonad",
   "ldapserviceuser": "serviceuser/data/dev/srvssolinux",
   "namespace": "q0",
-  "minReplicas": "4",
-  "maxReplicas": "6",
+  "minReplicas": "1",
+  "maxReplicas": "2",
   "ingresses": [
     "https://fpsak-q0.nais.preprod.local/"
   ],

--- a/nais/dev-fss-q1.json
+++ b/nais/dev-fss-q1.json
@@ -6,8 +6,8 @@
   "fpsakserviceuser": "serviceuser/data/dev/srvengangsstonad",
   "ldapserviceuser": "serviceuser/data/dev/srvssolinux",
   "namespace": "q1",
-  "minReplicas": "4",
-  "maxReplicas": "6",
+  "minReplicas": "1",
+  "maxReplicas": "2",
   "ingresses": [
     "https://fpsak-q1.nais.preprod.local/"
   ],

--- a/nais/dev-fss-t4.json
+++ b/nais/dev-fss-t4.json
@@ -6,8 +6,8 @@
   "fpsakserviceuser": "serviceuser/data/test/srvengangsstonad",
   "ldapserviceuser": "serviceuser/data/test/srvssolinux",
   "namespace": "t4",
-  "minReplicas": "4",
-  "maxReplicas": "6",
+  "minReplicas": "1",
+  "maxReplicas": "2",
   "ingresses": [
     "https://fpsak-t4.nais.preprod.local/"
   ],

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/aksjonspunkt/BehandlingsoppretterApplikasjonTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/aksjonspunkt/BehandlingsoppretterApplikasjonTjeneste.java
@@ -134,7 +134,7 @@ public class BehandlingsoppretterApplikasjonTjeneste {
             throw BehandlingsoppretterApplikasjonTjenesteFeil.FACTORY.kanIkkeOppretteRevurdering(fagsak.getSaksnummer()).toException();
         }
 
-        Optional<OrganisasjonsEnhet> enhet = behandlendeEnhetTjeneste.sjekkEnhetVedNyAvledetBehandling(fagsak);
+        OrganisasjonsEnhet enhet = behandlendeEnhetTjeneste.finnBehandlendeEnhetFor(fagsak);
         return revurderingTjeneste.opprettManuellRevurdering(fagsak, behandlingÅrsakType, enhet);
     }
 

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/forvaltning/BerørtBehandlingForvaltningTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/forvaltning/BerørtBehandlingForvaltningTjeneste.java
@@ -42,7 +42,7 @@ public class BerørtBehandlingForvaltningTjeneste {
         }
 
         Behandling nyBehandling = revurderingTjeneste.opprettAutomatiskRevurdering(fagsak, BehandlingÅrsakType.BERØRT_BEHANDLING,
-            behandlendeEnhetTjeneste.sjekkEnhetVedNyAvledetBehandling(fagsak));
+            behandlendeEnhetTjeneste.finnBehandlendeEnhetFor(fagsak));
         berørtBehandlingTjeneste.opprettHistorikkinnslagOmRevurdering(nyBehandling, BehandlingÅrsakType.BERØRT_BEHANDLING,
             null, HistorikkinnslagType.REVURD_OPPR);
         behandlingProsesseringTjeneste.opprettTasksForStartBehandling(nyBehandling);

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/forvaltning/OverstyrDekningsgradTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/forvaltning/OverstyrDekningsgradTjeneste.java
@@ -113,7 +113,7 @@ public class OverstyrDekningsgradTjeneste {
             return ytelseBehandlingOpt.get();
         }
         return revurderingTjeneste.opprettManuellRevurdering(fagsak, BehandlingÅrsakType.RE_ENDRING_FRA_BRUKER,
-            behandlendeEnhetTjeneste.sjekkEnhetVedNyAvledetBehandling(fagsak)
+            behandlendeEnhetTjeneste.finnBehandlendeEnhetFor(fagsak)
         );
     }
 

--- a/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/aksjonspunkt/BehandlingsutredningApplikasjonTjenesteImplTest.java
+++ b/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/aksjonspunkt/BehandlingsutredningApplikasjonTjenesteImplTest.java
@@ -7,7 +7,6 @@ import static org.mockito.Mockito.when;
 
 import java.time.LocalDate;
 import java.time.Period;
-import java.util.Optional;
 
 import javax.inject.Inject;
 
@@ -87,7 +86,7 @@ public class BehandlingsutredningApplikasjonTjenesteImplTest {
 
         BehandlingskontrollTjenesteImpl behandlingskontrollTjenesteImpl = new BehandlingskontrollTjenesteImpl(behandlingskontrollServiceProvider);
 
-        when(behandlendeEnhetTjeneste.sjekkEnhetVedNyAvledetBehandling(any(Fagsak.class))).thenReturn(Optional.empty());
+        when(behandlendeEnhetTjeneste.finnBehandlendeEnhetFor(any(Fagsak.class))).thenReturn(new OrganisasjonsEnhet("1234", "Testlokasjon"));
 
         behandlingsutredningApplikasjonTjeneste = new BehandlingsutredningApplikasjonTjeneste(
             Period.parse("P4W"),

--- a/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/innsyn/VurderInnsynOppdatererTest.java
+++ b/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/innsyn/VurderInnsynOppdatererTest.java
@@ -21,7 +21,6 @@ import no.nav.foreldrepenger.behandling.aksjonspunkt.AksjonspunktOppdaterParamet
 import no.nav.foreldrepenger.behandling.aksjonspunkt.OverhoppKontroll;
 import no.nav.foreldrepenger.behandlingskontroll.BehandlingskontrollTjeneste;
 import no.nav.foreldrepenger.behandlingslager.aktør.OrganisasjonsEnhet;
-import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingStegType;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingsresultatRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.AksjonspunktDefinisjon;
@@ -75,8 +74,7 @@ public class VurderInnsynOppdatererTest {
         oppdaterer = new VurderInnsynOppdaterer(behandlingskontrollTjeneste, innsynTjeneste);
 
         OrganisasjonsEnhet enhet = new OrganisasjonsEnhet("enhetId", "enhetNavn");
-        when(behandlendeEnhetTjeneste.finnBehandlendeEnhetFraSøker(any(Fagsak.class))).thenReturn(enhet);
-        when(behandlendeEnhetTjeneste.finnBehandlendeEnhetFraSøker(any(Behandling.class))).thenReturn(enhet);
+        when(behandlendeEnhetTjeneste.finnBehandlendeEnhetFor(any(Fagsak.class))).thenReturn(enhet);
     }
 
     @Test


### PR DESCRIPTION
Det ble som vanlig litt ekstra rydding.
Hovedpoenget er å ikke sende saker til Vikafossen som skal behandles ved normal enhet.
Dette gjøres ved å se på PO-grunnlaget (annepart og register) ettersom de er kun de som teller.
Så er det litt sikring av sakskobling (eldste sak er styrende, ikke sak1 i relasjon)

K9: Se på Enhetstjeneste, BehandlendeEnhetsTjeneste og OrganisasjoneEnhet (equals). 