### PR TITLE
TFP-2724 lagre fristtid, venteårsak og apdefinisjoner

### DIFF
--- a/domenetjenester/datavarehus/src/main/java/no/nav/foreldrepenger/datavarehus/domene/AksjonspunktDefDvh.java
+++ b/domenetjenester/datavarehus/src/main/java/no/nav/foreldrepenger/datavarehus/domene/AksjonspunktDefDvh.java
@@ -1,0 +1,105 @@
+package no.nav.foreldrepenger.datavarehus.domene;
+
+import java.io.Serializable;
+import java.time.LocalDateTime;
+import java.util.Objects;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.PrePersist;
+import javax.persistence.PreUpdate;
+import javax.persistence.Table;
+
+@Entity(name = "AksjonspunktDefDvh")
+@Table(name = "AKSJONSPUNKT_DEF_DVH")
+public class AksjonspunktDefDvh implements Serializable {
+
+    @Id
+    @Column(name = "AKSJONSPUNKT_DEF", nullable = false)
+    private String aksjonspunktDef;
+
+    @Column(name = "AKSJONSPUNKT_TYPE", nullable = false)
+    private String aksjonspunktType;
+
+    @Column(name = "AKSJONSPUNKT_NAVN")
+    private String aksjonspunktNavn;
+
+    @Column(name = "opprettet_tid", nullable = false, updatable=false)
+    private LocalDateTime opprettetTidspunkt; // NOSONAR
+
+    @Column(name = "endret_tid")
+    private LocalDateTime endretTidspunkt; // NOSONAR
+
+    @PrePersist
+    protected void onCreate() {
+        this.opprettetTidspunkt = opprettetTidspunkt != null ? opprettetTidspunkt : LocalDateTime.now();
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        endretTidspunkt = LocalDateTime.now();
+    }
+
+    AksjonspunktDefDvh() {
+        // Hibernate
+    }
+
+    public String getAksjonspunktDef() {
+        return aksjonspunktDef;
+    }
+
+    public String getAksjonspunktType() {
+        return aksjonspunktType;
+    }
+
+    public String getAksjonspunktNavn() {
+        return aksjonspunktNavn;
+    }
+
+    public void setAksjonspunktNavn(String aksjonspunktNavn) {
+        this.aksjonspunktNavn = aksjonspunktNavn;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        AksjonspunktDefDvh that = (AksjonspunktDefDvh) o;
+        return aksjonspunktDef.equals(that.aksjonspunktDef);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(aksjonspunktDef);
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private AksjonspunktDefDvh kladd = new AksjonspunktDefDvh();
+
+        public Builder aksjonspunktDef(String aksjonspunktDef) {
+            this.kladd.aksjonspunktDef = aksjonspunktDef;
+            return this;
+        }
+
+        public Builder aksjonspunktType(String aksjonspunktType) {
+            this.kladd.aksjonspunktType = aksjonspunktType;
+            return this;
+        }
+
+        public Builder aksjonspunktNavn(String aksjonspunktNavn) {
+            this.kladd.aksjonspunktNavn = aksjonspunktNavn;
+            return this;
+        }
+
+        public AksjonspunktDefDvh build() {
+            Objects.requireNonNull(kladd.aksjonspunktDef, "Mangler aksjonspunkdef");
+            Objects.requireNonNull(kladd.aksjonspunktType, "Mangler aksjonspuntType");
+            return kladd;
+        }
+    }
+}

--- a/domenetjenester/datavarehus/src/main/java/no/nav/foreldrepenger/datavarehus/domene/AksjonspunktDvh.java
+++ b/domenetjenester/datavarehus/src/main/java/no/nav/foreldrepenger/datavarehus/domene/AksjonspunktDvh.java
@@ -54,6 +54,12 @@ public class AksjonspunktDvh extends DvhBaseEntitet {
     @Column(name = "TOTRINN_BEHANDLING_GODKJENT")
     private Boolean toTrinnsBehandlingGodkjent;
 
+    @Column(name = "frist_tid")
+    private LocalDateTime fristTid;
+
+    @Column(name="vent_aarsak")
+    private String venteårsak;
+
     AksjonspunktDvh() {
         // Hibernate
     }
@@ -102,6 +108,14 @@ public class AksjonspunktDvh extends DvhBaseEntitet {
         return toTrinnsBehandlingGodkjent;
     }
 
+    public LocalDateTime getFristTid() {
+        return fristTid;
+    }
+
+    public String getVenteårsak() {
+        return venteårsak;
+    }
+
     @Override
     public boolean equals(final Object obj) {
         if (this == obj) {
@@ -135,94 +149,80 @@ public class AksjonspunktDvh extends DvhBaseEntitet {
     }
 
     public static class Builder {
-        private Long behandlingStegId;
-        private Long aksjonspunktId;
-        private Long behandlingId;
-        private String behandlendeEnhetKode;
-        private String ansvarligBeslutter;
-        private String ansvarligSaksbehandler;
-        private String aksjonspunktDef;
-        private String aksjonspunktStatus;
-        private LocalDateTime funksjonellTid;
-        private String endretAv;
-        private boolean toTrinnsBehandling;
-        private Boolean toTrinnsBehandlingGodkjent;
+        AksjonspunktDvh kladd = new AksjonspunktDvh();
 
         public Builder behandlingStegId(Long behandlingStegId) {
-            this.behandlingStegId = behandlingStegId;
+            this.kladd.behandlingStegId = behandlingStegId;
             return this;
         }
 
         public Builder aksjonspunktId(Long aksjonspunktId) {
-            this.aksjonspunktId = aksjonspunktId;
+            this.kladd.aksjonspunktId = aksjonspunktId;
             return this;
         }
 
         public Builder behandlingId(Long behandlingId) {
-            this.behandlingId = behandlingId;
+            this.kladd.behandlingId = behandlingId;
             return this;
         }
 
         public Builder behandlendeEnhetKode(String behandlendeEnhetKode) {
-            this.behandlendeEnhetKode = behandlendeEnhetKode;
+            this.kladd.behandlendeEnhetKode = behandlendeEnhetKode;
             return this;
         }
 
         public Builder ansvarligBeslutter(String ansvarligBeslutter) {
-            this.ansvarligBeslutter = ansvarligBeslutter;
+            this.kladd.ansvarligBeslutter = ansvarligBeslutter;
             return this;
         }
 
         public Builder ansvarligSaksbehandler(String ansvarligSaksbehandler) {
-            this.ansvarligSaksbehandler = ansvarligSaksbehandler;
+            this.kladd.ansvarligSaksbehandler = ansvarligSaksbehandler;
             return this;
         }
 
         public Builder aksjonspunktDef(String aksjonspunktDef) {
-            this.aksjonspunktDef = aksjonspunktDef;
+            this.kladd.aksjonspunktDef = aksjonspunktDef;
             return this;
         }
 
         public Builder aksjonspunktStatus(String aksjonspunktStatus) {
-            this.aksjonspunktStatus = aksjonspunktStatus;
+            this.kladd.aksjonspunktStatus = aksjonspunktStatus;
             return this;
         }
 
         public Builder funksjonellTid(LocalDateTime funksjonellTid) {
-            this.funksjonellTid = funksjonellTid;
+            this.kladd.setFunksjonellTid(funksjonellTid);
             return this;
         }
 
         public Builder endretAv(String endretAv) {
-            this.endretAv = endretAv;
+            this.kladd.setEndretAv(endretAv);
             return this;
         }
 
         public Builder toTrinnsBehandling(boolean toTrinnsBehandling) {
-            this.toTrinnsBehandling = toTrinnsBehandling;
+            this.kladd.toTrinnsBehandling = toTrinnsBehandling;
             return this;
         }
 
         public Builder toTrinnsBehandlingGodkjent(Boolean toTrinnsBehandlingGodkjent) {
-            this.toTrinnsBehandlingGodkjent = toTrinnsBehandlingGodkjent;
+            this.kladd.toTrinnsBehandlingGodkjent = toTrinnsBehandlingGodkjent;
+            return this;
+        }
+
+        public Builder fristTid(LocalDateTime fristTid) {
+            this.kladd.fristTid = fristTid;
+            return this;
+        }
+
+        public Builder venteårsak(String venteårsak) {
+            this.kladd.venteårsak = venteårsak;
             return this;
         }
 
         public AksjonspunktDvh build() {
-            AksjonspunktDvh aksjonspunktDvh = new AksjonspunktDvh();
-            aksjonspunktDvh.behandlingStegId = behandlingStegId;
-            aksjonspunktDvh.aksjonspunktId = aksjonspunktId;
-            aksjonspunktDvh.behandlingId = behandlingId;
-            aksjonspunktDvh.behandlendeEnhetKode = behandlendeEnhetKode;
-            aksjonspunktDvh.ansvarligBeslutter = ansvarligBeslutter;
-            aksjonspunktDvh.ansvarligSaksbehandler = ansvarligSaksbehandler;
-            aksjonspunktDvh.aksjonspunktDef = aksjonspunktDef;
-            aksjonspunktDvh.aksjonspunktStatus = aksjonspunktStatus;
-            aksjonspunktDvh.toTrinnsBehandling = toTrinnsBehandling;
-            aksjonspunktDvh.toTrinnsBehandlingGodkjent = toTrinnsBehandlingGodkjent;
-            aksjonspunktDvh.setFunksjonellTid(funksjonellTid);
-            aksjonspunktDvh.setEndretAv(endretAv);
-            return aksjonspunktDvh;
+            return kladd;
         }
     }
 }

--- a/domenetjenester/datavarehus/src/main/java/no/nav/foreldrepenger/datavarehus/domene/DatavarehusRepository.java
+++ b/domenetjenester/datavarehus/src/main/java/no/nav/foreldrepenger/datavarehus/domene/DatavarehusRepository.java
@@ -2,6 +2,7 @@ package no.nav.foreldrepenger.datavarehus.domene;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -114,7 +115,6 @@ public class DatavarehusRepository {
     public long lagre(KlageVurderingResultatDvh klageVurderingResultat) {
         entityManager.persist(klageVurderingResultat);
         return klageVurderingResultat.getId();
-
     }
 
     public long lagre(AnkeVurderingResultatDvh ankeVurderingResultat) {
@@ -127,6 +127,17 @@ public class DatavarehusRepository {
         entityManager.persist(fagsakRelasjonDvh);
         entityManager.flush();
         return fagsakRelasjonDvh.getId();
+    }
+
+    public Map<String, AksjonspunktDefDvh> hentAksjonspunktDefinisjoner() {
+        TypedQuery<AksjonspunktDefDvh> query = entityManager.createQuery("from AksjonspunktDefDvh", AksjonspunktDefDvh.class);
+
+        return query.getResultList().stream().collect(Collectors.toMap(AksjonspunktDefDvh::getAksjonspunktDef, a -> a));
+    }
+
+    public void lagre( AksjonspunktDefDvh aksjonspunktDefDvh ) {
+        entityManager.persist(aksjonspunktDefDvh);
+        entityManager.flush();
     }
 
 }

--- a/domenetjenester/datavarehus/src/main/java/no/nav/foreldrepenger/datavarehus/domene/DvhBaseEntitet.java
+++ b/domenetjenester/datavarehus/src/main/java/no/nav/foreldrepenger/datavarehus/domene/DvhBaseEntitet.java
@@ -8,8 +8,6 @@ import javax.persistence.Column;
 import javax.persistence.MappedSuperclass;
 import javax.persistence.PrePersist;
 
-import no.nav.vedtak.util.FPDateUtil;
-
 @MappedSuperclass
 public class DvhBaseEntitet implements Serializable {
 
@@ -24,9 +22,9 @@ public class DvhBaseEntitet implements Serializable {
 
     @PrePersist
     protected void onCreate() {
-        this.transTid = FPDateUtil.nå();
+        this.transTid = LocalDateTime.now();
         if (this.funksjonellTid == null) {
-            this.funksjonellTid = FPDateUtil.nå();
+            this.funksjonellTid = LocalDateTime.now();
         }
     }
 

--- a/domenetjenester/datavarehus/src/main/java/no/nav/foreldrepenger/datavarehus/domene/VedtakUtbetalingDvh.java
+++ b/domenetjenester/datavarehus/src/main/java/no/nav/foreldrepenger/datavarehus/domene/VedtakUtbetalingDvh.java
@@ -12,8 +12,6 @@ import javax.persistence.Id;
 import javax.persistence.Lob;
 import javax.persistence.Table;
 
-import no.nav.vedtak.util.FPDateUtil;
-
 @Entity(name = "VedtakUtbetalingDvh")
 @Table(name = "VEDTAK_UTBETALING_DVH")
 public class VedtakUtbetalingDvh extends DvhBaseEntitet {
@@ -72,7 +70,7 @@ public class VedtakUtbetalingDvh extends DvhBaseEntitet {
     }
 
     public void setTransTid(){
-        setTransTid( FPDateUtil.nå());
+        setTransTid( LocalDateTime.now());
     }
     public Long getFagsakId() {
         return fagsakId;

--- a/domenetjenester/datavarehus/src/main/java/no/nav/foreldrepenger/datavarehus/task/OppdaterAksjonspunktDefinisjonBatchTjeneste.java
+++ b/domenetjenester/datavarehus/src/main/java/no/nav/foreldrepenger/datavarehus/task/OppdaterAksjonspunktDefinisjonBatchTjeneste.java
@@ -1,0 +1,70 @@
+package no.nav.foreldrepenger.datavarehus.task;
+
+import java.time.LocalDate;
+import java.util.Map;
+import java.util.Objects;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import no.nav.foreldrepenger.batch.BatchArguments;
+import no.nav.foreldrepenger.batch.BatchStatus;
+import no.nav.foreldrepenger.batch.BatchTjeneste;
+import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.AksjonspunktDefinisjon;
+import no.nav.foreldrepenger.datavarehus.domene.AksjonspunktDefDvh;
+import no.nav.foreldrepenger.datavarehus.domene.DatavarehusRepository;
+
+/**
+ *  Batchservice som finner alle behandlinger som skal gjenopptas, og lager en ditto prosess task for hver.
+ *  Kriterier for gjenopptagelse: Behandlingen har et åpent aksjonspunkt som er et autopunkt og
+ *  har en frist som er passert.
+ */
+@ApplicationScoped
+public class OppdaterAksjonspunktDefinisjonBatchTjeneste implements BatchTjeneste {
+
+    static final String BATCHNAME = "BVL010";
+    private static final String EXECUTION_ID_SEPARATOR = "-";
+
+    private DatavarehusRepository datavarehusRepository;
+
+    @Inject
+    public OppdaterAksjonspunktDefinisjonBatchTjeneste(DatavarehusRepository datavarehusRepository) {
+        this.datavarehusRepository = datavarehusRepository;
+    }
+
+    @Override
+    public String launch(BatchArguments arguments) {
+        oppdaterAksjonspunktDefinisjonDVH();
+        return BATCHNAME + EXECUTION_ID_SEPARATOR + LocalDate.now().toString();
+    }
+
+    @Override
+    public BatchStatus status(String executionId) {
+        return BatchStatus.OK;
+    }
+
+    @Override
+    public String getBatchName() {
+        return BATCHNAME;
+    }
+
+    private void oppdaterAksjonspunktDefinisjonDVH() {
+        Map<String, AksjonspunktDefDvh> eksisterende = datavarehusRepository.hentAksjonspunktDefinisjoner();
+        AksjonspunktDefinisjon.kodeMap().values().stream().filter(ad -> ad.getKode() != null).forEach(ad -> {
+            if (eksisterende.get(ad.getKode()) == null) {
+                AksjonspunktDefDvh defDvh = AksjonspunktDefDvh.builder()
+                    .aksjonspunktDef(ad.getKode())
+                    .aksjonspunktType(ad.getAksjonspunktType().getKode())
+                    .aksjonspunktNavn(ad.getNavn())
+                    .build();
+                datavarehusRepository.lagre(defDvh);
+            } else {
+                AksjonspunktDefDvh dvhDefinisjon = eksisterende.get(ad.getKode());
+                if (!Objects.equals(ad.getNavn(), dvhDefinisjon.getAksjonspunktNavn())) {
+                    dvhDefinisjon.setAksjonspunktNavn(ad.getNavn());
+                    datavarehusRepository.lagre(dvhDefinisjon);
+                }
+            }
+        });
+    }
+}

--- a/domenetjenester/datavarehus/src/main/java/no/nav/foreldrepenger/datavarehus/tjeneste/AksjonspunktDvhMapper.java
+++ b/domenetjenester/datavarehus/src/main/java/no/nav/foreldrepenger/datavarehus/tjeneste/AksjonspunktDvhMapper.java
@@ -1,12 +1,13 @@
 package no.nav.foreldrepenger.datavarehus.tjeneste;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingStegTilstand;
 import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.Aksjonspunkt;
+import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.Venteårsak;
 import no.nav.foreldrepenger.datavarehus.domene.AksjonspunktDvh;
-import no.nav.vedtak.util.FPDateUtil;
 
 public class AksjonspunktDvhMapper {
 
@@ -21,9 +22,11 @@ public class AksjonspunktDvhMapper {
             .behandlingId(behandling.getId())
             .behandlingStegId(behandlingStegTilstand.map(BehandlingStegTilstand::getId).orElse(null))
             .endretAv(CommonDvhMapper.finnEndretAvEllerOpprettetAv(aksjonspunkt))
-            .funksjonellTid(FPDateUtil.nå())
+            .funksjonellTid(LocalDateTime.now())
             .toTrinnsBehandling(aksjonspunkt.isToTrinnsBehandling())
             .toTrinnsBehandlingGodkjent(aksjonspunktGodkjennt)
+            .fristTid(aksjonspunkt.getFristTid())
+            .venteårsak(Venteårsak.UDEFINERT.equals(aksjonspunkt.getVenteårsak()) ? null : aksjonspunkt.getVenteårsak().getKode())
             .build();
     }
 

--- a/domenetjenester/datavarehus/src/main/java/no/nav/foreldrepenger/datavarehus/tjeneste/BehandlingDvhMapper.java
+++ b/domenetjenester/datavarehus/src/main/java/no/nav/foreldrepenger/datavarehus/tjeneste/BehandlingDvhMapper.java
@@ -19,7 +19,6 @@ import no.nav.foreldrepenger.behandlingslager.behandling.vedtak.BehandlingVedtak
 import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakStatus;
 import no.nav.foreldrepenger.behandlingslager.uttak.UttakResultatEntitet;
 import no.nav.foreldrepenger.datavarehus.domene.BehandlingDvh;
-import no.nav.vedtak.util.FPDateUtil;
 
 public class BehandlingDvhMapper {
 
@@ -45,7 +44,7 @@ public class BehandlingDvhMapper {
             .behandlingType(behandling.getType().getKode())
             .endretAv(CommonDvhMapper.finnEndretAvEllerOpprettetAv(behandling))
             .fagsakId(behandling.getFagsakId())
-            .funksjonellTid(FPDateUtil.nå())
+            .funksjonellTid(LocalDateTime.now())
             .opprettetDato(behandling.getOpprettetDato().toLocalDate())
             .utlandstilsnitt(mapUtlandstilsnitt(behandling))
             .toTrinnsBehandling(behandling.isToTrinnsBehandling())

--- a/domenetjenester/datavarehus/src/main/resources/META-INF/pu-default.datavarehus.orm.xml
+++ b/domenetjenester/datavarehus/src/main/resources/META-INF/pu-default.datavarehus.orm.xml
@@ -25,6 +25,7 @@
     <entity class="no.nav.foreldrepenger.datavarehus.domene.BehandlingStegDvh"/>
     <entity class="no.nav.foreldrepenger.datavarehus.domene.BehandlingVedtakDvh"/>
     <entity class="no.nav.foreldrepenger.datavarehus.domene.AksjonspunktDvh"/>
+    <entity class="no.nav.foreldrepenger.datavarehus.domene.AksjonspunktDefDvh"/>
     <entity class="no.nav.foreldrepenger.datavarehus.domene.KontrollDvh"/>
     <entity class="no.nav.foreldrepenger.datavarehus.domene.VedtakUtbetalingDvh"/>
     <entity class="no.nav.foreldrepenger.datavarehus.domene.KlageFormkravDvh"/>

--- a/domenetjenester/datavarehus/src/test/java/no/nav/foreldrepenger/datavarehus/tjeneste/AksjonspunktDvhMapperTest.java
+++ b/domenetjenester/datavarehus/src/test/java/no/nav/foreldrepenger/datavarehus/tjeneste/AksjonspunktDvhMapperTest.java
@@ -25,8 +25,9 @@ import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingStegType;
 import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.Aksjonspunkt;
 import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.AksjonspunktDefinisjon;
 import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.AksjonspunktStatus;
-import no.nav.foreldrepenger.datavarehus.domene.AksjonspunktDvh;
+import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.Venteårsak;
 import no.nav.foreldrepenger.behandlingslager.testutilities.behandling.ScenarioMorSøkerEngangsstønad;
+import no.nav.foreldrepenger.datavarehus.domene.AksjonspunktDvh;
 import no.nav.vedtak.felles.testutilities.Whitebox;
 
 @SuppressWarnings("deprecation")
@@ -89,6 +90,8 @@ public class AksjonspunktDvhMapperTest {
 
         Whitebox.setInternalState(behandling.getAksjonspunktMedDefinisjonOptional(AKSJONSPUNKT_DEF).get(), OPPRETTET_AV, OPPRETTET_AV);
         Whitebox.setInternalState(behandling.getAksjonspunktMedDefinisjonOptional(AKSJONSPUNKT_DEF).get(), "opprettetTidspunkt", OPPRETTET_TID);
+        Whitebox.setInternalState(behandling.getAksjonspunktMedDefinisjonOptional(AKSJONSPUNKT_DEF).get(), "fristTid", OPPRETTET_TID.plusWeeks(3));
+        Whitebox.setInternalState(behandling.getAksjonspunktMedDefinisjonOptional(AKSJONSPUNKT_DEF).get(), "venteårsak", Venteårsak.UDEFINERT);
         Aksjonspunkt aksjonspunkt = behandling.getAksjonspunktMedDefinisjonOptional(AKSJONSPUNKT_DEF).get();
 
         AksjonspunktDvh dvh = mapper.map(aksjonspunkt, behandling, Optional.empty(), true);
@@ -96,6 +99,8 @@ public class AksjonspunktDvhMapperTest {
         assertThat(dvh).isNotNull();
 
         assertThat(dvh.getBehandlingStegId()).isNull();
+        assertThat(dvh.getVenteårsak()).isNull();
+        assertThat(dvh.getFristTid()).isEqualTo(OPPRETTET_TID.plusWeeks(3));
     }
 
     private Optional<BehandlingStegTilstand> byggBehandlingStegTilstand(Behandling behandling) {

--- a/infrastrukturtjenester/batch/src/main/java/no/nav/foreldrepenger/batch/BatchSupportTjeneste.java
+++ b/infrastrukturtjenester/batch/src/main/java/no/nav/foreldrepenger/batch/BatchSupportTjeneste.java
@@ -16,7 +16,6 @@ import no.nav.vedtak.felles.prosesstask.api.ProsessTaskGruppe;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTaskRepository;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTaskStatus;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTaskTypeInfo;
-import no.nav.vedtak.util.FPDateUtil;
 
 @ApplicationScoped
 public class BatchSupportTjeneste {
@@ -73,7 +72,7 @@ public class BatchSupportTjeneste {
         if (ptdList.isEmpty()) {
             return;
         }
-        LocalDateTime nå = FPDateUtil.nå();
+        LocalDateTime nå = LocalDateTime.now();
         Map<String, Integer> taskTypesMaxForsøk = new HashMap<>();
         ptdList.stream().map(ProsessTaskData::getTaskType).forEach(tasktype -> {
             if (taskTypesMaxForsøk.get(tasktype) == null) {

--- a/infrastrukturtjenester/batch/src/main/java/no/nav/foreldrepenger/batch/task/BatchSchedulerTask.java
+++ b/infrastrukturtjenester/batch/src/main/java/no/nav/foreldrepenger/batch/task/BatchSchedulerTask.java
@@ -18,7 +18,6 @@ import no.nav.vedtak.felles.prosesstask.api.ProsessTask;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTaskData;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTaskGruppe;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTaskHandler;
-import no.nav.vedtak.util.FPDateUtil;
 
 /**
  * Enkel scheduler for dagens situasjon der man kjører batcher mandag-fredag og det er noe variasjon i parametere.
@@ -54,7 +53,8 @@ public class BatchSchedulerTask implements ProsessTaskHandler {
         new BatchConfig(6, 59, "BVL005", null), // Kodeverk
         new BatchConfig(7, 0, "BVL004", null), // Gjenoppta
         new BatchConfig(7, 4, "BVL002", null), // Etterkontroll
-        new BatchConfig(7, 6, "BVL003", null)  // Forlengelsesbrev må kjøre noe etter Gjenoppta
+        new BatchConfig(7, 6, "BVL003", null),  // Forlengelsesbrev må kjøre noe etter Gjenoppta
+        new BatchConfig(2, 1, "BVL010", null)  //Oppdatering DVH. Bør kjøre før kl 03-04.
     );
 
     private final Set<MonthDay> fasteStengteDager = Set.of(
@@ -63,7 +63,6 @@ public class BatchSchedulerTask implements ProsessTaskHandler {
         MonthDay.of(5, 17),
         MonthDay.of(12, 25),
         MonthDay.of(12, 26),
-        MonthDay.of(12, 30), // TODO midlertidig pga KOR 2020
         MonthDay.of(12, 31)
     );
 
@@ -82,7 +81,7 @@ public class BatchSchedulerTask implements ProsessTaskHandler {
 
     @Override
     public void doTask(ProsessTaskData prosessTaskData) {
-        LocalDate dagensDato = FPDateUtil.iDag();
+        LocalDate dagensDato = LocalDate.now();
         DayOfWeek dagensUkedag = DayOfWeek.from(dagensDato);
 
         // Lagre neste instans av daglig scheduler straks over midnatt

--- a/migreringer/src/main/resources/db/migration/dvhDS/2.4.0/V2.4.0_10__TFP_2724_aksjonspunkt_vent.sql
+++ b/migreringer/src/main/resources/db/migration/dvhDS/2.4.0/V2.4.0_10__TFP_2724_aksjonspunkt_vent.sql
@@ -1,0 +1,22 @@
+ALTER TABLE AKSJONSPUNKT_DVH ADD "FRIST_TID" TIMESTAMP (3);
+ALTER TABLE AKSJONSPUNKT_DVH ADD "VENT_AARSAK" VARCHAR2(100 CHAR);
+
+COMMENT ON COLUMN "AKSJONSPUNKT_DVH"."FRIST_TID" IS 'Behandling blir automatisk gjenopptatt etter dette tidspunktet';
+COMMENT ON COLUMN "AKSJONSPUNKT_DVH"."VENT_AARSAK" IS 'Årsak for at behandling er satt på vent';
+
+CREATE TABLE AKSJONSPUNKT_DEF_DVH (
+                AKSJONSPUNKT_DEF  VARCHAR2(50 char) not null,
+                AKSJONSPUNKT_TYPE varchar2(50 char) not null,
+                AKSJONSPUNKT_NAVN varchar2(500 char),
+                opprettet_tid     TIMESTAMP(3) DEFAULT systimestamp NOT NULL,
+                endret_tid        TIMESTAMP(3),
+                CONSTRAINT PK_AKSJONSPUNKT_DEF PRIMARY KEY (AKSJONSPUNKT_DEF)
+);
+GRANT ALL ON AKSJONSPUNKT_DEF_DVH TO FPSAK_HIST_SKRIVE_ROLE;
+
+COMMENT ON TABLE AKSJONSPUNKT_DEF_DVH  IS 'En tabell over aksjonspunktkoder som autogenereres fra FPSAK.';
+COMMENT ON COLUMN AKSJONSPUNKT_DEF_DVH.AKSJONSPUNKT_DEF IS 'Primærnøkkel Aksjonspunkt_def i Aksjonspunkt_DVH';
+COMMENT ON COLUMN AKSJONSPUNKT_DEF_DVH.AKSJONSPUNKT_TYPE IS 'Type aksjonspunkt';
+COMMENT ON COLUMN AKSJONSPUNKT_DEF_DVH.AKSJONSPUNKT_NAVN IS 'Beskrivende tittel for aksjonspunkt';
+COMMENT ON COLUMN AKSJONSPUNKT_DEF_DVH.opprettet_tid IS 'Opprettet tidspunkt';
+COMMENT ON COLUMN AKSJONSPUNKT_DEF_DVH.endret_tid IS 'Tidspunkt ved endring av steg eller navn';


### PR DESCRIPTION
Lagre med fristtid og venteårsak for aksjonspunkt
Ikke-TX tabell over aksjonspunktdefinisjon med kode, type og navn - til presentasjon.
Batch for å generere/oppdatere apdef