### PR TITLE
TFP-2778: Når en ny fagsak opprettes fordi infobrev skal sendes til a…

### DIFF
--- a/domenetjenester/behandling-prosessering/src/main/java/no/nav/foreldrepenger/behandlingsprosess/dagligejobber/infobrev/SendInformasjonsbrevBatchTjeneste.java
+++ b/domenetjenester/behandling-prosessering/src/main/java/no/nav/foreldrepenger/behandlingsprosess/dagligejobber/infobrev/SendInformasjonsbrevBatchTjeneste.java
@@ -16,11 +16,6 @@ import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingÅrsakType;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTaskData;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTaskRepository;
 
-/**
- * Produserer en avstemmingsfil på XML-format som skal brukes i eksisterende grensesnitt for avstemmingskomponent i økonomisystemet.
- * Informasjonen i avstemmingsmelding hentes ut fra økonomilageret.
- */
-
 @ApplicationScoped
 public class SendInformasjonsbrevBatchTjeneste implements BatchTjeneste {
 
@@ -54,6 +49,7 @@ public class SendInformasjonsbrevBatchTjeneste implements BatchTjeneste {
             data.setProperty(OpprettInformasjonsFagsakTask.BEH_ENHET_ID_KEY, sak.getEnhet());
             data.setProperty(OpprettInformasjonsFagsakTask.BEH_ENHET_NAVN_KEY, sak.getEnhetNavn());
             data.setProperty(OpprettInformasjonsFagsakTask.BEHANDLING_AARSAK, BehandlingÅrsakType.INFOBREV_BEHANDLING.getKode());
+            data.setProperty(OpprettInformasjonsFagsakTask.FAGSAK_ID_MOR_KEY, sak.getKildeFagsakId().toString());
             prosessTaskRepository.lagre(data);
         });
         return BATCHNAVN + "-" + saker.size();

--- a/domenetjenester/behandling-prosessering/src/main/java/no/nav/foreldrepenger/behandlingsprosess/dagligejobber/infobrev/SendInformasjonsbrevOppholdBatchTjeneste.java
+++ b/domenetjenester/behandling-prosessering/src/main/java/no/nav/foreldrepenger/behandlingsprosess/dagligejobber/infobrev/SendInformasjonsbrevOppholdBatchTjeneste.java
@@ -16,11 +16,6 @@ import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingÅrsakType;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTaskData;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTaskRepository;
 
-/**
- * Produserer en avstemmingsfil på XML-format som skal brukes i eksisterende grensesnitt for avstemmingskomponent i økonomisystemet.
- * Informasjonen i avstemmingsmelding hentes ut fra økonomilageret.
- */
-
 @ApplicationScoped
 public class SendInformasjonsbrevOppholdBatchTjeneste implements BatchTjeneste {
 
@@ -54,6 +49,7 @@ public class SendInformasjonsbrevOppholdBatchTjeneste implements BatchTjeneste {
             data.setProperty(OpprettInformasjonsFagsakTask.BEH_ENHET_ID_KEY, sak.getEnhet());
             data.setProperty(OpprettInformasjonsFagsakTask.BEH_ENHET_NAVN_KEY, sak.getEnhetNavn());
             data.setProperty(OpprettInformasjonsFagsakTask.BEHANDLING_AARSAK, BehandlingÅrsakType.INFOBREV_OPPHOLD.getKode());
+            data.setProperty(OpprettInformasjonsFagsakTask.FAGSAK_ID_MOR_KEY, sak.getKildeFagsakId().toString());
             prosessTaskRepository.lagre(data);
         });
         return BATCHNAVN + "-" + saker.size();

--- a/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/BehandlingDtoTjenesteImplTest.java
+++ b/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/BehandlingDtoTjenesteImplTest.java
@@ -18,6 +18,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import no.nav.foreldrepenger.behandling.RelatertBehandlingTjeneste;
 import no.nav.foreldrepenger.behandling.UuidDto;
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingType;
@@ -68,6 +69,9 @@ public class BehandlingDtoTjenesteImplTest {
     @Inject
     private BehandlingDokumentRepository behandlingDokumentRepository;
 
+    @Inject
+    private RelatertBehandlingTjeneste relatertBehandlingTjeneste;
+
     private BehandlingDtoTjeneste tjeneste;
 
     private LocalDate now = LocalDate.now();
@@ -78,7 +82,7 @@ public class BehandlingDtoTjenesteImplTest {
     public void setUp() {
         existingRoutes = RestUtils.getRoutes();
         tjeneste = new BehandlingDtoTjeneste(repositoryProvider, beregningsgrunnlagTjeneste, tilbakekrevingRepository, skjæringstidspunktTjeneste,
-            opptjeningIUtlandDokStatusTjeneste, behandlingDokumentRepository);
+            opptjeningIUtlandDokStatusTjeneste, behandlingDokumentRepository, relatertBehandlingTjeneste);
     }
 
     @Test

--- a/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/BehandlingRestTjenesteESTest.java
+++ b/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/BehandlingRestTjenesteESTest.java
@@ -64,6 +64,7 @@ public class BehandlingRestTjenesteESTest {
     private OpptjeningIUtlandDokStatusTjeneste opptjeningIUtlandDokStatusTjeneste = mock(OpptjeningIUtlandDokStatusTjeneste.class);
     private TilbakekrevingRepository tilbakekrevingRepository = mock(TilbakekrevingRepository.class);
     private BehandlingDokumentRepository behandlingDokumentRepository = mock(BehandlingDokumentRepository.class);
+    private RelatertBehandlingTjeneste relatertBehandlingTjeneste = mock(RelatertBehandlingTjeneste.class);
 
     @Before
     public void setUp() {
@@ -73,7 +74,7 @@ public class BehandlingRestTjenesteESTest {
         var relatertBehandlingTjeneste = new RelatertBehandlingTjeneste(repositoryProvider);
         skjæringstidspunktTjeneste = new SkjæringstidspunktTjenesteImpl(repositoryProvider, new RegisterInnhentingIntervall(Period.of(1, 0, 0), Period.of(0, 6, 0)));
         BehandlingDtoTjeneste behandlingDtoTjeneste = new BehandlingDtoTjeneste(repositoryProvider, beregningsgrunnlagTjeneste,
-            tilbakekrevingRepository, skjæringstidspunktTjeneste, opptjeningIUtlandDokStatusTjeneste, behandlingDokumentRepository);
+            tilbakekrevingRepository, skjæringstidspunktTjeneste, opptjeningIUtlandDokStatusTjeneste, behandlingDokumentRepository, relatertBehandlingTjeneste);
 
         behandlingRestTjeneste = new BehandlingRestTjeneste(behandlingsutredningApplikasjonTjeneste,
             behandlingsoppretterApplikasjonTjeneste,

--- a/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/BehandlingRestTjenesteTest.java
+++ b/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/BehandlingRestTjenesteTest.java
@@ -52,6 +52,7 @@ public class BehandlingRestTjenesteTest {
     private OpptjeningIUtlandDokStatusTjeneste opptjeningIUtlandDokStatusTjeneste = mock(OpptjeningIUtlandDokStatusTjeneste.class);
     private TilbakekrevingRepository tilbakekrevingRepository = mock(TilbakekrevingRepository.class);
     private BehandlingDokumentRepository behandlingDokumentRepository = mock(BehandlingDokumentRepository.class);
+    private RelatertBehandlingTjeneste relatertBehandlingTjeneste = mock(RelatertBehandlingTjeneste.class);
 
     @Before
     public void setUp() {
@@ -64,7 +65,7 @@ public class BehandlingRestTjenesteTest {
         var ytelseMaksdatoTjeneste = new YtelseMaksdatoTjeneste(repositoryProvider, new RelatertBehandlingTjeneste(repositoryProvider));
         skjæringstidspunktTjeneste = new SkjæringstidspunktTjenesteImpl(repositoryProvider, ytelseMaksdatoTjeneste, stputil);
         var behandlingDtoTjeneste = new BehandlingDtoTjeneste(repositoryProvider, beregningsgrunnlagTjeneste, tilbakekrevingRepository,
-            skjæringstidspunktTjeneste, opptjeningIUtlandDokStatusTjeneste, behandlingDokumentRepository);
+            skjæringstidspunktTjeneste, opptjeningIUtlandDokStatusTjeneste, behandlingDokumentRepository, relatertBehandlingTjeneste);
 
         behandlingRestTjeneste = new BehandlingRestTjeneste(behandlingsutredningApplikasjonTjeneste,
             behandlingsoppretterApplikasjonTjeneste,

--- a/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/BehandlingÅrsakDtoTest.java
+++ b/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/BehandlingÅrsakDtoTest.java
@@ -42,6 +42,7 @@ public class BehandlingÅrsakDtoTest {
     private SkjæringstidspunktTjeneste skjæringstidspunktTjeneste;
     private TilbakekrevingRepository tilbakekrevingRepository = new TilbakekrevingRepository(repoRule.getEntityManager());
     private BehandlingDokumentRepository behandlingDokumentRepository = new BehandlingDokumentRepository(repoRule.getEntityManager());
+    private RelatertBehandlingTjeneste relatertBehandlingTjeneste = new RelatertBehandlingTjeneste(repositoryProvider);
 
     @Before
     public void setup() {
@@ -52,7 +53,7 @@ public class BehandlingÅrsakDtoTest {
         var beregningsgrunnlagTjeneste = new HentOgLagreBeregningsgrunnlagTjeneste(repoRule.getEntityManager());
         var opptjeningIUtlandDokStatusTjeneste = new OpptjeningIUtlandDokStatusTjeneste(new OpptjeningIUtlandDokStatusRepository(repoRule.getEntityManager()));
         behandlingDtoTjeneste = new BehandlingDtoTjeneste(repositoryProvider, beregningsgrunnlagTjeneste, tilbakekrevingRepository,
-            skjæringstidspunktTjeneste, opptjeningIUtlandDokStatusTjeneste, behandlingDokumentRepository);
+            skjæringstidspunktTjeneste, opptjeningIUtlandDokStatusTjeneste, behandlingDokumentRepository, relatertBehandlingTjeneste);
 
         var scenario = ScenarioMorSøkerForeldrepenger.forFødsel();
         scenario.medSøknadHendelse().medFødselsDato(LocalDate.now());


### PR DESCRIPTION
…nnen forelder, blir fagsaken nå koblet til mors fagsak med en gang. BehandlingDtoTjeneste returnerer nå link til uttaksresultatet også dersom bare annen part har et uttaksresultat. Dette gjør det mulig for fp-formidling å hente ut uttaksresultatet, slik at siste uttaksdag på mors vedtak kan vises i infobrev.