### PR TITLE
TFP-3372 ikke klå på berørte behandlinger

### DIFF
--- a/web/es-vtp.properties
+++ b/web/es-vtp.properties
@@ -8,6 +8,11 @@ arbeidsfordeling.rs.url=https://localhost:8063/rest/norg2/api/v1/arbeidsfordelin
 oppgave.rs.uri=https://localhost:8063/rest/oppgave/api/v1/oppgaver
 sak.rs.url=https://localhost:8063/rest/sak/api/v1/saker
 fpabakus.url=http://localhost:8015/fpabakus
+
+fpsak.it.fp.grunnlag.url=https://localhost:8063/rest/infotrygd/grunnlag/foreldrepenger
+fpsak.it.svp.grunnlag.url=https://localhost:8063/rest/infotrygd/grunnlag/svangerskapspenger
+fpsak.it.sp.grunnlag.url=https://localhost:8063/rest/infotrygd/grunnlag/sykepenger
+fpsak.it.ps.grunnlag.url=https://localhost:8063/rest/infotrygd/grunnlag/paaroerende-sykdom
 #######################################################################################################
 # SIKKERHET - FOR VTP LOKALT
 # KOMMENTER INN NÅR LOKAL PÅLOGGING FUNGERER 100% MED VTP


### PR DESCRIPTION
Denne løser det første problemet @espenwaaga ser med Verdikjedetest 11 - nemlig oppdatering av en berørt behandling samtidig som det er aktivitet i den berørte - gir mye lockexcetions. Skjer en svært sjelden gang i P

@AnjaAalerud  testen adopsjonFarFørstSkalIkkeOpphøresAvMor skal ikke opphøre fars sak. Bruk den i TFP-3373 - håndtering av adopsjon