### PR TITLE
TFP-2837 unngå oppdatering/tilbakehopp ved avslag

### DIFF
--- a/domenetjenester/arbeidsforhold/src/test/java/no/nav/foreldrepenger/domene/arbeidsforhold/impl/VurderArbeidsforholdTjenesteImplTest.java
+++ b/domenetjenester/arbeidsforhold/src/test/java/no/nav/foreldrepenger/domene/arbeidsforhold/impl/VurderArbeidsforholdTjenesteImplTest.java
@@ -207,31 +207,6 @@ public class VurderArbeidsforholdTjenesteImplTest {
         assertThat(vurder).isEmpty();
     }
 
-    private void opprettAktørArbeidMedYrkesaktivitet(Behandling behandling, EksternArbeidsforholdRef ref, Arbeidsgiver arbeidsgiver) {
-        InntektArbeidYtelseAggregatBuilder builder = iayTjeneste.opprettBuilderForRegister(behandling.getId());
-
-        InternArbeidsforholdRef internRef = builder.medNyInternArbeidsforholdRef(arbeidsgiver, ref);
-        InntektArbeidYtelseAggregatBuilder.AktørArbeidBuilder aktørArbeidBuilder = builder.getAktørArbeidBuilder(behandling.getAktørId());
-        YrkesaktivitetBuilder yrkesaktivitetBuilder = aktørArbeidBuilder.getYrkesaktivitetBuilderForType(ArbeidType.ORDINÆRT_ARBEIDSFORHOLD);
-        AktivitetsAvtaleBuilder aktivitetsAvtale = yrkesaktivitetBuilder.getAktivitetsAvtaleBuilder()
-            .medPeriode(DatoIntervallEntitet.fraOgMed(skjæringstidspunkt.minusYears(2)))
-            .medProsentsats(BigDecimal.TEN)
-            .medAntallTimer(BigDecimal.valueOf(20.4d))
-            .medAntallTimerFulltid(BigDecimal.valueOf(10.2d));
-        AktivitetsAvtaleBuilder arbeidsperiode = yrkesaktivitetBuilder.getAktivitetsAvtaleBuilder()
-            .medPeriode(DatoIntervallEntitet.fraOgMed(skjæringstidspunkt.minusYears(2)));
-        yrkesaktivitetBuilder
-            .medArbeidType(ArbeidType.ORDINÆRT_ARBEIDSFORHOLD)
-            .medArbeidsgiver(arbeidsgiver)
-            .leggTilAktivitetsAvtale(aktivitetsAvtale)
-            .leggTilAktivitetsAvtale(arbeidsperiode)
-            .medArbeidsforholdId(internRef);
-
-        InntektArbeidYtelseAggregatBuilder.AktørArbeidBuilder aktørArbeid = aktørArbeidBuilder.leggTilYrkesaktivitet(yrkesaktivitetBuilder);
-        builder.leggTilAktørArbeid(aktørArbeid);
-        iayTjeneste.lagreIayAggregat(behandling.getId(), builder);
-    }
-
     private void sendNyInntektsmelding(Behandling behandling, Arbeidsgiver arbeidsgiver,  EksternArbeidsforholdRef ref) {
         MottattDokument mottattDokument = new MottattDokument.Builder()
             .medFagsakId(behandling.getFagsakId())

--- a/domenetjenester/registerinnhenting/src/main/java/no/nav/foreldrepenger/domene/registerinnhenting/RegisterdataEndringshåndterer.java
+++ b/domenetjenester/registerinnhenting/src/main/java/no/nav/foreldrepenger/domene/registerinnhenting/RegisterdataEndringshåndterer.java
@@ -24,6 +24,8 @@ import no.nav.foreldrepenger.behandlingslager.behandling.EndringsresultatSnapsho
 import no.nav.foreldrepenger.behandlingslager.behandling.familiehendelse.FamilieHendelseGrunnlagEntitet;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepositoryProvider;
+import no.nav.foreldrepenger.behandlingslager.behandling.vilkår.Vilkår;
+import no.nav.foreldrepenger.behandlingslager.behandling.vilkår.VilkårUtfallType;
 import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakYtelseType;
 import no.nav.foreldrepenger.behandlingslager.hendelser.StartpunktType;
 import no.nav.foreldrepenger.domene.registerinnhenting.impl.Endringskontroller;
@@ -83,7 +85,10 @@ public class RegisterdataEndringshåndterer {
     }
 
     public boolean skalInnhenteRegisteropplysningerPåNytt(Behandling behandling) {
-        if (behandling.harBehandlingÅrsak(BehandlingÅrsakType.BERØRT_BEHANDLING)) {
+        var erAvslag = behandling.getBehandlingsresultat().getVilkårResultat().getVilkårene().stream()
+            .map(Vilkår::getGjeldendeVilkårUtfall)
+            .anyMatch(VilkårUtfallType.IKKE_OPPFYLT::equals);
+        if (erAvslag || behandling.harBehandlingÅrsak(BehandlingÅrsakType.BERØRT_BEHANDLING)) {
             return false;
         }
         LocalDateTime midnatt = LocalDate.now().atStartOfDay();

--- a/domenetjenester/registerinnhenting/src/main/java/no/nav/foreldrepenger/domene/registerinnhenting/RegisterdataEndringshåndterer.java
+++ b/domenetjenester/registerinnhenting/src/main/java/no/nav/foreldrepenger/domene/registerinnhenting/RegisterdataEndringshåndterer.java
@@ -85,10 +85,7 @@ public class RegisterdataEndringshåndterer {
     }
 
     public boolean skalInnhenteRegisteropplysningerPåNytt(Behandling behandling) {
-        var erAvslag = behandling.getBehandlingsresultat().getVilkårResultat().getVilkårene().stream()
-            .map(Vilkår::getGjeldendeVilkårUtfall)
-            .anyMatch(VilkårUtfallType.IKKE_OPPFYLT::equals);
-        if (erAvslag || behandling.harBehandlingÅrsak(BehandlingÅrsakType.BERØRT_BEHANDLING)) {
+        if (erAvslag(behandling) || behandling.harBehandlingÅrsak(BehandlingÅrsakType.BERØRT_BEHANDLING)) {
             return false;
         }
         LocalDateTime midnatt = LocalDate.now().atStartOfDay();
@@ -144,7 +141,7 @@ public class RegisterdataEndringshåndterer {
     }
 
     public void oppdaterRegisteropplysningerOgReposisjonerBehandlingVedEndringer(Behandling behandling) {
-        if (!endringskontroller.erRegisterinnhentingPassert(behandling)) {
+        if (!endringskontroller.erRegisterinnhentingPassert(behandling) || erAvslag(behandling)) {
             return;
         }
         boolean skalOppdatereRegisterdata = skalInnhenteRegisteropplysningerPåNytt(behandling);
@@ -176,6 +173,12 @@ public class RegisterdataEndringshåndterer {
 
     private EndringsresultatDiff opprettDiffUtenEndring() {
         return EndringsresultatDiff.opprettForSporingsendringer();
+    }
+
+    private boolean erAvslag(Behandling behandling) {
+        return behandling.getBehandlingsresultat().getVilkårResultat().getVilkårene().stream()
+            .map(Vilkår::getGjeldendeVilkårUtfall)
+            .anyMatch(VilkårUtfallType.IKKE_OPPFYLT::equals);
     }
 
     private void lagBehandlingÅrsakerOgHistorikk(Behandling behandling, EndringsresultatDiff endringsresultat) {


### PR DESCRIPTION
Disse logginnslagene "Fant ikke forventet OpptjeningAktiviteter" skyldes forsøk på tilbakehopp til midt i prosessen når det allerede er valgt avslag (og man har hoppet over en rekke vilkår).

Første tiltak er å bli stående der man er (Uttak, ForVed) i tilfelle avslag.
