### PR TITLE
TFP-3468 sammenlign resutledning og logg

### DIFF
--- a/domenetjenester/behandling-revurdering/src/main/java/no/nav/foreldrepenger/behandling/revurdering/ytelse/fp/UttakResultatHolderImpl.java
+++ b/domenetjenester/behandling-revurdering/src/main/java/no/nav/foreldrepenger/behandling/revurdering/ytelse/fp/UttakResultatHolderImpl.java
@@ -157,7 +157,7 @@ public class UttakResultatHolderImpl implements UttakResultatHolder {
             .compress(WrapFUP::erLikeNaboer, this::kombinerLikeNaboer);
         LocalDateTimeline<WrapFUP> kombinert = uttaksTL.combine(originalTL, this::fjernLikePerioder, LocalDateTimeline.JoinStyle.CROSS_JOIN);
         var nyImpl = !kombinert.filterValue(Objects::nonNull).getDatoIntervaller().isEmpty();
-        if (gammelImpl != nyImpl)
+        if (gammelImpl != nyImpl && vedtak != null)
             LOG.info("BEHRES TIMELINE behresId {} avvik gammel {} ny {} timeline {} original {}", vedtak.getBehandlingsresultat().getId(), gammelImpl, nyImpl, uttaksTL, originalTL);
     }
 

--- a/domenetjenester/behandling-revurdering/src/main/java/no/nav/foreldrepenger/behandling/revurdering/ytelse/fp/UttakResultatHolderImpl.java
+++ b/domenetjenester/behandling-revurdering/src/main/java/no/nav/foreldrepenger/behandling/revurdering/ytelse/fp/UttakResultatHolderImpl.java
@@ -125,8 +125,11 @@ public class UttakResultatHolderImpl implements UttakResultatHolder {
             Objects.equals(p1.getResultatType(), p2.getResultatType()) &&
             Objects.equals(p1.getResultatÅrsak(), p2.getResultatÅrsak()) &&
             Objects.equals(p1.isGraderingInnvilget(), p2.isGraderingInnvilget()) &&
+            Objects.equals(p1.isSamtidigUttak(), p2.isSamtidigUttak()) &&
             Objects.equals(p1.getUtsettelseType(), p2.getUtsettelseType()) &&
             Objects.equals(p1.getGraderingAvslagÅrsak(), p2.getGraderingAvslagÅrsak()) &&
+            (Objects.equals(p1.getSamtidigUttaksprosent(), p2.getSamtidigUttaksprosent()) || p1.getSamtidigUttaksprosent().compareTo(p2.getSamtidigUttaksprosent()) == 0) &&
+            Objects.equals(p1.getOppholdÅrsak(), p2.getOppholdÅrsak()) &&
             likeAktivitieter;
         if (!sammenlign)
             LOG.info("BEHRES avvik i periodedata, like aktiviteter {}", likeAktivitieter);
@@ -235,9 +238,12 @@ public class UttakResultatHolderImpl implements UttakResultatHolder {
         return Objects.equals(p1.isFlerbarnsdager(), p2.isFlerbarnsdager()) &&
             Objects.equals(p1.getResultatType(), p2.getResultatType()) &&
             Objects.equals(p1.getResultatÅrsak(), p2.getResultatÅrsak()) &&
+            Objects.equals(p1.isSamtidigUttak(), p2.isSamtidigUttak()) &&
             Objects.equals(p1.isGraderingInnvilget(), p2.isGraderingInnvilget()) &&
             Objects.equals(p1.getUtsettelseType(), p2.getUtsettelseType()) &&
             Objects.equals(p1.getGraderingAvslagÅrsak(), p2.getGraderingAvslagÅrsak()) &&
+            (Objects.equals(p1.getSamtidigUttaksprosent(), p2.getSamtidigUttaksprosent()) || p1.getSamtidigUttaksprosent().compareTo(p2.getSamtidigUttaksprosent()) == 0) &&
+            Objects.equals(p1.getOppholdÅrsak(), p2.getOppholdÅrsak()) &&
             likeAktivitieter;
     }
 

--- a/domenetjenester/behandling-revurdering/src/test/java/no/nav/foreldrepenger/behandling/revurdering/ytelse/fp/ErEndringIUttakTest.java
+++ b/domenetjenester/behandling-revurdering/src/test/java/no/nav/foreldrepenger/behandling/revurdering/ytelse/fp/ErEndringIUttakTest.java
@@ -184,6 +184,31 @@ public class ErEndringIUttakTest {
     @Test
     public void skal_ikke_gi_endring_i_uttak_null_trekkdager_ulik_konto() {
         // Arrange
+        LocalDate dato = LocalDate.now();
+        lagBeregningsresultatperiodeMedEndringstidspunkt(dato);
+
+        UttakResultatEntitet uttakResultatOriginal = lagUttakResultatPlanForBehandling(behandlingSomSkalRevurderes,
+            List.of(new LocalDateInterval(dato, dato.plusDays(10))),
+            List.of(false), List.of(false), List.of(PeriodeResultatType.INNVILGET), List.of(PeriodeResultatÅrsak.UKJENT), List.of(false), List.of(100), List.of(100), List.of(Trekkdager.ZERO), List.of(StønadskontoType.UDEFINERT));
+
+        UttakResultatEntitet uttakResultatRevurdering = lagUttakResultatPlanForBehandling(revurdering,
+            List.of(new LocalDateInterval(dato, dato.plusDays(10))),
+            List.of(false), List.of(false), List.of(PeriodeResultatType.INNVILGET), List.of(PeriodeResultatÅrsak.UKJENT), List.of(false), List.of(100), List.of(100), List.of(Trekkdager.ZERO), List.of(StønadskontoType.FORELDREPENGER));
+
+        // Act
+        var revurderingHolder = new UttakResultatHolderImpl(Optional.of(map(uttakResultatRevurdering)), null);
+        var originalBehandlingHolder = new UttakResultatHolderImpl(Optional.of(map(uttakResultatOriginal)), null);
+        boolean endringIUttak = erEndringIUttak.vurder(revurderingHolder,  originalBehandlingHolder);
+
+        // Assert
+        assertThat(endringIUttak).isTrue(); // TODO: skal være false
+    }
+
+
+
+    @Test
+    public void case_fra_prod_bør_gi_ingen_endring() {
+        // Arrange
         LocalDate dato = LocalDate.of(2020,4,9);
         LocalDateInterval orig1 = new LocalDateInterval(dato, LocalDate.of(2020,4,30));
         LocalDateInterval orig2 = new LocalDateInterval(LocalDate.of(2020,5,1), LocalDate.of(2020,9,10));
@@ -215,7 +240,7 @@ public class ErEndringIUttakTest {
         boolean endringIUttak = erEndringIUttak.vurder(revurderingHolder,  originalBehandlingHolder);
 
         // Assert
-        assertThat(endringIUttak).isTrue();
+        assertThat(endringIUttak).isTrue(); // TODO: skal være false
     }
 
     @Test

--- a/domenetjenester/behandling-revurdering/src/test/java/no/nav/foreldrepenger/behandling/revurdering/ytelse/fp/ErEndringIUttakTest.java
+++ b/domenetjenester/behandling-revurdering/src/test/java/no/nav/foreldrepenger/behandling/revurdering/ytelse/fp/ErEndringIUttakTest.java
@@ -40,12 +40,12 @@ import no.nav.foreldrepenger.behandlingslager.behandling.vedtak.VedtakResultatTy
 import no.nav.foreldrepenger.behandlingslager.behandling.verge.VergeRepository;
 import no.nav.foreldrepenger.behandlingslager.testutilities.behandling.ScenarioMorSøkerForeldrepenger;
 import no.nav.foreldrepenger.behandlingslager.uttak.PeriodeResultatType;
+import no.nav.foreldrepenger.behandlingslager.uttak.UttakArbeidType;
+import no.nav.foreldrepenger.behandlingslager.uttak.fp.FpUttakRepository;
 import no.nav.foreldrepenger.behandlingslager.uttak.fp.PeriodeResultatÅrsak;
 import no.nav.foreldrepenger.behandlingslager.uttak.fp.StønadskontoType;
 import no.nav.foreldrepenger.behandlingslager.uttak.fp.Trekkdager;
 import no.nav.foreldrepenger.behandlingslager.uttak.fp.UttakAktivitetEntitet;
-import no.nav.foreldrepenger.behandlingslager.uttak.UttakArbeidType;
-import no.nav.foreldrepenger.behandlingslager.uttak.fp.FpUttakRepository;
 import no.nav.foreldrepenger.behandlingslager.uttak.fp.UttakResultatEntitet;
 import no.nav.foreldrepenger.behandlingslager.uttak.fp.UttakResultatPeriodeAktivitetEntitet;
 import no.nav.foreldrepenger.behandlingslager.uttak.fp.UttakResultatPeriodeEntitet;
@@ -171,6 +171,43 @@ public class ErEndringIUttakTest {
         UttakResultatEntitet uttakResultatRevurdering = lagUttakResultatPlanForBehandling(revurdering,
             List.of(new LocalDateInterval(dato, dato.plusDays(10))),
             List.of(false), List.of(false), List.of(PeriodeResultatType.INNVILGET), List.of(PeriodeResultatÅrsak.UKJENT), List.of(true), List.of(100), List.of(100), List.of(new Trekkdager(10)), List.of(StønadskontoType.FORELDREPENGER));
+
+        // Act
+        var revurderingHolder = new UttakResultatHolderImpl(Optional.of(map(uttakResultatRevurdering)), null);
+        var originalBehandlingHolder = new UttakResultatHolderImpl(Optional.of(map(uttakResultatOriginal)), null);
+        boolean endringIUttak = erEndringIUttak.vurder(revurderingHolder,  originalBehandlingHolder);
+
+        // Assert
+        assertThat(endringIUttak).isTrue();
+    }
+
+    @Test
+    public void skal_ikke_gi_endring_i_uttak_null_trekkdager_ulik_konto() {
+        // Arrange
+        LocalDate dato = LocalDate.of(2020,4,9);
+        LocalDateInterval orig1 = new LocalDateInterval(dato, LocalDate.of(2020,4,30));
+        LocalDateInterval orig2 = new LocalDateInterval(LocalDate.of(2020,5,1), LocalDate.of(2020,9,10));
+        LocalDateInterval ny1a = new LocalDateInterval(dato, LocalDate.of(2020,4,11));
+        LocalDateInterval ny1b = new LocalDateInterval(LocalDate.of(2020,4,12), LocalDate.of(2020,4,30));
+        LocalDateInterval ny2a = new LocalDateInterval(LocalDate.of(2020,5,1), LocalDate.of(2020,9,8));
+        LocalDateInterval ny2b = new LocalDateInterval(LocalDate.of(2020,9,9), LocalDate.of(2020,9,10));
+
+        lagBeregningsresultatperiodeMedEndringstidspunkt(dato);
+
+        UttakResultatEntitet uttakResultatOriginal = lagUttakResultatPlanForBehandlingLogging(behandlingSomSkalRevurderes,
+            List.of(orig1, orig2),
+            List.of(false, false), List.of(false, false), List.of(PeriodeResultatType.INNVILGET, PeriodeResultatType.INNVILGET),
+            List.of(PeriodeResultatÅrsak.UKJENT, PeriodeResultatÅrsak.UKJENT), List.of(false, false), List.of(100, 0), List.of(0, 100), List.of(Trekkdager.ZERO, new Trekkdager(95)),
+            List.of(StønadskontoType.UDEFINERT, StønadskontoType.FEDREKVOTE));
+
+        UttakResultatEntitet uttakResultatRevurdering = lagUttakResultatPlanForBehandlingLogging(revurdering,
+            List.of(ny1a, ny1b, ny2a, ny2b),
+            List.of(false, false, false, false), List.of(false, false, false, false),
+            List.of(PeriodeResultatType.INNVILGET, PeriodeResultatType.INNVILGET, PeriodeResultatType.INNVILGET, PeriodeResultatType.INNVILGET),
+            List.of(PeriodeResultatÅrsak.UKJENT, PeriodeResultatÅrsak.UKJENT, PeriodeResultatÅrsak.UKJENT, PeriodeResultatÅrsak.UKJENT),
+            List.of(false, false, false, false), List.of(100, 100, 0, 0), List.of(0, 0, 100, 100),
+            List.of(Trekkdager.ZERO, Trekkdager.ZERO, new Trekkdager(93), new Trekkdager(2)),
+            List.of(StønadskontoType.UDEFINERT, StønadskontoType.FEDREKVOTE, StønadskontoType.FEDREKVOTE, StønadskontoType.FEDREKVOTE));
 
         // Act
         var revurderingHolder = new UttakResultatHolderImpl(Optional.of(map(uttakResultatRevurdering)), null);
@@ -498,6 +535,28 @@ public class ErEndringIUttakTest {
         for (int i = 0; i < antallPerioder; i++) {
             lagUttakPeriodeMedPeriodeAktivitet(uttakResultatPerioder, perioder.get(i),
                 samtidigUttak.get(i), periodeResultatTyper.get(i), periodeResultatÅrsak.get(i), graderingInnvilget.get(i), erFlerbarnsdager.get(i), andelIArbeid, utbetalingsgrad, trekkdager, stønadskontoTyper);
+        }
+        UttakResultatEntitet uttakResultat = uttakResultatPlanBuilder.medOpprinneligPerioder(uttakResultatPerioder).build();
+        fpUttakRepository.lagreOpprinneligUttakResultatPerioder(behandling.getId(), uttakResultat.getGjeldendePerioder());
+        return uttakResultat;
+
+    }
+
+    private UttakResultatEntitet lagUttakResultatPlanForBehandlingLogging(Behandling behandling, List<LocalDateInterval> perioder, List<Boolean> samtidigUttak,
+                                                                   List<Boolean> erFlerbarnsdager, List<PeriodeResultatType> periodeResultatTyper, List<PeriodeResultatÅrsak> periodeResultatÅrsak,
+                                                                   List<Boolean> graderingInnvilget, List<Integer> andelIArbeid,
+                                                                   List<Integer> utbetalingsgrad, List<Trekkdager> trekkdager, List<StønadskontoType> stønadskontoTyper) {
+        UttakResultatEntitet.Builder uttakResultatPlanBuilder = new UttakResultatEntitet.Builder(behandling.getBehandlingsresultat());
+        UttakResultatPerioderEntitet uttakResultatPerioder = new UttakResultatPerioderEntitet();
+        assertThat(perioder).hasSize(samtidigUttak.size());
+        assertThat(perioder).hasSize(periodeResultatTyper.size());
+        assertThat(perioder).hasSize(periodeResultatÅrsak.size());
+        assertThat(perioder).hasSize(graderingInnvilget.size());
+        int antallPerioder = perioder.size();
+        for (int i = 0; i < antallPerioder; i++) {
+            lagUttakPeriodeMedPeriodeAktivitet(uttakResultatPerioder, perioder.get(i),
+                samtidigUttak.get(i), periodeResultatTyper.get(i), periodeResultatÅrsak.get(i), graderingInnvilget.get(i), erFlerbarnsdager.get(i),
+                List.of(andelIArbeid.get(i)), List.of(utbetalingsgrad.get(i)), List.of(trekkdager.get(i)), List.of(stønadskontoTyper.get(i)));
         }
         UttakResultatEntitet uttakResultat = uttakResultatPlanBuilder.medOpprinneligPerioder(uttakResultatPerioder).build();
         fpUttakRepository.lagreOpprinneligUttakResultatPerioder(behandling.getId(), uttakResultat.getGjeldendePerioder());


### PR DESCRIPTION
Første forsøk:
komprimerer ved å slå sammen like naboer
sammenligner timelines ved å fjerne like perioder - impl mengdeoperasjon (A - B union B - A)

Kanskje tune sammenligningen litt