### PR TITLE
TFP-3114: Innført støtte for endringstype (opprettet, annullert, etc)…

### DIFF
--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/BehandlingÅrsakType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/BehandlingÅrsakType.java
@@ -173,4 +173,8 @@ public enum BehandlingÅrsakType implements Kodeverdi {
     public static Set<BehandlingÅrsakType> årsakerEtterKlageBehandling() {
         return Set.of(ETTER_KLAGE, RE_KLAGE_MED_END_INNTEKT, RE_KLAGE_UTEN_END_INNTEKT);
     }
+
+    public static Set<BehandlingÅrsakType> årsakerRelatertTilDød() {
+        return Set.of(RE_OPPLYSNINGER_OM_DØD, RE_HENDELSE_DØD_BARN, RE_HENDELSE_DØD_FORELDER, RE_HENDELSE_DØDFØDSEL);
+    }
 }

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/hendelser/Endringstype.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/hendelser/Endringstype.java
@@ -1,0 +1,8 @@
+package no.nav.foreldrepenger.behandlingslager.hendelser;
+
+public enum Endringstype {
+    OPPRETTET,
+    KORRIGERT,
+    ANNULLERT,
+    OPPHOERT;
+}

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/hendelser/Forretningshendelse.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/hendelser/Forretningshendelse.java
@@ -7,11 +7,18 @@ import no.nav.foreldrepenger.domene.typer.AktørId;
 public abstract class Forretningshendelse {
     private List<AktørId> aktørIdListe;
 
-    protected Forretningshendelse(List<AktørId> aktørIdListe) {
+    private Endringstype endringstype;
+
+    protected Forretningshendelse(List<AktørId> aktørIdListe, Endringstype endringstype) {
         this.aktørIdListe = aktørIdListe;
+        this.endringstype = endringstype;
     }
 
     public List<AktørId> getAktørIdListe() {
         return aktørIdListe;
+    }
+
+    public Endringstype getEndringstype() {
+        return endringstype;
     }
 }

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/hendelser/HendelseHåndteringRepository.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/hendelser/HendelseHåndteringRepository.java
@@ -29,7 +29,7 @@ public class HendelseHåndteringRepository {
 
     public List<Fagsak> hentFagsakerSomHarAktørIdSomBarn(AktørId aktørId) {
         TypedQuery<Fagsak> query = entityManager.createQuery(
-            "select f from Fagsak f " +
+            "select distinct f from Fagsak f " +
                 "inner join Behandling b on b.fagsak = f " +
                 "inner join PersonopplysningGrunnlagEntitet gr on gr.behandlingId = b.id " +
                 "inner join PersonInformasjon poi on gr.registrertePersonopplysninger = poi " +

--- a/domenetjenester/familie-hendelse/src/main/java/no/nav/foreldrepenger/familiehendelse/dødsfall/DødForretningshendelse.java
+++ b/domenetjenester/familie-hendelse/src/main/java/no/nav/foreldrepenger/familiehendelse/dødsfall/DødForretningshendelse.java
@@ -3,6 +3,7 @@ package no.nav.foreldrepenger.familiehendelse.dødsfall;
 import java.time.LocalDate;
 import java.util.List;
 
+import no.nav.foreldrepenger.behandlingslager.hendelser.Endringstype;
 import no.nav.foreldrepenger.behandlingslager.hendelser.Forretningshendelse;
 import no.nav.foreldrepenger.domene.typer.AktørId;
 
@@ -10,8 +11,8 @@ public class DødForretningshendelse extends Forretningshendelse {
 
     private LocalDate dødsdato;
 
-    public DødForretningshendelse(List<AktørId> aktørIdListe, LocalDate dødsdato) {
-        super(aktørIdListe);
+    public DødForretningshendelse(List<AktørId> aktørIdListe, LocalDate dødsdato, Endringstype endringstype) {
+        super(aktørIdListe, endringstype);
         this.dødsdato = dødsdato;
     }
 

--- a/domenetjenester/familie-hendelse/src/main/java/no/nav/foreldrepenger/familiehendelse/dødsfall/DødfødselForretningshendelse.java
+++ b/domenetjenester/familie-hendelse/src/main/java/no/nav/foreldrepenger/familiehendelse/dødsfall/DødfødselForretningshendelse.java
@@ -3,6 +3,7 @@ package no.nav.foreldrepenger.familiehendelse.dødsfall;
 import java.time.LocalDate;
 import java.util.List;
 
+import no.nav.foreldrepenger.behandlingslager.hendelser.Endringstype;
 import no.nav.foreldrepenger.behandlingslager.hendelser.Forretningshendelse;
 import no.nav.foreldrepenger.domene.typer.AktørId;
 
@@ -10,8 +11,8 @@ public class DødfødselForretningshendelse extends Forretningshendelse {
 
     private LocalDate dødfødselsdato;
 
-    public DødfødselForretningshendelse(List<AktørId> aktørIdListe, LocalDate dødfødselsdato) {
-        super(aktørIdListe);
+    public DødfødselForretningshendelse(List<AktørId> aktørIdListe, LocalDate dødfødselsdato, Endringstype endringstype) {
+        super(aktørIdListe, endringstype);
         this.dødfødselsdato = dødfødselsdato;
     }
 

--- a/domenetjenester/familie-hendelse/src/main/java/no/nav/foreldrepenger/familiehendelse/fødsel/FødselForretningshendelse.java
+++ b/domenetjenester/familie-hendelse/src/main/java/no/nav/foreldrepenger/familiehendelse/fødsel/FødselForretningshendelse.java
@@ -4,6 +4,7 @@ package no.nav.foreldrepenger.familiehendelse.fødsel;
 import java.time.LocalDate;
 import java.util.List;
 
+import no.nav.foreldrepenger.behandlingslager.hendelser.Endringstype;
 import no.nav.foreldrepenger.behandlingslager.hendelser.Forretningshendelse;
 import no.nav.foreldrepenger.domene.typer.AktørId;
 
@@ -11,8 +12,8 @@ public class FødselForretningshendelse extends Forretningshendelse {
 
     private LocalDate fødselsdato;
 
-    public FødselForretningshendelse(List<AktørId> aktørIdListe, LocalDate fødselsdato) {
-        super(aktørIdListe);
+    public FødselForretningshendelse(List<AktørId> aktørIdListe, LocalDate fødselsdato, Endringstype endringstype) {
+        super(aktørIdListe, endringstype);
         this.fødselsdato = fødselsdato;
     }
 

--- a/domenetjenester/mottak/pom.xml
+++ b/domenetjenester/mottak/pom.xml
@@ -77,6 +77,10 @@
             <artifactId>abonnent-v1</artifactId>
         </dependency>
         <dependency>
+            <groupId>no.nav.foreldrepenger.kontrakter</groupId>
+            <artifactId>abonnent-v2</artifactId>
+        </dependency>
+        <dependency>
             <groupId>no.nav.foreldrepenger.kontrakter.topics</groupId>
             <artifactId>hendelser-inntektsmelding</artifactId>
         </dependency>

--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/dokumentmottak/HistorikkinnslagTjeneste.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/dokumentmottak/HistorikkinnslagTjeneste.java
@@ -4,7 +4,6 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
@@ -27,7 +26,6 @@ import no.nav.foreldrepenger.behandlingslager.behandling.personopplysning.Relasj
 import no.nav.foreldrepenger.behandlingslager.behandling.skjermlenke.SkjermlenkeType;
 import no.nav.foreldrepenger.behandlingslager.fagsak.Fagsak;
 import no.nav.foreldrepenger.dokumentarkiv.ArkivDokument;
-import no.nav.foreldrepenger.dokumentarkiv.ArkivJournalPost;
 import no.nav.foreldrepenger.dokumentarkiv.DokumentArkivTjeneste;
 import no.nav.foreldrepenger.domene.person.tps.PersoninfoAdapter;
 import no.nav.foreldrepenger.domene.typer.JournalpostId;
@@ -199,6 +197,20 @@ public class HistorikkinnslagTjeneste {
         HistorikkInnslagTekstBuilder builder = new HistorikkInnslagTekstBuilder()
             .medHendelse(HistorikkinnslagType.BEH_OPPDATERT_NYE_OPPL)
             .medBegrunnelse(behandlingÅrsakType);
+        builder.build(historikkinnslag);
+
+        historikkRepository.lagre(historikkinnslag);
+    }
+
+    public void opprettHistorikkinnslagForEndringshendelse(Fagsak fagsak, String begrunnelse) {
+        Historikkinnslag historikkinnslag = new Historikkinnslag();
+        historikkinnslag.setAktør(HistorikkAktør.VEDTAKSLØSNINGEN);
+        historikkinnslag.setType(HistorikkinnslagType.BEH_OPPDATERT_NYE_OPPL);
+        historikkinnslag.setFagsakId(fagsak.getId());
+
+        HistorikkInnslagTekstBuilder builder = new HistorikkInnslagTekstBuilder()
+            .medHendelse(HistorikkinnslagType.BEH_OPPDATERT_NYE_OPPL)
+            .medBegrunnelse(begrunnelse);
         builder.build(historikkinnslag);
 
         historikkRepository.lagre(historikkinnslag);

--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/hendelser/ForretningshendelseMottak.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/hendelser/ForretningshendelseMottak.java
@@ -25,16 +25,17 @@ import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRe
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRevurderingRepository;
 import no.nav.foreldrepenger.behandlingslager.fagsak.Fagsak;
 import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakRepository;
+import no.nav.foreldrepenger.behandlingslager.hendelser.Endringstype;
 import no.nav.foreldrepenger.behandlingslager.hendelser.Forretningshendelse;
 import no.nav.foreldrepenger.behandlingslager.hendelser.ForretningshendelseType;
 import no.nav.foreldrepenger.domene.typer.AktørId;
 import no.nav.foreldrepenger.familiehendelse.dødsfall.DødForretningshendelse;
 import no.nav.foreldrepenger.familiehendelse.dødsfall.DødfødselForretningshendelse;
 import no.nav.foreldrepenger.familiehendelse.fødsel.FødselForretningshendelse;
-import no.nav.foreldrepenger.kontrakter.abonnent.HendelseDto;
-import no.nav.foreldrepenger.kontrakter.abonnent.tps.DødHendelseDto;
-import no.nav.foreldrepenger.kontrakter.abonnent.tps.DødfødselHendelseDto;
-import no.nav.foreldrepenger.kontrakter.abonnent.tps.FødselHendelseDto;
+import no.nav.foreldrepenger.kontrakter.abonnent.v2.HendelseDto;
+import no.nav.foreldrepenger.kontrakter.abonnent.v2.pdl.DødHendelseDto;
+import no.nav.foreldrepenger.kontrakter.abonnent.v2.pdl.DødfødselHendelseDto;
+import no.nav.foreldrepenger.kontrakter.abonnent.v2.pdl.FødselHendelseDto;
 import no.nav.foreldrepenger.mottak.dokumentmottak.impl.KøKontroller;
 import no.nav.foreldrepenger.mottak.hendelser.håndterer.ForretningshendelseHåndtererProvider;
 import no.nav.foreldrepenger.mottak.hendelser.saksvelger.ForretningshendelseSaksvelgerProvider;
@@ -48,9 +49,9 @@ public class ForretningshendelseMottak {
     private static final LocalTime OPPDRAG_VÅKNER = LocalTime.of(6, 30);
 
     private static final Map<ForretningshendelseType, Function<HendelseDto , ? extends Forretningshendelse>> OVERSETTER = Map.of(
-        ForretningshendelseType.DØD, d -> new DødForretningshendelse(mapToAktørIds(d), ((DødHendelseDto)d).getDødsdato()),
-        ForretningshendelseType.DØDFØDSEL, d -> new DødfødselForretningshendelse(mapToAktørIds(d), ((DødfødselHendelseDto)d).getDødfødselsdato()),
-        ForretningshendelseType.FØDSEL, f -> new FødselForretningshendelse(mapToAktørIds(f), ((FødselHendelseDto)f).getFødselsdato())
+        ForretningshendelseType.DØD, d -> new DødForretningshendelse(mapToAktørIds(d), ((DødHendelseDto)d).getDødsdato(), getEndringstype(d)),
+        ForretningshendelseType.DØDFØDSEL, d -> new DødfødselForretningshendelse(mapToAktørIds(d), ((DødfødselHendelseDto)d).getDødfødselsdato(), getEndringstype(d)),
+        ForretningshendelseType.FØDSEL, f -> new FødselForretningshendelse(mapToAktørIds(f), ((FødselHendelseDto)f).getFødselsdato(), getEndringstype(f))
     );
 
     private Logger LOGGER = LoggerFactory.getLogger(getClass());
@@ -182,5 +183,9 @@ public class ForretningshendelseMottak {
 
     private static List<AktørId> mapToAktørIds(HendelseDto hendelseDto) {
         return hendelseDto.getAlleAktørId().stream().map(AktørId::new).collect(Collectors.toList());
+    }
+
+    private static Endringstype getEndringstype(HendelseDto d) {
+        return Endringstype.valueOf(d.getEndringstype().name());
     }
 }

--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/hendelser/KlargjørHendelseTask.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/hendelser/KlargjørHendelseTask.java
@@ -5,7 +5,7 @@ import javax.inject.Inject;
 
 import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakProsesstaskRekkefølge;
 import no.nav.foreldrepenger.behandlingslager.hendelser.ForretningshendelseType;
-import no.nav.foreldrepenger.kontrakter.abonnent.HendelseDto;
+import no.nav.foreldrepenger.kontrakter.abonnent.v2.HendelseDto;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTask;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTaskData;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTaskHandler;

--- a/domenetjenester/mottak/src/test/java/no/nav/foreldrepenger/mottak/hendelser/KlargjørHendelseTaskTest.java
+++ b/domenetjenester/mottak/src/test/java/no/nav/foreldrepenger/mottak/hendelser/KlargjørHendelseTaskTest.java
@@ -23,10 +23,12 @@ import no.nav.foreldrepenger.domene.typer.AktørId;
 import no.nav.foreldrepenger.familiehendelse.dødsfall.DødForretningshendelse;
 import no.nav.foreldrepenger.familiehendelse.dødsfall.DødfødselForretningshendelse;
 import no.nav.foreldrepenger.familiehendelse.fødsel.FødselForretningshendelse;
-import no.nav.foreldrepenger.kontrakter.abonnent.HendelseDto;
-import no.nav.foreldrepenger.kontrakter.abonnent.tps.DødHendelseDto;
-import no.nav.foreldrepenger.kontrakter.abonnent.tps.DødfødselHendelseDto;
-import no.nav.foreldrepenger.kontrakter.abonnent.tps.FødselHendelseDto;
+import no.nav.foreldrepenger.kontrakter.abonnent.v2.AktørIdDto;
+import no.nav.foreldrepenger.kontrakter.abonnent.v2.Endringstype;
+import no.nav.foreldrepenger.kontrakter.abonnent.v2.HendelseDto;
+import no.nav.foreldrepenger.kontrakter.abonnent.v2.pdl.DødHendelseDto;
+import no.nav.foreldrepenger.kontrakter.abonnent.v2.pdl.DødfødselHendelseDto;
+import no.nav.foreldrepenger.kontrakter.abonnent.v2.pdl.FødselHendelseDto;
 import no.nav.foreldrepenger.mottak.hendelser.saksvelger.DødForretningshendelseSaksvelger;
 import no.nav.foreldrepenger.mottak.hendelser.saksvelger.DødfødselForretningshendelseSaksvelger;
 import no.nav.foreldrepenger.mottak.hendelser.saksvelger.ForretningshendelseSaksvelgerProvider;
@@ -37,7 +39,7 @@ import no.nav.vedtak.felles.prosesstask.api.ProsessTaskRepository;
 public class KlargjørHendelseTaskTest {
 
     @Test
-    public void skal_kalle_videre_på_domenetjeneste() throws Exception {
+    public void skal_kalle_videre_på_domenetjeneste() {
         ForretningshendelseMottak domenetjeneste = mock(ForretningshendelseMottak.class);
         KlargjørHendelseTask task = new KlargjørHendelseTask(domenetjeneste);
 
@@ -46,7 +48,7 @@ public class KlargjørHendelseTaskTest {
         taskData.setProperty(KlargjørHendelseTask.PROPERTY_UID, "id_1");
         var hendelse = new FødselHendelseDto();
         hendelse.setId("id_1");
-        hendelse.setAktørIdForeldre(Collections.singletonList(AktørId.dummy().getId()));
+        hendelse.setAktørIdForeldre(Collections.singletonList(new AktørIdDto(AktørId.dummy().getId())));
         hendelse.setFødselsdato(LocalDate.now());
         taskData.setPayload(JsonMapper.toJson(hendelse));
 
@@ -61,7 +63,7 @@ public class KlargjørHendelseTaskTest {
     }
 
     @Test
-    public void skal_motta_fødsel() throws Exception {
+    public void skal_motta_fødsel() {
         AktørId aktørId = AktørId.dummy();
         ForretningshendelseSaksvelgerProvider saksvelgerProvider = mock(ForretningshendelseSaksvelgerProvider.class);
         ForretningshendelseSaksvelger saksvelger = mock(FødselForretningshendelseSaksvelger.class);
@@ -77,7 +79,8 @@ public class KlargjørHendelseTaskTest {
         taskData.setProperty(KlargjørHendelseTask.PROPERTY_UID, "id_1");
         var hendelse = new FødselHendelseDto();
         hendelse.setId("id_1");
-        hendelse.setAktørIdForeldre(Collections.singletonList(aktørId.getId()));
+        hendelse.setEndringstype(Endringstype.OPPRETTET);
+        hendelse.setAktørIdForeldre(Collections.singletonList(new AktørIdDto(aktørId.getId())));
         hendelse.setFødselsdato(LocalDate.now());
         taskData.setPayload(JsonMapper.toJson(hendelse));
 
@@ -93,7 +96,7 @@ public class KlargjørHendelseTaskTest {
 
 
     @Test
-    public void skal_motta_dødfødsel() throws Exception {
+    public void skal_motta_dødfødsel() {
         ForretningshendelseSaksvelgerProvider saksvelgerProvider = mock(ForretningshendelseSaksvelgerProvider.class);
         ForretningshendelseSaksvelger saksvelger = mock(DødfødselForretningshendelseSaksvelger.class);
         when(saksvelger.finnRelaterteFagsaker(any())).thenReturn(new LinkedHashMap<BehandlingÅrsakType, List<Fagsak>>());
@@ -108,7 +111,8 @@ public class KlargjørHendelseTaskTest {
         taskData.setProperty(KlargjørHendelseTask.PROPERTY_UID, "id_1");
         var hendelse = new DødfødselHendelseDto();
         hendelse.setId("id_1");
-        hendelse.setAktørId(Collections.singletonList(AktørId.dummy().getId()));
+        hendelse.setEndringstype(Endringstype.OPPRETTET);
+        hendelse.setAktørId(Collections.singletonList(new AktørIdDto(AktørId.dummy().getId())));
         hendelse.setDødfødselsdato(LocalDate.now());
         taskData.setPayload(JsonMapper.toJson(hendelse));
 
@@ -122,7 +126,7 @@ public class KlargjørHendelseTaskTest {
     }
 
     @Test
-    public void skal_motta_død() throws Exception {
+    public void skal_motta_død() {
         ForretningshendelseSaksvelgerProvider saksvelgerProvider = mock(ForretningshendelseSaksvelgerProvider.class);
         ForretningshendelseSaksvelger saksvelger = mock(DødForretningshendelseSaksvelger.class);
         when(saksvelger.finnRelaterteFagsaker(any())).thenReturn(new LinkedHashMap<BehandlingÅrsakType, List<Fagsak>>());
@@ -137,7 +141,8 @@ public class KlargjørHendelseTaskTest {
         taskData.setProperty(KlargjørHendelseTask.PROPERTY_UID, "id_1");
         var hendelse = new DødHendelseDto();
         hendelse.setId("id_1");
-        hendelse.setAktørId(Collections.singletonList(AktørId.dummy().getId()));
+        hendelse.setEndringstype(Endringstype.OPPRETTET);
+        hendelse.setAktørId(Collections.singletonList(new AktørIdDto(AktørId.dummy().getId())));
         hendelse.setDødsdato(LocalDate.now());
         taskData.setPayload(JsonMapper.toJson(hendelse));
 

--- a/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/input/UttakInput.java
+++ b/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/input/UttakInput.java
@@ -91,6 +91,10 @@ public class UttakInput {
         return behandlingÅrsaker.stream().anyMatch(årsak -> årsak.equals(behandlingÅrsakType));
     }
 
+    public boolean harBehandlingÅrsakRelatertTilDød() {
+        return behandlingÅrsaker.stream().anyMatch(årsak -> BehandlingÅrsakType.årsakerRelatertTilDød().contains(årsak));
+    }
+
     public boolean isBehandlingManueltOpprettet() {
         return behandlingManueltOpprettet;
     }

--- a/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/kontroller/fakta/uttakperioder/AvklarHendelseAksjonspunktUtleder.java
+++ b/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/kontroller/fakta/uttakperioder/AvklarHendelseAksjonspunktUtleder.java
@@ -24,8 +24,7 @@ public class AvklarHendelseAksjonspunktUtleder implements FaktaUttakAksjonspunkt
             resultat.add(AksjonspunktDefinisjon.KONTROLLER_REALITETSBEHANDLING_ELLER_KLAGE);
         }
 
-        if (input.harBehandlingÅrsak(BehandlingÅrsakType.RE_OPPLYSNINGER_OM_DØD)
-            || input.isOpplysningerOmDødEndret()) {
+        if (input.harBehandlingÅrsakRelatertTilDød() || input.isOpplysningerOmDødEndret()) {
             resultat.add(AksjonspunktDefinisjon.KONTROLLER_OPPLYSNINGER_OM_DØD);
         }
 

--- a/domenetjenester/uttak/src/test/java/no/nav/foreldrepenger/domene/uttak/kontroller/fakta/uttakperioder/AvklarHendelseAksjonspunktUtlederTest.java
+++ b/domenetjenester/uttak/src/test/java/no/nav/foreldrepenger/domene/uttak/kontroller/fakta/uttakperioder/AvklarHendelseAksjonspunktUtlederTest.java
@@ -88,6 +88,21 @@ public class AvklarHendelseAksjonspunktUtlederTest {
         assertThat(aksjonspunkter).contains(AksjonspunktDefinisjon.KONTROLLER_OPPLYSNINGER_OM_DØD);
     }
 
+    @Test
+    public void skal_utlede_aksjonspunkt_for_død_når_behandlingen_har_en_årsak_relatert_til_hendelse_død() {
+        // Arrange
+        Behandling revurdering = testUtil.opprettRevurdering(BehandlingÅrsakType.RE_HENDELSE_DØD_FORELDER);
+        var input = lagInput(revurdering)
+            .medErOpplysningerOmDødEndret(false)
+            .medBehandlingÅrsaker(Set.of(BehandlingÅrsakType.RE_HENDELSE_DØD_FORELDER));
+
+        // Act
+        var aksjonspunkter = avklarHendelseAksjonspunktUtleder.utledAksjonspunkterFor(input);
+
+        // Assert
+        assertThat(aksjonspunkter).contains(AksjonspunktDefinisjon.KONTROLLER_OPPLYSNINGER_OM_DØD);
+    }
+
     @Test // #5
     public void skal_utlede_aksjonspunkt_for_søknadsfrist_når_behandling_er_manuelt_opprettet_med_søknadsfristårsak() {
         // Arrange

--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
 
         <metrics.version>3.2.5</metrics.version>
 
-        <fp-kontrakter.version>5.1-20200523185736-199c1db</fp-kontrakter.version>
+        <fp-kontrakter.version>5.1-20200810151031-853914b</fp-kontrakter.version>
 
         <kalkulus.version>1.0-2020.07.09.134511-2427b50</kalkulus.version>
     </properties>
@@ -191,6 +191,11 @@
             <dependency>
                 <groupId>no.nav.foreldrepenger.kontrakter</groupId>
                 <artifactId>grensesnittavstemming-v1</artifactId>
+                <version>${fp-kontrakter.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>no.nav.foreldrepenger.kontrakter</groupId>
+                <artifactId>abonnent-v2</artifactId>
                 <version>${fp-kontrakter.version}</version>
             </dependency>
             <dependency>

--- a/web/es-vtp.properties
+++ b/web/es-vtp.properties
@@ -18,6 +18,7 @@ fpsak.it.ps.grunnlag.url=https://localhost:8063/rest/infotrygd/grunnlag/paaroere
 # KOMMENTER INN NÅR LOKAL PÅLOGGING FUNGERER 100% MED VTP
 #######################################################################################################
 
+abac.attributt.drift=no.nav.abac.attributter.foreldrepenger.drift
 abac.pdp.endpoint.url=https://localhost:8063/rest/asm-pdp/authorize
 oidc.sts.issuer.url=https://localhost:8063/rest/sts/issuer
 oidc.sts.jwks.url=https://localhost:8063/rest/sts/jwks

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -58,6 +58,10 @@
 		</dependency>
 		<dependency>
 			<groupId>no.nav.foreldrepenger.kontrakter</groupId>
+			<artifactId>abonnent-v2</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>no.nav.foreldrepenger.kontrakter</groupId>
 			<artifactId>fordel-v1</artifactId>
 		</dependency>
 		<dependency>

--- a/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/hendelser/HendelserRestTjenesteTest.java
+++ b/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/hendelser/HendelserRestTjenesteTest.java
@@ -20,8 +20,9 @@ import no.nav.foreldrepenger.behandlingslager.hendelser.HendelseSorteringReposit
 import no.nav.foreldrepenger.behandlingslager.hendelser.HendelsemottakRepository;
 import no.nav.foreldrepenger.dbstoette.UnittestRepositoryRule;
 import no.nav.foreldrepenger.domene.typer.AktørId;
-import no.nav.foreldrepenger.kontrakter.abonnent.tps.DødfødselHendelseDto;
-import no.nav.foreldrepenger.kontrakter.abonnent.tps.FødselHendelseDto;
+import no.nav.foreldrepenger.kontrakter.abonnent.v2.AktørIdDto;
+import no.nav.foreldrepenger.kontrakter.abonnent.v2.pdl.DødfødselHendelseDto;
+import no.nav.foreldrepenger.kontrakter.abonnent.v2.pdl.FødselHendelseDto;
 import no.nav.foreldrepenger.mottak.hendelser.JsonMapper;
 import no.nav.foreldrepenger.mottak.hendelser.KlargjørHendelseTask;
 import no.nav.foreldrepenger.web.app.tjenester.hendelser.HendelserRestTjeneste.AbacAktørIdDto;
@@ -145,7 +146,7 @@ public class HendelserRestTjenesteTest {
     private FødselHendelseDto lagFødselHendelse(List<AktørId> aktørIdForeldre, LocalDate fødselsdato) {
         FødselHendelseDto hendelse = new FødselHendelseDto();
         hendelse.setId(HENDELSE_ID);
-        hendelse.setAktørIdForeldre(aktørIdForeldre.stream().map(AktørId::getId).collect(Collectors.toList()));
+        hendelse.setAktørIdForeldre(aktørIdForeldre.stream().map(AktørId::getId).map(AktørIdDto::new).collect(Collectors.toList()));
         hendelse.setFødselsdato(fødselsdato);
         return hendelse;
     }
@@ -153,7 +154,7 @@ public class HendelserRestTjenesteTest {
     private DødfødselHendelseDto lagDødfødselHendelse(List<AktørId> aktørIdForeldre, LocalDate dødfødseldato) {
         DødfødselHendelseDto hendelse = new DødfødselHendelseDto();
         hendelse.setId(HENDELSE_ID);
-        hendelse.setAktørId(aktørIdForeldre.stream().map(AktørId::getId).collect(Collectors.toList()));
+        hendelse.setAktørId(aktørIdForeldre.stream().map(AktørId::getId).map(AktørIdDto::new).collect(Collectors.toList()));
         hendelse.setDødfødselsdato(dødfødseldato);
         return hendelse;
     }


### PR DESCRIPTION
… på hendelser, slik at dette kan vises for saksbehandler i historikkinnslagene.

Fp-kontrakter må releases først, slik at denne kan få riktig versjonsnummer.