### PR TITLE
Fix: Henter ikke organisasjon på nytt når finnes i cache

### DIFF
--- a/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/arbeidsgiver/VirksomhetTjeneste.java
+++ b/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/arbeidsgiver/VirksomhetTjeneste.java
@@ -56,7 +56,7 @@ public class VirksomhetTjeneste {
     public Optional<Virksomhet> finnOrganisasjon(String orgNummer) {
         if (orgNummer == null)
             return Optional.empty();
-        if(OrgNummer.erKunstig(orgNummer)) {
+        if (OrgNummer.erKunstig(orgNummer)) {
             return Optional.of(hent(orgNummer));
         }
         return OrganisasjonsNummerValidator.erGyldig(orgNummer) ? Optional.of(hent(orgNummer)) : Optional.empty();
@@ -66,9 +66,9 @@ public class VirksomhetTjeneste {
         if (Objects.equals(KUNSTIG_VIRKSOMHET.getOrgnr(), orgnr)) {
             return KUNSTIG_VIRKSOMHET;
         }
-        var response =Optional.ofNullable(cache.get(orgnr)).orElse(hentOrganisasjonRest(orgnr));
-        cache.put(orgnr, response);
-        return response;
+        Virksomhet virksomhet = Optional.ofNullable(cache.get(orgnr)).orElseGet(() -> hentOrganisasjonRest(orgnr));
+        cache.put(orgnr, virksomhet);
+        return virksomhet;
     }
 
     private Virksomhet hentOrganisasjonRest(String orgNummer) {


### PR DESCRIPTION
Det er en semantis forskjell på .orElse og .orElseGet: innholdet i .orElse blir alltid utført (og henter dermed fra integrasjonen) funksjonen i .orElseGet utføres bare når optional var tom.

Se https://dzone.com/articles/optionalorelse-vs-optionalorelseget 

![image](https://user-images.githubusercontent.com/45484434/88373136-90201980-cd97-11ea-9f15-e093a856a06e.png)

![image](https://user-images.githubusercontent.com/45484434/88372305-e9874900-cd95-11ea-8d6d-8583e956ecfc.png)


