### PR TITLE
NOJIRA ekstra ingress for q1 slik at fpsak.preprod rutes dit

### DIFF
--- a/nais/dev-fss-q1.json
+++ b/nais/dev-fss-q1.json
@@ -9,7 +9,8 @@
   "minReplicas": "2",
   "maxReplicas": "2",
   "ingresses": [
-    "https://fpsak-q1.nais.preprod.local/"
+    "https://fpsak-q1.nais.preprod.local/",
+    "https://fpsak.nais.preprod.local/"
   ],
   "env": {
     "APPDYNAMICS_AGENT_ACCOUNT_NAME": "NON-PROD",


### PR DESCRIPTION
Manglet ingress for fpsak.nais.preprod.local - var kun fpsak-<miljø>. Tilbys av Q1
Gosys venter fpsak på fpsak.nais....