### PR TITLE
TFP-1836 TFP-2620 TFP-3650 køsynk ved StartP/Uttak og oppretting

### DIFF
--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/aksjonspunkt/AksjonspunktDefinisjon.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/aksjonspunkt/AksjonspunktDefinisjon.java
@@ -399,7 +399,7 @@ public enum AksjonspunktDefinisjon implements Kodeverdi {
             BehandlingStegType.FATTE_VEDTAK, VurderingspunktType.INN, UTEN_VILKÅR, UTEN_SKJERMLENKE, ENTRINN, FORBLI, UTEN_FRIST, EnumSet.of(ES, FP, SVP)),
 
     AUTO_KØET_BEHANDLING(AksjonspunktKodeDefinisjon.AUTO_KØET_BEHANDLING_KODE,
-            AksjonspunktType.AUTOPUNKT, "Autokøet behandling", BehandlingStegType.INNHENT_SØKNADOPP, VurderingspunktType.UT, UTEN_VILKÅR, UTEN_SKJERMLENKE, ENTRINN,
+            AksjonspunktType.AUTOPUNKT, "Autokøet behandling", BehandlingStegType.KONTROLLER_LØPENDE_MEDLEMSKAP, VurderingspunktType.UT, UTEN_VILKÅR, UTEN_SKJERMLENKE, ENTRINN,
         FORBLI, UTEN_FRIST, EnumSet.of(FP)),
     VENT_PÅ_SØKNAD(AksjonspunktKodeDefinisjon.VENT_PÅ_SØKNAD_KODE,
             AksjonspunktType.AUTOPUNKT, "Venter på søknad", BehandlingStegType.REGISTRER_SØKNAD, VurderingspunktType.UT, UTEN_VILKÅR, UTEN_SKJERMLENKE, ENTRINN, TILBAKE,

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/hendelser/StartpunktType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/hendelser/StartpunktType.java
@@ -39,7 +39,7 @@ public enum StartpunktType implements Kodeverdi {
     BEREGNING("BEREGNING", "Beregning", 7, BehandlingStegType.FASTSETT_SKJÆRINGSTIDSPUNKT_BEREGNING),
     // StartpunktType BEREGNING_FORESLÅ skal kun brukes ved G-regulering
     BEREGNING_FORESLÅ("BEREGNING_FORESLÅ", "Beregning foreslå", 8, BehandlingStegType.FORESLÅ_BEREGNINGSGRUNNLAG),
-    UTTAKSVILKÅR("UTTAKSVILKÅR", "Uttaksvilkår", 9, BehandlingStegType.KONTROLLER_LØPENDE_MEDLEMSKAP),
+    UTTAKSVILKÅR("UTTAKSVILKÅR", "Uttaksvilkår", 9, BehandlingStegType.KONTROLLER_LØPENDE_MEDLEMSKAP), // OBS: Endrer du startsteg må du flytte køhåndtering ....
 
     UDEFINERT("-", "Ikke definert", 99, BehandlingStegType.KONTROLLERER_SØKERS_OPPLYSNINGSPLIKT),
     ;

--- a/behandlingsprosess/src/main/java/no/nav/foreldrepenger/behandling/steg/medlemskap/fp/KontrollerFaktaLøpendeMedlemskapStegFørstegangsøknad.java
+++ b/behandlingsprosess/src/main/java/no/nav/foreldrepenger/behandling/steg/medlemskap/fp/KontrollerFaktaLøpendeMedlemskapStegFørstegangsøknad.java
@@ -1,13 +1,24 @@
 package no.nav.foreldrepenger.behandling.steg.medlemskap.fp;
 
-import javax.enterprise.context.ApplicationScoped;
+import static no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.AksjonspunktDefinisjon.AUTO_KØET_BEHANDLING;
 
+import java.util.List;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import no.nav.foreldrepenger.behandling.revurdering.flytkontroll.BehandlingFlytkontroll;
 import no.nav.foreldrepenger.behandling.steg.medlemskap.KontrollerFaktaLøpendeMedlemskapSteg;
+import no.nav.foreldrepenger.behandlingskontroll.AksjonspunktResultat;
 import no.nav.foreldrepenger.behandlingskontroll.BehandleStegResultat;
 import no.nav.foreldrepenger.behandlingskontroll.BehandlingStegRef;
 import no.nav.foreldrepenger.behandlingskontroll.BehandlingTypeRef;
 import no.nav.foreldrepenger.behandlingskontroll.BehandlingskontrollKontekst;
 import no.nav.foreldrepenger.behandlingskontroll.FagsakYtelseTypeRef;
+import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.Venteårsak;
 
 @BehandlingStegRef(kode = "KOFAK_LOP_MEDL")
 @BehandlingTypeRef("BT-002") //Førstegangssøknad
@@ -15,12 +26,26 @@ import no.nav.foreldrepenger.behandlingskontroll.FagsakYtelseTypeRef;
 @ApplicationScoped
 public class KontrollerFaktaLøpendeMedlemskapStegFørstegangsøknad implements KontrollerFaktaLøpendeMedlemskapSteg {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(KontrollerFaktaLøpendeMedlemskapStegFørstegangsøknad.class);
+
+    private BehandlingFlytkontroll flytkontroll;
+
     KontrollerFaktaLøpendeMedlemskapStegFørstegangsøknad() {
         //CDI
     }
 
+    @Inject
+    public KontrollerFaktaLøpendeMedlemskapStegFørstegangsøknad(BehandlingFlytkontroll flytkontroll) {
+        this.flytkontroll = flytkontroll;
+    }
+
     @Override
     public BehandleStegResultat utførSteg(BehandlingskontrollKontekst kontekst) {
+        if (flytkontroll.uttaksProsessenSkalVente(kontekst.getBehandlingId())) {
+            LOGGER.info("Flytkontroll UTTAK: Setter behandling {} førstegang på vent grunnet annen part", kontekst.getBehandlingId());
+            var køAutopunkt = AksjonspunktResultat.opprettForAksjonspunktMedFrist(AUTO_KØET_BEHANDLING, Venteårsak.VENT_ÅPEN_BEHANDLING, null);
+            return BehandleStegResultat.utførtMedAksjonspunktResultater(List.of(køAutopunkt));
+        }
         //kan utvides ved behov for sjekk av løpende medlemskap.
         //er tomt nå fordi startpunktutlederen peker på KOFAK_LOP_MEDL for uttak.
         return BehandleStegResultat.utførtUtenAksjonspunkter();

--- a/behandlingsprosess/src/main/java/no/nav/foreldrepenger/behandling/steg/medlemskap/fp/KontrollerFaktaLøpendeMedlemskapStegRevurdering.java
+++ b/behandlingsprosess/src/main/java/no/nav/foreldrepenger/behandling/steg/medlemskap/fp/KontrollerFaktaLøpendeMedlemskapStegRevurdering.java
@@ -1,6 +1,9 @@
 package no.nav.foreldrepenger.behandling.steg.medlemskap.fp;
 
+import static no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.AksjonspunktDefinisjon.AUTO_KØET_BEHANDLING;
+
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -10,9 +13,14 @@ import java.util.Set;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import no.nav.foreldrepenger.behandling.BehandlingReferanse;
 import no.nav.foreldrepenger.behandling.Skjæringstidspunkt;
+import no.nav.foreldrepenger.behandling.revurdering.flytkontroll.BehandlingFlytkontroll;
 import no.nav.foreldrepenger.behandling.steg.medlemskap.KontrollerFaktaLøpendeMedlemskapSteg;
+import no.nav.foreldrepenger.behandlingskontroll.AksjonspunktResultat;
 import no.nav.foreldrepenger.behandlingskontroll.BehandleStegResultat;
 import no.nav.foreldrepenger.behandlingskontroll.BehandlingStegRef;
 import no.nav.foreldrepenger.behandlingskontroll.BehandlingTypeRef;
@@ -22,6 +30,7 @@ import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandlingsresultat;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingsresultatRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.AksjonspunktDefinisjon;
+import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.Venteårsak;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepositoryProvider;
 import no.nav.foreldrepenger.behandlingslager.behandling.vilkår.VilkårType;
@@ -37,12 +46,16 @@ import no.nav.foreldrepenger.skjæringstidspunkt.SkjæringstidspunktTjeneste;
 @ApplicationScoped
 public class KontrollerFaktaLøpendeMedlemskapStegRevurdering implements KontrollerFaktaLøpendeMedlemskapSteg {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(KontrollerFaktaLøpendeMedlemskapStegRevurdering.class);
+
     private BehandlingsresultatRepository behandlingsresultatRepository;
     private UtledVurderingsdatoerForMedlemskapTjeneste tjeneste;
 
     private BehandlingRepository behandlingRepository;
     private VurderMedlemskapTjeneste vurderMedlemskapTjeneste;
     private SkjæringstidspunktTjeneste skjæringstidspunktTjeneste;
+
+    private BehandlingFlytkontroll flytkontroll;
 
     KontrollerFaktaLøpendeMedlemskapStegRevurdering() {
         //CDI
@@ -52,17 +65,25 @@ public class KontrollerFaktaLøpendeMedlemskapStegRevurdering implements Kontrol
     public KontrollerFaktaLøpendeMedlemskapStegRevurdering(UtledVurderingsdatoerForMedlemskapTjeneste vurderingsdatoer,
                                                            BehandlingRepositoryProvider provider,
                                                            VurderMedlemskapTjeneste vurderMedlemskapTjeneste,
-                                                           SkjæringstidspunktTjeneste skjæringstidspunktTjeneste) {
+                                                           SkjæringstidspunktTjeneste skjæringstidspunktTjeneste,
+                                                           BehandlingFlytkontroll flytkontroll) {
         this.tjeneste = vurderingsdatoer;
         this.skjæringstidspunktTjeneste = skjæringstidspunktTjeneste;
         this.behandlingRepository = provider.getBehandlingRepository();
         this.vurderMedlemskapTjeneste = vurderMedlemskapTjeneste;
         this.behandlingsresultatRepository = provider.getBehandlingsresultatRepository();
+        this.flytkontroll = flytkontroll;
     }
 
     @Override
     public BehandleStegResultat utførSteg(BehandlingskontrollKontekst kontekst) {
         Long behandlingId = kontekst.getBehandlingId();
+        List<AksjonspunktResultat> aksjonspunkter = new ArrayList<>();
+        if (flytkontroll.uttaksProsessenSkalVente(kontekst.getBehandlingId())) {
+            LOGGER.info("Flytkontroll UTTAK: Setter behandling {} revurdering på vent grunnet berørt eller annen part", kontekst.getBehandlingId());
+            aksjonspunkter.add(AksjonspunktResultat.opprettForAksjonspunktMedFrist(AUTO_KØET_BEHANDLING, Venteårsak.VENT_ÅPEN_BEHANDLING, null));
+        }
+
         if (skalVurdereLøpendeMedlemskap(kontekst.getBehandlingId())) {
             Behandling behandling = behandlingRepository.hentBehandling(behandlingId);
             if (!(behandling.erRevurdering() && behandling.getFagsakYtelseType().gjelderForeldrepenger())) {
@@ -76,10 +97,10 @@ public class KontrollerFaktaLøpendeMedlemskapStegRevurdering implements Kontrol
                 finnVurderingsdatoer.forEach(dato -> resultat.addAll(vurderMedlemskapTjeneste.vurderMedlemskap(ref, dato)));
             }
             if (!resultat.isEmpty()) {
-                return BehandleStegResultat.utførtMedAksjonspunkter(List.of(AksjonspunktDefinisjon.AVKLAR_FORTSATT_MEDLEMSKAP));
+                aksjonspunkter.add(AksjonspunktResultat.opprettForAksjonspunkt(AksjonspunktDefinisjon.AVKLAR_FORTSATT_MEDLEMSKAP));
             }
         }
-        return BehandleStegResultat.utførtUtenAksjonspunkter();
+        return aksjonspunkter.isEmpty() ? BehandleStegResultat.utførtUtenAksjonspunkter() : BehandleStegResultat.utførtMedAksjonspunktResultater(aksjonspunkter);
     }
 
     private boolean skalVurdereLøpendeMedlemskap(Long behandlingId) {

--- a/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/medlemskap/KontrollerFaktaLøpendeMedlemskapStegRevurderingTest.java
+++ b/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/medlemskap/KontrollerFaktaLøpendeMedlemskapStegRevurderingTest.java
@@ -14,6 +14,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import no.nav.foreldrepenger.behandling.revurdering.flytkontroll.BehandlingFlytkontroll;
 import no.nav.foreldrepenger.behandling.steg.medlemskap.fp.KontrollerFaktaLøpendeMedlemskapStegRevurdering;
 import no.nav.foreldrepenger.behandlingskontroll.BehandleStegResultat;
 import no.nav.foreldrepenger.behandlingskontroll.BehandlingskontrollKontekst;
@@ -82,12 +83,14 @@ public class KontrollerFaktaLøpendeMedlemskapStegRevurderingTest {
     private InntektArbeidYtelseTjeneste iayTjeneste;
     @Inject
     private SkjæringstidspunktTjeneste skjæringstidspunktTjeneste;
+    @Inject
+    private BehandlingFlytkontroll flytkontroll;
 
     private KontrollerFaktaLøpendeMedlemskapStegRevurdering steg;
 
     @Before
     public void setUp() {
-        steg = new KontrollerFaktaLøpendeMedlemskapStegRevurdering(utlederTjeneste, provider, vurderMedlemskapTjeneste, skjæringstidspunktTjeneste);
+        steg = new KontrollerFaktaLøpendeMedlemskapStegRevurdering(utlederTjeneste, provider, vurderMedlemskapTjeneste, skjæringstidspunktTjeneste, flytkontroll);
     }
 
     @Test

--- a/domenetjenester/behandling-revurdering/src/main/java/no/nav/foreldrepenger/behandling/revurdering/flytkontroll/BehandlingFlytkontroll.java
+++ b/domenetjenester/behandling-revurdering/src/main/java/no/nav/foreldrepenger/behandling/revurdering/flytkontroll/BehandlingFlytkontroll.java
@@ -1,0 +1,73 @@
+package no.nav.foreldrepenger.behandling.revurdering.flytkontroll;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import no.nav.foreldrepenger.behandlingskontroll.BehandlingskontrollTjeneste;
+import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingStegType;
+import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingÅrsakType;
+import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepository;
+import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRevurderingRepository;
+import no.nav.foreldrepenger.behandlingslager.fagsak.Fagsak;
+import no.nav.foreldrepenger.behandlingslager.hendelser.StartpunktType;
+
+/*
+ * Metoder for å sekvensiere flyten av behandlinger for koblede saker.
+ * Tar hensyn til kobling og hvor langt åpne behandlinger for annen parts sak har kommet.
+ * Dessuten berørte behandlinger på egen sak.
+ */
+
+@ApplicationScoped
+public class BehandlingFlytkontroll {
+
+    private static final BehandlingStegType SYNK_STEG = StartpunktType.UTTAKSVILKÅR.getBehandlingSteg();
+
+    private BehandlingRevurderingRepository behandlingRevurderingRepository;
+    private BehandlingskontrollTjeneste behandlingskontrollTjeneste;
+    private BehandlingRepository behandlingRepository;
+
+    public BehandlingFlytkontroll() {
+        // For CDI proxy
+    }
+
+    @Inject
+    public BehandlingFlytkontroll(BehandlingRevurderingRepository behandlingRevurderingRepository,
+                                  BehandlingskontrollTjeneste behandlingskontrollTjeneste,
+                                  BehandlingRepository behandlingRepository) {
+        this.behandlingskontrollTjeneste = behandlingskontrollTjeneste;
+        this.behandlingRevurderingRepository = behandlingRevurderingRepository;
+        this.behandlingRepository = behandlingRepository;
+    }
+
+
+    // Vente = true hvis egen sak har åpen berørt eller 2 part har åpen berørt eller behandling som er i Uttak
+    public boolean uttaksProsessenSkalVente(Long behandlingId) {
+        var behandling = behandlingRepository.hentBehandling(behandlingId);
+        var annenpartFagsak = behandlingRevurderingRepository.finnFagsakPåMedforelder(behandling.getFagsak()).orElse(null);
+        if (annenpartFagsak == null)
+            return false;
+        var finnesBerørt = behandlingRepository.hentÅpneYtelseBehandlingerForFagsakId(behandling.getFagsak().getId()).stream()
+            .anyMatch(b -> !b.getId().equals(behandling.getId()) && b.harBehandlingÅrsak(BehandlingÅrsakType.BERØRT_BEHANDLING));
+        var annenpartÅpneBehandlinger = behandlingRepository.hentÅpneYtelseBehandlingerForFagsakId(annenpartFagsak.getId());
+        var annenPartHarBerørt = annenpartÅpneBehandlinger.stream()
+            .anyMatch(b -> b.harBehandlingÅrsak(BehandlingÅrsakType.BERØRT_BEHANDLING));
+        var annenPartAktivUttak = annenpartÅpneBehandlinger.stream()
+            .anyMatch(b ->  behandlingskontrollTjeneste.erStegPassert(b, SYNK_STEG));
+        // TODO avklare om aktivUttak skal ekskludere behandling.isBehandlingPåVent();
+        return finnesBerørt || annenPartHarBerørt || annenPartAktivUttak;
+    }
+
+    // Vente = true hvis egen sak har åpen berørt eller 2 part har åpen revurdering (inkl berørt) eller førstegang som er i Uttak
+    public boolean nyRevurderingSkalVente(Fagsak fagsak) {
+        var annenpartFagsak = behandlingRevurderingRepository.finnFagsakPåMedforelder(fagsak).orElse(null);
+        if (annenpartFagsak == null)
+            return false;
+        var finnesBerørt = behandlingRepository.hentÅpneYtelseBehandlingerForFagsakId(fagsak.getId()).stream()
+            .anyMatch(b -> b.harBehandlingÅrsak(BehandlingÅrsakType.BERØRT_BEHANDLING));
+        var annenPartRevurderingEllerAktivUttak = behandlingRepository.hentÅpneYtelseBehandlingerForFagsakId(annenpartFagsak.getId()).stream()
+            .anyMatch(b ->  b.erRevurdering() || behandlingskontrollTjeneste.erStegPassert(b, SYNK_STEG));
+        // TODO avklare om aktivUttak skal ekskludere behandling.isBehandlingPåVent();
+        return finnesBerørt || annenPartRevurderingEllerAktivUttak;
+    }
+
+}

--- a/domenetjenester/behandling-revurdering/src/test/java/no/nav/foreldrepenger/behandling/revurdering/flytkontroll/BehandlingFlytkontrollTest.java
+++ b/domenetjenester/behandling-revurdering/src/test/java/no/nav/foreldrepenger/behandling/revurdering/flytkontroll/BehandlingFlytkontrollTest.java
@@ -1,0 +1,166 @@
+package no.nav.foreldrepenger.behandling.revurdering.flytkontroll;
+
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import no.nav.foreldrepenger.behandlingskontroll.BehandlingskontrollTjeneste;
+import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
+import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingÅrsakType;
+import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepository;
+import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRevurderingRepository;
+import no.nav.foreldrepenger.behandlingslager.fagsak.Fagsak;
+import no.nav.foreldrepenger.behandlingslager.hendelser.StartpunktType;
+
+public class BehandlingFlytkontrollTest {
+
+    private static Long FAGSAK_ID = 1L;
+    private static Long FAGSAK_AP_ID = 2L;
+    private static Long BEHANDLING_ID = 99L;
+    private static Long BERØRT_ID = 98L;
+
+    private BehandlingRepository behandlingRepository = mock(BehandlingRepository.class);
+    private BehandlingRevurderingRepository behandlingRevurderingRepository = mock(BehandlingRevurderingRepository.class);
+    private BehandlingskontrollTjeneste behandlingskontrollTjeneste = mock(BehandlingskontrollTjeneste.class);
+    private BehandlingFlytkontroll flytkontroll;
+    private Behandling behandling = mock(Behandling.class);
+    private Behandling behandlingAnnenPart = mock(Behandling.class);
+    private Behandling behandlingBerørt = mock(Behandling.class);
+    private Behandling behandlingSammeSak = mock(Behandling.class);
+    private Fagsak fagsak = mock(Fagsak.class);
+    private Fagsak fagsakAnnenPart = mock(Fagsak.class);
+
+
+    @Before
+    public void setup(){
+        when(behandling.getFagsak()).thenReturn(fagsak);
+        when(behandling.getId()).thenReturn(BEHANDLING_ID);
+        when(behandlingBerørt.getId()).thenReturn(BERØRT_ID);
+        when(behandlingBerørt.erRevurdering()).thenReturn(true);
+        when(fagsak.getId()).thenReturn(FAGSAK_ID);
+        when(fagsakAnnenPart.getId()).thenReturn(FAGSAK_AP_ID);
+        when(behandlingRepository.hentBehandling(BEHANDLING_ID)).thenReturn(behandling);
+        when(behandlingBerørt.harBehandlingÅrsak(BehandlingÅrsakType.BERØRT_BEHANDLING)).thenReturn(true);
+        flytkontroll = new BehandlingFlytkontroll(behandlingRevurderingRepository, behandlingskontrollTjeneste, behandlingRepository);
+    }
+
+    @Test
+    public void fgangSkalIkkeVenteNårUkoblet() {
+        when(behandlingRevurderingRepository.finnFagsakPåMedforelder(fagsak)).thenReturn(Optional.empty());
+        assertThat(flytkontroll.uttaksProsessenSkalVente(BEHANDLING_ID)).isFalse();
+    }
+
+    @Test
+    public void fgangSkalIkkeVenteNårKobletIngenBehandlinger() {
+        when(behandlingRevurderingRepository.finnFagsakPåMedforelder(fagsak)).thenReturn(Optional.of(fagsakAnnenPart));
+        when(behandlingRepository.hentÅpneYtelseBehandlingerForFagsakId(FAGSAK_AP_ID)).thenReturn(Collections.emptyList());
+        assertThat(flytkontroll.uttaksProsessenSkalVente(BEHANDLING_ID)).isFalse();
+    }
+
+    @Test
+    public void fgangSkalIkkeVenteNårKobletBehandlingErFørUttak() {
+        when(behandlingRevurderingRepository.finnFagsakPåMedforelder(fagsak)).thenReturn(Optional.of(fagsakAnnenPart));
+        when(behandlingRepository.hentÅpneYtelseBehandlingerForFagsakId(FAGSAK_AP_ID)).thenReturn(List.of(behandlingAnnenPart));
+        when(behandlingskontrollTjeneste.erStegPassert(behandlingAnnenPart, StartpunktType.UTTAKSVILKÅR.getBehandlingSteg())).thenReturn(false);
+        assertThat(flytkontroll.uttaksProsessenSkalVente(BEHANDLING_ID)).isFalse();
+    }
+
+    @Test
+    public void fgangSkalVenteNårKobletBehandlingErIUttak() {
+        when(behandlingRevurderingRepository.finnFagsakPåMedforelder(fagsak)).thenReturn(Optional.of(fagsakAnnenPart));
+        when(behandlingRepository.hentÅpneYtelseBehandlingerForFagsakId(FAGSAK_AP_ID)).thenReturn(List.of(behandlingAnnenPart));
+        when(behandlingskontrollTjeneste.erStegPassert(behandlingAnnenPart, StartpunktType.UTTAKSVILKÅR.getBehandlingSteg())).thenReturn(true);
+        assertThat(flytkontroll.uttaksProsessenSkalVente(BEHANDLING_ID)).isTrue();
+    }
+
+    @Test
+    public void fgangSkalVenteNårKobletHarBerørt() {
+        when(behandlingRevurderingRepository.finnFagsakPåMedforelder(fagsak)).thenReturn(Optional.of(fagsakAnnenPart));
+        when(behandlingRepository.hentÅpneYtelseBehandlingerForFagsakId(FAGSAK_AP_ID)).thenReturn(List.of(behandlingBerørt));
+        when(behandlingskontrollTjeneste.erStegPassert(behandlingBerørt, StartpunktType.UTTAKSVILKÅR.getBehandlingSteg())).thenReturn(false);
+        assertThat(flytkontroll.uttaksProsessenSkalVente(BEHANDLING_ID)).isTrue();
+    }
+
+    @Test
+    public void revurderingSkalVenteNårSammeSakHarBerørt() {
+        when(behandlingRevurderingRepository.finnFagsakPåMedforelder(fagsak)).thenReturn(Optional.of(fagsakAnnenPart));
+        when(behandlingRepository.hentÅpneYtelseBehandlingerForFagsakId(FAGSAK_ID)).thenReturn(List.of(behandlingBerørt));
+        when(behandlingRepository.hentÅpneYtelseBehandlingerForFagsakId(FAGSAK_AP_ID)).thenReturn(Collections.emptyList());
+        when(behandlingskontrollTjeneste.erStegPassert(behandlingBerørt, StartpunktType.UTTAKSVILKÅR.getBehandlingSteg())).thenReturn(false);
+        assertThat(flytkontroll.uttaksProsessenSkalVente(BEHANDLING_ID)).isTrue();
+    }
+
+    @Test
+    public void nyrevurderingSkalIkkeVenteNårUkoblet() {
+        when(behandlingRevurderingRepository.finnFagsakPåMedforelder(fagsak)).thenReturn(Optional.empty());
+        assertThat(flytkontroll.nyRevurderingSkalVente(fagsak)).isFalse();
+    }
+
+    @Test
+    public void nyrevurderingSkalIkkeVenteNårKobletIngenBehandlinger() {
+        when(behandlingRevurderingRepository.finnFagsakPåMedforelder(fagsak)).thenReturn(Optional.of(fagsakAnnenPart));
+        when(behandlingRepository.hentÅpneYtelseBehandlingerForFagsakId(FAGSAK_AP_ID)).thenReturn(Collections.emptyList());
+        assertThat(flytkontroll.nyRevurderingSkalVente(fagsak)).isFalse();
+    }
+
+    @Test
+    public void nyrevurderingSkalIkkeVenteNårKobletFørstegangBehandlingErFørUttak() {
+        when(behandlingRevurderingRepository.finnFagsakPåMedforelder(fagsak)).thenReturn(Optional.of(fagsakAnnenPart));
+        when(behandlingRepository.hentÅpneYtelseBehandlingerForFagsakId(FAGSAK_AP_ID)).thenReturn(List.of(behandlingAnnenPart));
+        when(behandlingAnnenPart.erRevurdering()).thenReturn(false);
+        when(behandlingskontrollTjeneste.erStegPassert(behandlingAnnenPart, StartpunktType.UTTAKSVILKÅR.getBehandlingSteg())).thenReturn(false);
+        assertThat(flytkontroll.nyRevurderingSkalVente(fagsak)).isFalse();
+    }
+
+    @Test
+    public void nyrevurderingSkalVenteNårKobletRevurderingBehandlingErFørUttak() {
+        when(behandlingRevurderingRepository.finnFagsakPåMedforelder(fagsak)).thenReturn(Optional.of(fagsakAnnenPart));
+        when(behandlingRepository.hentÅpneYtelseBehandlingerForFagsakId(FAGSAK_AP_ID)).thenReturn(List.of(behandlingAnnenPart));
+        when(behandlingAnnenPart.erRevurdering()).thenReturn(true);
+        when(behandlingskontrollTjeneste.erStegPassert(behandlingAnnenPart, StartpunktType.UTTAKSVILKÅR.getBehandlingSteg())).thenReturn(false);
+        assertThat(flytkontroll.nyRevurderingSkalVente(fagsak)).isTrue();
+    }
+
+    @Test
+    public void nyrevurderingSkalVenteNårKobletFørstegangBehandlingErIUttak() {
+        when(behandlingRevurderingRepository.finnFagsakPåMedforelder(fagsak)).thenReturn(Optional.of(fagsakAnnenPart));
+        when(behandlingRepository.hentÅpneYtelseBehandlingerForFagsakId(FAGSAK_AP_ID)).thenReturn(List.of(behandlingAnnenPart));
+        when(behandlingAnnenPart.erRevurdering()).thenReturn(false);
+        when(behandlingskontrollTjeneste.erStegPassert(behandlingAnnenPart, StartpunktType.UTTAKSVILKÅR.getBehandlingSteg())).thenReturn(true);
+        assertThat(flytkontroll.nyRevurderingSkalVente(fagsak)).isTrue();
+    }
+
+    @Test
+    public void nyrevurderingSkalVenteNårKobletHarBerørt() {
+        when(behandlingRevurderingRepository.finnFagsakPåMedforelder(fagsak)).thenReturn(Optional.of(fagsakAnnenPart));
+        when(behandlingRepository.hentÅpneYtelseBehandlingerForFagsakId(FAGSAK_AP_ID)).thenReturn(List.of(behandlingBerørt));
+        when(behandlingskontrollTjeneste.erStegPassert(behandlingBerørt, StartpunktType.UTTAKSVILKÅR.getBehandlingSteg())).thenReturn(false);
+        assertThat(flytkontroll.nyRevurderingSkalVente(fagsak)).isTrue();
+    }
+
+    @Test
+    public void nyrevurderingSkalIkkeVenteNårSammesakHarÅpenBehandling() {
+        when(behandlingRevurderingRepository.finnFagsakPåMedforelder(fagsak)).thenReturn(Optional.of(fagsakAnnenPart));
+        when(behandlingRepository.hentÅpneYtelseBehandlingerForFagsakId(FAGSAK_ID)).thenReturn(List.of(behandlingSammeSak));
+        assertThat(flytkontroll.nyRevurderingSkalVente(fagsak)).isFalse();
+        verifyNoInteractions(behandlingskontrollTjeneste);
+    }
+
+    @Test
+    public void nyrevurderingSkalVenteNårSammeSakHarBerørt() {
+        when(behandlingRevurderingRepository.finnFagsakPåMedforelder(fagsak)).thenReturn(Optional.of(fagsakAnnenPart));
+        when(behandlingRepository.hentÅpneYtelseBehandlingerForFagsakId(FAGSAK_ID)).thenReturn(List.of(behandlingBerørt));
+        when(behandlingRepository.hentÅpneYtelseBehandlingerForFagsakId(FAGSAK_AP_ID)).thenReturn(Collections.emptyList());
+        when(behandlingskontrollTjeneste.erStegPassert(behandlingBerørt, StartpunktType.UTTAKSVILKÅR.getBehandlingSteg())).thenReturn(false);
+        assertThat(flytkontroll.nyRevurderingSkalVente(fagsak)).isTrue();
+    }
+}

--- a/domenetjenester/behandlingskontroll/src/main/java/no/nav/foreldrepenger/behandlingskontroll/BehandleStegResultat.java
+++ b/domenetjenester/behandlingskontroll/src/main/java/no/nav/foreldrepenger/behandlingskontroll/BehandleStegResultat.java
@@ -77,7 +77,7 @@ public class BehandleStegResultat {
 
     private static List<AksjonspunktResultat> konverterTilAksjonspunktResultat(List<AksjonspunktDefinisjon> aksjonspunktListe) {
         return aksjonspunktListe.stream()
-            .map(apDef -> AksjonspunktResultat.opprettForAksjonspunkt(apDef))
+            .map(AksjonspunktResultat::opprettForAksjonspunkt)
             .collect(toList());
     }
 

--- a/domenetjenester/behandlingskontroll/src/main/java/no/nav/foreldrepenger/behandlingskontroll/impl/transisjoner/Transisjoner.java
+++ b/domenetjenester/behandlingskontroll/src/main/java/no/nav/foreldrepenger/behandlingskontroll/impl/transisjoner/Transisjoner.java
@@ -29,8 +29,7 @@ public class Transisjoner {
         new SpolFremoverTransisjon(BehandlingStegType.SØKERS_RELASJON_TIL_BARN),
         new SpolFremoverTransisjon(BehandlingStegType.VURDER_MEDLEMSKAPVILKÅR),
         new SpolFremoverTransisjon(BehandlingStegType.KONTROLLER_LØPENDE_MEDLEMSKAP),
-        new SpolFremoverTransisjon(BehandlingStegType.FASTSETT_OPPTJENINGSPERIODE),
-        new SpolFremoverTransisjon(BehandlingStegType.SØKNADSFRIST_FORELDREPENGER)
+        new SpolFremoverTransisjon(BehandlingStegType.FASTSETT_OPPTJENINGSPERIODE)
     );
 
     private Transisjoner() {

--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/dokumentmottak/impl/InnhentDokumentTjeneste.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/dokumentmottak/impl/InnhentDokumentTjeneste.java
@@ -95,7 +95,7 @@ public class InnhentDokumentTjeneste {
     }
 
     private boolean skalMottasSomKøet(Fagsak fagsak) {
-        return køKontroller.skalNyEvtNyBehandlingKøes(fagsak);
+        return køKontroller.skalEvtNyBehandlingKøes(fagsak);
     }
 
     private boolean brukDokumentKategori(DokumentTypeId dokumentTypeId, DokumentKategori dokumentKategori) {

--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/dokumentmottak/impl/InnhentDokumentTjeneste.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/dokumentmottak/impl/InnhentDokumentTjeneste.java
@@ -3,7 +3,6 @@ package no.nav.foreldrepenger.mottak.dokumentmottak.impl;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 
 import javax.enterprise.context.Dependent;
 import javax.enterprise.inject.Any;
@@ -11,7 +10,6 @@ import javax.enterprise.inject.Instance;
 import javax.inject.Inject;
 
 import no.nav.foreldrepenger.behandlingskontroll.FagsakYtelseTypeRef;
-import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingÅrsakType;
 import no.nav.foreldrepenger.behandlingslager.behandling.DokumentKategori;
 import no.nav.foreldrepenger.behandlingslager.behandling.DokumentTypeId;
@@ -97,14 +95,7 @@ public class InnhentDokumentTjeneste {
     }
 
     private boolean skalMottasSomKøet(Fagsak fagsak) {
-        Optional<Behandling> køetBehandling = revurderingRepository.finnKøetYtelsesbehandling(fagsak.getId());
-        Optional<Behandling> åpenBerørtBehandling = revurderingRepository.finnÅpenYtelsesbehandling(fagsak.getId())
-            .filter(b -> b.harBehandlingÅrsak(BehandlingÅrsakType.BERØRT_BEHANDLING));
-        return køetBehandling.isPresent() || åpenBerørtBehandling.isPresent() || skalKøesGrunnetMedforelder(fagsak);
-    }
-
-    private boolean skalKøesGrunnetMedforelder(Fagsak fagsak) {
-        return revurderingRepository.finnÅpenBehandlingMedforelder(fagsak).map(b -> !køKontroller.skalSnikeIKø(fagsak, b)).orElse(false);
+        return køKontroller.skalNyEvtNyBehandlingKøes(fagsak);
     }
 
     private boolean brukDokumentKategori(DokumentTypeId dokumentTypeId, DokumentKategori dokumentKategori) {

--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/dokumentmottak/impl/KøKontroller.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/dokumentmottak/impl/KøKontroller.java
@@ -5,14 +5,12 @@ import java.util.Optional;
 import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
 
-import no.nav.foreldrepenger.behandlingskontroll.BehandlingskontrollKontekst;
+import no.nav.foreldrepenger.behandling.revurdering.flytkontroll.BehandlingFlytkontroll;
 import no.nav.foreldrepenger.behandlingskontroll.BehandlingskontrollTjeneste;
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
-import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingType;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingÅrsakType;
 import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.AksjonspunktDefinisjon;
 import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.Venteårsak;
-import no.nav.foreldrepenger.behandlingslager.behandling.historikk.HistorikkinnslagType;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepositoryProvider;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRevurderingRepository;
@@ -21,7 +19,6 @@ import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.Ytelses
 import no.nav.foreldrepenger.behandlingslager.fagsak.Fagsak;
 import no.nav.foreldrepenger.behandlingsprosess.prosessering.BehandlingProsesseringTjeneste;
 import no.nav.foreldrepenger.mottak.Behandlingsoppretter;
-import no.nav.foreldrepenger.mottak.dokumentmottak.HistorikkinnslagTjeneste;
 
 @Dependent
 public class KøKontroller {
@@ -30,10 +27,10 @@ public class KøKontroller {
     private BehandlingRevurderingRepository behandlingRevurderingRepository;
     private BehandlingskontrollTjeneste behandlingskontrollTjeneste;
     private BehandlingRepository behandlingRepository;
-    private HistorikkinnslagTjeneste historikkinnslagTjeneste;
     private YtelsesFordelingRepository ytelsesFordelingRepository;
     private Behandlingsoppretter behandlingsoppretter;
     private SøknadRepository søknadRepository;
+    private BehandlingFlytkontroll flytkontroll;
 
     public KøKontroller() {
         // For CDI proxy
@@ -44,16 +41,16 @@ public class KøKontroller {
                         BehandlingRevurderingRepository behandlingRevurderingRepository,
                         BehandlingskontrollTjeneste behandlingskontrollTjeneste,
                         BehandlingRepositoryProvider repositoryProvider,
-                        HistorikkinnslagTjeneste historikkinnslagTjeneste,
-                        Behandlingsoppretter behandlingsoppretter) {
+                        Behandlingsoppretter behandlingsoppretter,
+                        BehandlingFlytkontroll flytkontroll) {
         this.behandlingProsesseringTjeneste = prosesseringTjeneste;
         this.behandlingskontrollTjeneste = behandlingskontrollTjeneste;
         this.behandlingRevurderingRepository = behandlingRevurderingRepository;
         this.behandlingRepository = repositoryProvider.getBehandlingRepository();
         this.ytelsesFordelingRepository = repositoryProvider.getYtelsesFordelingRepository();
-        this.historikkinnslagTjeneste = historikkinnslagTjeneste;
         this.behandlingsoppretter = behandlingsoppretter;
         this.søknadRepository = repositoryProvider.getSøknadRepository();
+        this.flytkontroll = flytkontroll;
     }
 
 
@@ -112,35 +109,12 @@ public class KøKontroller {
         return oppdatertBehandling;
     }
 
-    public boolean skalSnikeIKø(Fagsak brukersFagsak, Behandling åpenBehandlingPåMedforelder) {
-        Optional<Behandling> innvilgetBehandling = behandlingRevurderingRepository.finnSisteInnvilgetBehandlingForMedforelder(brukersFagsak);
-        if (innvilgetBehandling.isEmpty() && medforelderHarÅpentApForTidligSøknad(åpenBehandlingPåMedforelder)
-            && BehandlingType.FØRSTEGANGSSØKNAD.equals(åpenBehandlingPåMedforelder.getType())) {
-
-            settAksjonspunktForTidligSøknadUtført(åpenBehandlingPåMedforelder);
-            enkøBehandling(åpenBehandlingPåMedforelder);
-            historikkinnslagTjeneste.opprettHistorikkinnslagForVenteFristRelaterteInnslag(åpenBehandlingPåMedforelder,
-                HistorikkinnslagType.BEH_KØET, null, Venteårsak.VENT_ÅPEN_BEHANDLING);
-            return true;
+    public boolean skalNyEvtNyBehandlingKøes(Fagsak fagsak) {
+        // Finnes ingen tidligere innvilget -> Skal ikke opprettes revurdering.
+        if (behandlingRepository.finnSisteInnvilgetBehandling(fagsak.getId()).isEmpty()) {
+            return false;
         }
-        // Informasjonsbrev og IM fører til VentPåSøknad med VP REGSØK - før køhåndtering
-        return medforelderHarÅpentApVentPåSøknad(åpenBehandlingPåMedforelder);
+        return behandlingRevurderingRepository.finnKøetYtelsesbehandling(fagsak.getId()).isPresent() || flytkontroll.nyRevurderingSkalVente(fagsak);
     }
 
-    private boolean medforelderHarÅpentApForTidligSøknad(Behandling behandling) {
-        return behandling.harÅpentAksjonspunktMedType(AksjonspunktDefinisjon.VENT_PGA_FOR_TIDLIG_SØKNAD);
-    }
-
-    private boolean medforelderHarÅpentApVentPåSøknad(Behandling behandling) {
-        return behandling.harÅpentAksjonspunktMedType(AksjonspunktDefinisjon.VENT_PÅ_SØKNAD);
-    }
-
-    private void settAksjonspunktForTidligSøknadUtført(Behandling åpenBehandlingPåMedforelder) {
-        // TODO: Finn bedre modell. Ønsker ikke klå på andre behandlingers aksjonspunkt.
-        BehandlingskontrollKontekst kontekst = behandlingskontrollTjeneste.initBehandlingskontroll(åpenBehandlingPåMedforelder);
-        behandlingskontrollTjeneste.lagreAksjonspunkterUtført(kontekst, null,
-            åpenBehandlingPåMedforelder.getAksjonspunktFor(AksjonspunktDefinisjon.VENT_PGA_FOR_TIDLIG_SØKNAD),
-            "Utført fordi den sperrer for behandling av annen forelder som starter uttak først");
-
-    }
 }

--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/dokumentmottak/impl/KøKontroller.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/dokumentmottak/impl/KøKontroller.java
@@ -109,7 +109,7 @@ public class KøKontroller {
         return oppdatertBehandling;
     }
 
-    public boolean skalNyEvtNyBehandlingKøes(Fagsak fagsak) {
+    public boolean skalEvtNyBehandlingKøes(Fagsak fagsak) {
         // Finnes ingen tidligere innvilget -> Skal ikke opprettes revurdering.
         if (behandlingRepository.finnSisteInnvilgetBehandling(fagsak.getId()).isEmpty()) {
             return false;

--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/hendelser/ForretningshendelseMottak.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/hendelser/ForretningshendelseMottak.java
@@ -121,7 +121,7 @@ public class ForretningshendelseMottak {
         }
 
         // Case 2: Berørt (køet) behandling eller behandling på medforelder
-        if (køKontroller.skalNyEvtNyBehandlingKøes(fagsak)) {
+        if (køKontroller.skalEvtNyBehandlingKøes(fagsak)) {
             håndterer.håndterKøetBehandling(fagsak, behandlingÅrsakType);
             return;
         }

--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/hendelser/ForretningshendelseMottak.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/hendelser/ForretningshendelseMottak.java
@@ -120,18 +120,14 @@ public class ForretningshendelseMottak {
             return;
         }
 
-        // Case 2: Berørt (køet) behandling
-        if (behandlingSkalLeggesPåKøPåGrunnAvÅpenBehandlingPåMedforelder(sisteYtelsebehandling)) {
+        // Case 2: Berørt (køet) behandling eller behandling på medforelder
+        if (køKontroller.skalNyEvtNyBehandlingKøes(fagsak)) {
             håndterer.håndterKøetBehandling(fagsak, behandlingÅrsakType);
             return;
         }
 
         // Case 3: Åpen ytelsesbehandling
         if (!sisteYtelsebehandling.erStatusFerdigbehandlet()) {
-            if (erBehandlingBerørt(sisteYtelsebehandling) || harAlleredeKøetBehandling(sisteYtelsebehandling)) {
-                håndterer.håndterKøetBehandling(fagsak, behandlingÅrsakType);
-                return;
-            }
             håndterer.håndterÅpenBehandling(sisteYtelsebehandling, behandlingÅrsakType);
             return;
         }
@@ -139,7 +135,7 @@ public class ForretningshendelseMottak {
         Optional<Behandling> sisteInnvilgedeYtelsesbehandling = behandlingRepository.finnSisteInnvilgetBehandling(fagsak.getId());
 
         // Case 4: Ytelsesbehandling finnes, men verken åpen eller innvilget. Antas å inntreffe sjelden
-        if (!sisteInnvilgedeYtelsesbehandling.isPresent()) {
+        if (sisteInnvilgedeYtelsesbehandling.isEmpty()) {
             FEILFACTORY.finnesYtelsebehandlingSomVerkenErÅpenEllerInnvilget(hendelseType.getKode(), fagsakId).log(LOGGER);
             return;
         }
@@ -162,23 +158,8 @@ public class ForretningshendelseMottak {
         prosessTaskRepository.lagre(taskData);
     }
 
-    private boolean behandlingSkalLeggesPåKøPåGrunnAvÅpenBehandlingPåMedforelder(Behandling sisteYtelsebehandling) {
-        Optional<Behandling> åpenBehandlingPåMedforelder = finnÅpenBehandlingPåMedforelder(sisteYtelsebehandling.getFagsak());
-        return åpenBehandlingPåMedforelder.isPresent()
-            && !køKontroller.skalSnikeIKø(sisteYtelsebehandling.getFagsak(), åpenBehandlingPåMedforelder.get());
-    }
-
     private Optional<Behandling> finnÅpenBehandlingPåMedforelder(Fagsak fagsak) {
         return revurderingRepository.finnÅpenBehandlingMedforelder(fagsak);
-    }
-
-    private boolean erBehandlingBerørt(Behandling behandling) {
-        return behandling.harBehandlingÅrsak(BehandlingÅrsakType.BERØRT_BEHANDLING);
-    }
-
-    private boolean harAlleredeKøetBehandling(Behandling behandling) {
-        Optional<Behandling> køetBehandling = revurderingRepository.finnKøetYtelsesbehandling(behandling.getFagsakId());
-        return køetBehandling.isPresent();
     }
 
     private static List<AktørId> mapToAktørIds(HendelseDto hendelseDto) {

--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/vedtak/BerørtBehandlingKontroller.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/vedtak/BerørtBehandlingKontroller.java
@@ -129,6 +129,9 @@ public class BerørtBehandlingKontroller {
     }
 
     private void opprettBerørtBehandling(Fagsak fagsakMedforelder, Optional<Behandlingsresultat> behandlingsresultat) {
+        // Hvis det nå allerede skulle være en åpen behandling (ikke i kø) så legg den i kø før oppretting av berørt.
+        behandlingRevurderingRepository.finnÅpenYtelsesbehandling(fagsakMedforelder.getId())
+            .ifPresent(b -> behandlingskontrollTjeneste.settBehandlingPåVent(b, AksjonspunktDefinisjon.AUTO_KØET_BEHANDLING, null, null, Venteårsak.VENT_ÅPEN_BEHANDLING));
         Behandling revurdering = behandlingsoppretter.opprettRevurdering(fagsakMedforelder, BehandlingÅrsakType.BERØRT_BEHANDLING);
         opprettHistorikkinnslag(revurdering, behandlingsresultat, HistorikkinnslagType.REVURD_OPPR);
         behandlingProsesseringTjeneste.opprettTasksForStartBehandling(revurdering);

--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/vedtak/overlapp/VurderOpphørAvYtelser.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/vedtak/overlapp/VurderOpphørAvYtelser.java
@@ -217,7 +217,7 @@ public class VurderOpphørAvYtelser  {
             var harÅpenOrdinærBehandling = behandlingRepository.harÅpenOrdinærYtelseBehandlingerForFagsakId(sakOpphør.getId());
             if (!harÅpenOrdinærBehandling) {
                 fagsakLåsRepository.taLås(sakOpphør.getId());
-                var skalKøes = !behandling.erAvsluttet() && behandling.harBehandlingÅrsak(BehandlingÅrsakType.BERØRT_BEHANDLING);
+                var skalKøes = køKontroller.skalNyEvtNyBehandlingKøes(sakOpphør);
                 Behandling revurderingOpphør = opprettRevurdering(sakOpphør, BehandlingÅrsakType.OPPHØR_YTELSE_NYTT_BARN, skalKøes);
                 if (revurderingOpphør != null) {
                     LOG.info("Overlapp FPSAK: Vurder opphør av ytelse har opprettet revurdering med behandlingId {} på sak med saksnummer {} pga behandlingId {}", revurderingOpphør.getId(), sakOpphør.getSaksnummer(), behandlingId);

--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/vedtak/overlapp/VurderOpphørAvYtelser.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/vedtak/overlapp/VurderOpphørAvYtelser.java
@@ -217,7 +217,7 @@ public class VurderOpphørAvYtelser  {
             var harÅpenOrdinærBehandling = behandlingRepository.harÅpenOrdinærYtelseBehandlingerForFagsakId(sakOpphør.getId());
             if (!harÅpenOrdinærBehandling) {
                 fagsakLåsRepository.taLås(sakOpphør.getId());
-                var skalKøes = køKontroller.skalNyEvtNyBehandlingKøes(sakOpphør);
+                var skalKøes = køKontroller.skalEvtNyBehandlingKøes(sakOpphør);
                 Behandling revurderingOpphør = opprettRevurdering(sakOpphør, BehandlingÅrsakType.OPPHØR_YTELSE_NYTT_BARN, skalKøes);
                 if (revurderingOpphør != null) {
                     LOG.info("Overlapp FPSAK: Vurder opphør av ytelse har opprettet revurdering med behandlingId {} på sak med saksnummer {} pga behandlingId {}", revurderingOpphør.getId(), sakOpphør.getSaksnummer(), behandlingId);

--- a/domenetjenester/mottak/src/test/java/no/nav/foreldrepenger/mottak/dokumentmottak/impl/KøKontrollerTest.java
+++ b/domenetjenester/mottak/src/test/java/no/nav/foreldrepenger/mottak/dokumentmottak/impl/KøKontrollerTest.java
@@ -3,12 +3,9 @@ package no.nav.foreldrepenger.mottak.dokumentmottak.impl;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.when;
 
-import java.time.LocalDate;
-import java.util.List;
 import java.util.Optional;
 
 import org.junit.Before;
@@ -18,24 +15,20 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 
+import no.nav.foreldrepenger.behandling.revurdering.flytkontroll.BehandlingFlytkontroll;
 import no.nav.foreldrepenger.behandlingskontroll.BehandlingskontrollTjeneste;
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingType;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingÅrsakType;
-import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.AksjonspunktDefinisjon;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepositoryProvider;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRevurderingRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.søknad.SøknadRepository;
-import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.YtelseFordelingAggregat;
 import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.YtelsesFordelingRepository;
-import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.periode.OppgittFordelingEntitet;
-import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.periode.OppgittPeriodeEntitet;
 import no.nav.foreldrepenger.behandlingslager.testutilities.behandling.ScenarioFarSøkerForeldrepenger;
 import no.nav.foreldrepenger.behandlingslager.testutilities.behandling.ScenarioMorSøkerForeldrepenger;
 import no.nav.foreldrepenger.behandlingsprosess.prosessering.BehandlingProsesseringTjeneste;
 import no.nav.foreldrepenger.mottak.Behandlingsoppretter;
-import no.nav.foreldrepenger.mottak.dokumentmottak.HistorikkinnslagTjeneste;
 import no.nav.vedtak.felles.testutilities.cdi.CdiRunner;
 
 @RunWith(CdiRunner.class)
@@ -51,13 +44,13 @@ public class KøKontrollerTest {
     @Mock
     private BehandlingskontrollTjeneste behandlingskontrollTjeneste;
     @Mock
-    private HistorikkinnslagTjeneste historikkinnslagTjeneste;
-    @Mock
     private SøknadRepository søknadRepository;
     @Mock
     private YtelsesFordelingRepository ytelsesFordelingRepository;
     @Mock
     private Behandlingsoppretter behandlingsoppretter;
+    @Mock
+    private BehandlingFlytkontroll flytkontroll;
 
     private KøKontroller køKontroller;
 
@@ -69,7 +62,7 @@ public class KøKontrollerTest {
         when(behandlingRepositoryProvider.getSøknadRepository()).thenReturn(søknadRepository);
         when(behandlingRepositoryProvider.getYtelsesFordelingRepository()).thenReturn(ytelsesFordelingRepository);
         køKontroller = new KøKontroller(behandlingProsesseringTjeneste, behandlingRevurderingRepository, behandlingskontrollTjeneste,
-            behandlingRepositoryProvider, historikkinnslagTjeneste, behandlingsoppretter);
+            behandlingRepositoryProvider, behandlingsoppretter, flytkontroll);
     }
 
     @Test
@@ -129,50 +122,35 @@ public class KøKontrollerTest {
     }
 
     @Test
-    public void skal_snike_i_kø_hvis_en_behandling_ligger_på_vent_pga_for_tidlig_søknad(){
+    public void skal_starte_hvis_en_2part_behandling_ligger_i_iv(){
         //Arrange
         Behandling behandling = ScenarioMorSøkerForeldrepenger.forFødsel().medBehandlingType(BehandlingType.REVURDERING).lagMocked();
         ScenarioMorSøkerForeldrepenger scenario = ScenarioMorSøkerForeldrepenger.forFødsel();
-        scenario.leggTilAksjonspunkt(AksjonspunktDefinisjon.VENT_PGA_FOR_TIDLIG_SØKNAD, null);
-        Behandling behandlingMedforelder = scenario.lagMocked();
-        when(behandlingRevurderingRepository.finnKøetBehandlingMedforelder(behandling.getFagsak())).thenReturn(Optional.empty());
-
-        YtelseFordelingAggregat ytelse1 = lagYtelse(LocalDate.now());
-        when(ytelsesFordelingRepository.hentAggregatHvisEksisterer(behandling.getId())).thenReturn(Optional.of(ytelse1));
-        YtelseFordelingAggregat ytelse2 = lagYtelse(LocalDate.now().plusMonths(4));
-        when(ytelsesFordelingRepository.hentAggregatHvisEksisterer(behandlingMedforelder.getId())).thenReturn(Optional.of(ytelse2));
-
-        //Act
-        boolean skalSnike = køKontroller.skalSnikeIKø(behandling.getFagsak(), behandlingMedforelder);
-
-        //Assert
-        assertThat(skalSnike).isTrue();
-    }
-
-    @Test
-    public void skal_ikke_snike_i_kø_hvis_en_behandling_ligger_på_vent_pga_feks_fødsel(){
-        //Arrange
-        Behandling behandling = ScenarioMorSøkerForeldrepenger.forFødsel().lagMocked();
-        ScenarioMorSøkerForeldrepenger scenario = ScenarioMorSøkerForeldrepenger.forFødsel();
-        scenario.leggTilAksjonspunkt(AksjonspunktDefinisjon.VENT_PÅ_FØDSEL, null);
-        Behandling behandlingMedforelder = scenario.lagMocked();
+        scenario.lagMocked();
+        when(flytkontroll.nyRevurderingSkalVente(behandling.getFagsak())).thenReturn(false);
         when(behandlingRevurderingRepository.finnKøetBehandlingMedforelder(behandling.getFagsak())).thenReturn(Optional.empty());
 
         //Act
-        boolean skalSnike = køKontroller.skalSnikeIKø(behandling.getFagsak(), behandlingMedforelder);
+        boolean skalSnike = køKontroller.skalNyEvtNyBehandlingKøes(behandling.getFagsak());
 
         //Assert
         assertThat(skalSnike).isFalse();
     }
 
-    private YtelseFordelingAggregat lagYtelse(LocalDate fomDato) {
-        var ytelse = mock(YtelseFordelingAggregat.class);
+    @Test
+    public void skal_ikke_starte_hvis_en_2part_behandling_ligger_til_vedtak(){
+        //Arrange
+        Behandling behandling = ScenarioMorSøkerForeldrepenger.forFødsel().lagMocked();
+        ScenarioMorSøkerForeldrepenger scenario = ScenarioMorSøkerForeldrepenger.forFødsel();
+        scenario.lagMocked();
+        when(flytkontroll.nyRevurderingSkalVente(behandling.getFagsak())).thenReturn(true);
+        when(behandlingRepository.finnSisteInnvilgetBehandling(any())).thenReturn(Optional.of(behandling));
 
-        OppgittFordelingEntitet oppgittFordeling = mock(OppgittFordelingEntitet.class);
-        OppgittPeriodeEntitet oppgittPeriode = mock(OppgittPeriodeEntitet.class);
-        when(oppgittPeriode.getFom()).thenReturn(fomDato);
-        when(oppgittFordeling.getOppgittePerioder()).thenReturn(List.of(oppgittPeriode));
-        when(ytelse.getOppgittFordeling()).thenReturn(oppgittFordeling);
-        return ytelse;
+        //Act
+        boolean skalSnike = køKontroller.skalNyEvtNyBehandlingKøes(behandling.getFagsak());
+
+        //Assert
+        assertThat(skalSnike).isTrue();
     }
+
 }

--- a/domenetjenester/mottak/src/test/java/no/nav/foreldrepenger/mottak/dokumentmottak/impl/KøKontrollerTest.java
+++ b/domenetjenester/mottak/src/test/java/no/nav/foreldrepenger/mottak/dokumentmottak/impl/KøKontrollerTest.java
@@ -122,7 +122,7 @@ public class KøKontrollerTest {
     }
 
     @Test
-    public void skal_starte_hvis_en_2part_behandling_ligger_i_iv(){
+    public void skal_starte_hvis_en_2part_behandling_ligger_før_uttak(){
         //Arrange
         Behandling behandling = ScenarioMorSøkerForeldrepenger.forFødsel().medBehandlingType(BehandlingType.REVURDERING).lagMocked();
         ScenarioMorSøkerForeldrepenger scenario = ScenarioMorSøkerForeldrepenger.forFødsel();
@@ -131,10 +131,10 @@ public class KøKontrollerTest {
         when(behandlingRevurderingRepository.finnKøetBehandlingMedforelder(behandling.getFagsak())).thenReturn(Optional.empty());
 
         //Act
-        boolean skalSnike = køKontroller.skalNyEvtNyBehandlingKøes(behandling.getFagsak());
+        boolean skalKøes = køKontroller.skalEvtNyBehandlingKøes(behandling.getFagsak());
 
         //Assert
-        assertThat(skalSnike).isFalse();
+        assertThat(skalKøes).isFalse();
     }
 
     @Test
@@ -147,10 +147,10 @@ public class KøKontrollerTest {
         when(behandlingRepository.finnSisteInnvilgetBehandling(any())).thenReturn(Optional.of(behandling));
 
         //Act
-        boolean skalSnike = køKontroller.skalNyEvtNyBehandlingKøes(behandling.getFagsak());
+        boolean skalKøes = køKontroller.skalEvtNyBehandlingKøes(behandling.getFagsak());
 
         //Assert
-        assertThat(skalSnike).isTrue();
+        assertThat(skalKøes).isTrue();
     }
 
 }


### PR DESCRIPTION
Flyttet analyse av saker/behandling til egen bønne BehandlingFlytkontroll i beh-revurdering
Flyttet køhåndtering i Steg fra INSØK til Startpunkt.UTTAK = KOFAK_LOP_MEDL - kan gå videre i uttak med mindre annen part har behandling i uttak eller det finnes berørt
Oppdatert køhåndtering i mottak: Ingen kø hvis det ikke har vært Innvilget i aktuell sak (->1gang) og legg på kø hvis det finnes behandling i kø, berørt, aller 2part har åpen revurdering eller 1gang i uttak.
Opprett Berørt vil ligge evt åpne revurderinger på samme sak i kø før den starter
Fjernet øvrig fikling med andre behandlingers autopunkter
