### PR TITLE
FIX: Ruller tilbake endring på fpoppdrag.override.proxy.url i es-vtp.…

### DIFF
--- a/web/es-vtp.properties
+++ b/web/es-vtp.properties
@@ -77,7 +77,7 @@ kafka.risikoklassifisering.topic=privat-foreldrepenger-fprisk-lokal
 kafka.sakogbehandling.topic=aapen-sob-oppgaveHendelse-v1
 fp.tilkjentytelse.v1.topic.url=privat-foreldrepenger-tilkjentytelse-v1-local
 
-fpoppdrag.override.proxy.url=http://localhost:9000/fpoppdrag/api
+fpoppdrag.override.proxy.url=http://localhost:8060/rest/dummy/fpoppdrag
 fpoppdrag.override.direkte.url=http://localhost:8060/rest/dummy/fpoppdrag
 fptilbake.override.direkte.url=http://localhost:8060/rest/dummy/boolean/false
 


### PR DESCRIPTION
…properties som gjorde at man ikke kan kjøre Fpsak lokalt uten Fpoppdrag.