### PR TITLE
TFP-3857 riktig utbetgrad/dagsats for SVP i publisert ytelse

### DIFF
--- a/domenetjenester/mottak/src/test/java/no/nav/foreldrepenger/mottak/vedtak/overlapp/LoggOverlappEksterneYtelserTjenesteTest.java
+++ b/domenetjenester/mottak/src/test/java/no/nav/foreldrepenger/mottak/vedtak/overlapp/LoggOverlappEksterneYtelserTjenesteTest.java
@@ -62,6 +62,7 @@ public class LoggOverlappEksterneYtelserTjenesteTest extends EntityManagerAwareT
     private BehandlingRepositoryProvider repositoryProvider;
     private BeregningsresultatRepository beregningsresultatRepository;
     private OverlappVedtakRepository overlappRepository;
+    private BehandlingRepository behandlingRepository;
 
     @Mock
     private PersoninfoAdapter personinfoAdapter;
@@ -77,11 +78,12 @@ public class LoggOverlappEksterneYtelserTjenesteTest extends EntityManagerAwareT
     public void oppsett() {
         repositoryProvider = new BehandlingRepositoryProvider(getEntityManager());
         overlappRepository = new OverlappVedtakRepository(getEntityManager());
+        behandlingRepository = new BehandlingRepository(getEntityManager());
         beregningsresultatRepository = new BeregningsresultatRepository(getEntityManager());
-        overlappendeInfotrygdYtelseTjeneste = new LoggOverlappEksterneYtelserTjeneste(beregningsresultatRepository, personinfoAdapter,
+        overlappendeInfotrygdYtelseTjeneste = new LoggOverlappEksterneYtelserTjeneste(null, beregningsresultatRepository, personinfoAdapter,
                 infotrygdPSGrTjenesteMock,
                 infotrygdSPGrTjenesteMock, mock(AbakusTjeneste.class), mock(SpokelseKlient.class), overlappRepository,
-                mock(BehandlingRepository.class));
+                behandlingRepository);
         førsteUttaksdatoFp = LocalDate.now().minusMonths(4).minusWeeks(2);
         førsteUttaksdatoFp = VirkedagUtil.fomVirkedag(førsteUttaksdatoFp);
 

--- a/domenetjenester/vedtak/src/test/java/no/nav/foreldrepenger/domene/vedtak/observer/VedtattYtelseTjenesteTest.java
+++ b/domenetjenester/vedtak/src/test/java/no/nav/foreldrepenger/domene/vedtak/observer/VedtattYtelseTjenesteTest.java
@@ -1,0 +1,148 @@
+package no.nav.foreldrepenger.domene.vedtak.observer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import no.nav.abakus.vedtak.ytelse.v1.YtelseV1;
+import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
+import no.nav.foreldrepenger.behandlingslager.behandling.beregning.BeregningsresultatAndel;
+import no.nav.foreldrepenger.behandlingslager.behandling.beregning.BeregningsresultatEntitet;
+import no.nav.foreldrepenger.behandlingslager.behandling.beregning.BeregningsresultatPeriode;
+import no.nav.foreldrepenger.behandlingslager.behandling.beregning.BeregningsresultatRepository;
+import no.nav.foreldrepenger.behandlingslager.behandling.beregning.Inntektskategori;
+import no.nav.foreldrepenger.behandlingslager.behandling.vedtak.BehandlingVedtak;
+import no.nav.foreldrepenger.behandlingslager.behandling.vedtak.BehandlingVedtakRepository;
+import no.nav.foreldrepenger.behandlingslager.testutilities.behandling.ScenarioMorSøkerSvangerskapspenger;
+import no.nav.foreldrepenger.behandlingslager.virksomhet.Arbeidsgiver;
+import no.nav.foreldrepenger.domene.SKAL_FLYTTES_TIL_KALKULUS.AktivitetStatus;
+import no.nav.foreldrepenger.domene.SKAL_FLYTTES_TIL_KALKULUS.BGAndelArbeidsforhold;
+import no.nav.foreldrepenger.domene.SKAL_FLYTTES_TIL_KALKULUS.BeregningsgrunnlagEntitet;
+import no.nav.foreldrepenger.domene.SKAL_FLYTTES_TIL_KALKULUS.BeregningsgrunnlagPeriode;
+import no.nav.foreldrepenger.domene.SKAL_FLYTTES_TIL_KALKULUS.BeregningsgrunnlagPrStatusOgAndel;
+import no.nav.foreldrepenger.domene.SKAL_FLYTTES_TIL_KALKULUS.BeregningsgrunnlagRepository;
+import no.nav.foreldrepenger.domene.typer.InternArbeidsforholdRef;
+import no.nav.vedtak.konfig.Tid;
+
+@ExtendWith(MockitoExtension.class)
+public class VedtattYtelseTjenesteTest {
+
+    @Mock
+    private BehandlingVedtakRepository behandlingVedtakRepository;
+    @Mock
+    private BehandlingVedtak vedtak;
+    @Mock
+    private BeregningsgrunnlagRepository beregningsgrunnlagRepository;
+    @Mock
+    private BeregningsresultatRepository beregningsresultatRepository;
+
+    LocalDate stp = LocalDate.now().minusMonths(3);
+    LocalDate knekk1 = LocalDate.now().minusMonths(2);
+    LocalDate knekk2 = LocalDate.now().minusMonths(1);
+
+
+    @Test
+    public void skal_teste_arena_ytelser_finnes_ikke() {
+        // Arrange
+        Behandling behandling = ScenarioMorSøkerSvangerskapspenger.forSvangerskapspenger().lagMocked();
+        var bg = lagBG();
+        var br = lagBR();
+        when(beregningsgrunnlagRepository.hentBeregningsgrunnlagForBehandling(behandling.getId())).thenReturn(Optional.of(bg));
+        when(beregningsresultatRepository.hentBeregningsresultat(behandling.getId())).thenReturn(Optional.of(br));
+        when(behandlingVedtakRepository.hentForBehandling(behandling.getId())).thenReturn(vedtak);
+        when(vedtak.getVedtakstidspunkt()).thenReturn(stp.atStartOfDay());
+        var tjeneste = new VedtattYtelseTjeneste(behandlingVedtakRepository, beregningsgrunnlagRepository, beregningsresultatRepository);
+
+        YtelseV1 ytelse= (YtelseV1)tjeneste.genererYtelse(behandling);
+        // Assert
+        assertThat(ytelse.getAnvist()).hasSize(3);
+        assertThat(ytelse.getAnvist().get(0).getUtbetalingsgrad().getVerdi().longValue()).isEqualTo(20);
+        assertThat(ytelse.getAnvist().get(2).getUtbetalingsgrad().getVerdi().longValue()).isEqualTo(60);
+    }
+
+    private BeregningsgrunnlagEntitet lagBG() {
+        BeregningsgrunnlagEntitet beregningsgrunnlag = BeregningsgrunnlagEntitet.builder()
+            .medSkjæringstidspunkt(LocalDate.now())
+            .medGrunnbeløp(new BigDecimal(100000))
+            .leggTilBeregningsgrunnlagPeriode(BeregningsgrunnlagPeriode.builder()
+                .medBeregningsgrunnlagPeriode(stp, knekk1.minusDays(1))
+                .medRedusertPrÅr(new BigDecimal(120000))
+                .leggTilBeregningsgrunnlagPrStatusOgAndel(BeregningsgrunnlagPrStatusOgAndel.builder()
+                    .medBeregnetPrÅr(new BigDecimal(700000))
+                    .medRedusertPrÅr(new BigDecimal(120000))
+                    .medRedusertBrukersAndelPrÅr(new BigDecimal(120000))
+                    .medBGAndelArbeidsforhold(BGAndelArbeidsforhold.builder()
+                        .medArbeidsforholdRef(InternArbeidsforholdRef.nullRef())
+                        .medArbeidsgiver(Arbeidsgiver.virksomhet("999999999")))
+                    .medAktivitetStatus(AktivitetStatus.ARBEIDSTAKER)))
+            .leggTilBeregningsgrunnlagPeriode(BeregningsgrunnlagPeriode.builder()
+                .medBeregningsgrunnlagPeriode(knekk1, knekk2.minusDays(1))
+                .medRedusertPrÅr(new BigDecimal(240000))
+                .leggTilBeregningsgrunnlagPrStatusOgAndel(BeregningsgrunnlagPrStatusOgAndel.builder()
+                    .medBeregnetPrÅr(new BigDecimal(700000))
+                    .medRedusertPrÅr(new BigDecimal(240000))
+                    .medRedusertBrukersAndelPrÅr(new BigDecimal(240000))
+                    .medBGAndelArbeidsforhold(BGAndelArbeidsforhold.builder()
+                        .medArbeidsforholdRef(InternArbeidsforholdRef.nullRef())
+                        .medArbeidsgiver(Arbeidsgiver.virksomhet("999999999")))
+                    .medAktivitetStatus(AktivitetStatus.ARBEIDSTAKER)))
+            .leggTilBeregningsgrunnlagPeriode(BeregningsgrunnlagPeriode.builder()
+                .medBeregningsgrunnlagPeriode(knekk2, Tid.TIDENES_ENDE)
+                .medRedusertPrÅr(new BigDecimal(360000))
+                .leggTilBeregningsgrunnlagPrStatusOgAndel(BeregningsgrunnlagPrStatusOgAndel.builder()
+                    .medBeregnetPrÅr(new BigDecimal(700000))
+                    .medRedusertPrÅr(new BigDecimal(360000))
+                    .medRedusertBrukersAndelPrÅr(new BigDecimal(360000))
+                    .medBGAndelArbeidsforhold(BGAndelArbeidsforhold.builder()
+                        .medArbeidsforholdRef(InternArbeidsforholdRef.nullRef())
+                        .medArbeidsgiver(Arbeidsgiver.virksomhet("999999999")))
+                    .medAktivitetStatus(AktivitetStatus.ARBEIDSTAKER)))
+            .build();
+        return beregningsgrunnlag;
+    }
+
+
+    private BeregningsresultatEntitet lagBR() {
+        BeregningsresultatEntitet beregningsresultat = BeregningsresultatEntitet.builder()
+            .medRegelInput("clob1")
+            .medRegelSporing("clob2")
+            .build();
+        var per1a = BeregningsresultatPeriode.builder()
+            .medBeregningsresultatPeriodeFomOgTom(stp, stp.plusDays(14))
+            .build(beregningsresultat);
+        var per1b = BeregningsresultatPeriode.builder()
+            .medBeregningsresultatPeriodeFomOgTom(stp.plusDays(15), knekk1.minusDays(1))
+            .build(beregningsresultat);
+        var per2 = BeregningsresultatPeriode.builder()
+            .medBeregningsresultatPeriodeFomOgTom(knekk1, knekk2.minusDays(1))
+            .build(beregningsresultat);
+        var per3 = BeregningsresultatPeriode.builder()
+            .medBeregningsresultatPeriodeFomOgTom(knekk2, LocalDate.now().plusWeeks(2))
+            .build(beregningsresultat);
+        byggandel(per1a, 460);
+        byggandel(per1b, 460);
+        byggandel(per2, 920);
+        byggandel(per3, 1380);
+        return beregningsresultat;
+    }
+
+    private void byggandel(BeregningsresultatPeriode periode, int dagsats) {
+        BeregningsresultatAndel.builder()
+            .medDagsats(dagsats)
+            .medDagsatsFraBg(dagsats)
+            .medBrukerErMottaker(true)
+            .medStillingsprosent(BigDecimal.TEN.multiply(BigDecimal.TEN))
+            .medUtbetalingsgrad(BigDecimal.TEN.multiply(BigDecimal.TEN))
+            .medInntektskategori(Inntektskategori.ARBEIDSTAKER)
+            .build(periode);
+    }
+
+}


### PR DESCRIPTION
Denne vil sette riktig utbetalingsgrad for graderte FP-perioder og for SVP på Vedtak som publiseres på Kafka (+overlappsjekk).
Alle SVP som er publisert på Kafka har 100% utbetalingsgrad - fordi Beregningsgrunnlaget har trukket inn SVP-uttak.

Utleder ikke-redusert dagsats fra dagsats * kalkulertAvkortet / redusert og utbetalingsgrad fra redusert / kalkulertAvkortet

Beregningsgrunnlaget for SVP har trukket inn SVP-uttak:
* Avkortet = redusert. Burde ikke avkortet vært = min(brutto,6G)? Har kompensert manuelt her
* Det er kun lagret redusert dagsats, ikke full beregnet. Prøver utlede full dagsats.
* Regner utbetalingsgrad ved å summere redusert og brutto over andelene (og manuelt avkorte)