### PR TITLE
NOJIRA rydd offisiellkode + logging

### DIFF
--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/aktør/AdresseType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/aktør/AdresseType.java
@@ -17,10 +17,11 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
+import no.nav.foreldrepenger.behandlingslager.kodeverk.MedOffisiellKode;
 
 @JsonFormat(shape = Shape.OBJECT)
 @JsonAutoDetect(getterVisibility = Visibility.NONE, setterVisibility = Visibility.NONE, fieldVisibility = Visibility.ANY)
-public enum AdresseType implements Kodeverdi {
+public enum AdresseType implements Kodeverdi, MedOffisiellKode {
 
     BOSTEDSADRESSE("BOSTEDSADRESSE", "Bostedsadresse", "BOAD"),
     POSTADRESSE("POSTADRESSE", "Postadresse", "POST"),

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/aktør/NavBrukerKjønn.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/aktør/NavBrukerKjønn.java
@@ -81,11 +81,6 @@ public enum NavBrukerKjønn implements Kodeverdi {
         return kode;
     }
 
-    @Override
-    public String getOffisiellKode() {
-        return getKode();
-    }
-
     @JsonProperty
     @Override
     public String getKodeverk() {

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/aktør/PersonstatusType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/aktør/PersonstatusType.java
@@ -107,11 +107,6 @@ public enum PersonstatusType implements Kodeverdi {
         return kode;
     }
 
-    @Override
-    public String getOffisiellKode() {
-        return getKode();
-    }
-
     static {
         for (var v : values()) {
             if (KODER.putIfAbsent(v.kode, v) != null) {

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/BehandlingResultatType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/BehandlingResultatType.java
@@ -125,11 +125,6 @@ public enum BehandlingResultatType implements Kodeverdi {
         return kode;
     }
 
-    @Override
-    public String getOffisiellKode() {
-        return getKode();
-    }
-
     @JsonProperty
     @Override
     public String getKodeverk() {

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/BehandlingStatus.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/BehandlingStatus.java
@@ -95,11 +95,6 @@ public enum BehandlingStatus implements Kodeverdi {
         return kode;
     }
 
-    @Override
-    public String getOffisiellKode() {
-        return getKode();
-    }
-
     static {
         for (var v : values()) {
             if (KODER.putIfAbsent(v.kode, v) != null) {

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/BehandlingStegStatus.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/BehandlingStegStatus.java
@@ -119,11 +119,6 @@ public enum BehandlingStegStatus implements Kodeverdi {
         return kode;
     }
 
-    @Override
-    public String getOffisiellKode() {
-        return getKode();
-    }
-
     static {
         for (var v : values()) {
             if (KODER.putIfAbsent(v.kode, v) != null) {

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/BehandlingStegType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/BehandlingStegType.java
@@ -152,11 +152,6 @@ public enum BehandlingStegType implements Kodeverdi {
         return KODEVERK;
     }
 
-    @Override
-    public String getOffisiellKode() {
-        return getKode();
-    }
-
     @JsonCreator
     public static BehandlingStegType fraKode(@JsonProperty("kode") String kode) {
         if (kode == null) {

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/BehandlingTema.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/BehandlingTema.java
@@ -19,10 +19,11 @@ import no.nav.foreldrepenger.behandlingslager.behandling.familiehendelse.Familie
 import no.nav.foreldrepenger.behandlingslager.fagsak.Fagsak;
 import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakYtelseType;
 import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
+import no.nav.foreldrepenger.behandlingslager.kodeverk.MedOffisiellKode;
 
 @JsonFormat(shape = Shape.OBJECT)
 @JsonAutoDetect(getterVisibility = Visibility.NONE, setterVisibility = Visibility.NONE, fieldVisibility = Visibility.ANY)
-public enum BehandlingTema implements Kodeverdi {
+public enum BehandlingTema implements Kodeverdi, MedOffisiellKode {
 
     ENGANGSSTØNAD("ENGST", "Engangsstønad", "ab0327"),
     ENGANGSSTØNAD_FØDSEL("ENGST_FODS", "Engangsstønad ved fødsel", "ab0050"),

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/BehandlingType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/BehandlingType.java
@@ -17,11 +17,12 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
+import no.nav.foreldrepenger.behandlingslager.kodeverk.MedOffisiellKode;
 import no.nav.foreldrepenger.behandlingslager.kodeverk.TempAvledeKode;
 
 @JsonFormat(shape = Shape.OBJECT)
 @JsonAutoDetect(getterVisibility = Visibility.NONE, setterVisibility = Visibility.NONE, fieldVisibility = Visibility.ANY)
-public enum BehandlingType implements Kodeverdi {
+public enum BehandlingType implements Kodeverdi, MedOffisiellKode {
 
     /**
      * Konstanter for å skrive ned kodeverdi. For å hente ut andre data konfigurert, må disse leses fra databasen (eks.

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/BehandlingÅrsakType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/BehandlingÅrsakType.java
@@ -145,11 +145,6 @@ public enum BehandlingÅrsakType implements Kodeverdi {
         return kode;
     }
 
-    @Override
-    public String getOffisiellKode() {
-        return getKode();
-    }
-
     static {
         for (var v : values()) {
             if (KODER.putIfAbsent(v.kode, v) != null) {

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/DokumentKategori.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/DokumentKategori.java
@@ -18,10 +18,11 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
+import no.nav.foreldrepenger.behandlingslager.kodeverk.MedOffisiellKode;
 
 @JsonFormat(shape = Shape.OBJECT)
 @JsonAutoDetect(getterVisibility = Visibility.NONE, setterVisibility = Visibility.NONE, fieldVisibility = Visibility.ANY)
-public enum DokumentKategori implements Kodeverdi {
+public enum DokumentKategori implements Kodeverdi, MedOffisiellKode {
 
     UDEFINERT("-", "Ikke definert", null),
     KLAGE_ELLER_ANKE("KLGA", "Klage eller anke", "KA"),

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/DokumentTypeId.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/DokumentTypeId.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
+import no.nav.foreldrepenger.behandlingslager.kodeverk.MedOffisiellKode;
 
 /*
  * Opprettet fra https://kodeverk-web.nais.adeo.no/kodeverksoversikt/kodeverk/DokumentTypeId-er
@@ -32,7 +33,7 @@ import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
 
 @JsonFormat(shape = Shape.OBJECT)
 @JsonAutoDetect(getterVisibility = Visibility.NONE, setterVisibility = Visibility.NONE, fieldVisibility = Visibility.ANY)
-public enum DokumentTypeId implements Kodeverdi {
+public enum DokumentTypeId implements Kodeverdi, MedOffisiellKode {
 
     // Søknader
     SØKNAD_SVANGERSKAPSPENGER("SØKNAD_SVANGERSKAPSPENGER", "I000001", "Søknad om svangerskapspenger"),

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/KonsekvensForYtelsen.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/KonsekvensForYtelsen.java
@@ -78,11 +78,6 @@ public enum KonsekvensForYtelsen implements Kodeverdi{
         return kode;
     }
 
-    @Override
-    public String getOffisiellKode() {
-        return getKode();
-    }
-
     static {
         for (var v : values()) {
             if (KODER.putIfAbsent(v.kode, v) != null) {

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/RettenTil.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/RettenTil.java
@@ -73,11 +73,6 @@ public enum RettenTil implements Kodeverdi {
         return kode;
     }
 
-    @Override
-    public String getOffisiellKode() {
-        return getKode();
-    }
-
     static {
         for (var v : values()) {
             if (KODER.putIfAbsent(v.kode, v) != null) {

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/RevurderingVarslingÅrsak.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/RevurderingVarslingÅrsak.java
@@ -88,9 +88,4 @@ public enum RevurderingVarslingÅrsak implements Kodeverdi {
         return kode;
     }
 
-    @Override
-    public String getOffisiellKode() {
-        return getKode();
-    }
-
 }

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/Tema.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/Tema.java
@@ -15,10 +15,11 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
+import no.nav.foreldrepenger.behandlingslager.kodeverk.MedOffisiellKode;
 
 @JsonFormat(shape = Shape.OBJECT)
 @JsonAutoDetect(getterVisibility = Visibility.NONE, setterVisibility = Visibility.NONE, fieldVisibility = Visibility.ANY)
-public enum Tema implements Kodeverdi {
+public enum Tema implements Kodeverdi, MedOffisiellKode {
 
     FOR("FOR", "Foreldre- og Svangerskapspenger", "FOR"),
 

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/Temagrupper.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/Temagrupper.java
@@ -12,10 +12,11 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
+import no.nav.foreldrepenger.behandlingslager.kodeverk.MedOffisiellKode;
 
 @JsonFormat(shape = Shape.OBJECT)
 @JsonAutoDetect(getterVisibility = Visibility.NONE, setterVisibility = Visibility.NONE, fieldVisibility = Visibility.ANY)
-public enum Temagrupper implements Kodeverdi {
+public enum Temagrupper implements Kodeverdi, MedOffisiellKode {
 
     FAMILIEYTELSER("FMLI", "Familie", "FMLI"),
     UDEFINERT("-", "Udefinert", null),

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/VariantFormat.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/VariantFormat.java
@@ -15,10 +15,11 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
+import no.nav.foreldrepenger.behandlingslager.kodeverk.MedOffisiellKode;
 
 @JsonFormat(shape = Shape.OBJECT)
 @JsonAutoDetect(getterVisibility = Visibility.NONE, setterVisibility = Visibility.NONE, fieldVisibility = Visibility.ANY)
-public enum VariantFormat implements Kodeverdi{
+public enum VariantFormat implements Kodeverdi, MedOffisiellKode {
 
     SLADDET("SLADD", "Sladdet format", "SLADDET"),
     SKANNING_META("SKANM", "Skanning metadata", "SKANNING_META"),

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/aksjonspunkt/AksjonspunktDefinisjon.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/aksjonspunkt/AksjonspunktDefinisjon.java
@@ -649,11 +649,6 @@ public enum AksjonspunktDefinisjon implements Kodeverdi {
     }
 
     @Override
-    public String getOffisiellKode() {
-        return getKode();
-    }
-
-    @Override
     public String getNavn() {
         return navn;
     }

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/aksjonspunkt/AksjonspunktStatus.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/aksjonspunkt/AksjonspunktStatus.java
@@ -61,11 +61,6 @@ public enum AksjonspunktStatus implements Kodeverdi {
         return kode;
     }
 
-    @Override
-    public String getOffisiellKode() {
-        return getKode();
-    }
-
     @JsonProperty
     @Override
     public String getKodeverk() {

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/aksjonspunkt/AksjonspunktType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/aksjonspunkt/AksjonspunktType.java
@@ -45,14 +45,10 @@ public enum AksjonspunktType implements Kodeverdi {
 
     private String kode;
 
-    @JsonIgnore
-    private String offisiellKode;
-
     private AksjonspunktType(String kode, String navn) {
         this.kode = kode;
-        this.navn = navn;
         /* merkelig nok har navn blit brukt som offisiell kode bla. mot Pip/ABAC. */
-        this.offisiellKode = navn;
+        this.navn = navn;
     }
 
     @JsonCreator
@@ -76,11 +72,6 @@ public enum AksjonspunktType implements Kodeverdi {
     @Override
     public String getKode() {
         return kode;
-    }
-
-    @Override
-    public String getOffisiellKode() {
-        return offisiellKode;
     }
 
     @JsonProperty

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/aksjonspunkt/ReaktiveringStatus.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/aksjonspunkt/ReaktiveringStatus.java
@@ -80,11 +80,6 @@ public enum ReaktiveringStatus implements Kodeverdi {
         return kode;
     }
 
-    @Override
-    public String getOffisiellKode() {
-        return getKode();
-    }
-
     @JsonProperty
     @Override
     public String getKodeverk() {

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/aksjonspunkt/Venteårsak.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/aksjonspunkt/Venteårsak.java
@@ -115,11 +115,6 @@ public enum Venteårsak implements Kodeverdi {
         return kode;
     }
 
-    @Override
-    public String getOffisiellKode() {
-        return getKode();
-    }
-
     @JsonProperty
     @Override
     public String getKodeverk() {

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/aksjonspunkt/VurderÅrsak.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/aksjonspunkt/VurderÅrsak.java
@@ -86,11 +86,6 @@ public enum VurderÅrsak implements Kodeverdi {
         return kode;
     }
 
-    @Override
-    public String getOffisiellKode() {
-        return getKode();
-    }
-
     @JsonProperty
     @Override
     public String getKodeverk() {

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/anke/AnkeAvvistÅrsak.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/anke/AnkeAvvistÅrsak.java
@@ -82,8 +82,4 @@ public enum AnkeAvvistÅrsak implements Kodeverdi {
         return kode;
     }
 
-    @Override
-    public String getOffisiellKode() {
-        return getKode();
-    }
 }

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/anke/AnkeOmgjørÅrsak.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/anke/AnkeOmgjørÅrsak.java
@@ -89,11 +89,6 @@ public enum AnkeOmgjørÅrsak implements Kodeverdi {
         return kode;
     }
 
-    @Override
-    public String getOffisiellKode() {
-        return getKode();
-    }
-
     @Converter(autoApply = true)
     public static class KodeverdiConverter implements AttributeConverter<AnkeOmgjørÅrsak, String> {
         @Override

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/anke/AnkeVurdering.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/anke/AnkeVurdering.java
@@ -90,11 +90,6 @@ public enum AnkeVurdering implements Kodeverdi {
         return kode;
     }
 
-    @Override
-    public String getOffisiellKode() {
-        return getKode();
-    }
-
     @Converter(autoApply = true)
     public static class KodeverdiConverter implements AttributeConverter<AnkeVurdering, String> {
         @Override

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/anke/AnkeVurderingOmgjør.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/anke/AnkeVurderingOmgjør.java
@@ -87,11 +87,6 @@ public enum AnkeVurderingOmgjør implements Kodeverdi {
         return kode;
     }
 
-    @Override
-    public String getOffisiellKode() {
-        return getKode();
-    }
-
     @Converter(autoApply = true)
     public static class KodeverdiConverter implements AttributeConverter<AnkeVurderingOmgjør, String> {
         @Override

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/beregning/AktivitetStatus.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/beregning/AktivitetStatus.java
@@ -120,11 +120,6 @@ public enum AktivitetStatus implements Kodeverdi {
         return kode;
     }
 
-    @Override
-    public String getOffisiellKode() {
-        return getKode();
-    }
-
     public Inntektskategori getInntektskategori() {
         return inntektskategori;
     }

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/beregning/BeregningSatsType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/beregning/BeregningSatsType.java
@@ -79,11 +79,6 @@ public enum BeregningSatsType implements Kodeverdi {
         return kode;
     }
 
-    @Override
-    public String getOffisiellKode() {
-        return getKode();
-    }
-
     @Converter(autoApply = true)
     public static class KodeverdiConverter implements AttributeConverter<BeregningSatsType, String> {
 

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/beregning/Inntektskategori.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/beregning/Inntektskategori.java
@@ -89,11 +89,6 @@ public enum Inntektskategori implements Kodeverdi {
         return kode;
     }
 
-    @Override
-    public String getOffisiellKode() {
-        return getKode();
-    }
-
     @Converter(autoApply = true)
     public static class KodeverdiConverter implements AttributeConverter<Inntektskategori, String> {
         @Override

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/familiehendelse/FamilieHendelseType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/familiehendelse/FamilieHendelseType.java
@@ -90,11 +90,6 @@ public enum FamilieHendelseType implements Kodeverdi {
         return kode;
     }
 
-    @Override
-    public String getOffisiellKode() {
-        return getKode();
-    }
-
     static {
         for (var v : values()) {
             if (KODER.putIfAbsent(v.kode, v) != null) {

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/familiehendelse/OmsorgsovertakelseVilkårType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/familiehendelse/OmsorgsovertakelseVilkårType.java
@@ -81,11 +81,6 @@ public enum OmsorgsovertakelseVilkårType implements Kodeverdi {
         return kode;
     }
 
-    @Override
-    public String getOffisiellKode() {
-        return getKode();
-    }
-
     static {
         for (var v : values()) {
             if (KODER.putIfAbsent(v.kode, v) != null) {

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/historikk/HistorikkAktør.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/historikk/HistorikkAktør.java
@@ -88,11 +88,6 @@ public enum HistorikkAktør implements Kodeverdi {
         return kode;
     }
 
-    @Override
-    public String getOffisiellKode() {
-        return getKode();
-    }
-
     @Converter(autoApply = true)
     public static class KodeverdiConverter implements AttributeConverter<HistorikkAktør, String> {
         @Override

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/historikk/HistorikkBegrunnelseType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/historikk/HistorikkBegrunnelseType.java
@@ -84,8 +84,4 @@ public enum HistorikkBegrunnelseType implements Kodeverdi {
         return kode;
     }
 
-    @Override
-    public String getOffisiellKode() {
-        return getKode();
-    }
 }

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/historikk/HistorikkEndretFeltType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/historikk/HistorikkEndretFeltType.java
@@ -202,11 +202,6 @@ public enum HistorikkEndretFeltType implements Kodeverdi {
         return kode;
     }
 
-    @Override
-    public String getOffisiellKode() {
-        return getKode();
-    }
-
     @Converter(autoApply = true)
     public static class KodeverdiConverter implements AttributeConverter<HistorikkEndretFeltType, String> {
         @Override

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/historikk/HistorikkEndretFeltVerdiType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/historikk/HistorikkEndretFeltVerdiType.java
@@ -147,11 +147,6 @@ public enum HistorikkEndretFeltVerdiType implements Kodeverdi {
         return kode;
     }
 
-    @Override
-    public String getOffisiellKode() {
-        return getKode();
-    }
-
     @Converter(autoApply = true)
     public static class KodeverdiConverter implements AttributeConverter<HistorikkEndretFeltVerdiType, String> {
         @Override

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/historikk/HistorikkOpplysningType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/historikk/HistorikkOpplysningType.java
@@ -88,11 +88,6 @@ public enum HistorikkOpplysningType implements Kodeverdi {
         return kode;
     }
 
-    @Override
-    public String getOffisiellKode() {
-        return getKode();
-    }
-
     @Converter(autoApply = true)
     public static class KodeverdiConverter implements AttributeConverter<HistorikkOpplysningType, String> {
         @Override

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/historikk/HistorikkResultatType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/historikk/HistorikkResultatType.java
@@ -96,11 +96,6 @@ public enum HistorikkResultatType implements Kodeverdi {
         return KODEVERK;
     }
 
-    @Override
-    public String getOffisiellKode() {
-        return getKode();
-    }
-
     @JsonProperty
     @Override
     public String getKode() {

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/historikk/HistorikkinnslagFeltType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/historikk/HistorikkinnslagFeltType.java
@@ -96,11 +96,6 @@ public enum HistorikkinnslagFeltType implements Kodeverdi {
         return kode;
     }
 
-    @Override
-    public String getOffisiellKode() {
-        return getKode();
-    }
-
     @Converter(autoApply = true)
     public static class KodeverdiConverter implements AttributeConverter<HistorikkinnslagFeltType, String> {
         @Override

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/historikk/HistorikkinnslagType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/historikk/HistorikkinnslagType.java
@@ -75,27 +75,27 @@ public enum HistorikkinnslagType implements Kodeverdi {
 
     // Mal Type 6
     NY_INFO_FRA_TPS("NY_INFO_FRA_TPS", "Ny info fra TPS", HistorikkinnslagMal.MAL_TYPE_6),
-    
+
     // Mal Type 7
     OVERSTYRT("OVERSTYRT", "Overstyrt", HistorikkinnslagMal.MAL_TYPE_7),
-    
+
     // Mal Type 8
     OPPTJENING("OPPTJENING", "Behandlet opptjeningsperiode", HistorikkinnslagMal.MAL_TYPE_8),
-    
+
     // Mal Type 9
     OVST_UTTAK_SPLITT("OVST_UTTAK_SPLITT", "Manuelt overstyring av uttak - splitting av periode", HistorikkinnslagMal.MAL_TYPE_9),
     FASTSATT_UTTAK_SPLITT("FASTSATT_UTTAK_SPLITT", "Manuelt fastsetting av uttak - splitting av periode", HistorikkinnslagMal.MAL_TYPE_9),
-    
+
     // Mal Type 10
     FASTSATT_UTTAK("FASTSATT_UTTAK", "Manuelt fastsetting av uttak", HistorikkinnslagMal.MAL_TYPE_10),
     OVST_UTTAK("OVST_UTTAK", "Manuelt overstyring av uttak", HistorikkinnslagMal.MAL_TYPE_10),
 
     UDEFINERT("-", "Ikke definert", null),
     ;
-    
+
     @Transient
     private String mal;
-    
+
     private static final Map<String, HistorikkinnslagType> KODER = new LinkedHashMap<>();
 
     public static final String KODEVERK = "HISTORIKKINNSLAG_TYPE";
@@ -151,16 +151,11 @@ public enum HistorikkinnslagType implements Kodeverdi {
     public String getKode() {
         return kode;
     }
-    
-    @Override
-    public String getOffisiellKode() {
-        return getKode();
-    }
 
     public String getMal() {
         return mal;
     }
-    
+
     @Converter(autoApply = true)
     public static class KodeverdiConverter implements AttributeConverter<HistorikkinnslagType, String> {
         @Override

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/innsyn/InnsynResultatType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/innsyn/InnsynResultatType.java
@@ -88,11 +88,6 @@ public enum InnsynResultatType implements Kodeverdi {
         return kode;
     }
 
-    @Override
-    public String getOffisiellKode() {
-        return getKode();
-    }
-
     @Converter(autoApply = true)
     public static class KodeverdiConverter implements AttributeConverter<InnsynResultatType, String> {
         @Override

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/klage/KlageAvvistÅrsak.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/klage/KlageAvvistÅrsak.java
@@ -105,11 +105,6 @@ public enum KlageAvvistÅrsak implements Kodeverdi, ÅrsakskodeMedLovreferanse {
         return lovHjemmel;
     }
 
-    @Override
-    public String getOffisiellKode() {
-        return getKode();
-    }
-
     @Converter(autoApply = true)
     public static class KodeverdiConverter implements AttributeConverter<KlageAvvistÅrsak, String> {
         @Override

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/klage/KlageMedholdÅrsak.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/klage/KlageMedholdÅrsak.java
@@ -89,11 +89,6 @@ public enum KlageMedholdÅrsak implements Kodeverdi {
         return kode;
     }
 
-    @Override
-    public String getOffisiellKode() {
-        return getKode();
-    }
-
     @Converter(autoApply = true)
     public static class KodeverdiConverter implements AttributeConverter<KlageMedholdÅrsak, String> {
         @Override

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/klage/KlageVurdering.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/klage/KlageVurdering.java
@@ -90,11 +90,6 @@ public enum KlageVurdering implements Kodeverdi {
         return kode;
     }
 
-    @Override
-    public String getOffisiellKode() {
-        return getKode();
-    }
-
     @Converter(autoApply = true)
     public static class KodeverdiConverter implements AttributeConverter<KlageVurdering, String> {
         @Override

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/klage/KlageVurderingOmgjør.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/klage/KlageVurderingOmgjør.java
@@ -88,11 +88,6 @@ public enum KlageVurderingOmgjør implements Kodeverdi {
         return kode;
     }
 
-    @Override
-    public String getOffisiellKode() {
-        return getKode();
-    }
-
     @Converter(autoApply = true)
     public static class KodeverdiConverter implements AttributeConverter<KlageVurderingOmgjør, String> {
         @Override

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/klage/KlageVurdertAv.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/klage/KlageVurdertAv.java
@@ -80,11 +80,6 @@ public enum KlageVurdertAv implements Kodeverdi {
         return kode;
     }
 
-    @Override
-    public String getOffisiellKode() {
-        return getKode();
-    }
-
     @Converter(autoApply = true)
     public static class KodeverdiConverter implements AttributeConverter<KlageVurdertAv, String> {
         @Override

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/medlemskap/MedlemskapDekningType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/medlemskap/MedlemskapDekningType.java
@@ -1,7 +1,6 @@
 package no.nav.foreldrepenger.behandlingslager.behandling.medlemskap;
 
 import static java.util.Arrays.asList;
-import static java.util.Collections.singletonList;
 import static java.util.Collections.unmodifiableList;
 
 import java.util.Collections;
@@ -55,27 +54,20 @@ public enum MedlemskapDekningType implements Kodeverdi {
         FULL,
         UNNTATT));
 
-    public static final List<MedlemskapDekningType> DEKNINGSTYPE_ER_FRIVILLIG_MEDLEM = unmodifiableList(asList(
+    public static final List<MedlemskapDekningType> DEKNINGSTYPE_ER_FRIVILLIG_MEDLEM = List.of(
         FTL_2_7_a,
         FTL_2_7_b,
         FTL_2_9_1_a,
         FTL_2_9_1_c,
         FTL_2_9_2_a,
         FTL_2_9_2_c,
-        FULL
-            ));
+        FULL);
 
-    public static final List<MedlemskapDekningType> DEKNINGSTYPE_ER_MEDLEM_UNNTATT = unmodifiableList(singletonList(
-        UNNTATT));
+    public static final List<MedlemskapDekningType> DEKNINGSTYPE_ER_MEDLEM_UNNTATT = List.of(UNNTATT);
 
-    public static final List<MedlemskapDekningType> DEKNINGSTYPE_ER_IKKE_MEDLEM = unmodifiableList(asList(
-        FTL_2_6,
-        FTL_2_9_1_b
-            ));
+    public static final List<MedlemskapDekningType> DEKNINGSTYPE_ER_IKKE_MEDLEM = List.of(FTL_2_6, FTL_2_9_1_b);
 
-    public static final List<MedlemskapDekningType> DEKNINGSTYPE_ER_UAVKLART = unmodifiableList(asList(
-        IHT_AVTALE,
-        OPPHOR));
+    public static final List<MedlemskapDekningType> DEKNINGSTYPE_ER_UAVKLART = List.of(IHT_AVTALE, OPPHOR);
 
 
     private static final Map<String, MedlemskapDekningType> KODER = new LinkedHashMap<>();
@@ -135,11 +127,6 @@ public enum MedlemskapDekningType implements Kodeverdi {
     @Override
     public String getKode() {
         return kode;
-    }
-
-    @Override
-    public String getOffisiellKode() {
-        return getKode();
     }
 
     @Converter(autoApply = true)

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/medlemskap/MedlemskapKildeType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/medlemskap/MedlemskapKildeType.java
@@ -96,11 +96,6 @@ public enum MedlemskapKildeType implements Kodeverdi {
         return kode;
     }
 
-    @Override
-    public String getOffisiellKode() {
-        return getKode();
-    }
-
     @Converter(autoApply = true)
     public static class KodeverdiConverter implements AttributeConverter<MedlemskapKildeType, String> {
         @Override

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/medlemskap/MedlemskapManuellVurderingType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/medlemskap/MedlemskapManuellVurderingType.java
@@ -90,11 +90,6 @@ public enum MedlemskapManuellVurderingType implements Kodeverdi {
         return kode;
     }
 
-    @Override
-    public String getOffisiellKode() {
-        return getKode();
-    }
-
     static {
         for (var v : values()) {
             if (KODER.putIfAbsent(v.kode, v) != null) {

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/medlemskap/MedlemskapType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/medlemskap/MedlemskapType.java
@@ -86,11 +86,6 @@ public enum MedlemskapType implements Kodeverdi {
         return kode;
     }
 
-    @Override
-    public String getOffisiellKode() {
-        return getKode();
-    }
-
     @Converter(autoApply = true)
     public static class KodeverdiConverter implements AttributeConverter<MedlemskapType, String> {
         @Override

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/opptjening/OpptjeningAktivitetKlassifisering.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/opptjening/OpptjeningAktivitetKlassifisering.java
@@ -87,11 +87,6 @@ public enum OpptjeningAktivitetKlassifisering implements Kodeverdi {
         return kode;
     }
 
-    @Override
-    public String getOffisiellKode() {
-        return getKode();
-    }
-
     @Converter(autoApply = true)
     public static class KodeverdiConverter implements AttributeConverter<OpptjeningAktivitetKlassifisering, String> {
         @Override

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/opptjening/OpptjeningAktivitetType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/opptjening/OpptjeningAktivitetType.java
@@ -197,11 +197,6 @@ public enum OpptjeningAktivitetType implements Kodeverdi {
         return kode;
     }
 
-    @Override
-    public String getOffisiellKode() {
-        return getKode();
-    }
-
     @Converter(autoApply = true)
     public static class KodeverdiConverter implements AttributeConverter<OpptjeningAktivitetType, String> {
         @Override

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/opptjening/ReferanseType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/opptjening/ReferanseType.java
@@ -85,11 +85,6 @@ public enum ReferanseType implements Kodeverdi {
         return kode;
     }
 
-    @Override
-    public String getOffisiellKode() {
-        return getKode();
-    }
-
     @Converter(autoApply = true)
     public static class KodeverdiConverter implements AttributeConverter<ReferanseType, String> {
         @Override

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/personopplysning/Diskresjonskode.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/personopplysning/Diskresjonskode.java
@@ -15,10 +15,11 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
+import no.nav.foreldrepenger.behandlingslager.kodeverk.MedOffisiellKode;
 
 @JsonFormat(shape = Shape.OBJECT)
 @JsonAutoDetect(getterVisibility = Visibility.NONE, setterVisibility = Visibility.NONE, fieldVisibility = Visibility.ANY)
-public enum Diskresjonskode implements Kodeverdi {
+public enum Diskresjonskode implements Kodeverdi, MedOffisiellKode {
 
     UDEFINERT("UDEF", "Udefinert", null),
     KODE6("SPSF", "Sperret adresse, strengt fortrolig", "SPSF"),

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/personopplysning/RelasjonsRolleType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/personopplysning/RelasjonsRolleType.java
@@ -111,11 +111,6 @@ public enum RelasjonsRolleType implements Kodeverdi {
         return kode;
     }
 
-    @Override
-    public String getOffisiellKode() {
-        return getKode();
-    }
-
     public static boolean erFar(RelasjonsRolleType relasjon) {
         return FARA.getKode().equals(relasjon.getKode());
     }

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/personopplysning/SivilstandType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/personopplysning/SivilstandType.java
@@ -74,11 +74,6 @@ public enum SivilstandType implements Kodeverdi {
         return navn;
     }
 
-    @Override
-    public String getOffisiellKode() {
-        return getKode();
-    }
-
     @JsonCreator
     public static SivilstandType fraKode(@JsonProperty("kode") String kode) {
         if (kode == null) {

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/skjermlenke/SkjermlenkeType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/skjermlenke/SkjermlenkeType.java
@@ -123,11 +123,6 @@ public enum SkjermlenkeType implements Kodeverdi {
     }
 
     @Override
-    public String getOffisiellKode() {
-        return getKode();
-    }
-
-    @Override
     public String getKodeverk() {
         return KODEVERK;
     }

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/søknad/FarSøkerType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/søknad/FarSøkerType.java
@@ -81,11 +81,6 @@ public enum FarSøkerType implements Kodeverdi {
         return kode;
     }
 
-    @Override
-    public String getOffisiellKode() {
-        return getKode();
-    }
-
     @JsonProperty
     @Override
     public String getKodeverk() {

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/søknad/ForeldreType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/søknad/ForeldreType.java
@@ -88,9 +88,4 @@ public enum ForeldreType implements Kodeverdi {
         return kode;
     }
 
-    @Override
-    public String getOffisiellKode() {
-        return getKode();
-    }
-
 }

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/søknad/Innsendingsvalg.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/søknad/Innsendingsvalg.java
@@ -88,11 +88,6 @@ public enum Innsendingsvalg implements Kodeverdi {
         return kode;
     }
 
-    @Override
-    public String getOffisiellKode() {
-        return getKode();
-    }
-
     @Converter(autoApply = true)
     public static class KodeverdiConverter implements AttributeConverter<Innsendingsvalg, String> {
         @Override

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/søknad/SøknadAnnenPartType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/søknad/SøknadAnnenPartType.java
@@ -88,11 +88,6 @@ public enum SøknadAnnenPartType implements Kodeverdi {
         return kode;
     }
 
-    @Override
-    public String getOffisiellKode() {
-        return getKode();
-    }
-
     @Converter(autoApply = true)
     public static class KodeverdiConverter implements AttributeConverter<SøknadAnnenPartType, String> {
         @Override

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/tilbakekreving/TilbakekrevingVidereBehandling.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/tilbakekreving/TilbakekrevingVidereBehandling.java
@@ -89,11 +89,6 @@ public enum TilbakekrevingVidereBehandling implements Kodeverdi {
         return kode;
     }
 
-    @Override
-    public String getOffisiellKode() {
-        return getKode();
-    }
-
     @Converter(autoApply = true)
     public static class KodeverdiConverter implements AttributeConverter<TilbakekrevingVidereBehandling, String> {
         @Override

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/tilrettelegging/TilretteleggingType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/tilrettelegging/TilretteleggingType.java
@@ -87,11 +87,6 @@ public enum TilretteleggingType implements Kodeverdi {
         return kode;
     }
 
-    @Override
-    public String getOffisiellKode() {
-        return getKode();
-    }
-
     @Converter(autoApply = true)
     public static class KodeverdiConverter implements AttributeConverter<TilretteleggingType, String> {
         @Override

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/vedtak/IverksettingStatus.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/vedtak/IverksettingStatus.java
@@ -75,11 +75,6 @@ public enum IverksettingStatus implements Kodeverdi {
         return kode;
     }
 
-    @Override
-    public String getOffisiellKode() {
-        return getKode();
-    }
-
     static {
         for (var v : values()) {
             if (KODER.putIfAbsent(v.kode, v) != null) {

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/vedtak/VedtakResultatType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/vedtak/VedtakResultatType.java
@@ -83,11 +83,6 @@ public enum VedtakResultatType implements Kodeverdi {
         return kode;
     }
 
-    @Override
-    public String getOffisiellKode() {
-        return getKode();
-    }
-
     static {
         for (var v : values()) {
             if (KODER.putIfAbsent(v.kode, v) != null) {

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/vedtak/Vedtaksbrev.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/vedtak/Vedtaksbrev.java
@@ -75,11 +75,6 @@ public enum Vedtaksbrev implements Kodeverdi{
         return kode;
     }
 
-    @Override
-    public String getOffisiellKode() {
-        return getKode();
-    }
-
     static {
         for (var v : values()) {
             if (KODER.putIfAbsent(v.kode, v) != null) {

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/verge/VergeType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/verge/VergeType.java
@@ -89,11 +89,6 @@ public enum VergeType implements Kodeverdi {
         return kode;
     }
 
-    @Override
-    public String getOffisiellKode() {
-        return getKode();
-    }
-
     @Converter(autoApply = true)
     public static class KodeverdiConverter implements AttributeConverter<VergeType, String> {
         @Override

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/vilkår/Avslagsårsak.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/vilkår/Avslagsårsak.java
@@ -1,9 +1,7 @@
 package no.nav.foreldrepenger.behandlingslager.behandling.vilkår;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
 
@@ -84,9 +82,8 @@ public enum Avslagsårsak implements Kodeverdi, ÅrsakskodeMedLovreferanse{
 
     public static final String KODEVERK = "AVSLAGSARSAK"; //$NON-NLS-1$
 
-    private static final Set<Avslagsårsak> ALLEREDE_UTBETALT_ENGANGSSTØNAD_ÅRSAKER = Collections.unmodifiableSet(new LinkedHashSet<>(
-        Arrays.asList(ENGANGSSTØNAD_ALLEREDE_UTBETALT_TIL_MOR, ENGANGSTØNAD_ER_ALLEREDE_UTBETAL_TIL_MOR,
-            ENGANGSSTØNAD_ER_ALLEREDE_UTBETALT_TIL_FAR_MEDMOR)));
+    private static final Set<Avslagsårsak> ALLEREDE_UTBETALT_ENGANGSSTØNAD_ÅRSAKER = Set.of(ENGANGSSTØNAD_ALLEREDE_UTBETALT_TIL_MOR,
+        ENGANGSTØNAD_ER_ALLEREDE_UTBETAL_TIL_MOR, ENGANGSSTØNAD_ER_ALLEREDE_UTBETALT_TIL_FAR_MEDMOR);
 
 
     // TODO endre fra raw json
@@ -135,11 +132,6 @@ public enum Avslagsårsak implements Kodeverdi, ÅrsakskodeMedLovreferanse{
     @Override
     public String getKodeverk() {
         return KODEVERK;
-    }
-
-    @Override
-    public String getOffisiellKode() {
-        return getKode();
     }
 
     /**

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/vilkår/VilkårResultatType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/vilkår/VilkårResultatType.java
@@ -79,11 +79,6 @@ public enum VilkårResultatType implements Kodeverdi {
         return kode;
     }
 
-    @Override
-    public String getOffisiellKode() {
-        return getKode();
-    }
-
     static {
         for (var v : values()) {
             if (KODER.putIfAbsent(v.kode, v) != null) {

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/vilkår/VilkårType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/vilkår/VilkårType.java
@@ -222,11 +222,6 @@ public enum VilkårType implements Kodeverdi {
         return kode;
     }
 
-    @Override
-    public String getOffisiellKode() {
-        return getKode();
-    }
-
     static {
         for (var v : values()) {
             if (KODER.putIfAbsent(v.kode, v) != null) {

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/vilkår/VilkårUtfallMerknad.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/vilkår/VilkårUtfallMerknad.java
@@ -113,11 +113,6 @@ public enum VilkårUtfallMerknad implements Kodeverdi {
         return kode;
     }
 
-    @Override
-    public String getOffisiellKode() {
-        return getKode();
-    }
-
     static {
         for (var v : values()) {
             if (KODER.putIfAbsent(v.kode, v) != null) {

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/vilkår/VilkårUtfallType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/vilkår/VilkårUtfallType.java
@@ -82,11 +82,6 @@ public enum VilkårUtfallType implements Kodeverdi {
         return kode;
     }
 
-    @Override
-    public String getOffisiellKode() {
-        return getKode();
-    }
-
     static {
         for (var v : values()) {
             if (KODER.putIfAbsent(v.kode, v) != null) {

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/ytelsefordeling/MorsAktivitet.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/ytelsefordeling/MorsAktivitet.java
@@ -88,11 +88,6 @@ public enum MorsAktivitet implements Kodeverdi {
         return kode;
     }
 
-    @Override
-    public String getOffisiellKode() {
-        return this.getKode();
-    }
-
     @Converter(autoApply = true)
     public static class KodeverdiConverter implements AttributeConverter<MorsAktivitet, String> {
         @Override

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/ytelsefordeling/UttakDokumentasjonType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/ytelsefordeling/UttakDokumentasjonType.java
@@ -89,11 +89,6 @@ public enum UttakDokumentasjonType implements Kodeverdi {
         return kode;
     }
 
-    @Override
-    public String getOffisiellKode() {
-        return this.getKode();
-    }
-
     @Converter(autoApply = true)
     public static class KodeverdiConverter implements AttributeConverter<UttakDokumentasjonType, String> {
         @Override

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/ytelsefordeling/periode/FordelingPeriodeKilde.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/ytelsefordeling/periode/FordelingPeriodeKilde.java
@@ -79,11 +79,6 @@ public enum FordelingPeriodeKilde implements Kodeverdi {
         return kode;
     }
 
-    @Override
-    public String getOffisiellKode() {
-        return this.getKode();
-    }
-
     @Converter(autoApply = true)
     public static class KodeverdiConverter implements AttributeConverter<FordelingPeriodeKilde, String> {
         @Override

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/ytelsefordeling/periode/UttakPeriodeType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/ytelsefordeling/periode/UttakPeriodeType.java
@@ -87,11 +87,6 @@ public enum UttakPeriodeType implements Kodeverdi {
         return kode;
     }
 
-    @Override
-    public String getOffisiellKode() {
-        return this.getKode();
-    }
-
     @Converter(autoApply = true)
     public static class KodeverdiConverter implements AttributeConverter<UttakPeriodeType, String> {
         @Override

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/ytelsefordeling/periode/UttakPeriodeVurderingType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/ytelsefordeling/periode/UttakPeriodeVurderingType.java
@@ -82,11 +82,6 @@ public enum UttakPeriodeVurderingType implements Kodeverdi {
         return kode;
     }
 
-    @Override
-    public String getOffisiellKode() {
-        return this.getKode();
-    }
-
     @Converter(autoApply = true)
     public static class KodeverdiConverter implements AttributeConverter<UttakPeriodeVurderingType, String> {
         @Override

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/ytelsefordeling/årsak/OppholdÅrsak.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/ytelsefordeling/årsak/OppholdÅrsak.java
@@ -83,11 +83,6 @@ public enum OppholdÅrsak implements Årsak {
         return kode;
     }
 
-    @Override
-    public String getOffisiellKode() {
-        return this.getKode();
-    }
-
     @Converter(autoApply = true)
     public static class KodeverdiConverter implements AttributeConverter<OppholdÅrsak, String> {
         @Override

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/ytelsefordeling/årsak/OverføringÅrsak.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/ytelsefordeling/årsak/OverføringÅrsak.java
@@ -81,11 +81,6 @@ public enum OverføringÅrsak implements Årsak {
         return kode;
     }
 
-    @Override
-    public String getOffisiellKode() {
-        return this.getKode();
-    }
-
     @Converter(autoApply = true)
     public static class KodeverdiConverter implements AttributeConverter<OverføringÅrsak, String> {
         @Override

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/ytelsefordeling/årsak/UtsettelseÅrsak.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/ytelsefordeling/årsak/UtsettelseÅrsak.java
@@ -85,11 +85,6 @@ public enum UtsettelseÅrsak implements Årsak {
         return kode;
     }
 
-    @Override
-    public String getOffisiellKode() {
-        return this.getKode();
-    }
-
     @Converter(autoApply = true)
     public static class KodeverdiConverter implements AttributeConverter<UtsettelseÅrsak, String> {
         @Override

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/ytelsefordeling/årsak/Årsak.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/ytelsefordeling/årsak/Årsak.java
@@ -21,9 +21,5 @@ public interface Årsak extends Kodeverdi {
             return "-";
         }
 
-        @Override
-        public String getOffisiellKode() {
-            return getKode();
-        }
     };
 }

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/fagsak/FagsakStatus.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/fagsak/FagsakStatus.java
@@ -81,11 +81,6 @@ public enum FagsakStatus implements Kodeverdi {
         return kode;
     }
 
-    @Override
-    public String getOffisiellKode() {
-        return getKode();
-    }
-
     @JsonProperty
     @Override
     public String getKodeverk() {

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/fagsak/FagsakYtelseType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/fagsak/FagsakYtelseType.java
@@ -92,11 +92,6 @@ public enum FagsakYtelseType implements Kodeverdi {
         return navn;
     }
 
-    @Override
-    public String getOffisiellKode() {
-        return getKode();
-    }
-
     @Converter(autoApply = true)
     public static class KodeverdiConverter implements AttributeConverter<FagsakYtelseType, String> {
         @Override

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/geografisk/Landkoder.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/geografisk/Landkoder.java
@@ -334,11 +334,6 @@ public enum Landkoder implements Kodeverdi {
         return navn;
     }
 
-    @Override
-    public String getOffisiellKode() {
-        return getKode();
-    }
-
     @JsonProperty
     @Override
     public String getKode() {

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/geografisk/Region.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/geografisk/Region.java
@@ -80,11 +80,6 @@ public enum Region implements Kodeverdi {
         return navn;
     }
 
-    @Override
-    public String getOffisiellKode() {
-        return getKode();
-    }
-
     @JsonProperty
     @Override
     public String getKode() {

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/geografisk/Språkkode.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/geografisk/Språkkode.java
@@ -18,11 +18,12 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
+import no.nav.foreldrepenger.behandlingslager.kodeverk.MedOffisiellKode;
 import no.nav.foreldrepenger.behandlingslager.kodeverk.TempAvledeKode;
 
 @JsonFormat(shape = Shape.OBJECT)
 @JsonAutoDetect(getterVisibility = Visibility.NONE, setterVisibility = Visibility.NONE, fieldVisibility = Visibility.ANY)
-public enum Språkkode implements Kodeverdi {
+public enum Språkkode implements Kodeverdi, MedOffisiellKode {
 
     /**
      * Konstanter for å skrive ned kodeverdi.

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/hendelser/ForretningshendelseType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/hendelser/ForretningshendelseType.java
@@ -73,11 +73,6 @@ public enum ForretningshendelseType implements Kodeverdi {
         return kode;
     }
 
-    @Override
-    public String getOffisiellKode() {
-        return getKode();
-    }
-
     static {
         for (var v : values()) {
             if (KODER.putIfAbsent(v.kode, v) != null) {

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/hendelser/StartpunktType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/hendelser/StartpunktType.java
@@ -157,11 +157,6 @@ public enum StartpunktType implements Kodeverdi {
     }
 
     @Override
-    public String getOffisiellKode() {
-        return getKode();
-    }
-
-    @Override
     public String toString() {
         return super.toString() + "('" + getKode() + "')";
     }

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/kodeverk/BasisKodeverdi.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/kodeverk/BasisKodeverdi.java
@@ -4,13 +4,11 @@ import no.nav.foreldrepenger.behandlingslager.diff.IndexKey;
 
 public interface BasisKodeverdi extends IndexKey {
     String getKode();
-    
-    String getOffisiellKode();
-    
+
     String getKodeverk();
 
     String getNavn();
-    
+
     @Override
     default String getIndexKey() {
         return getKode();

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/kodeverk/DefaultKodeverdi.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/kodeverk/DefaultKodeverdi.java
@@ -11,33 +11,29 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 @JsonFormat(shape = Shape.OBJECT)
 @JsonAutoDetect(getterVisibility = Visibility.NONE, setterVisibility = Visibility.NONE, fieldVisibility = Visibility.ANY)
 public class DefaultKodeverdi implements BasisKodeverdi {
-    
+
     @JsonProperty("kode")
     private String kode;
-    
-    @JsonProperty("offisiellKode")
-    private String offisiellKode;
-    
+
     @JsonProperty("navn")
     private String navn;
-    
+
     @JsonProperty("kodeverk")
     private String kodeverk;
-    
+
     @JsonProperty("gyldigFom")
     private LocalDate gyldigFom;
-    
+
     @JsonProperty("gyldigTom")
     private LocalDate gyldigtom;
 
-    public DefaultKodeverdi(String kodeverk, String offisiellKode, String navn) {
-        this(kodeverk, offisiellKode, offisiellKode, navn, null, null);
+    public DefaultKodeverdi(String kodeverk, String kode, String navn) {
+        this(kodeverk, kode, navn, null, null);
     }
 
-    public DefaultKodeverdi(String kodeverk, String kode, String offisiellKode, String navn, LocalDate gyldigFom, LocalDate gyldigtom) {
+    public DefaultKodeverdi(String kodeverk, String kode, String navn, LocalDate gyldigFom, LocalDate gyldigtom) {
         this.kodeverk = kodeverk;
         this.kode = kode;
-        this.offisiellKode = offisiellKode;
         this.navn = navn;
         this.gyldigFom = gyldigFom;
         this.gyldigtom = gyldigtom;
@@ -45,12 +41,7 @@ public class DefaultKodeverdi implements BasisKodeverdi {
 
     @Override
     public String getKode() {
-        return getOffisiellKode();
-    }
-
-    @Override
-    public String getOffisiellKode() {
-        return offisiellKode;
+        return kode;
     }
 
     @Override
@@ -62,11 +53,11 @@ public class DefaultKodeverdi implements BasisKodeverdi {
     public String getNavn() {
         return navn;
     }
-    
+
     public LocalDate getGyldigFom() {
         return gyldigFom;
     }
-    
+
     public LocalDate getGyldigTom() {
         return gyldigtom;
     }

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/kodeverk/Fagsystem.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/kodeverk/Fagsystem.java
@@ -17,7 +17,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 @JsonFormat(shape = Shape.OBJECT)
 @JsonAutoDetect(getterVisibility = Visibility.NONE, setterVisibility = Visibility.NONE, fieldVisibility = Visibility.ANY)
-public enum Fagsystem implements Kodeverdi {
+public enum Fagsystem implements Kodeverdi, MedOffisiellKode {
 
     FPSAK("FPSAK", "Vedtaksløsning Foreldrepenger", "FS36"),
     TPS("TPS", "TPS", "FS03"),

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/kodeverk/MedOffisiellKode.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/kodeverk/MedOffisiellKode.java
@@ -1,0 +1,8 @@
+package no.nav.foreldrepenger.behandlingslager.kodeverk;
+
+/** Kodeverk som er portet til java. */
+public interface MedOffisiellKode {
+
+    String getOffisiellKode();
+
+}

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/pip/PipRepository.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/pip/PipRepository.java
@@ -171,13 +171,9 @@ public class PipRepository {
     }
 
     public Set<String> hentAksjonspunktTypeForAksjonspunktKoder(Collection<String> aksjonspunktKoder) {
-        if (aksjonspunktKoder.isEmpty()) {
-            return Collections.emptySet();
-        }
         return aksjonspunktKoder.stream()
-            .map(ak -> AksjonspunktDefinisjon.fraKode(ak).getAksjonspunktType().getOffisiellKode())
-            .distinct().sorted()
-            .collect(Collectors.toCollection(LinkedHashSet::new));
+            .map(ak -> AksjonspunktDefinisjon.fraKode(ak).getAksjonspunktType().getNavn()) // ja, getNavn er riktig her....
+            .collect(Collectors.toSet());
     }
 
     @SuppressWarnings({ "unchecked", "cast" })

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/risikoklassifisering/FaresignalVurdering.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/risikoklassifisering/FaresignalVurdering.java
@@ -85,11 +85,6 @@ public enum FaresignalVurdering implements Kodeverdi {
         return kode;
     }
 
-    @Override
-    public String getOffisiellKode() {
-        return getKode();
-    }
-
     @Converter(autoApply = true)
     public static class KodeverdiConverter implements AttributeConverter<FaresignalVurdering, String> {
         @Override

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/risikoklassifisering/Kontrollresultat.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/risikoklassifisering/Kontrollresultat.java
@@ -86,11 +86,6 @@ public enum Kontrollresultat implements Kodeverdi {
         return kode;
     }
 
-    @Override
-    public String getOffisiellKode() {
-        return getKode();
-    }
-
     @Converter(autoApply = true)
     public static class KodeverdiConverter implements AttributeConverter<Kontrollresultat, String> {
         @Override

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/uttak/PeriodeResultatType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/uttak/PeriodeResultatType.java
@@ -96,11 +96,6 @@ public enum PeriodeResultatType implements Kodeverdi {
         return kode;
     }
 
-    @Override
-    public String getOffisiellKode() {
-        return getKode();
-    }
-
     @Converter(autoApply = true)
     public static class KodeverdiConverter implements AttributeConverter<PeriodeResultatType, String> {
         @Override

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/uttak/UttakArbeidType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/uttak/UttakArbeidType.java
@@ -82,11 +82,6 @@ public enum UttakArbeidType implements Kodeverdi {
         return kode;
     }
 
-    @Override
-    public String getOffisiellKode() {
-        return this.getKode();
-    }
-
     @Converter(autoApply = true)
     public static class KodeverdiConverter implements AttributeConverter<UttakArbeidType, String> {
         @Override

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/uttak/fp/GraderingAvslagÅrsak.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/uttak/fp/GraderingAvslagÅrsak.java
@@ -107,11 +107,6 @@ public enum GraderingAvslagÅrsak implements Kodeverdi {
         return kode;
     }
 
-    @Override
-    public String getOffisiellKode() {
-        return getKode();
-    }
-
     public LocalDate getGyldigFraOgMed() {
         return LocalDate.of(2001, 01, 01);
     }

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/uttak/fp/IkkeOppfyltÅrsak.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/uttak/fp/IkkeOppfyltÅrsak.java
@@ -228,11 +228,6 @@ public enum IkkeOppfyltÅrsak implements PeriodeResultatÅrsak {
         return kode;
     }
 
-    @Override
-    public String getOffisiellKode() {
-        return getKode();
-    }
-
     /** Returnerer p.t. Raw json. */
     @Override
     public String getLovHjemmelData() {

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/uttak/fp/InnvilgetÅrsak.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/uttak/fp/InnvilgetÅrsak.java
@@ -183,11 +183,6 @@ public enum InnvilgetÅrsak implements PeriodeResultatÅrsak {
         return kode;
     }
 
-    @Override
-    public String getOffisiellKode() {
-        return getKode();
-    }
-
     /** Returnerer p.t. Raw json. */
     @Override
     public String getLovHjemmelData() {

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/uttak/fp/ManuellBehandlingÅrsak.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/uttak/fp/ManuellBehandlingÅrsak.java
@@ -96,11 +96,6 @@ public enum ManuellBehandlingÅrsak implements Kodeverdi {
         return kode;
     }
 
-    @Override
-    public String getOffisiellKode() {
-        return this.getKode();
-    }
-
     @Converter(autoApply = true)
     public static class KodeverdiConverter implements AttributeConverter<ManuellBehandlingÅrsak, String> {
         @Override

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/uttak/fp/PeriodeResultatÅrsak.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/uttak/fp/PeriodeResultatÅrsak.java
@@ -51,11 +51,6 @@ public interface PeriodeResultatÅrsak extends ÅrsakskodeMedLovreferanse, Kodev
         public String getLovHjemmelData() {
             return null;
         }
-
-        @Override
-        public String getOffisiellKode() {
-            return getKode();
-        }
     };
 
     @JsonProperty("gyldigFom")

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/uttak/fp/StønadskontoType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/uttak/fp/StønadskontoType.java
@@ -91,11 +91,6 @@ public enum StønadskontoType implements Kodeverdi {
         return kode;
     }
 
-    @Override
-    public String getOffisiellKode() {
-        return getKode();
-    }
-
     @Converter(autoApply = true)
     public static class KodeverdiConverter implements AttributeConverter<StønadskontoType, String> {
         @Override

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/uttak/fp/UttakUtsettelseType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/uttak/fp/UttakUtsettelseType.java
@@ -84,11 +84,6 @@ public enum UttakUtsettelseType implements Kodeverdi {
         return kode;
     }
 
-    @Override
-    public String getOffisiellKode() {
-        return this.getKode();
-    }
-
     @Converter(autoApply = true)
     public static class KodeverdiConverter implements AttributeConverter<UttakUtsettelseType, String> {
         @Override

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/uttak/svp/ArbeidsforholdIkkeOppfyltÅrsak.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/uttak/svp/ArbeidsforholdIkkeOppfyltÅrsak.java
@@ -87,11 +87,6 @@ public enum ArbeidsforholdIkkeOppfyltÅrsak implements Kodeverdi {
         return kode;
     }
 
-    @Override
-    public String getOffisiellKode() {
-        return getKode();
-    }
-
     @Converter(autoApply = true)
     public static class KodeverdiConverter implements AttributeConverter<ArbeidsforholdIkkeOppfyltÅrsak, String> {
         @Override

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/uttak/svp/PeriodeIkkeOppfyltÅrsak.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/uttak/svp/PeriodeIkkeOppfyltÅrsak.java
@@ -107,11 +107,6 @@ public enum PeriodeIkkeOppfyltÅrsak implements Kodeverdi, ÅrsakskodeMedLovrefe
     }
 
     @Override
-    public String getOffisiellKode() {
-        return getKode();
-    }
-
-    @Override
     public String getLovHjemmelData() {
         return lovHjemmel;
     }

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/virksomhet/ArbeidType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/virksomhet/ArbeidType.java
@@ -15,6 +15,7 @@ package no.nav.foreldrepenger.behandlingslager.virksomhet;
  * <li></li>
  * </ul>
  */
+
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -34,11 +35,12 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
+import no.nav.foreldrepenger.behandlingslager.kodeverk.MedOffisiellKode;
 import no.nav.foreldrepenger.behandlingslager.kodeverk.TempAvledeKode;
 
 @JsonFormat(shape = Shape.OBJECT)
 @JsonAutoDetect(getterVisibility = Visibility.NONE, setterVisibility = Visibility.NONE, fieldVisibility = Visibility.ANY)
-public enum ArbeidType implements Kodeverdi {
+public enum ArbeidType implements Kodeverdi, MedOffisiellKode {
 
     ETTERLØNN_SLUTTPAKKE("ETTERLØNN_SLUTTPAKKE", "Etterlønn eller sluttpakke", null, true),
     FORENKLET_OPPGJØRSORDNING("FORENKLET_OPPGJØRSORDNING", "Forenklet oppgjørsordning ", "forenkletOppgjoersordning", false),

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/virksomhet/Organisasjonstype.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/virksomhet/Organisasjonstype.java
@@ -84,11 +84,6 @@ public enum Organisasjonstype implements Kodeverdi {
         return kode;
     }
 
-    @Override
-    public String getOffisiellKode() {
-        return getKode();
-    }
-
     public static boolean erKunstig(String orgNr) {
         return OrgNummer.KUNSTIG_ORG.equals(orgNr);
     }

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/ytelse/RelatertYtelseType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/ytelse/RelatertYtelseType.java
@@ -105,11 +105,6 @@ public enum RelatertYtelseType implements Kodeverdi {
         return kode;
     }
 
-    @Override
-    public String getOffisiellKode() {
-        return getKode();
-    }
-
     public boolean girOpptjeningsTid(FagsakYtelseType ytelseType) {
         final var relatertYtelseTypeSet = OPPTJENING_RELATERTYTELSE_CONFIG.get(ytelseType);
         if (relatertYtelseTypeSet == null) {

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/ytelse/TemaUnderkategori.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/ytelse/TemaUnderkategori.java
@@ -40,7 +40,7 @@ public enum TemaUnderkategori implements Kodeverdi {
     BT("BT", "Stønad til barnetilsyn", "BT"),
     FL("FL", "Tilskudd til flytting", "FL"),
     UT("UT", "Skolepenger", "UT"),
-    
+
     UDEFINERT("-", "Udefinert", null),
     ;
 
@@ -104,11 +104,6 @@ public enum TemaUnderkategori implements Kodeverdi {
     @Override
     public String getKode() {
         return kode;
-    }
-
-    @Override
-    public String getOffisiellKode() {
-        return offisiellKode;
     }
 
 }

--- a/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/iay/modell/kodeverk/ArbeidsforholdHandlingType.java
+++ b/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/iay/modell/kodeverk/ArbeidsforholdHandlingType.java
@@ -98,11 +98,6 @@ public enum ArbeidsforholdHandlingType implements Kodeverdi {
         return kode;
     }
 
-    @Override
-    public String getOffisiellKode() {
-        return getKode();
-    }
-
     public boolean erPeriodeOverstyrt() {
         return MED_OVERSTYRT_PERIODE.contains(this);
     }

--- a/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/iay/modell/kodeverk/Arbeidskategori.java
+++ b/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/iay/modell/kodeverk/Arbeidskategori.java
@@ -95,10 +95,6 @@ public enum Arbeidskategori implements Kodeverdi {
     public String getKode() {
         return kode;
     }
-    
-    @Override
-    public String getOffisiellKode() {
-        return getKode();
-    }
+
 
 }

--- a/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/iay/modell/kodeverk/BekreftetPermisjonStatus.java
+++ b/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/iay/modell/kodeverk/BekreftetPermisjonStatus.java
@@ -87,9 +87,4 @@ public enum BekreftetPermisjonStatus implements Kodeverdi {
     public String getKode() {
         return kode;
     }
-    
-    @Override
-    public String getOffisiellKode() {
-        return getKode();
-    }
 }

--- a/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/iay/modell/kodeverk/InntektPeriodeType.java
+++ b/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/iay/modell/kodeverk/InntektPeriodeType.java
@@ -14,10 +14,11 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
+import no.nav.foreldrepenger.behandlingslager.kodeverk.MedOffisiellKode;
 
 @JsonFormat(shape = Shape.OBJECT)
 @JsonAutoDetect(getterVisibility = Visibility.NONE, setterVisibility = Visibility.NONE, fieldVisibility = Visibility.ANY)
-public enum InntektPeriodeType implements Kodeverdi {
+public enum InntektPeriodeType implements Kodeverdi, MedOffisiellKode {
 
     DAGLIG("DAGLG", "Daglig", "D", Period.ofDays(1)),
     UKENTLIG("UKNLG", "Ukentlig", "U", Period.ofWeeks(1)),
@@ -93,7 +94,7 @@ public enum InntektPeriodeType implements Kodeverdi {
     public String getKode() {
         return kode;
     }
-    
+
     public Period getPeriode() {
         return periode;
     }

--- a/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/iay/modell/kodeverk/InntektsFilter.java
+++ b/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/iay/modell/kodeverk/InntektsFilter.java
@@ -15,10 +15,11 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
+import no.nav.foreldrepenger.behandlingslager.kodeverk.MedOffisiellKode;
 
 @JsonFormat(shape = Shape.OBJECT)
 @JsonAutoDetect(getterVisibility = Visibility.NONE, setterVisibility = Visibility.NONE, fieldVisibility = Visibility.ANY)
-public enum InntektsFilter implements Kodeverdi {
+public enum InntektsFilter implements Kodeverdi, MedOffisiellKode {
 
     BEREGNINGSGRUNNLAG("BEREGNINGSGRUNNLAG", "Beregningsgrunnlag", "8-28",
             InntektsKilde.INNTEKT_BEREGNING, InntektsFormål.FORMAAL_FORELDREPENGER),

--- a/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/iay/modell/kodeverk/InntektsFormål.java
+++ b/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/iay/modell/kodeverk/InntektsFormål.java
@@ -13,10 +13,11 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
+import no.nav.foreldrepenger.behandlingslager.kodeverk.MedOffisiellKode;
 
 @JsonFormat(shape = Shape.OBJECT)
 @JsonAutoDetect(getterVisibility = Visibility.NONE, setterVisibility = Visibility.NONE, fieldVisibility = Visibility.ANY)
-public enum InntektsFormål implements Kodeverdi {
+public enum InntektsFormål implements Kodeverdi, MedOffisiellKode {
 
     UDEFINERT("-", "Ikke definert", null),
     FORMAAL_FORELDREPENGER("FORMAAL_FORELDREPENGER", "Formålskode for foreldrepenger", "Foreldrepenger"),

--- a/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/iay/modell/kodeverk/InntektsKilde.java
+++ b/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/iay/modell/kodeverk/InntektsKilde.java
@@ -13,10 +13,11 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
+import no.nav.foreldrepenger.behandlingslager.kodeverk.MedOffisiellKode;
 
 @JsonFormat(shape = Shape.OBJECT)
 @JsonAutoDetect(getterVisibility = Visibility.NONE, setterVisibility = Visibility.NONE, fieldVisibility = Visibility.ANY)
-public enum InntektsKilde implements Kodeverdi {
+public enum InntektsKilde implements Kodeverdi, MedOffisiellKode {
 
     UDEFINERT("-", "Ikke definert", null),
     INNTEKT_OPPTJENING("INNTEKT_OPPTJENING", "INNTEKT_OPPTJENING", "INNTEKT"),

--- a/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/iay/modell/kodeverk/InntektsmeldingInnsendingsårsak.java
+++ b/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/iay/modell/kodeverk/InntektsmeldingInnsendingsårsak.java
@@ -77,9 +77,4 @@ public enum InntektsmeldingInnsendingsårsak implements Kodeverdi {
     public String getKode() {
         return kode;
     }
-    
-    @Override
-    public String getOffisiellKode() {
-        return getKode();
-    }
 }

--- a/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/iay/modell/kodeverk/InntektspostType.java
+++ b/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/iay/modell/kodeverk/InntektspostType.java
@@ -13,10 +13,11 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
+import no.nav.foreldrepenger.behandlingslager.kodeverk.MedOffisiellKode;
 
 @JsonFormat(shape = Shape.OBJECT)
 @JsonAutoDetect(getterVisibility = Visibility.NONE, setterVisibility = Visibility.NONE, fieldVisibility = Visibility.ANY)
-public enum InntektspostType implements Kodeverdi {
+public enum InntektspostType implements Kodeverdi, MedOffisiellKode {
 
     UDEFINERT("-", "Ikke definert", null),
     LØNN("LØNN", "Lønn", "LONN"),

--- a/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/iay/modell/kodeverk/NaturalYtelseType.java
+++ b/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/iay/modell/kodeverk/NaturalYtelseType.java
@@ -15,10 +15,11 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
+import no.nav.foreldrepenger.behandlingslager.kodeverk.MedOffisiellKode;
 
 @JsonFormat(shape = Shape.OBJECT)
 @JsonAutoDetect(getterVisibility = Visibility.NONE, setterVisibility = Visibility.NONE, fieldVisibility = Visibility.ANY)
-public enum NaturalYtelseType implements Kodeverdi {
+public enum NaturalYtelseType implements Kodeverdi, MedOffisiellKode {
 
     ELEKTRISK_KOMMUNIKASJON("ELEKTRISK_KOMMUNIKASJON", "Elektrisk kommunikasjon", "elektroniskKommunikasjon"),
     AKSJER_GRUNNFONDSBEVIS_TIL_UNDERKURS("AKSJER_UNDERKURS", "Aksjer grunnfondsbevis til underkurs", "aksjerGrunnfondsbevisTilUnderkurs"),

--- a/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/iay/modell/kodeverk/NæringsinntektType.java
+++ b/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/iay/modell/kodeverk/NæringsinntektType.java
@@ -13,10 +13,11 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
+import no.nav.foreldrepenger.behandlingslager.kodeverk.MedOffisiellKode;
 
 @JsonFormat(shape = Shape.OBJECT)
 @JsonAutoDetect(getterVisibility = Visibility.NONE, setterVisibility = Visibility.NONE, fieldVisibility = Visibility.ANY)
-public enum NæringsinntektType implements Kodeverdi, YtelseType {
+public enum NæringsinntektType implements Kodeverdi, MedOffisiellKode, YtelseType {
 
     VEDERLAG_DAGMAMMA_I_EGETHJEM("VEDERLAG_DAGMAMMA_I_EGETHJEM", "Vederlag dagmamma i egethjem", "vederlagDagmammaIEgetHjem"),
     VEDERLAG("VEDERLAG", "Vederlag", "vederlag"),

--- a/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/iay/modell/kodeverk/OffentligYtelseType.java
+++ b/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/iay/modell/kodeverk/OffentligYtelseType.java
@@ -13,10 +13,11 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
+import no.nav.foreldrepenger.behandlingslager.kodeverk.MedOffisiellKode;
 
 @JsonFormat(shape = Shape.OBJECT)
 @JsonAutoDetect(getterVisibility = Visibility.NONE, setterVisibility = Visibility.NONE, fieldVisibility = Visibility.ANY)
-public enum OffentligYtelseType implements Kodeverdi, YtelseType {
+public enum OffentligYtelseType implements Kodeverdi, MedOffisiellKode, YtelseType {
 
     UDEFINERT("-", "UNDEFINED", null),
     AAP("AAP", "Arbeidsavklaringspenger", "arbeidsavklaringspenger"),

--- a/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/iay/modell/kodeverk/PensjonTrygdType.java
+++ b/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/iay/modell/kodeverk/PensjonTrygdType.java
@@ -13,10 +13,11 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
+import no.nav.foreldrepenger.behandlingslager.kodeverk.MedOffisiellKode;
 
 @JsonFormat(shape = Shape.OBJECT)
 @JsonAutoDetect(getterVisibility = Visibility.NONE, setterVisibility = Visibility.NONE, fieldVisibility = Visibility.ANY)
-public enum PensjonTrygdType implements Kodeverdi, YtelseType {
+public enum PensjonTrygdType implements Kodeverdi, MedOffisiellKode, YtelseType {
 
     UDEFINERT("-", "Undefined", null),
     ALDERSPENSJON("ALDERSPENSJON", "Alderspensjon", "alderspensjon"),

--- a/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/iay/modell/kodeverk/PermisjonsbeskrivelseType.java
+++ b/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/iay/modell/kodeverk/PermisjonsbeskrivelseType.java
@@ -14,11 +14,12 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
+import no.nav.foreldrepenger.behandlingslager.kodeverk.MedOffisiellKode;
 import no.nav.foreldrepenger.behandlingslager.kodeverk.TempAvledeKode;
 
 @JsonFormat(shape = Shape.OBJECT)
 @JsonAutoDetect(getterVisibility = Visibility.NONE, setterVisibility = Visibility.NONE, fieldVisibility = Visibility.ANY)
-public enum PermisjonsbeskrivelseType implements Kodeverdi {
+public enum PermisjonsbeskrivelseType implements Kodeverdi, MedOffisiellKode {
 
     UDEFINERT("-", "Ikke definert", null),
     PERMISJON("PERMISJON", "Permisjon", "permisjon"),

--- a/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/iay/modell/kodeverk/RelatertYtelseTilstand.java
+++ b/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/iay/modell/kodeverk/RelatertYtelseTilstand.java
@@ -13,10 +13,11 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
+import no.nav.foreldrepenger.behandlingslager.kodeverk.MedOffisiellKode;
 
 @JsonFormat(shape = Shape.OBJECT)
 @JsonAutoDetect(getterVisibility = Visibility.NONE, setterVisibility = Visibility.NONE, fieldVisibility = Visibility.ANY)
-public enum RelatertYtelseTilstand implements Kodeverdi {
+public enum RelatertYtelseTilstand implements Kodeverdi, MedOffisiellKode {
 
     ÅPEN("ÅPEN", "Åpen"),
     LØPENDE("LØPENDE", "Løpende"),

--- a/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/iay/modell/kodeverk/SkatteOgAvgiftsregelType.java
+++ b/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/iay/modell/kodeverk/SkatteOgAvgiftsregelType.java
@@ -13,10 +13,11 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
+import no.nav.foreldrepenger.behandlingslager.kodeverk.MedOffisiellKode;
 
 @JsonFormat(shape = Shape.OBJECT)
 @JsonAutoDetect(getterVisibility = Visibility.NONE, setterVisibility = Visibility.NONE, fieldVisibility = Visibility.ANY)
-public enum SkatteOgAvgiftsregelType implements Kodeverdi {
+public enum SkatteOgAvgiftsregelType implements Kodeverdi, MedOffisiellKode {
 
     SÆRSKILT_FRADRAG_FOR_SJØFOLK("SÆRSKILT_FRADRAG_FOR_SJØFOLK", "Særskilt fradrag for sjøfolk", "saerskiltFradragForSjoefolk"),
     SVALBARD("SVALBARD", "Svalbardinntekt", "svalbard"),

--- a/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/iay/modell/kodeverk/VirksomhetType.java
+++ b/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/iay/modell/kodeverk/VirksomhetType.java
@@ -82,11 +82,6 @@ public enum VirksomhetType implements Kodeverdi {
         return kode;
     }
 
-    @Override
-    public String getOffisiellKode() {
-        return getKode();
-    }
-    
     public Inntektskategori getInntektskategori() {
         return inntektskategori;
     }

--- a/domenetjenester/behandling-revurdering/src/main/java/no/nav/foreldrepenger/behandling/revurdering/etterkontroll/KontrollType.java
+++ b/domenetjenester/behandling-revurdering/src/main/java/no/nav/foreldrepenger/behandling/revurdering/etterkontroll/KontrollType.java
@@ -75,11 +75,6 @@ public enum KontrollType implements Kodeverdi {
         return kode;
     }
 
-    @Override
-    public String getOffisiellKode() {
-        return getKode();
-    }
-
     static {
         for (var v : values()) {
             if (KODER.putIfAbsent(v.kode, v) != null) {

--- a/domenetjenester/behandling/src/main/java/no/nav/foreldrepenger/historikk/HistorikkAvklartSoeknadsperiodeType.java
+++ b/domenetjenester/behandling/src/main/java/no/nav/foreldrepenger/historikk/HistorikkAvklartSoeknadsperiodeType.java
@@ -97,9 +97,4 @@ public enum HistorikkAvklartSoeknadsperiodeType implements Kodeverdi {
         return kode;
     }
 
-    @Override
-    public String getOffisiellKode() {
-        return getKode();
-    }
-
 }

--- a/domenetjenester/behandling/src/main/java/no/nav/foreldrepenger/historikk/Oppgavetyper.java
+++ b/domenetjenester/behandling/src/main/java/no/nav/foreldrepenger/historikk/Oppgavetyper.java
@@ -16,10 +16,11 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
+import no.nav.foreldrepenger.behandlingslager.kodeverk.MedOffisiellKode;
 
 @JsonFormat(shape = Shape.OBJECT)
 @JsonAutoDetect(getterVisibility = Visibility.NONE, setterVisibility = Visibility.NONE, fieldVisibility = Visibility.ANY)
-public enum Oppgavetyper implements Kodeverdi {
+public enum Oppgavetyper implements Kodeverdi, MedOffisiellKode {
 
     BEHANDLE_SAK_VL("BEH_SAK_VL", "Behandle sak i VL"),
     REVURDER_VL("RV_VL", "Revurdere i VL"),

--- a/domenetjenester/behandling/src/main/java/no/nav/foreldrepenger/historikk/OppgaveÅrsak.java
+++ b/domenetjenester/behandling/src/main/java/no/nav/foreldrepenger/historikk/OppgaveÅrsak.java
@@ -80,11 +80,6 @@ public enum OppgaveÅrsak implements Kodeverdi {
         return kode;
     }
 
-    @Override
-    public String getOffisiellKode() {
-        return getKode();
-    }
-
     static {
         for (var v : values()) {
             if (KODER.putIfAbsent(v.kode, v) != null) {

--- a/domenetjenester/behandling/src/main/java/no/nav/foreldrepenger/historikk/VurderArbeidsforholdHistorikkinnslag.java
+++ b/domenetjenester/behandling/src/main/java/no/nav/foreldrepenger/historikk/VurderArbeidsforholdHistorikkinnslag.java
@@ -91,9 +91,4 @@ public enum VurderArbeidsforholdHistorikkinnslag implements Kodeverdi {
         return kode;
     }
 
-    
-    @Override
-    public String getOffisiellKode() {
-        return getKode();
-    }
 }

--- a/domenetjenester/beregningsgrunnlag/src/main/java/no/nav/foreldrepenger/domene/SKAL_FLYTTES_TIL_KALKULUS/AktivitetStatus.java
+++ b/domenetjenester/beregningsgrunnlag/src/main/java/no/nav/foreldrepenger/domene/SKAL_FLYTTES_TIL_KALKULUS/AktivitetStatus.java
@@ -122,11 +122,6 @@ public enum AktivitetStatus implements Kodeverdi {
         return kode;
     }
 
-    @Override
-    public String getOffisiellKode() {
-        return getKode();
-    }
-
     public Inntektskategori getInntektskategori() {
         return inntektskategori;
     }

--- a/domenetjenester/beregningsgrunnlag/src/main/java/no/nav/foreldrepenger/domene/SKAL_FLYTTES_TIL_KALKULUS/AndelKilde.java
+++ b/domenetjenester/beregningsgrunnlag/src/main/java/no/nav/foreldrepenger/domene/SKAL_FLYTTES_TIL_KALKULUS/AndelKilde.java
@@ -83,11 +83,6 @@ public enum AndelKilde implements Kodeverdi {
         return kode;
     }
 
-    @Override
-    public String getOffisiellKode() {
-        return getKode();
-    }
-
     @Converter(autoApply = true)
     public static class KodeverdiConverter implements AttributeConverter<AndelKilde, String> {
         @Override

--- a/domenetjenester/beregningsgrunnlag/src/main/java/no/nav/foreldrepenger/domene/SKAL_FLYTTES_TIL_KALKULUS/BeregningAktivitetHandlingType.java
+++ b/domenetjenester/beregningsgrunnlag/src/main/java/no/nav/foreldrepenger/domene/SKAL_FLYTTES_TIL_KALKULUS/BeregningAktivitetHandlingType.java
@@ -80,11 +80,6 @@ public enum BeregningAktivitetHandlingType implements Kodeverdi {
         return kode;
     }
 
-    @Override
-    public String getOffisiellKode() {
-        return getKode();
-    }
-
     @Converter(autoApply = true)
     public static class KodeverdiConverter implements AttributeConverter<BeregningAktivitetHandlingType, String> {
 

--- a/domenetjenester/beregningsgrunnlag/src/main/java/no/nav/foreldrepenger/domene/SKAL_FLYTTES_TIL_KALKULUS/BeregningsgrunnlagAndeltype.java
+++ b/domenetjenester/beregningsgrunnlag/src/main/java/no/nav/foreldrepenger/domene/SKAL_FLYTTES_TIL_KALKULUS/BeregningsgrunnlagAndeltype.java
@@ -76,8 +76,4 @@ public enum BeregningsgrunnlagAndeltype implements Kodeverdi {
         return kode;
     }
 
-    @Override
-    public String getOffisiellKode() {
-        return getKode();
-    }
 }

--- a/domenetjenester/beregningsgrunnlag/src/main/java/no/nav/foreldrepenger/domene/SKAL_FLYTTES_TIL_KALKULUS/BeregningsgrunnlagPeriodeRegelType.java
+++ b/domenetjenester/beregningsgrunnlag/src/main/java/no/nav/foreldrepenger/domene/SKAL_FLYTTES_TIL_KALKULUS/BeregningsgrunnlagPeriodeRegelType.java
@@ -84,11 +84,6 @@ public enum BeregningsgrunnlagPeriodeRegelType implements Kodeverdi {
         return kode;
     }
 
-    @Override
-    public String getOffisiellKode() {
-        return getKode();
-    }
-
     @Converter(autoApply = true)
     public static class KodeverdiConverter implements AttributeConverter<BeregningsgrunnlagPeriodeRegelType, String> {
 

--- a/domenetjenester/beregningsgrunnlag/src/main/java/no/nav/foreldrepenger/domene/SKAL_FLYTTES_TIL_KALKULUS/BeregningsgrunnlagRegelType.java
+++ b/domenetjenester/beregningsgrunnlag/src/main/java/no/nav/foreldrepenger/domene/SKAL_FLYTTES_TIL_KALKULUS/BeregningsgrunnlagRegelType.java
@@ -85,11 +85,6 @@ public enum BeregningsgrunnlagRegelType implements Kodeverdi {
         return kode;
     }
 
-    @Override
-    public String getOffisiellKode() {
-        return getKode();
-    }
-
     @Converter(autoApply = true)
     public static class KodeverdiConverter implements AttributeConverter<BeregningsgrunnlagRegelType, String> {
 

--- a/domenetjenester/beregningsgrunnlag/src/main/java/no/nav/foreldrepenger/domene/SKAL_FLYTTES_TIL_KALKULUS/BeregningsgrunnlagTilstand.java
+++ b/domenetjenester/beregningsgrunnlag/src/main/java/no/nav/foreldrepenger/domene/SKAL_FLYTTES_TIL_KALKULUS/BeregningsgrunnlagTilstand.java
@@ -116,11 +116,6 @@ public enum BeregningsgrunnlagTilstand implements Kodeverdi {
         return kode;
     }
 
-    @Override
-    public String getOffisiellKode() {
-        return getKode();
-    }
-
     @Converter(autoApply = true)
     public static class KodeverdiConverter implements AttributeConverter<BeregningsgrunnlagTilstand, String> {
 

--- a/domenetjenester/beregningsgrunnlag/src/main/java/no/nav/foreldrepenger/domene/SKAL_FLYTTES_TIL_KALKULUS/FaktaOmBeregningTilfelle.java
+++ b/domenetjenester/beregningsgrunnlag/src/main/java/no/nav/foreldrepenger/domene/SKAL_FLYTTES_TIL_KALKULUS/FaktaOmBeregningTilfelle.java
@@ -97,11 +97,6 @@ public enum FaktaOmBeregningTilfelle implements Kodeverdi {
         return kode;
     }
 
-    @Override
-    public String getOffisiellKode() {
-        return getKode();
-    }
-
     @Converter(autoApply = true)
     public static class KodeverdiConverter implements AttributeConverter<FaktaOmBeregningTilfelle, String> {
 

--- a/domenetjenester/beregningsgrunnlag/src/main/java/no/nav/foreldrepenger/domene/SKAL_FLYTTES_TIL_KALKULUS/Hjemmel.java
+++ b/domenetjenester/beregningsgrunnlag/src/main/java/no/nav/foreldrepenger/domene/SKAL_FLYTTES_TIL_KALKULUS/Hjemmel.java
@@ -94,11 +94,6 @@ public enum Hjemmel implements Kodeverdi {
         return kode;
     }
 
-    @Override
-    public String getOffisiellKode() {
-        return getKode();
-    }
-
     @Converter(autoApply = true)
     public static class KodeverdiConverter implements AttributeConverter<Hjemmel, String> {
         @Override

--- a/domenetjenester/beregningsgrunnlag/src/main/java/no/nav/foreldrepenger/domene/SKAL_FLYTTES_TIL_KALKULUS/Inntektskategori.java
+++ b/domenetjenester/beregningsgrunnlag/src/main/java/no/nav/foreldrepenger/domene/SKAL_FLYTTES_TIL_KALKULUS/Inntektskategori.java
@@ -89,11 +89,6 @@ public enum Inntektskategori implements Kodeverdi {
         return kode;
     }
 
-    @Override
-    public String getOffisiellKode() {
-        return getKode();
-    }
-
     @Converter(autoApply = true)
     public static class KodeverdiConverter implements AttributeConverter<Inntektskategori, String> {
         @Override

--- a/domenetjenester/beregningsgrunnlag/src/main/java/no/nav/foreldrepenger/domene/SKAL_FLYTTES_TIL_KALKULUS/PeriodeÅrsak.java
+++ b/domenetjenester/beregningsgrunnlag/src/main/java/no/nav/foreldrepenger/domene/SKAL_FLYTTES_TIL_KALKULUS/PeriodeÅrsak.java
@@ -92,11 +92,6 @@ public enum PeriodeÅrsak implements Kodeverdi {
         return kode;
     }
 
-    @Override
-    public String getOffisiellKode() {
-        return getKode();
-    }
-
     @Converter(autoApply = true)
     public static class KodeverdiConverter implements AttributeConverter<PeriodeÅrsak, String> {
         @Override

--- a/domenetjenester/beregningsgrunnlag/src/main/java/no/nav/foreldrepenger/domene/SKAL_FLYTTES_TIL_KALKULUS/SammenligningsgrunnlagType.java
+++ b/domenetjenester/beregningsgrunnlag/src/main/java/no/nav/foreldrepenger/domene/SKAL_FLYTTES_TIL_KALKULUS/SammenligningsgrunnlagType.java
@@ -93,11 +93,6 @@ public enum SammenligningsgrunnlagType implements Kodeverdi {
         return kode;
     }
 
-    @Override
-    public String getOffisiellKode() {
-        return getKode();
-    }
-
     @Converter(autoApply = true)
     public static class KodeverdiConverter implements AttributeConverter<SammenligningsgrunnlagType, String> {
         @Override

--- a/domenetjenester/dokumentarkiv/src/main/java/no/nav/foreldrepenger/dokumentarkiv/ArkivFilType.java
+++ b/domenetjenester/dokumentarkiv/src/main/java/no/nav/foreldrepenger/dokumentarkiv/ArkivFilType.java
@@ -14,10 +14,11 @@ import com.fasterxml.jackson.annotation.JsonFormat.Shape;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
+import no.nav.foreldrepenger.behandlingslager.kodeverk.MedOffisiellKode;
 
 @JsonFormat(shape = Shape.OBJECT)
 @JsonAutoDetect(getterVisibility = Visibility.NONE, setterVisibility = Visibility.NONE, fieldVisibility = Visibility.ANY)
-public enum ArkivFilType implements Kodeverdi {
+public enum ArkivFilType implements Kodeverdi, MedOffisiellKode {
 
     PDF ("PDF"),
     PDFA ("PDFA"),
@@ -85,6 +86,7 @@ public enum ArkivFilType implements Kodeverdi {
     public String getOffisiellKode() {
         return getKode();
     }
+
     static {
         for (var v : values()) {
             if (KODER.putIfAbsent(v.kode, v) != null) {

--- a/domenetjenester/dokumentbestiller/src/main/java/no/nav/foreldrepenger/dokumentbestiller/DokumentMalRestriksjon.java
+++ b/domenetjenester/dokumentbestiller/src/main/java/no/nav/foreldrepenger/dokumentbestiller/DokumentMalRestriksjon.java
@@ -82,9 +82,4 @@ public enum DokumentMalRestriksjon implements Kodeverdi {
     public String getKode() {
         return kode;
     }
-
-    @Override
-    public String getOffisiellKode() {
-        return getKode();
-    }
 }

--- a/domenetjenester/dokumentbestiller/src/main/java/no/nav/foreldrepenger/dokumentbestiller/DokumentMalType.java
+++ b/domenetjenester/dokumentbestiller/src/main/java/no/nav/foreldrepenger/dokumentbestiller/DokumentMalType.java
@@ -87,11 +87,6 @@ public enum DokumentMalType implements Kodeverdi {
         return kode;
     }
 
-    @Override
-    public String getOffisiellKode() {
-        return getKode();
-    }
-
     @JsonProperty
     @Override
     public String getKodeverk() {

--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/dokumentmottak/impl/DokumentGruppe.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/dokumentmottak/impl/DokumentGruppe.java
@@ -74,11 +74,6 @@ public enum DokumentGruppe implements Kodeverdi {
         return kode;
     }
 
-    @Override
-    public String getOffisiellKode() {
-        return getKode();
-    }
-
     static {
         for (var v : values()) {
             if (KODER.putIfAbsent(v.kode, v) != null) {

--- a/domenetjenester/person/src/main/java/no/nav/foreldrepenger/domene/person/pdl/PersoninfoTjeneste.java
+++ b/domenetjenester/person/src/main/java/no/nav/foreldrepenger/domene/person/pdl/PersoninfoTjeneste.java
@@ -276,7 +276,7 @@ public class PersoninfoTjeneste {
         String postnummer = Optional.ofNullable(vegadresse.getPostnummer()).orElse(HARDKODET_POSTNR);
         var gateadresse = vegadresse.getAdressenavn() + hvisfinnes(vegadresse.getHusnummer()) + hvisfinnes(vegadresse.getHusbokstav());
         return Adresseinfo.builder(type)
-            .medMatrikkelId(vegadresse.getMatrikkelId())
+            // TODO: enable når sammenligning stabil .medMatrikkelId(vegadresse.getMatrikkelId())
             .medAdresselinje1(vegadresse.getTilleggsnavn() != null ? vegadresse.getTilleggsnavn() : gateadresse)
             .medAdresselinje2(vegadresse.getTilleggsnavn() != null ? gateadresse : null)
             .medPostNr(postnummer)
@@ -290,7 +290,7 @@ public class PersoninfoTjeneste {
             return null;
         String postnummer = Optional.ofNullable(matrikkeladresse.getPostnummer()).orElse(HARDKODET_POSTNR);
         return Adresseinfo.builder(type)
-            .medMatrikkelId(matrikkeladresse.getMatrikkelId())
+            // TODO: enable når sammenligning stabil .medMatrikkelId(matrikkeladresse.getMatrikkelId())
             .medAdresselinje1(matrikkeladresse.getTilleggsnavn() != null ? matrikkeladresse.getTilleggsnavn() : matrikkeladresse.getBruksenhetsnummer())
             .medAdresselinje2(matrikkeladresse.getTilleggsnavn() != null ? matrikkeladresse.getBruksenhetsnummer() : null)
             .medPostNr(postnummer)

--- a/domenetjenester/registerinnhenting/src/main/java/no/nav/foreldrepenger/domene/registerinnhenting/impl/behandlingårsak/EndringResultatType.java
+++ b/domenetjenester/registerinnhenting/src/main/java/no/nav/foreldrepenger/domene/registerinnhenting/impl/behandlingårsak/EndringResultatType.java
@@ -78,11 +78,6 @@ public enum EndringResultatType implements Kodeverdi {
         return kode;
     }
 
-    @Override
-    public String getOffisiellKode() {
-        return getKode();
-    }
-
     static {
         for (var v : values()) {
             if (KODER.putIfAbsent(v.kode, v) != null) {

--- a/domenetjenester/vedtak/src/main/java/no/nav/foreldrepenger/domene/vedtak/xml/Tema.java
+++ b/domenetjenester/vedtak/src/main/java/no/nav/foreldrepenger/domene/vedtak/xml/Tema.java
@@ -13,10 +13,11 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
+import no.nav.foreldrepenger.behandlingslager.kodeverk.MedOffisiellKode;
 
 @JsonFormat(shape = Shape.OBJECT)
 @JsonAutoDetect(getterVisibility = Visibility.NONE, setterVisibility = Visibility.NONE, fieldVisibility = Visibility.ANY)
-public enum Tema implements Kodeverdi {
+public enum Tema implements Kodeverdi, MedOffisiellKode {
 
     FORELDRE_OG_SVANGERSKAPSPENGER("FOR_SVA", "Foreldre- og svangerskapspenger", "FOR"),
     UDEFINERT("-", "Ikke definert", null),

--- a/web/src/main/java/no/nav/foreldrepenger/web/server/abac/AppPdpRequestBuilderImpl.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/server/abac/AppPdpRequestBuilderImpl.java
@@ -84,9 +84,8 @@ public class AppPdpRequestBuilderImpl implements PdpRequestBuilder {
         Set<AktørId> aktørIder = utledAktørIder(attributter, fagsakIder);
         Set<String> aksjonspunktType = pipRepository
                 .hentAksjonspunktTypeForAksjonspunktKoder(attributter.getVerdier(AppAbacAttributtType.AKSJONSPUNKT_KODE));
-        return behandlingData.isPresent()
-                ? lagPdpRequest(attributter, aktørIder, aksjonspunktType, behandlingData.get())
-                : lagPdpRequest(attributter, aktørIder, aksjonspunktType);
+        return behandlingData.map(b -> lagPdpRequest(attributter, aktørIder, aksjonspunktType, b))
+            .orElseGet(() -> lagPdpRequest(attributter, aktørIder, aksjonspunktType));
     }
 
     private static PdpRequest lagPdpRequest(AbacAttributtSamling attributter, Set<AktørId> aktørIder, Collection<String> aksjonspunktType) {


### PR DESCRIPTION
Offisiell kode refererer til FKV og brukes ifm integrasjoner mot arkiv, sak, oppgave, norg, sob + arbeid/inntekt

Fjern offisellKode fra generell kodeverdi og implementer MedOffisiellKode der den faktisk brukes 