### PR TITLE
TFP-3995 takle at en klassekode allerede er opphørt

### DIFF
--- a/domenetjenester/okonomistotte/src/main/java/no/nav/foreldrepenger/økonomi/økonomistøtte/dagytelse/opphør/OppdragskontrollOpphør.java
+++ b/domenetjenester/okonomistotte/src/main/java/no/nav/foreldrepenger/økonomi/økonomistøtte/dagytelse/opphør/OppdragskontrollOpphør.java
@@ -17,6 +17,7 @@ import no.nav.foreldrepenger.behandlingslager.økonomioppdrag.Oppdragskontroll;
 import no.nav.foreldrepenger.behandlingslager.økonomioppdrag.Oppdragslinje150;
 import no.nav.foreldrepenger.behandlingslager.økonomioppdrag.OppdragsmottakerStatus;
 import no.nav.foreldrepenger.behandlingslager.økonomioppdrag.Refusjonsinfo156;
+import no.nav.foreldrepenger.behandlingslager.økonomioppdrag.ØkonomiKodeKlassifik;
 import no.nav.foreldrepenger.økonomi.økonomistøtte.OppdragskontrollManager;
 import no.nav.foreldrepenger.økonomi.økonomistøtte.Oppdragsmottaker;
 import no.nav.foreldrepenger.økonomi.økonomistøtte.OpprettOppdragTjeneste;
@@ -112,6 +113,8 @@ public class OppdragskontrollOpphør implements OppdragskontrollManager {
         int iter = 0;
         Oppdrag110 nyOppdrag110 = null;
         for (Map.Entry<String, List<Oppdragslinje150>> opp150ListePerKlassekode : opp150ListePerKlassekodeMap.entrySet()) {
+            if (OpphørUtil.erBrukerAllredeFullstendigOpphørtForKlassekode(behandlingInfo, ØkonomiKodeKlassifik.fraKode(opp150ListePerKlassekode.getKey())))
+                continue;
             List<Oppdragslinje150> opp150MedSammeKlassekodeListe = opp150ListePerKlassekode.getValue();
             Optional<Oppdragslinje150> sisteOppdr150BrukerOpt = opp150MedSammeKlassekodeListe
                 .stream()

--- a/domenetjenester/okonomistotte/src/main/java/no/nav/foreldrepenger/økonomi/økonomistøtte/dagytelse/opphør/OpphørUtil.java
+++ b/domenetjenester/okonomistotte/src/main/java/no/nav/foreldrepenger/økonomi/økonomistøtte/dagytelse/opphør/OpphørUtil.java
@@ -73,6 +73,16 @@ public class OpphørUtil {
         return førsteAktiveDatoPrKodeKlassifik(oppdragForBruker, true, null).isEmpty();
     }
 
+    static boolean erBrukerAllredeFullstendigOpphørtForKlassekode(OppdragInput behandlingInfo, ØkonomiKodeKlassifik klassekode) {
+        List<Oppdrag110> oppdragForBruker = behandlingInfo.getAlleTidligereOppdrag110().stream()
+            .filter(OpphørUtil::gjelderBruker)
+            .filter(o -> o.venterKvittering() || OppdragKvitteringTjeneste.harPositivKvittering(o))
+            .collect(Collectors.toList());
+
+        var brukersKlassekoder = førsteAktiveDatoPrKodeKlassifik(oppdragForBruker, true, null);
+        return brukersKlassekoder.get(klassekode) == null;
+    }
+
     static boolean erArbeidsgiverAllredeFullstendigOpphørt(OppdragInput behandlingInfo, String refunderesId) {
         List<Oppdrag110> oppdragForAG = behandlingInfo.getAlleTidligereOppdrag110().stream()
             .filter(o -> gjelderArbeidsgiver(o, refunderesId))


### PR DESCRIPTION
Testet med en variant av testen skalSendeEndringsoppdragNårDetErFlereKlassekodeBådeIForrigeOgNyOppdragOgEnInntektskategoriIForrigeBehandlingBlirAnnerledesIRevurdering der man har to klassekoder i førstegang (FPATORD, FPSND) begge med utbetaling til bruker. Første revurdering setter FPSND til dagsats 0, neste revurdering setter AT til dagsats 0.
Gjenskapte feil. Verifisert at fiks oppfører seg som den skal - sender riktige opphørs150 for begge revurderinger