### PR TITLE
TFP-4029: Støtte for Dokgen-versjonen av "ingen endring etter revurde…

### DIFF
--- a/domenetjenester/dokumentbestiller/src/main/java/no/nav/foreldrepenger/dokumentbestiller/DokumentMalType.java
+++ b/domenetjenester/dokumentbestiller/src/main/java/no/nav/foreldrepenger/dokumentbestiller/DokumentMalType.java
@@ -49,6 +49,7 @@ public enum DokumentMalType implements Kodeverdi {
     VARSEL_OM_REVURDERING("VARREV", "Varsel om revurdering"),
     INFO_OM_HENLEGGELSE("IOHENL", "Behandling henlagt"),
     IKKE_SØKT("IKKESO", "Ikke mottatt søknad"),
+    INGEN_ENDRING("INGEND", "Uendret utfall"),
 
     // Disse brevene er utgåtte, men beholdes her grunnet historisk bruk i databasen:
     @Deprecated

--- a/domenetjenester/dokumentbestiller/src/main/java/no/nav/foreldrepenger/dokumentbestiller/vedtak/VedtaksbrevUtleder.java
+++ b/domenetjenester/dokumentbestiller/src/main/java/no/nav/foreldrepenger/dokumentbestiller/vedtak/VedtaksbrevUtleder.java
@@ -58,7 +58,7 @@ public class VedtaksbrevUtleder {
         if (erLagetFritekstBrev(behandlingsresultat)) {
             dokumentMal = DokumentMalType.FRITEKST_DOK;
         } else if (erRevurderingMedUendretUtfall(behandlingVedtak)) {
-            dokumentMal = DokumentMalType.UENDRETUTFALL_DOK;
+            dokumentMal = Environment.current().isProd() ? DokumentMalType.UENDRETUTFALL_DOK : DokumentMalType.INGEN_ENDRING;
         } else if (erKlageBehandling(behandlingVedtak)) {
             dokumentMal = velgKlagemal(behandling, klageRepository);
         } else if (erAnkeBehandling(behandlingVedtak)) {

--- a/domenetjenester/dokumentbestiller/src/test/java/no/nav/foreldrepenger/dokumentbestiller/vedtak/VedtaksbrevUtlederTest.java
+++ b/domenetjenester/dokumentbestiller/src/test/java/no/nav/foreldrepenger/dokumentbestiller/vedtak/VedtaksbrevUtlederTest.java
@@ -7,8 +7,6 @@ import static org.mockito.Mockito.lenient;
 
 import java.util.Optional;
 
-import no.nav.foreldrepenger.behandlingslager.behandling.anke.AnkeVurdering;
-import no.nav.foreldrepenger.behandlingslager.behandling.anke.AnkeVurderingResultatEntitet;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -18,6 +16,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandlingsresultat;
 import no.nav.foreldrepenger.behandlingslager.behandling.anke.AnkeRepository;
+import no.nav.foreldrepenger.behandlingslager.behandling.anke.AnkeVurdering;
+import no.nav.foreldrepenger.behandlingslager.behandling.anke.AnkeVurderingResultatEntitet;
 import no.nav.foreldrepenger.behandlingslager.behandling.klage.KlageRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.klage.KlageVurdering;
 import no.nav.foreldrepenger.behandlingslager.behandling.klage.KlageVurderingResultat;
@@ -95,7 +95,7 @@ public class VedtaksbrevUtlederTest {
     public void skal_velge_uendret_utfall() {
         doReturn(true).when(behandlingVedtakMock).isBeslutningsvedtak();
         assertThat(VedtaksbrevUtleder.velgDokumentMalForVedtak(behandling, behandlingsresultatMock, behandlingVedtakMock, klageRepository,
-                ankeRepository)).isEqualTo(DokumentMalType.UENDRETUTFALL_DOK);
+                ankeRepository)).isEqualTo(DokumentMalType.INGEN_ENDRING);
     }
 
     @Test


### PR DESCRIPTION
…ring" / "uendret utfall" brevet.