### PR TITLE
NOJIRA mindre verbos og differensiell logging feriepenger

### DIFF
--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/beregning/BeregningsresultatFeriepenger.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/beregning/BeregningsresultatFeriepenger.java
@@ -97,6 +97,14 @@ public class BeregningsresultatFeriepenger extends BaseEntitet {
         return Objects.hash(id);
     }
 
+    @Override
+    public String toString() {
+        return "BRFeriepenger{" +
+            "fom=" + feriepengerPeriodeFom +
+            ", tom=" + feriepengerPeriodeTom +
+            '}';
+    }
+
     public static Builder builder() {
         return new Builder();
     }

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/beregning/BeregningsresultatFeriepengerPrÅr.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/beregning/BeregningsresultatFeriepengerPrÅr.java
@@ -91,6 +91,15 @@ public class BeregningsresultatFeriepengerPrÅr extends BaseEntitet {
         return Objects.hash(opptjeningsår, årsbeløp);
     }
 
+    @Override
+    public String toString() {
+        return "BRFerPrÅr{" +
+            "brFerie=" + beregningsresultatFeriepenger +
+            ", opptjeningsår=" + opptjeningsår +
+            ", årsbeløp=" + årsbeløp +
+            '}';
+    }
+
     public static Builder builder() {
         return new Builder();
     }

--- a/domenetjenester/beregning-ytelse/src/main/java/no/nav/foreldrepenger/ytelse/beregning/Feriepengesammenligner.java
+++ b/domenetjenester/beregning-ytelse/src/main/java/no/nav/foreldrepenger/ytelse/beregning/Feriepengesammenligner.java
@@ -1,20 +1,30 @@
 package no.nav.foreldrepenger.ytelse.beregning;
 
-import no.nav.foreldrepenger.behandlingslager.behandling.beregning.AktivitetOgArbeidsforholdNøkkel;
-import no.nav.foreldrepenger.behandlingslager.behandling.beregning.BeregningsresultatEntitet;
-import no.nav.foreldrepenger.behandlingslager.behandling.beregning.BeregningsresultatFeriepenger;
-import no.nav.foreldrepenger.behandlingslager.behandling.beregning.BeregningsresultatFeriepengerPrÅr;
-import no.nav.foreldrepenger.domene.typer.Beløp;
-import no.nav.foreldrepenger.domene.typer.Saksnummer;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
+import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.time.Year;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import no.nav.foreldrepenger.behandlingslager.behandling.beregning.AktivitetOgArbeidsforholdNøkkel;
+import no.nav.foreldrepenger.behandlingslager.behandling.beregning.AktivitetStatus;
+import no.nav.foreldrepenger.behandlingslager.behandling.beregning.BeregningsresultatEntitet;
+import no.nav.foreldrepenger.behandlingslager.behandling.beregning.BeregningsresultatFeriepenger;
+import no.nav.foreldrepenger.behandlingslager.behandling.beregning.BeregningsresultatFeriepengerPrÅr;
+import no.nav.foreldrepenger.behandlingslager.behandling.beregning.Inntektskategori;
+import no.nav.foreldrepenger.behandlingslager.virksomhet.Arbeidsgiver;
+import no.nav.foreldrepenger.domene.typer.Beløp;
+import no.nav.foreldrepenger.domene.typer.InternArbeidsforholdRef;
+import no.nav.foreldrepenger.domene.typer.Saksnummer;
 
 public class Feriepengesammenligner {
     private static final Logger logger = LoggerFactory.getLogger(Feriepengesammenligner.class);
@@ -22,8 +32,8 @@ public class Feriepengesammenligner {
     private final Saksnummer saksnummer;
     private final BeregningsresultatEntitet nyttResultat;
     private final BeregningsresultatEntitet gjeldendeResultat;
-    private final String AVVIK_KODE = "FP-110711: ";
-    private final String INGEN_AVVIK_KODE = "FP-110710: ";
+    private static final String AVVIK_KODE = "FP-110711";
+    private static final String BRUKER = "Bruker";
 
     private boolean finnesAvvik = false;
 
@@ -49,9 +59,6 @@ public class Feriepengesammenligner {
             // Vet at kun en av de er present
             loggOgSettAvvik("beregningsresultatFeriepenger", nyttFeriepengegrunnlag, gjeldendeFeriepengegrunnlag);
         }
-        if (!finnesAvvik) {
-            loggIngenAvvik();
-        }
         return finnesAvvik;
     }
 
@@ -59,33 +66,47 @@ public class Feriepengesammenligner {
                                                 List<BeregningsresultatFeriepengerPrÅr> gjeldendeAndeler) {
         Map<LocalDate, List<BeregningsresultatFeriepengerPrÅr>> nyÅrTilBeløpMap = årTilAndelerMap(nyeAndeler);
         Map<LocalDate, List<BeregningsresultatFeriepengerPrÅr>> gjeldendeÅrTilBeløpMap = årTilAndelerMap(gjeldendeAndeler);
-        nyÅrTilBeløpMap.forEach((år, andeler) -> {
-            List<BeregningsresultatFeriepengerPrÅr> gjeldendeAndelerForÅr = gjeldendeÅrTilBeløpMap.get(år);
-            if (gjeldendeAndelerForÅr == null) {
-                loggOgSettAvvik("Feriepengeandeler i år " + år, andeler, null);
-            } else {
-                Map<AktivitetOgArbeidsforholdNøkkel, List<BeregningsresultatFeriepengerPrÅr>> nyNøkkelTilAndelerMap = nøkkelTilAndelerMap(andeler);
-                Map<AktivitetOgArbeidsforholdNøkkel, List<BeregningsresultatFeriepengerPrÅr>> gjeldendeNøkkelTilAndelerMap = nøkkelTilAndelerMap(gjeldendeAndelerForÅr);
-                sammenlignNøkler(år, nyNøkkelTilAndelerMap, gjeldendeNøkkelTilAndelerMap);
-            }
-        });
+        sammenlignÅrligeFeriepenger(nyÅrTilBeløpMap, gjeldendeÅrTilBeløpMap);
+        Set<LocalDate> alleÅrene = Stream.concat(nyÅrTilBeløpMap.keySet().stream(), gjeldendeÅrTilBeløpMap.keySet().stream()).collect(Collectors.toSet());
+        alleÅrene.forEach(år -> sammenlignGrupperteFeriepenger(år, nyÅrTilBeløpMap.getOrDefault(år, List.of()), gjeldendeÅrTilBeløpMap.getOrDefault(år, List.of())));
+    }
 
+    private void sammenlignÅrligeFeriepenger(Map<LocalDate, List<BeregningsresultatFeriepengerPrÅr>> nytt,
+                                             Map<LocalDate, List<BeregningsresultatFeriepengerPrÅr>> eksisterende) {
+        Map<LocalDate, BigDecimal> summert = new LinkedHashMap<>();
+        eksisterende.forEach((key, value) -> summert.put(key, finnÅrsbeløp(value).getVerdi()));
+        nytt.forEach((key, value) -> summert.put(key, summert.getOrDefault(key, BigDecimal.ZERO).subtract(finnÅrsbeløp(value).getVerdi())));
+        summert.entrySet().stream()
+            .filter(e -> Math.abs(e.getValue().longValue()) > 3)
+            .forEach(e -> loggOgSettAvvik("Årsbeløp for " + Year.from(e.getKey()) + " diff " + e.getValue().longValue(),
+                finnÅrsbeløp(nytt.getOrDefault(e.getKey(), List.of())).getVerdi().longValue(),
+                finnÅrsbeløp(eksisterende.getOrDefault(e.getKey(), List.of())).getVerdi().longValue()));
+    }
+
+    private void sammenlignGrupperteFeriepenger(LocalDate år, List<BeregningsresultatFeriepengerPrÅr> nytt,
+                                             List<BeregningsresultatFeriepengerPrÅr> eksisterende) {
+        var nyGruppert = nøkkelTilGrupperingMap(nytt);
+        var gmlGruppert = nøkkelTilGrupperingMap(eksisterende);
+        Map<Feriepengesammenligner.AndelGruppering, BigDecimal> summert = new LinkedHashMap<>();
+        gmlGruppert.forEach((k, v) -> summert.put(k, finnÅrsbeløp(v).getVerdi()));
+        nyGruppert.forEach((k, v) -> summert.put(k, summert.getOrDefault(k, BigDecimal.ZERO).subtract(finnÅrsbeløp(v).getVerdi())));
+        summert.entrySet().stream()
+            .filter(e -> Math.abs(e.getValue().longValue()) > 3)
+            .forEach(e -> loggOgSettAvvik("Andelsbeløp for " + e.getKey() + " år " + Year.from(år) + " diff " + e.getValue().longValue(),
+                finnÅrsbeløp(nyGruppert.getOrDefault(e.getKey(), List.of())).getVerdi().longValue(),
+                finnÅrsbeløp(gmlGruppert.getOrDefault(e.getKey(), List.of())).getVerdi().longValue()));
     }
 
     private void sammenlignNøkler(LocalDate år, Map<AktivitetOgArbeidsforholdNøkkel, List<BeregningsresultatFeriepengerPrÅr>> nyNøkkelTilAndelerMap,
                                   Map<AktivitetOgArbeidsforholdNøkkel, List<BeregningsresultatFeriepengerPrÅr>> gjeldendeNøkkelTilAndelerMap) {
         nyNøkkelTilAndelerMap.forEach((nøkkel, andeler) -> {
-            List<BeregningsresultatFeriepengerPrÅr> gjeldendeAndelerForNøkkel = gjeldendeNøkkelTilAndelerMap.get(nøkkel);
-            if (gjeldendeAndelerForNøkkel == null) {
-                loggOgSettAvvik("AktivitetOgArbeidsforholdNøkkel", nøkkel, null);
-            } else {
-                Beløp gjeldendeÅrsbeløp = finnÅrsbeløp(gjeldendeAndelerForNøkkel);
-                Beløp nyttÅrsbeløp = finnÅrsbeløp(andeler);
-                if (gjeldendeÅrsbeløp.compareTo(nyttÅrsbeløp) != 0) {
-                    loggOgSettAvvik("Årsbeløp for andel " + nøkkel + " i år " + år, nyttÅrsbeløp, gjeldendeÅrsbeløp);
-                }
+            List<BeregningsresultatFeriepengerPrÅr> gjeldendeAndelerForNøkkel = gjeldendeNøkkelTilAndelerMap.getOrDefault(nøkkel, List.of());
+            Beløp gjeldendeÅrsbeløp = finnÅrsbeløp(gjeldendeAndelerForNøkkel);
+            Beløp nyttÅrsbeløp = finnÅrsbeløp(andeler);
+            var diff = gjeldendeÅrsbeløp.getVerdi().subtract(nyttÅrsbeløp.getVerdi()).longValue();
+            if (Math.abs(diff) > 3) {
+                loggOgSettAvvik("Årsbeløp for andel " + nøkkel + " i år " + Year.from(år), nyttÅrsbeløp.getVerdi().longValue(), gjeldendeÅrsbeløp.getVerdi().longValue());
             }
-
         });
     }
 
@@ -96,6 +117,11 @@ public class Feriepengesammenligner {
     private Map<AktivitetOgArbeidsforholdNøkkel, List<BeregningsresultatFeriepengerPrÅr>> nøkkelTilAndelerMap(List<BeregningsresultatFeriepengerPrÅr> andeler) {
         return andeler.stream()
             .collect(Collectors.groupingBy(an -> an.getBeregningsresultatAndel().getAktivitetOgArbeidsforholdNøkkel()));
+    }
+
+    private Map<AndelGruppering, List<BeregningsresultatFeriepengerPrÅr>> nøkkelTilGrupperingMap(List<BeregningsresultatFeriepengerPrÅr> andeler) {
+        return andeler.stream()
+            .collect(Collectors.groupingBy(AndelGruppering::new));
     }
 
     private Map<LocalDate, List<BeregningsresultatFeriepengerPrÅr>> årTilAndelerMap(List<BeregningsresultatFeriepengerPrÅr> andeler) {
@@ -117,13 +143,46 @@ public class Feriepengesammenligner {
         this.finnesAvvik = true;
         String gammelBeskrivelse = gammelt == null ? "null" : gammelt.toString();
         String nyBeskrivelse = nytt == null ? "null" : nytt.toString();
-        logger.info(AVVIK_KODE + "Avvik mellom ny og gammel feriepengeberegning på saksnummer " + saksnummer.getVerdi()  + " på behandling med id: " + behandlingId +
-            ". Avvik på " + beskrivelse + ". Gammelt grunnlag hadde verdi " + gammelBeskrivelse + ". Nytt grunnlag hadde verdi: " + nyBeskrivelse);
+        logger.info("{} Avvik mellom ny og gammel feriepengeberegning på saksnummer {} behandling {}\n   Avvik {}\n    Gammelt {} Nytt {}",
+            AVVIK_KODE, saksnummer.getVerdi(), behandlingId, beskrivelse, gammelBeskrivelse, nyBeskrivelse);
     }
 
-    private void loggIngenAvvik() {
-        logger.info(INGEN_AVVIK_KODE + "Finner ingen avvik mellom ny og gammel feriepengeberegning på saksnummer " + saksnummer.getVerdi() + " på behandling med id: " + behandlingId);
-    }
+    private static class AndelGruppering {
+        String mottaker;
+        String arbeidsgiver;
+        InternArbeidsforholdRef arbeidsforholdRef;
+        AktivitetStatus aktivitetStatus;
+        Inntektskategori inntektskategori;
 
+        AndelGruppering(BeregningsresultatFeriepengerPrÅr andel) {
+            this.mottaker = andel.getBeregningsresultatAndel().erBrukerMottaker() ? BRUKER : "Arbgiv";
+            this.arbeidsgiver = andel.getBeregningsresultatAndel().getArbeidsgiver().map(Arbeidsgiver::getIdentifikator).orElse(null);
+            this.arbeidsforholdRef = andel.getBeregningsresultatAndel().getArbeidsforholdRef();
+            this.aktivitetStatus = andel.getBeregningsresultatAndel().getAktivitetStatus();
+            this.inntektskategori = andel.getBeregningsresultatAndel().getInntektskategori();
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            AndelGruppering that = (AndelGruppering) o;
+            return mottaker.equals(that.mottaker) && Objects.equals(arbeidsgiver, that.arbeidsgiver) && Objects.equals(arbeidsforholdRef, that.arbeidsforholdRef) && aktivitetStatus == that.aktivitetStatus && inntektskategori == that.inntektskategori;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(mottaker, arbeidsgiver, arbeidsforholdRef, aktivitetStatus, inntektskategori);
+        }
+
+        @Override
+        public String toString() {
+            return "AndelGruppering{" +
+                "mottaker='" + mottaker + '\'' +
+                ", arbeidsgiver=" + arbeidsgiver +
+                ", aktivitetStatus=" + aktivitetStatus +
+                '}';
+        }
+    }
 
 }

--- a/domenetjenester/beregning-ytelse/src/test/java/no/nav/foreldrepenger/ytelse/beregning/FeriepengesammenlignerTest.java
+++ b/domenetjenester/beregning-ytelse/src/test/java/no/nav/foreldrepenger/ytelse/beregning/FeriepengesammenlignerTest.java
@@ -62,7 +62,7 @@ class FeriepengesammenlignerTest {
     @Test
     public void skal_gi_avvik_når_beløp_er_ulikt() {
         // Arrange
-        lagFerieandel(gr1, 2020, 4999, lagAndel(gr1, "123", true));
+        lagFerieandel(gr1, 2020, 4990, lagAndel(gr1, "123", true));
         lagFerieandel(gr1, 2020, 5000, lagAndel(gr1, "123", false));
 
         lagFerieandel(gr2, 2020, 5000, lagAndel(gr2, "123", true));
@@ -102,7 +102,7 @@ class FeriepengesammenlignerTest {
         BeregningsresultatAndel andel2 = lagAndel(gr2, "123", true);
         lagFerieandel(gr2, 2020, 5000, andel2);
         lagFerieandel(gr2, 2020, 5000, lagAndel(gr2, "321", true));
-        lagFerieandel(gr2, 2021, 4999, andel2);
+        lagFerieandel(gr2, 2021, 4990, andel2);
 
         // Act
         boolean finnesAvvik = sjekker.finnesAvvik();

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/forvaltning/ForvaltningFeriepengerRestTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/forvaltning/ForvaltningFeriepengerRestTjeneste.java
@@ -26,6 +26,7 @@ import no.nav.foreldrepenger.web.app.tjenester.forvaltning.dto.AvstemmingPeriode
 import no.nav.foreldrepenger.web.app.tjenester.forvaltning.dto.ForvaltningBehandlingIdDto;
 import no.nav.foreldrepenger.ytelse.beregning.FeriepengeRegeregnTjeneste;
 import no.nav.vedtak.sikkerhet.abac.BeskyttetRessurs;
+import no.nav.vedtak.util.Tuple;
 
 @Path("/forvaltningFeriepenger")
 @ApplicationScoped
@@ -65,13 +66,9 @@ public class ForvaltningFeriepengerRestTjeneste {
     @Operation(description = "Lagrer task for å finne overlapp. Resultat i app-logg", tags = "FORVALTNING-feriepenger")
     @BeskyttetRessurs(action = READ, resource = FPSakBeskyttetRessursAttributt.DRIFT)
     public Response avstemPeriodeForOverlapp(@Parameter(description = "Periode") @BeanParam @Valid AvstemmingPeriodeDto dto) {
-        repository.finnSakerForAvstemmingFeriepenger(dto.getFom(), dto.getTom())
-            .forEach(b -> {
-                var avvik = feriepengeRegeregnTjeneste.harDiff(b.getElement2());
-                if (avvik) {
-                    logger.info("Feriepenger avvik for sak {} behandling {}", b.getElement1(), b.getElement2());
-                }
-            });
+        repository.finnSakerForAvstemmingFeriepenger(dto.getFom(), dto.getTom()).stream()
+            .map(Tuple::getElement2)
+            .forEach(feriepengeRegeregnTjeneste::harDiff);
 
         return Response.ok().build();
     }


### PR DESCRIPTION
Lager loggstatements som er lettere å formattere i en editor.
Filtrer vekk de som er noen kroners avvik (avrundingsdiff)
Gjør en toveis-diff ved å spinne gjennom begge og regne ut

Jeg har kjørt lokalt og får noen diffs på tester jeg kjørte 20/1-2021 - husker bare ikke hvilke testcases
Typisk Avvik mellom ny og gammel feriepengeberegning på saksnummer 120132014 behandling 1010577
   Avvik Andelsbeløp for AndelGruppering{mottaker='Bruker', arbeidsgiver='994884174', aktivitetStatus=ARBEIDSTAKER} år 2021 diff 1883
    Gammelt 3389 Nytt 1506