### PR TITLE
TFP-1684 TFP-1687 Rikere faresignalvurdering

### DIFF
--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/risikoklassifisering/FaresignalVurdering.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/risikoklassifisering/FaresignalVurdering.java
@@ -16,13 +16,18 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
+import no.nav.foreldrepenger.behandlingslager.kodeverk.TempAvledeKode;
 
 @JsonFormat(shape = Shape.OBJECT)
 @JsonAutoDetect(getterVisibility = Visibility.NONE, setterVisibility = Visibility.NONE, fieldVisibility = Visibility.ANY)
 public enum FaresignalVurdering implements Kodeverdi {
 
-    INNVIRKNING("INNVIRKNING", "Faresignalene hadde innvirkning på behandlingen"),
-    INGEN_INNVIRKNING("INGEN_INNVIRKNING", "Faresignalene hadde ingen innvirkning på behandlingen"),
+    INNVIRKNING("INNVIRKNING", "Faresignalene vurderes som reelle"),
+    INNVILGET_REDUSERT("INNVILGET_REDUSERT", "Saken er innvilget med redusert beregningsgrunnlag"),
+    INNVILGET_UENDRET("INNVILGET_UENDRET", "Saken er innvilget uten at faresignalene påvirket utfallet"),
+    AVSLAG_FARESIGNAL("AVSLAG_FARESIGNAL", "Saken er avslått på grunn av faresignalene"),
+    AVSLAG_ANNET("AVSLAG_ANNET", "Saken er avslått av andre årsaker"),
+    INGEN_INNVIRKNING("INGEN_INNVIRKNING", "Faresignalene vurderes ikke som reelle"),
     UDEFINERT("-", "Udefinert"),
     ;
 
@@ -52,11 +57,12 @@ public enum FaresignalVurdering implements Kodeverdi {
         this.navn = navn;
     }
 
-    @JsonCreator
-    public static FaresignalVurdering fraKode(@JsonProperty("kode") String kode) {
-        if (kode == null) {
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+    public static FaresignalVurdering fraKode(@JsonProperty(value = "kode") Object node) {
+        if (node == null) {
             return null;
         }
+        String kode = TempAvledeKode.getVerdi(FaresignalVurdering.class, node, "kode");
         var ad = KODER.get(kode);
         if (ad == null) {
             throw new IllegalArgumentException("Ukjent FaresignalVurdering: " + kode);

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/risikoklassifisering/RisikoklassifiseringRepository.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/risikoklassifisering/RisikoklassifiseringRepository.java
@@ -28,17 +28,12 @@ public class RisikoklassifiseringRepository {
 
     public void lagreVurderingAvFaresignalerForRisikoklassifisering(FaresignalVurdering faresignalVurdering, long behandlingId) {
 
-        Optional<RisikoklassifiseringEntitet> gammelEntitetOpt = hentRisikoklassifiseringForBehandling(behandlingId);
-
-        if (gammelEntitetOpt.isEmpty()) {
-            throw new IllegalStateException("Finner ikke risikoklassifisering for behandling med id " + behandlingId);
-        }
-
-        RisikoklassifiseringEntitet gammelEntitet = gammelEntitetOpt.get();
+        var gammelEntitet = hentRisikoklassifiseringForBehandling(behandlingId)
+            .orElseThrow(() -> new IllegalStateException("Finner ikke risikoklassifisering for behandling med id " + behandlingId));
 
         deaktiverGrunnlag(gammelEntitet);
 
-        RisikoklassifiseringEntitet nyEntitet = RisikoklassifiseringEntitet.builder()
+        var nyEntitet = RisikoklassifiseringEntitet.builder()
             .medKontrollresultat(gammelEntitet.getKontrollresultat())
             .medFaresignalVurdering(faresignalVurdering)
             .buildFor(gammelEntitet.getBehandlingId());
@@ -72,8 +67,7 @@ public class RisikoklassifiseringRepository {
     }
 
     private void deaktiverGammeltGrunnlagOmNødvendig(Long behandlingId) {
-        Optional<RisikoklassifiseringEntitet> risikoklassifiseringEntitet = hentRisikoklassifiseringForBehandling(behandlingId);
-        risikoklassifiseringEntitet.ifPresent(this::deaktiverGrunnlag);
+        hentRisikoklassifiseringForBehandling(behandlingId).ifPresent(this::deaktiverGrunnlag);
     }
 
     private void deaktiverGrunnlag(RisikoklassifiseringEntitet risikoklassifiseringEntitet) {

--- a/behandlingslager/domene/src/test/java/no/nav/foreldrepenger/behandlingslager/risikoklassifisering/RisikoklassifiseringRepositoryTest.java
+++ b/behandlingslager/domene/src/test/java/no/nav/foreldrepenger/behandlingslager/risikoklassifisering/RisikoklassifiseringRepositoryTest.java
@@ -100,7 +100,7 @@ public class RisikoklassifiseringRepositoryTest {
         assertThat(persistertKlassifisering.get()).isEqualTo(risikoklassifiseringEntitet);
 
         // Act
-        risikorepository.lagreVurderingAvFaresignalerForRisikoklassifisering(FaresignalVurdering.INNVIRKNING, behandling.getId());
+        risikorepository.lagreVurderingAvFaresignalerForRisikoklassifisering(FaresignalVurdering.INNVILGET_REDUSERT, behandling.getId());
         Optional<RisikoklassifiseringEntitet> nyPersistertKlassifisering = risikorepository.hentRisikoklassifiseringForBehandling(behandling.getId());
 
         // Assert
@@ -108,7 +108,7 @@ public class RisikoklassifiseringRepositoryTest {
         RisikoklassifiseringEntitet entitet = nyPersistertKlassifisering.get();
         assertThat(entitet.getKontrollresultat()).isEqualTo(risikoklassifiseringEntitet.getKontrollresultat());
         assertThat(entitet.getBehandlingId()).isEqualTo(risikoklassifiseringEntitet.getBehandlingId());
-        assertThat(entitet.getFaresignalVurdering()).isEqualTo(FaresignalVurdering.INNVIRKNING);
+        assertThat(entitet.getFaresignalVurdering()).isEqualTo(FaresignalVurdering.INNVILGET_REDUSERT);
     }
 
     @Test

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/risikoklassifisering/VurderFaresignalerDto.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/risikoklassifisering/VurderFaresignalerDto.java
@@ -5,19 +5,22 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 
 import no.nav.foreldrepenger.behandling.aksjonspunkt.BekreftetAksjonspunktDto;
 import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.AksjonspunktKodeDefinisjon;
+import no.nav.foreldrepenger.behandlingslager.risikoklassifisering.FaresignalVurdering;
 
 @JsonTypeName(AksjonspunktKodeDefinisjon.VURDER_FARESIGNALER_KODE)
 public class VurderFaresignalerDto extends BekreftetAksjonspunktDto {
 
     private Boolean harInnvirketBehandlingen;
+    private FaresignalVurdering faresignalVurdering;
 
     VurderFaresignalerDto() {
         // For Jackson
     }
 
-    public VurderFaresignalerDto(String begrunnelse, Boolean harInnvirketBehandlingen) {
+    public VurderFaresignalerDto(String begrunnelse, Boolean harInnvirketBehandlingen, FaresignalVurdering faresignalVurdering) {
         super(begrunnelse);
         this.harInnvirketBehandlingen = harInnvirketBehandlingen;
+        this.faresignalVurdering = faresignalVurdering;
     }
 
 
@@ -27,5 +30,13 @@ public class VurderFaresignalerDto extends BekreftetAksjonspunktDto {
 
     public void setHarInnvirketBehandlingen(Boolean harInnvirketBehandlingen) {
         this.harInnvirketBehandlingen = harInnvirketBehandlingen;
+    }
+
+    public FaresignalVurdering getFaresignalVurdering() {
+        return faresignalVurdering;
+    }
+
+    public void setFaresignalVurdering(FaresignalVurdering faresignalVurdering) {
+        this.faresignalVurdering = faresignalVurdering;
     }
 }

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/kodeverk/app/HentKodeverkTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/kodeverk/app/HentKodeverkTjeneste.java
@@ -67,6 +67,7 @@ import no.nav.foreldrepenger.behandlingslager.geografisk.Språkkode;
 import no.nav.foreldrepenger.behandlingslager.kodeverk.BasisKodeverdi;
 import no.nav.foreldrepenger.behandlingslager.kodeverk.Fagsystem;
 import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
+import no.nav.foreldrepenger.behandlingslager.risikoklassifisering.FaresignalVurdering;
 import no.nav.foreldrepenger.behandlingslager.uttak.UttakArbeidType;
 import no.nav.foreldrepenger.behandlingslager.uttak.fp.GraderingAvslagÅrsak;
 import no.nav.foreldrepenger.behandlingslager.uttak.fp.IkkeOppfyltÅrsak;
@@ -165,6 +166,7 @@ public class HentKodeverkTjeneste {
         map.put(MorsAktivitet.class.getSimpleName(), MorsAktivitet.kodeMap().values());
         map.put(ManuellBehandlingÅrsak.class.getSimpleName(), ManuellBehandlingÅrsak.kodeMap().values());
         map.put(KontrollerAktivitetskravAvklaring.class.getSimpleName(), KontrollerAktivitetskravAvklaring.kodeMap().values());
+        map.put(FaresignalVurdering.class.getSimpleName(), FaresignalVurdering.kodeMap().values());
 
         Map<String, Collection<? extends Kodeverdi>> mapFiltered = new LinkedHashMap<>();
 

--- a/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/risikoklassifisering/VurderFaresignalerOppdatererUtvidetTest.java
+++ b/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/risikoklassifisering/VurderFaresignalerOppdatererUtvidetTest.java
@@ -27,7 +27,7 @@ import no.nav.foreldrepenger.domene.risikoklassifisering.tjeneste.Risikovurderin
 import no.nav.foreldrepenger.historikk.HistorikkInnslagTekstBuilder;
 import no.nav.foreldrepenger.historikk.HistorikkTjenesteAdapter;
 
-public class VurderFaresignalerOppdatererTest extends EntityManagerAwareTest {
+public class VurderFaresignalerOppdatererUtvidetTest extends EntityManagerAwareTest {
 
     private RisikoklassifiseringRepository risikoklassifiseringRepository;
 
@@ -54,7 +54,7 @@ public class VurderFaresignalerOppdatererTest extends EntityManagerAwareTest {
     @Test
     public void skal_oppdatere_korrekt_ved_ingen_innvirkning() {
         // Arrange
-        VurderFaresignalerDto dto = new VurderFaresignalerDto("Dustemikkel", false, null);
+        VurderFaresignalerDto dto = new VurderFaresignalerDto("Dustemikkel", false, FaresignalVurdering.INGEN_INNVIRKNING);
         risikoklassifiseringRepository.lagreRisikoklassifisering(
             lagRisikoklassifisering(Kontrollresultat.HØY, FaresignalVurdering.UDEFINERT), behandling.getId());
 
@@ -73,7 +73,7 @@ public class VurderFaresignalerOppdatererTest extends EntityManagerAwareTest {
     @Test
     public void skal_oppdatere_korrekt_ved_har_hatt_innvirkning() {
         // Arrange
-        VurderFaresignalerDto dto = new VurderFaresignalerDto("Dustemikkel", true, null);
+        VurderFaresignalerDto dto = new VurderFaresignalerDto("Dustemikkel", true, FaresignalVurdering.AVSLAG_FARESIGNAL);
         risikoklassifiseringRepository.lagreRisikoklassifisering(
             lagRisikoklassifisering(Kontrollresultat.HØY, FaresignalVurdering.UDEFINERT), behandling.getId());
 
@@ -85,14 +85,14 @@ public class VurderFaresignalerOppdatererTest extends EntityManagerAwareTest {
 
         // Assert
         assertThat(oppdatertEntitet).isPresent();
-        assertThat(oppdatertEntitet.get().getFaresignalVurdering()).isEqualTo(FaresignalVurdering.INNVIRKNING);
+        assertThat(oppdatertEntitet.get().getFaresignalVurdering()).isEqualTo(FaresignalVurdering.AVSLAG_FARESIGNAL);
         assertThat(oppdatertEntitet.get().getKontrollresultat()).isEqualTo(Kontrollresultat.HØY);
     }
 
     @Test
     public void skal_lage_korrekt_historikkinnslag_når_det_ikke_finnes_tidligere_vurdering() {
         // Arrange
-        VurderFaresignalerDto dto = new VurderFaresignalerDto("Dustemikkel", true, null);
+        VurderFaresignalerDto dto = new VurderFaresignalerDto("Dustemikkel", true, FaresignalVurdering.INNVILGET_UENDRET);
         risikoklassifiseringRepository.lagreRisikoklassifisering(
             lagRisikoklassifisering(Kontrollresultat.HØY, FaresignalVurdering.UDEFINERT), behandling.getId());
 
@@ -120,7 +120,7 @@ public class VurderFaresignalerOppdatererTest extends EntityManagerAwareTest {
     @Test
     public void skal_lage_korrekt_historikkinnslag_når_det_finnes_tidligere_vurdering_ingen_innvirkning() {
         // Arrange
-        VurderFaresignalerDto dto = new VurderFaresignalerDto("Dustemikkel", true, null);
+        VurderFaresignalerDto dto = new VurderFaresignalerDto("Dustemikkel", true, FaresignalVurdering.INNVILGET_REDUSERT);
         risikoklassifiseringRepository.lagreRisikoklassifisering(
             lagRisikoklassifisering(Kontrollresultat.HØY, FaresignalVurdering.INGEN_INNVIRKNING), behandling.getId());
 
@@ -149,7 +149,7 @@ public class VurderFaresignalerOppdatererTest extends EntityManagerAwareTest {
     @Test
     public void skal_lage_korrekt_historikkinnslag_når_det_finnes_tidligere_vurdering_innvirkning() {
         // Arrange
-        VurderFaresignalerDto dto = new VurderFaresignalerDto("Dustemikkel", false, null);
+        VurderFaresignalerDto dto = new VurderFaresignalerDto("Dustemikkel", false, FaresignalVurdering.INGEN_INNVIRKNING);
         risikoklassifiseringRepository.lagreRisikoklassifisering(
             lagRisikoklassifisering(Kontrollresultat.HØY, FaresignalVurdering.INNVIRKNING), behandling.getId());
 
@@ -178,7 +178,7 @@ public class VurderFaresignalerOppdatererTest extends EntityManagerAwareTest {
     @Test
     public void skal_feile_om_det_ikke_finnes_en_risikoklassifisering_for_behandlingen() {
         // Arrange
-        VurderFaresignalerDto dto = new VurderFaresignalerDto("Dustemikkel", true, null);
+        VurderFaresignalerDto dto = new VurderFaresignalerDto("Dustemikkel", true, FaresignalVurdering.AVSLAG_FARESIGNAL);
 
         // Act
         assertThrows(IllegalStateException.class, () -> vurderFaresignalerOppdaterer.oppdater(dto,


### PR DESCRIPTION
Oppdatert tekster og utvidet med 4 "underkategorier" av innvirkning.
Lagt til kodeverk så det kan hentes som kodeverkNavn frontend.
Oppdatert enum så den kan brukes i aksjonspunktoppdaterer

Denne bør kunne merges - mener den skal være kompatibel med dagens aksjonspunkt frontend