### PR TITLE
TFP-4013 TP-4085 medlemsvilkår ser kun på bosattvurdering ikke personstatus

### DIFF
--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/aksjonspunkt/AksjonspunktDefinisjon.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/aksjonspunkt/AksjonspunktDefinisjon.java
@@ -111,10 +111,6 @@ public enum AksjonspunktDefinisjon implements Kodeverdi {
             AksjonspunktKodeDefinisjon.AVKLAR_GYLDIG_MEDLEMSKAPSPERIODE_KODE, AksjonspunktType.MANUELL, "Avklar om bruker har gyldig periode.",
             BehandlingStegType.VURDER_MEDLEMSKAPVILKÅR, VurderingspunktType.INN, VilkårType.MEDLEMSKAPSVILKÅRET, SkjermlenkeType.FAKTA_OM_MEDLEMSKAP,
             ENTRINN, EnumSet.of(ES, FP, SVP)),
-    AVKLAR_FAKTA_FOR_PERSONSTATUS(
-            AksjonspunktKodeDefinisjon.AVKLAR_FAKTA_FOR_PERSONSTATUS_KODE, AksjonspunktType.MANUELL, "Avklar fakta for status på person.",
-            BehandlingStegType.KONTROLLER_FAKTA, VurderingspunktType.INN, VilkårType.MEDLEMSKAPSVILKÅRET, SkjermlenkeType.KONTROLL_AV_SAKSOPPLYSNINGER,
-            ENTRINN, EnumSet.of(ES, FP, SVP)),
     AVKLAR_OPPHOLDSRETT(AksjonspunktKodeDefinisjon.AVKLAR_OPPHOLDSRETT_KODE,
             AksjonspunktType.MANUELL, "Avklar oppholdsrett.", BehandlingStegType.VURDER_MEDLEMSKAPVILKÅR, VurderingspunktType.INN,
             VilkårType.MEDLEMSKAPSVILKÅRET, SkjermlenkeType.FAKTA_OM_MEDLEMSKAP, ENTRINN, EnumSet.of(ES, FP, SVP)),
@@ -473,6 +469,11 @@ public enum AksjonspunktDefinisjon implements Kodeverdi {
     TILKNYTTET_STORTINGET(AksjonspunktKodeDefinisjon.TILKNYTTET_STORTINGET_KODE,
         AksjonspunktType.MANUELL, "Søker er stortingsrepresentant/administrativt ansatt i Stortinget", BehandlingStegType.VURDER_UTTAK,
         VurderingspunktType.UT, UTEN_VILKÅR, SkjermlenkeType.UTTAK, TOTRINN, EnumSet.of(FP, SVP)),
+    @Deprecated
+    AVKLAR_FAKTA_FOR_PERSONSTATUS(
+        AksjonspunktKodeDefinisjon.AVKLAR_FAKTA_FOR_PERSONSTATUS_KODE, AksjonspunktType.MANUELL, "Avklar fakta for status på person.",
+        BehandlingStegType.KONTROLLER_FAKTA, VurderingspunktType.INN, VilkårType.MEDLEMSKAPSVILKÅRET, SkjermlenkeType.KONTROLL_AV_SAKSOPPLYSNINGER,
+        ENTRINN, EnumSet.of(ES, FP, SVP)),
     ;
 
     static final String KODEVERK = "AKSJONSPUNKT_DEF";

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/vilkår/VilkårUtfallMerknad.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/vilkår/VilkårUtfallMerknad.java
@@ -33,11 +33,11 @@ public enum VilkårUtfallMerknad implements Kodeverdi {
     VM_1019("1019", "Terminbekreftelse utstedt før 22. svangerskapsuke"),
 
     VM_1020("1020", "Bruker er registrert som ikke medlem"),
-    VM_1021("1021", "Bruker er ikke registrert i TPS som bosatt i Norge"),
+    VM_1021("1021", "Bruker er ikke registrert i TPS som bosatt i Norge"), // UTGÅTT
     VM_1022("1022", "1022"),
     VM_1023("1023", "Bruker ikke er registrert som norsk eller nordisk statsborger i TPS OG bruker ikke er registrert som borger av EU/EØS OG det ikke er avklart at bruker har lovlig opphold i Norge"),
     VM_1024("1024", "Bruker ikke er registrert som norsk eller nordisk statsborger i TPS OG bruker er registrert som borger av EU/EØS OG det ikke er avklart at bruker har oppholdsrett"),
-    VM_1025("1025", "Bruker er registrert i TPS som bosatt i Norge OG bruker avklart som ikke bosatt. (Denne kan ha 4 utfall)"),
+    VM_1025("1025", "Bruker avklart som ikke bosatt."),
 
     VM_1026("1026", "Fødselsdato ikke oppgitt eller registrert"),
     VM_1027("1027", "ingen barn dokumentert på far/medmor"),

--- a/behandlingsprosess/src/main/java/no/nav/foreldrepenger/behandling/steg/innhentsaksopplysninger/InnhentRegisteropplysningerResterendeOppgaverStegImpl.java
+++ b/behandlingsprosess/src/main/java/no/nav/foreldrepenger/behandling/steg/innhentsaksopplysninger/InnhentRegisteropplysningerResterendeOppgaverStegImpl.java
@@ -1,6 +1,5 @@
 package no.nav.foreldrepenger.behandling.steg.innhentsaksopplysninger;
 
-import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
 import static no.nav.foreldrepenger.behandling.steg.kompletthet.VurderKompletthetStegFelles.autopunktAlleredeUtført;
 import static no.nav.foreldrepenger.behandlingskontroll.AksjonspunktResultat.opprettForAksjonspunkt;
@@ -8,7 +7,6 @@ import static no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.Aks
 import static no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.AksjonspunktDefinisjon.AVKLAR_VERGE;
 
 import java.time.LocalDate;
-import java.util.ArrayList;
 import java.util.List;
 
 import javax.enterprise.context.ApplicationScoped;
@@ -23,13 +21,10 @@ import no.nav.foreldrepenger.behandlingskontroll.BehandlingStegRef;
 import no.nav.foreldrepenger.behandlingskontroll.BehandlingTypeRef;
 import no.nav.foreldrepenger.behandlingskontroll.BehandlingskontrollKontekst;
 import no.nav.foreldrepenger.behandlingskontroll.FagsakYtelseTypeRef;
-import no.nav.foreldrepenger.behandlingslager.aktør.PersonstatusType;
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
-import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.AksjonspunktDefinisjon;
 import no.nav.foreldrepenger.behandlingslager.behandling.historikk.HistorikkAktør;
 import no.nav.foreldrepenger.behandlingslager.behandling.personopplysning.PersonopplysningEntitet;
 import no.nav.foreldrepenger.behandlingslager.behandling.personopplysning.PersonopplysningerAggregat;
-import no.nav.foreldrepenger.behandlingslager.behandling.personopplysning.PersonstatusEntitet;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepositoryProvider;
 import no.nav.foreldrepenger.domene.personopplysning.PersonopplysningTjeneste;

--- a/domenetjenester/behandlingskontroll/src/test/java/no/nav/foreldrepenger/behandlingskontroll/impl/BehandlingModellTest.java
+++ b/domenetjenester/behandlingskontroll/src/test/java/no/nav/foreldrepenger/behandlingskontroll/impl/BehandlingModellTest.java
@@ -69,7 +69,7 @@ public class BehandlingModellTest {
         AksjonspunktDefinisjon a0_0 = AksjonspunktDefinisjon.AVKLAR_OPPHOLDSRETT;
         AksjonspunktDefinisjon a0_1 = AksjonspunktDefinisjon.SJEKK_MANGLENDE_FØDSEL;
         AksjonspunktDefinisjon a1_0 = AksjonspunktDefinisjon.AVKLAR_ADOPSJONSDOKUMENTAJON;
-        AksjonspunktDefinisjon a1_1 = AksjonspunktDefinisjon.AVKLAR_FAKTA_FOR_PERSONSTATUS;
+        AksjonspunktDefinisjon a1_1 = AksjonspunktDefinisjon.AVKLAR_LOVLIG_OPPHOLD;
         AksjonspunktDefinisjon a2_0 = AksjonspunktDefinisjon.AVKLAR_GYLDIG_MEDLEMSKAPSPERIODE;
         AksjonspunktDefinisjon a2_1 = AksjonspunktDefinisjon.AVKLAR_TILLEGGSOPPLYSNINGER;
 
@@ -142,7 +142,7 @@ public class BehandlingModellTest {
         AksjonspunktDefinisjon a0_0 = AksjonspunktDefinisjon.AVKLAR_OPPHOLDSRETT;
         AksjonspunktDefinisjon a0_1 = AksjonspunktDefinisjon.SJEKK_MANGLENDE_FØDSEL;
         AksjonspunktDefinisjon a1_0 = AksjonspunktDefinisjon.AVKLAR_ADOPSJONSDOKUMENTAJON;
-        AksjonspunktDefinisjon a1_1 = AksjonspunktDefinisjon.AVKLAR_FAKTA_FOR_PERSONSTATUS;
+        AksjonspunktDefinisjon a1_1 = AksjonspunktDefinisjon.AVKLAR_LOVLIG_OPPHOLD;
 
         DummySteg steg = new DummySteg();
         DummySteg steg0 = new DummySteg();

--- a/domenetjenester/behandlingskontroll/src/test/java/no/nav/foreldrepenger/behandlingskontroll/impl/BehandlingskontrollEventPublisererTest.java
+++ b/domenetjenester/behandlingskontroll/src/test/java/no/nav/foreldrepenger/behandlingskontroll/impl/BehandlingskontrollEventPublisererTest.java
@@ -195,7 +195,7 @@ public class BehandlingskontrollEventPublisererTest {
         AksjonspunktDefinisjon a0_0 = AksjonspunktDefinisjon.AVKLAR_OPPHOLDSRETT;
         AksjonspunktDefinisjon a0_1 = AksjonspunktDefinisjon.SJEKK_MANGLENDE_FØDSEL;
         AksjonspunktDefinisjon a1_0 = AksjonspunktDefinisjon.AVKLAR_ADOPSJONSDOKUMENTAJON;
-        AksjonspunktDefinisjon a1_1 = AksjonspunktDefinisjon.AVKLAR_FAKTA_FOR_PERSONSTATUS;
+        AksjonspunktDefinisjon a1_1 = AksjonspunktDefinisjon.AVKLAR_LOVLIG_OPPHOLD;
         AksjonspunktDefinisjon a2_0 = AksjonspunktDefinisjon.AVKLAR_GYLDIG_MEDLEMSKAPSPERIODE;
         AksjonspunktDefinisjon a2_1 = AksjonspunktDefinisjon.AVKLAR_TILLEGGSOPPLYSNINGER;
 

--- a/domenetjenester/behandlingskontroll/src/test/java/no/nav/foreldrepenger/behandlingskontroll/impl/BehandlingskontrollTjenesteImplTest.java
+++ b/domenetjenester/behandlingskontroll/src/test/java/no/nav/foreldrepenger/behandlingskontroll/impl/BehandlingskontrollTjenesteImplTest.java
@@ -320,7 +320,7 @@ public class BehandlingskontrollTjenesteImplTest {
         when(kontekst.getBehandlingId()).thenReturn(behandling.getId());
         when(kontekst.getFagsakId()).thenReturn(behandling.getFagsakId());
         assertThat(kontrollTjeneste.skalAksjonspunktLøsesIEllerEtterSteg(behandling.getFagsakYtelseType(),
-                behandling.getType(), steg4, AksjonspunktDefinisjon.AVKLAR_FAKTA_FOR_PERSONSTATUS))
+                behandling.getType(), steg4, AksjonspunktDefinisjon.AVKLAR_VERGE))
                         .isFalse();
     }
 

--- a/domenetjenester/datavarehus/src/test/java/no/nav/foreldrepenger/datavarehus/observer/DatavarehusEventObserverTest.java
+++ b/domenetjenester/datavarehus/src/test/java/no/nav/foreldrepenger/datavarehus/observer/DatavarehusEventObserverTest.java
@@ -208,7 +208,7 @@ public class DatavarehusEventObserverTest {
     private Behandling byggBehandling() {
         ScenarioMorSøkerEngangsstønad scenario = ScenarioMorSøkerEngangsstønad.forFødsel();
         scenario.leggTilAksjonspunkt(AksjonspunktDefinisjon.AUTO_MANUELT_SATT_PÅ_VENT, BehandlingStegType.VURDER_UTTAK);
-        scenario.leggTilAksjonspunkt(AksjonspunktDefinisjon.AVKLAR_FAKTA_FOR_PERSONSTATUS, BehandlingStegType.VURDER_UTTAK);
+        scenario.leggTilAksjonspunkt(AksjonspunktDefinisjon.AVKLAR_LOVLIG_OPPHOLD, BehandlingStegType.VURDER_UTTAK);
 
         Behandling behandling = scenario.lagMocked();
         return behandling;

--- a/domenetjenester/datavarehus/src/test/java/no/nav/foreldrepenger/datavarehus/tjeneste/AksjonspunktDvhMapperTest.java
+++ b/domenetjenester/datavarehus/src/test/java/no/nav/foreldrepenger/datavarehus/tjeneste/AksjonspunktDvhMapperTest.java
@@ -88,7 +88,7 @@ public class AksjonspunktDvhMapperTest {
     private Behandling behandling() {
         var scenario = ScenarioMorSøkerEngangsstønad.forFødsel();
         scenario.leggTilAksjonspunkt(AKSJONSPUNKT_DEF, SØKERS_RELASJON_TIL_BARN);
-        scenario.leggTilAksjonspunkt(AksjonspunktDefinisjon.AVKLAR_FAKTA_FOR_PERSONSTATUS, SØKERS_RELASJON_TIL_BARN);
+        scenario.leggTilAksjonspunkt(AksjonspunktDefinisjon.AVKLAR_TERMINBEKREFTELSE, SØKERS_RELASJON_TIL_BARN);
         var behandling = scenario.lagMocked();
         behandling.setAnsvarligBeslutter(ANSVARLIG_BESLUTTER);
         behandling.setAnsvarligSaksbehandler(ANSVARLIG_SAKSBEHANDLER);

--- a/domenetjenester/datavarehus/src/test/java/no/nav/foreldrepenger/datavarehus/tjeneste/DatavarehusTjenesteImplTest.java
+++ b/domenetjenester/datavarehus/src/test/java/no/nav/foreldrepenger/datavarehus/tjeneste/DatavarehusTjenesteImplTest.java
@@ -139,7 +139,7 @@ public class DatavarehusTjenesteImplTest {
     public void lagreNedAksjonspunkter() {
         ScenarioMorSøkerEngangsstønad scenario = ScenarioMorSøkerEngangsstønad.forFødsel();
         scenario.leggTilAksjonspunkt(AKSJONSPUNKT_DEF, BehandlingStegType.SØKERS_RELASJON_TIL_BARN);
-        scenario.leggTilAksjonspunkt(AksjonspunktDefinisjon.AVKLAR_FAKTA_FOR_PERSONSTATUS, BehandlingStegType.SØKERS_RELASJON_TIL_BARN);
+        scenario.leggTilAksjonspunkt(AksjonspunktDefinisjon.AVKLAR_TERMINBEKREFTELSE, BehandlingStegType.SØKERS_RELASJON_TIL_BARN);
         scenario.medBehandlingStegStart(BEHANDLING_STEG_TYPE);
         scenario.medBehandlendeEnhet(BEHANDLENDE_ENHET);
         Behandling behandling = scenario.lagre(repositoryProvider);
@@ -184,7 +184,7 @@ public class DatavarehusTjenesteImplTest {
     public void lagreNedBehandling() {
         ScenarioMorSøkerEngangsstønad scenario = ScenarioMorSøkerEngangsstønad.forFødsel();
         scenario.leggTilAksjonspunkt(AKSJONSPUNKT_DEF, BehandlingStegType.SØKERS_RELASJON_TIL_BARN);
-        scenario.leggTilAksjonspunkt(AksjonspunktDefinisjon.AVKLAR_FAKTA_FOR_PERSONSTATUS, BehandlingStegType.SØKERS_RELASJON_TIL_BARN);
+        scenario.leggTilAksjonspunkt(AksjonspunktDefinisjon.AVKLAR_TERMINBEKREFTELSE, BehandlingStegType.SØKERS_RELASJON_TIL_BARN);
         scenario.medBehandlendeEnhet(BEHANDLENDE_ENHET);
         Behandling behandling = scenario.lagMocked();
         forceOppdaterBehandlingSteg(behandling, BEHANDLING_STEG_TYPE);
@@ -204,7 +204,7 @@ public class DatavarehusTjenesteImplTest {
     public void lagreNedBehandlingMedMottattSøknadDokument() {
         ScenarioMorSøkerEngangsstønad scenario = ScenarioMorSøkerEngangsstønad.forFødsel();
         scenario.leggTilAksjonspunkt(AKSJONSPUNKT_DEF, BehandlingStegType.SØKERS_RELASJON_TIL_BARN);
-        scenario.leggTilAksjonspunkt(AksjonspunktDefinisjon.AVKLAR_FAKTA_FOR_PERSONSTATUS, BehandlingStegType.SØKERS_RELASJON_TIL_BARN);
+        scenario.leggTilAksjonspunkt(AksjonspunktDefinisjon.AVKLAR_TERMINBEKREFTELSE, BehandlingStegType.SØKERS_RELASJON_TIL_BARN);
         scenario.medBehandlendeEnhet(BEHANDLENDE_ENHET);
         Behandling behandling = scenario.lagMocked();
         forceOppdaterBehandlingSteg(behandling, BEHANDLING_STEG_TYPE);
@@ -233,7 +233,7 @@ public class DatavarehusTjenesteImplTest {
     public void lagreNedBehandlingMedId() {
         ScenarioMorSøkerEngangsstønad scenario = ScenarioMorSøkerEngangsstønad.forFødsel();
         scenario.leggTilAksjonspunkt(AKSJONSPUNKT_DEF, BehandlingStegType.SØKERS_RELASJON_TIL_BARN);
-        scenario.leggTilAksjonspunkt(AksjonspunktDefinisjon.AVKLAR_FAKTA_FOR_PERSONSTATUS, BehandlingStegType.SØKERS_RELASJON_TIL_BARN);
+        scenario.leggTilAksjonspunkt(AksjonspunktDefinisjon.AVKLAR_TERMINBEKREFTELSE, BehandlingStegType.SØKERS_RELASJON_TIL_BARN);
         scenario.medBehandlendeEnhet(BEHANDLENDE_ENHET);
 
         Behandling behandling = scenario.lagMocked();

--- a/domenetjenester/inngangsvilkar/regelmodell/src/main/java/no/nav/foreldrepenger/inngangsvilkaar/regelmodell/medlemskap/Medlemskapsvilkår.java
+++ b/domenetjenester/inngangsvilkar/regelmodell/src/main/java/no/nav/foreldrepenger/inngangsvilkaar/regelmodell/medlemskap/Medlemskapsvilkår.java
@@ -69,15 +69,19 @@ public class Medlemskapsvilkår implements RuleService<MedlemskapsvilkårGrunnla
                 .hvis(new SjekkOmBrukerHarArbeidsforholdOgInntekt(), new Oppfylt())
                 .ellers(new IkkeOppfylt(SjekkOmBrukerHarArbeidsforholdOgInntekt.IKKE_OPPFYLT_IKKE_BOSATT));
 
-        Specification<MedlemskapsvilkårGrunnlag> sjekkOmBrukHarArbeidsforholdOgInntektVedStatusUtvandretNode =
-            rs.hvisRegel(SjekkOmBrukerHarArbeidsforholdOgInntekt.ID, "Har bruker minst ett aktivt arbeidsforhold med inntekt i relevant periode")
-                .hvis(new SjekkOmBrukerHarArbeidsforholdOgInntekt(), new Oppfylt())
-                .ellers(new IkkeOppfylt(SjekkBrukerErAvklartSomBosattEllerDød.IKKE_OPPFYLT_BRUKER_ER_UTVANDRET));
-
         Specification<MedlemskapsvilkårGrunnlag> brukerAvklartSomIkkeBosattNode =
             rs.hvisRegel(SjekkBrukerErAvklartSomIkkeBosatt.ID, "Hvis ikke bruker er avklart som ikke bosatt")
                 .hvisIkke(new SjekkBrukerErAvklartSomIkkeBosatt(), brukerAvklartNordiskStatsborgerNode)
                 .ellers(sjekkOmBrukHarArbeidsforholdOgInntektVedStatusIkkeBosattNode);
+
+        /*
+         * Utgått: Regel FP_VK_2.1 er ikke lenger i bruk. Dvs brukerRegistrertSomBosattNode
+         * Andre personstatuser enn bosatt + død vil alltid gi aksjonspunkt for avklaring om bosatt -> behandles i FP_VK_2.x
+         */
+        Specification<MedlemskapsvilkårGrunnlag> sjekkOmBrukHarArbeidsforholdOgInntektVedStatusUtvandretNode =
+            rs.hvisRegel(SjekkOmBrukerHarArbeidsforholdOgInntekt.ID, "Har bruker minst ett aktivt arbeidsforhold med inntekt i relevant periode")
+                .hvis(new SjekkOmBrukerHarArbeidsforholdOgInntekt(), new Oppfylt())
+                .ellers(new IkkeOppfylt(SjekkBrukerErAvklartSomBosattEllerDød.IKKE_OPPFYLT_BRUKER_ER_UTVANDRET));
 
         Specification<MedlemskapsvilkårGrunnlag> brukerRegistrertSomBosattNode =
             rs.hvisRegel(SjekkBrukerErAvklartSomBosattEllerDød.ID, "Hvis bruker er avklart som bosatt eller død ...")
@@ -86,7 +90,7 @@ public class Medlemskapsvilkår implements RuleService<MedlemskapsvilkårGrunnla
 
         Specification<MedlemskapsvilkårGrunnlag> brukerPliktigEllerFrivilligMedlemNode =
             rs.hvisRegel(SjekkBrukerErAvklartSomPliktigEllerFrivilligMedlem.ID, "Hvis bruker ikke er avklart som pliktig eller frivillig medlem ...")
-                .hvisIkke(new SjekkBrukerErAvklartSomPliktigEllerFrivilligMedlem(), brukerRegistrertSomBosattNode)
+                .hvisIkke(new SjekkBrukerErAvklartSomPliktigEllerFrivilligMedlem(), brukerAvklartSomIkkeBosattNode)
                 .ellers(new Oppfylt());
 
         return rs.hvisRegel(SjekkBrukerErAvklartSomIkkeMedlem.ID, "Hvis ikke bruker er avklart som ikke medlem ...")

--- a/domenetjenester/inngangsvilkar/regelmodell/src/main/java/no/nav/foreldrepenger/inngangsvilkaar/regelmodell/medlemskap/SjekkBrukerErAvklartSomBosattEllerDød.java
+++ b/domenetjenester/inngangsvilkar/regelmodell/src/main/java/no/nav/foreldrepenger/inngangsvilkaar/regelmodell/medlemskap/SjekkBrukerErAvklartSomBosattEllerDød.java
@@ -6,6 +6,10 @@ import no.nav.fpsak.nare.evaluation.RuleReasonRef;
 import no.nav.fpsak.nare.evaluation.RuleReasonRefImpl;
 import no.nav.fpsak.nare.specification.LeafSpecification;
 
+/*
+ * Utgått: Regel FP_VK_2.1 er ikke lenger i bruk. Dvs brukerRegistrertSomBosattNode
+ * Andre personstatuser enn bosatt + død vil alltid gi aksjonspunkt for avklaring om bosatt -> behandles i FP_VK_2.x
+ */
 @RuleDocumentation(SjekkBrukerErAvklartSomBosattEllerDød.ID)
 public class SjekkBrukerErAvklartSomBosattEllerDød extends LeafSpecification<MedlemskapsvilkårGrunnlag> {
 

--- a/domenetjenester/inngangsvilkar/tjeneste/src/test/java/no/nav/foreldrepenger/inngangsvilkaar/medlemskap/MedlemskapsvilkårTest.java
+++ b/domenetjenester/inngangsvilkar/tjeneste/src/test/java/no/nav/foreldrepenger/inngangsvilkaar/medlemskap/MedlemskapsvilkårTest.java
@@ -176,13 +176,13 @@ public class MedlemskapsvilkårTest {
      * registrert som utvandret (FP VK 2.1) = JA - bruker har relevant
      * arbeidsforhold og inntekt som dekker skjæringstidspunkt (FP_VK_2.2.1) = NEI
      * <p>
-     * Forventet: Ikke oppfylt, avslagsid 1021
+     * Forventet: Ikke oppfylt, avslagsid 1025
      */
     @Test
     public void skal_vurdere_utvandret_som_vilkår_ikke_oppfylt_ingen_relevant_arbeid_og_inntekt() {
         // Arrange
         var scenario = lagTestScenario(MedlemskapDekningType.UNNTATT, Landkoder.NOR, PersonstatusType.UTVA);
-        scenario.medMedlemskap().medMedlemsperiodeManuellVurdering(MedlemskapManuellVurderingType.IKKE_RELEVANT);
+        scenario.medMedlemskap().medBosattVurdering(false).medMedlemsperiodeManuellVurdering(MedlemskapManuellVurderingType.IKKE_RELEVANT);
         Behandling behandling = lagre(scenario);
 
         // Act
@@ -191,7 +191,7 @@ public class MedlemskapsvilkårTest {
         // Assert
         assertThat(vilkårData.getVilkårType()).isEqualTo(VilkårType.MEDLEMSKAPSVILKÅRET);
         assertThat(vilkårData.getUtfallType()).isEqualTo(VilkårUtfallType.IKKE_OPPFYLT);
-        assertThat(vilkårData.getVilkårUtfallMerknad()).isEqualTo(VilkårUtfallMerknad.VM_1021);
+        assertThat(vilkårData.getVilkårUtfallMerknad()).isEqualTo(VilkårUtfallMerknad.VM_1025);
     }
 
     /**
@@ -200,7 +200,7 @@ public class MedlemskapsvilkårTest {
      * registrert som utvandret (FP VK 2.1) = JA - bruker har relevant
      * arbeidsforhold og inntekt som dekker skjæringstidspunkt (FP_VK_2.2.1) = JA
      * <p>
-     * Forventet: Ikke oppfylt, avslagsid 1021
+     * Forventet: oppfylt
      */
     @Test
     public void skal_vurdere_utvandret_som_vilkår_oppfylt_når_relevant_arbeid_og_inntekt_finnes() {
@@ -412,12 +412,11 @@ public class MedlemskapsvilkårTest {
      * (FP_VK_2.2.1) = NEI
      */
     @Test
-    public void skal_få_medlemskapsvilkåret_satt_til_ikke_oppfylt_når_saksbehandler_setter_personstatus_til_utvandert_og_ingen_relevant_arbeid_og_inntekt() {
+    public void skal_få_medlemskapsvilkåret_satt_til_ikke_oppfylt_når_saksbehandler_har_avklar_som_ikke_bosatt_og_ingen_relevant_arbeid_og_inntekt() {
         // Arrange
 
         var scenario = lagTestScenario(MedlemskapDekningType.FTL_2_9_1_c, Landkoder.NOR, PersonstatusType.UREG);
-        scenario.medMedlemskap().medMedlemsperiodeManuellVurdering(MedlemskapManuellVurderingType.IKKE_RELEVANT);
-
+        scenario.medMedlemskap().medBosattVurdering(false).medMedlemsperiodeManuellVurdering(MedlemskapManuellVurderingType.IKKE_RELEVANT);
         leggTilSøker(scenario, PersonstatusType.UREG, Region.NORDEN, Landkoder.SWE);
 
         Behandling behandling = lagre(scenario);
@@ -437,7 +436,7 @@ public class MedlemskapsvilkårTest {
         // Assert
         assertThat(vilkårData.getVilkårType()).isEqualTo(VilkårType.MEDLEMSKAPSVILKÅRET);
         assertThat(vilkårData.getUtfallType()).isEqualTo(VilkårUtfallType.IKKE_OPPFYLT);
-        assertThat(vilkårData.getVilkårUtfallMerknad()).isEqualTo(VilkårUtfallMerknad.VM_1021);
+        assertThat(vilkårData.getVilkårUtfallMerknad()).isEqualTo(VilkårUtfallMerknad.VM_1025);
     }
 
     /**

--- a/domenetjenester/medlem/src/test/java/no/nav/foreldrepenger/domene/medlem/impl/AvklarOmErBosattTest.java
+++ b/domenetjenester/medlem/src/test/java/no/nav/foreldrepenger/domene/medlem/impl/AvklarOmErBosattTest.java
@@ -56,13 +56,47 @@ public class AvklarOmErBosattTest {
     }
 
     @Test
+    public void skal_få_aksjonspunkt_ved_udefinert_personstatus() {
+        // Arrange
+        LocalDate fødselsDato = LocalDate.now();
+        ScenarioMorSøkerEngangsstønad scenario = ScenarioMorSøkerEngangsstønad.forFødsel();
+        scenario.medDefaultOppgittTilknytning();
+        scenario.medSøknadHendelse().medFødselsDato(fødselsDato).medAntallBarn(1);
+        leggTilSøker(scenario, AdresseType.POSTADRESSE_UTLAND, Landkoder.SWE, PersonstatusType.UDEFINERT);
+        Behandling behandling = scenario.lagre(provider);
+
+        // Act
+        Optional<MedlemResultat> resultat = avklarOmErBosatt.utled(behandling, fødselsDato);
+
+        // Assert
+        assertThat(resultat).contains(AVKLAR_OM_ER_BOSATT);
+    }
+
+    @Test
+    public void skal_få_aksjonspunkt_ved_utvandret_personstatus() {
+        // Arrange
+        LocalDate fødselsDato = LocalDate.now();
+        ScenarioMorSøkerEngangsstønad scenario = ScenarioMorSøkerEngangsstønad.forFødsel();
+        scenario.medDefaultOppgittTilknytning();
+        scenario.medSøknadHendelse().medFødselsDato(fødselsDato).medAntallBarn(1);
+        leggTilSøker(scenario, AdresseType.POSTADRESSE_UTLAND, Landkoder.SWE, PersonstatusType.UTVA);
+        Behandling behandling = scenario.lagre(provider);
+
+        // Act
+        Optional<MedlemResultat> resultat = avklarOmErBosatt.utled(behandling, fødselsDato);
+
+        // Assert
+        assertThat(resultat).contains(AVKLAR_OM_ER_BOSATT);
+    }
+
+    @Test
     public void skal_gi_medlem_resultat_AVKLAR_OM_ER_BOSATT() {
         // Arrange
         LocalDate fødselsDato = LocalDate.now();
         ScenarioMorSøkerEngangsstønad scenario = ScenarioMorSøkerEngangsstønad.forFødsel();
         scenario.medDefaultOppgittTilknytning();
         scenario.medSøknadHendelse().medFødselsDato(fødselsDato).medAntallBarn(1);
-        leggTilSøker(scenario, AdresseType.POSTADRESSE_UTLAND, Landkoder.SWE);
+        leggTilSøker(scenario, AdresseType.POSTADRESSE_UTLAND, Landkoder.SWE, PersonstatusType.BOSA);
         Behandling behandling = scenario.lagre(provider);
 
         // Act
@@ -80,7 +114,7 @@ public class AvklarOmErBosattTest {
         scenario.medDefaultOppgittTilknytning();
         scenario.medSøknadHendelse().medFødselsDato(fødselsDato).medAntallBarn(1);
 
-        leggTilSøker(scenario, AdresseType.BOSTEDSADRESSE, Landkoder.NOR);
+        leggTilSøker(scenario, AdresseType.BOSTEDSADRESSE, Landkoder.NOR, PersonstatusType.BOSA);
         Behandling behandling = scenario.lagre(provider);
 
         // Act
@@ -95,7 +129,7 @@ public class AvklarOmErBosattTest {
         // Arrange
         ScenarioMorSøkerEngangsstønad scenario = ScenarioMorSøkerEngangsstønad.forFødsel();
         scenario.medDefaultOppgittTilknytning();
-        leggTilSøker(scenario, AdresseType.MIDLERTIDIG_POSTADRESSE_UTLAND, Landkoder.USA);
+        leggTilSøker(scenario, AdresseType.MIDLERTIDIG_POSTADRESSE_UTLAND, Landkoder.USA, PersonstatusType.BOSA);
         LocalDate fødselsDato = LocalDate.now();
         scenario.medSøknadHendelse().medFødselsDato(fødselsDato);
         MedlemskapPerioderEntitet gyldigPeriodeUnderFødsel = new MedlemskapPerioderBuilder()
@@ -119,7 +153,7 @@ public class AvklarOmErBosattTest {
         // Arrange
         ScenarioMorSøkerEngangsstønad scenario = ScenarioMorSøkerEngangsstønad.forFødsel();
         scenario.medDefaultOppgittTilknytning();
-        leggTilSøker(scenario, AdresseType.MIDLERTIDIG_POSTADRESSE_UTLAND, Landkoder.USA);
+        leggTilSøker(scenario, AdresseType.MIDLERTIDIG_POSTADRESSE_UTLAND, Landkoder.USA, PersonstatusType.BOSA);
         LocalDate fødselsDato = LocalDate.now();
         scenario.medSøknadHendelse().medFødselsDato(LocalDate.now());
         MedlemskapPerioderEntitet gyldigPeriodeUnderFødsel = new MedlemskapPerioderBuilder()
@@ -149,7 +183,7 @@ public class AvklarOmErBosattTest {
                 .build();
         ScenarioMorSøkerEngangsstønad scenario = ScenarioMorSøkerEngangsstønad.forFødsel();
         scenario.medDefaultOppgittTilknytning();
-        leggTilSøker(scenario, AdresseType.BOSTEDSADRESSE, Landkoder.NOR);
+        leggTilSøker(scenario, AdresseType.BOSTEDSADRESSE, Landkoder.NOR, PersonstatusType.BOSA);
         scenario.medOppgittTilknytning().medOpphold(singletonList(oppholdUtlandForrigePeriode)).medOppholdNå(false);
         Behandling behandling = scenario.lagre(provider);
 
@@ -175,7 +209,7 @@ public class AvklarOmErBosattTest {
                 .medPeriode(LocalDate.now().plusDays(20), LocalDate.now().plusYears(2))
                 .build();
 
-        leggTilSøker(scenario, AdresseType.BOSTEDSADRESSE, Landkoder.NOR);
+        leggTilSøker(scenario, AdresseType.BOSTEDSADRESSE, Landkoder.NOR, PersonstatusType.BOSA);
         scenario.medOppgittTilknytning()
                 .medOpphold(List.of(fremtidigOppholdISverige))
                 .medOppholdNå(true);
@@ -221,7 +255,7 @@ public class AvklarOmErBosattTest {
                 .medPeriode(LocalDate.now().plusMonths(6), LocalDate.now().plusMonths(8))
                 .build();
 
-        leggTilSøker(scenario, AdresseType.BOSTEDSADRESSE, Landkoder.NOR);
+        leggTilSøker(scenario, AdresseType.BOSTEDSADRESSE, Landkoder.NOR, PersonstatusType.BOSA);
         scenario.medOppgittTilknytning()
                 .medOpphold(List.of(swe, usa, bel, png))
                 .medOppholdNå(true);
@@ -267,7 +301,7 @@ public class AvklarOmErBosattTest {
                 .medPeriode(LocalDate.now().plusMonths(6), LocalDate.now().plusMonths(15))
                 .build();
 
-        leggTilSøker(scenario, AdresseType.BOSTEDSADRESSE, Landkoder.NOR);
+        leggTilSøker(scenario, AdresseType.BOSTEDSADRESSE, Landkoder.NOR, PersonstatusType.BOSA);
         scenario.medOppgittTilknytning()
                 .medOpphold(List.of(swe, usa, bel, png))
                 .medOppholdNå(true);
@@ -293,7 +327,7 @@ public class AvklarOmErBosattTest {
                 .medPeriode(LocalDate.now().plusDays(20), LocalDate.now().plusYears(2))
                 .build();
 
-        leggTilSøker(scenario, AdresseType.BOSTEDSADRESSE, Landkoder.NOR);
+        leggTilSøker(scenario, AdresseType.BOSTEDSADRESSE, Landkoder.NOR, PersonstatusType.BOSA);
         scenario.medOppgittTilknytning()
                 .medOpphold(List.of(fremtidigOppholdISverige))
                 .medOppholdNå(true);
@@ -321,7 +355,7 @@ public class AvklarOmErBosattTest {
                 .medPeriode(LocalDate.now().plusDays(20), LocalDate.now().plusMonths(9))
                 .build();
 
-        leggTilSøker(scenario, AdresseType.BOSTEDSADRESSE, Landkoder.NOR);
+        leggTilSøker(scenario, AdresseType.BOSTEDSADRESSE, Landkoder.NOR, PersonstatusType.BOSA);
         scenario.medOppgittTilknytning()
                 .medOpphold(List.of(fremtidigOppholdISverige))
                 .medOppholdNå(true);
@@ -342,7 +376,7 @@ public class AvklarOmErBosattTest {
         ScenarioMorSøkerEngangsstønad scenario = ScenarioMorSøkerEngangsstønad.forFødsel();
         scenario.medDefaultOppgittTilknytning();
         scenario.medSøknadHendelse().medFødselsDato(LocalDate.now()).medAntallBarn(1);
-        leggTilSøker(scenario, AdresseType.BOSTEDSADRESSE, Landkoder.NOR);
+        leggTilSøker(scenario, AdresseType.BOSTEDSADRESSE, Landkoder.NOR, PersonstatusType.BOSA);
         Behandling behandling = scenario.lagre(provider);
 
         // Act
@@ -352,13 +386,13 @@ public class AvklarOmErBosattTest {
         assertThat(resultat).isEmpty();
     }
 
-    private void leggTilSøker(AbstractTestScenario<?> scenario, AdresseType adresseType, Landkoder adresseLand) {
+    private void leggTilSøker(AbstractTestScenario<?> scenario, AdresseType adresseType, Landkoder adresseLand, PersonstatusType personstatus) {
         PersonInformasjon.Builder builderForRegisteropplysninger = scenario.opprettBuilderForRegisteropplysninger();
         AktørId søkerAktørId = scenario.getDefaultBrukerAktørId();
         Personas persona = builderForRegisteropplysninger
                 .medPersonas()
                 .kvinne(søkerAktørId, SivilstandType.UOPPGITT, Region.UDEFINERT)
-                .personstatus(PersonstatusType.UDEFINERT)
+                .personstatus(personstatus)
                 .statsborgerskap(adresseLand);
 
         PersonAdresse.Builder adresseBuilder = PersonAdresse.builder().adresselinje1("Portveien 2").land(adresseLand);

--- a/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/aksjonspunkt/AksjonspunktTjenesteTest.java
+++ b/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/aksjonspunkt/AksjonspunktTjenesteTest.java
@@ -138,11 +138,11 @@ public class AksjonspunktTjenesteTest {
     @Test
     public void skal_sette_totrinn_når_revurdering_ap_medfører_endring_i_grunnlag() {
         // Arrange
-        Behandling førstegangsbehandling = opprettFørstegangsbehandlingMedAksjonspunkt(AksjonspunktDefinisjon.AVKLAR_FAKTA_FOR_PERSONSTATUS);
+        Behandling førstegangsbehandling = opprettFørstegangsbehandlingMedAksjonspunkt(AksjonspunktDefinisjon.AVKLAR_TERMINBEKREFTELSE);
         AksjonspunktTestSupport.setTilUtført(førstegangsbehandling.getAksjonspunkter().iterator().next(), BEGRUNNELSE);
         Behandling revurdering = opprettRevurderingsbehandlingMedAksjonspunkt(førstegangsbehandling,
-                AksjonspunktDefinisjon.AVKLAR_FAKTA_FOR_PERSONSTATUS);
-        AvklarSaksopplysningerDto dto = new AvklarSaksopplysningerDto(BEGRUNNELSE, "UTVA", true);
+                AksjonspunktDefinisjon.AVKLAR_TERMINBEKREFTELSE);
+        var dto = new BekreftTerminbekreftelseAksjonspunktDto(BEGRUNNELSE, LocalDate.now(), LocalDate.now(), 2);
 
         // Act
         aksjonspunktTjeneste.bekreftAksjonspunkter(singletonList(dto), revurdering.getId());

--- a/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/aksjonspunkt/AksjonspunktTjenesteTest.java
+++ b/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/aksjonspunkt/AksjonspunktTjenesteTest.java
@@ -35,7 +35,6 @@ import no.nav.foreldrepenger.behandlingslager.testutilities.behandling.ScenarioM
 import no.nav.foreldrepenger.dbstoette.CdiDbAwareTest;
 import no.nav.foreldrepenger.familiehendelse.aksjonspunkt.dto.BekreftTerminbekreftelseAksjonspunktDto;
 import no.nav.foreldrepenger.familiehendelse.aksjonspunkt.dto.OmsorgsvilkårAksjonspunktDto;
-import no.nav.foreldrepenger.web.app.tjenester.behandling.søknad.aksjonspunkt.AvklarSaksopplysningerDto;
 
 @CdiDbAwareTest
 public class AksjonspunktTjenesteTest {


### PR DESCRIPTION
Fjerner aksjonspunkt 5022 avklar personstatus

Utleder aksjonspunkt 5020 Bosatt dersom personstatus ikke er Bosatt eller Død

Fjerner gamle vilkår 2.1 (er bruker utvandret) slik at flyten går rett fra FP_VK_2.13 og FP_VK_2.2 (sjekk på om bruker er avklart som ikke-medlem eller medlem i MEDL) til FP_VK_2.x (er bruker avklart som ikke bosatt)