### PR TITLE
TFP-4189 sammenligner eksisterende mot regeloutput

### DIFF
--- a/domenetjenester/beregning-ytelse/src/main/java/no/nav/foreldrepenger/ytelse/beregning/FeriepengeRegeregnTjeneste.java
+++ b/domenetjenester/beregning-ytelse/src/main/java/no/nav/foreldrepenger/ytelse/beregning/FeriepengeRegeregnTjeneste.java
@@ -34,17 +34,6 @@ public class FeriepengeRegeregnTjeneste {
         this.behandlingRepository = behandlingRepository;
     }
 
-    public boolean harDiff(Long behandlingId) {
-        Behandling behandling = behandlingRepository.hentBehandling(behandlingId);
-        BehandlingReferanse ref = BehandlingReferanse.fra(behandling);
-        Optional<BeregningsresultatEntitet> gjeldendeResultat = beregningsresultatRepository.hentUtbetBeregningsresultat(ref.getBehandlingId());
-        if (gjeldendeResultat.isEmpty()) {
-            return false;
-        }
-        BeregningsresultatEntitet nyttResultat = utledNyttResultat(ref, behandling, gjeldendeResultat);
-        return new Feriepengesammenligner(ref.getBehandlingId(), ref.getSaksnummer(), nyttResultat, gjeldendeResultat.get()).finnesAvvik();
-    }
-
     public boolean harDiffUtenomPeriode(Long behandlingId) {
         Behandling behandling = behandlingRepository.hentBehandling(behandlingId);
         BehandlingReferanse ref = BehandlingReferanse.fra(behandling);
@@ -52,14 +41,11 @@ public class FeriepengeRegeregnTjeneste {
         if (gjeldendeResultat.isEmpty()) {
             return false;
         }
-        BeregningsresultatEntitet nyttResultat = utledNyttResultat(ref, behandling, gjeldendeResultat);
-        return new Feriepengesammenligner(ref.getBehandlingId(), ref.getSaksnummer(), nyttResultat, gjeldendeResultat.get()).finnesAvvikUtenomPeriode();
+        return utledNyttResultat(ref, behandling, gjeldendeResultat.get());
     }
 
-    private BeregningsresultatEntitet utledNyttResultat(BehandlingReferanse ref, Behandling behandling, Optional<BeregningsresultatEntitet> gjeldendeResultat) {
+    private boolean utledNyttResultat(BehandlingReferanse ref, Behandling behandling, BeregningsresultatEntitet gjeldendeResultat) {
         BeregnFeriepengerTjeneste feriepengetjeneste = FagsakYtelseTypeRef.Lookup.find(beregnFeriepengerTjenesteInstance, ref.getFagsakYtelseType()).orElseThrow();
-        BeregningsresultatEntitet kopi = BeregningsresultatEntitet.builder(gjeldendeResultat).build();
-        feriepengetjeneste.beregnFeriepenger(behandling, kopi);
-        return kopi;
+        return feriepengetjeneste.avvikBeregnetFeriepengerBeregningsresultat(behandling, gjeldendeResultat, true);
     }
 }

--- a/domenetjenester/beregning-ytelse/src/main/java/no/nav/foreldrepenger/ytelse/beregning/adapter/SammenlignBeregningsresultatFeriepengerMedRegelResultat.java
+++ b/domenetjenester/beregning-ytelse/src/main/java/no/nav/foreldrepenger/ytelse/beregning/adapter/SammenlignBeregningsresultatFeriepengerMedRegelResultat.java
@@ -1,0 +1,185 @@
+package no.nav.foreldrepenger.ytelse.beregning.adapter;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.Year;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import no.nav.foreldrepenger.behandlingslager.behandling.beregning.BeregningsresultatEntitet;
+import no.nav.foreldrepenger.behandlingslager.behandling.beregning.BeregningsresultatFeriepenger;
+import no.nav.foreldrepenger.behandlingslager.behandling.beregning.BeregningsresultatFeriepengerPrÅr;
+import no.nav.foreldrepenger.behandlingslager.virksomhet.Arbeidsgiver;
+import no.nav.foreldrepenger.domene.typer.Beløp;
+import no.nav.foreldrepenger.domene.typer.Saksnummer;
+import no.nav.foreldrepenger.ytelse.beregning.regelmodell.feriepenger.BeregningsresultatFeriepengerRegelModell;
+
+public class SammenlignBeregningsresultatFeriepengerMedRegelResultat {
+
+    private static final Logger LOG = LoggerFactory.getLogger(SammenlignBeregningsresultatFeriepengerMedRegelResultat.class);
+
+    private static final int AKSEPTERT_AVVIK = 3;
+
+    private static final String AVVIK_KODE = "FP-110713";
+    private static final String BRUKER = "Bruker";
+    private static final String ARBGIVER = "ArbGiv";
+
+    private SammenlignBeregningsresultatFeriepengerMedRegelResultat() {
+        // unused
+    }
+
+    public static boolean erAvvik(BeregningsresultatEntitet resultat, BeregningsresultatFeriepengerRegelModell regelModell) {
+
+        if (regelModell.getFeriepengerPeriode() == null) {
+            // Lagrer sporing
+            var tilkjent = resultat.getBeregningsresultatFeriepenger()
+                .map(BeregningsresultatFeriepenger::getBeregningsresultatFeriepengerPrÅrListe).orElse(List.of()).stream()
+                .map(BeregningsresultatFeriepengerPrÅr::getÅrsbeløp)
+                .reduce(new Beløp(BigDecimal.ZERO), Beløp::adder);
+            return Math.abs(tilkjent.getVerdi().longValue()) > AKSEPTERT_AVVIK;
+        }
+
+        List<no.nav.foreldrepenger.ytelse.beregning.regelmodell.feriepenger.BeregningsresultatFeriepengerPrÅr> andelerFraRegelKjøring =
+            regelModell.getBeregningsresultatPerioder().stream()
+                .flatMap(periode -> periode.getBeregningsresultatAndelList().stream())
+                .flatMap(andel -> andel.getBeregningsresultatFeriepengerPrÅrListe().stream())
+                .filter(SammenlignBeregningsresultatFeriepengerMedRegelResultat::erAvrundetÅrsbeløpUlik0)
+                .collect(Collectors.toList());
+
+        return sammenlignFeriepengeandeler(andelerFraRegelKjøring,
+            resultat.getBeregningsresultatFeriepenger().map(BeregningsresultatFeriepenger::getBeregningsresultatFeriepengerPrÅrListe).orElse(List.of()));
+    }
+
+    public static boolean loggAvvik(Saksnummer saksnummer, Long behandlingId, BeregningsresultatEntitet resultat, BeregningsresultatFeriepengerRegelModell regelModell) {
+
+        if (regelModell.getFeriepengerPeriode() == null) {
+            // Lagrer sporing
+            var tilkjent = resultat.getBeregningsresultatFeriepenger()
+                .map(BeregningsresultatFeriepenger::getBeregningsresultatFeriepengerPrÅrListe).orElse(List.of()).stream()
+                .map(BeregningsresultatFeriepengerPrÅr::getÅrsbeløp)
+                .reduce(new Beløp(BigDecimal.ZERO), Beløp::adder);
+            return Math.abs(tilkjent.getVerdi().longValue()) > AKSEPTERT_AVVIK;
+        }
+
+        List<no.nav.foreldrepenger.ytelse.beregning.regelmodell.feriepenger.BeregningsresultatFeriepengerPrÅr> andelerFraRegelKjøring =
+            regelModell.getBeregningsresultatPerioder().stream()
+                .flatMap(periode -> periode.getBeregningsresultatAndelList().stream())
+                .flatMap(andel -> andel.getBeregningsresultatFeriepengerPrÅrListe().stream())
+                .filter(SammenlignBeregningsresultatFeriepengerMedRegelResultat::erAvrundetÅrsbeløpUlik0)
+                .collect(Collectors.toList());
+
+        return sammenlignFeriepengerLogg(saksnummer, behandlingId, andelerFraRegelKjøring,
+            resultat.getBeregningsresultatFeriepenger().map(BeregningsresultatFeriepenger::getBeregningsresultatFeriepengerPrÅrListe).orElse(List.of()));
+    }
+
+    private static boolean erAvrundetÅrsbeløpUlik0(no.nav.foreldrepenger.ytelse.beregning.regelmodell.feriepenger.BeregningsresultatFeriepengerPrÅr prÅr) {
+        long årsbeløp = prÅr.getÅrsbeløp().setScale(0, RoundingMode.HALF_UP).longValue();
+        return årsbeløp != 0L;
+    }
+
+    private static boolean sammenlignFeriepengeandeler(List<no.nav.foreldrepenger.ytelse.beregning.regelmodell.feriepenger.BeregningsresultatFeriepengerPrÅr> nyeAndeler,
+                                                List<BeregningsresultatFeriepengerPrÅr> gjeldendeAndeler) {
+        var simulert = sorterteTilkjenteRegelFeriepenger(nyeAndeler);
+        var tilkjent = sorterteTilkjenteFeriepenger(gjeldendeAndeler);
+
+        Map<AndelGruppering, BigDecimal> summert = new LinkedHashMap<>();
+        tilkjent.forEach((key, value) -> summert.put(key, value.getVerdi()));
+        simulert.forEach((key, value) -> summert.put(key, summert.getOrDefault(key, BigDecimal.ZERO).subtract(value.getVerdi())));
+
+        return summert.values().stream().anyMatch(SammenlignBeregningsresultatFeriepengerMedRegelResultat::erAvvik);
+    }
+
+    private static boolean sammenlignFeriepengerLogg(Saksnummer saksnummer, Long behandlingId,
+                                                     List<no.nav.foreldrepenger.ytelse.beregning.regelmodell.feriepenger.BeregningsresultatFeriepengerPrÅr> nyeAndeler,
+                                                     List<BeregningsresultatFeriepengerPrÅr> gjeldendeAndeler) {
+        var simulert = sorterteTilkjenteRegelFeriepenger(nyeAndeler);
+        var tilkjent = sorterteTilkjenteFeriepenger(gjeldendeAndeler);
+
+        Map<AndelGruppering, BigDecimal> summert = new LinkedHashMap<>();
+        tilkjent.forEach((key, value) -> summert.put(key, value.getVerdi()));
+        simulert.forEach((key, value) -> summert.put(key, summert.getOrDefault(key, BigDecimal.ZERO).subtract(value.getVerdi())));
+
+        Map<Year, BigDecimal> summertÅr = new LinkedHashMap<>();
+        tilkjent.forEach((key,value) -> summertÅr.put(key.getOpptjent(), summertÅr.getOrDefault(key.getOpptjent(), BigDecimal.ZERO).add(value.getVerdi())));
+        simulert.forEach((key,value) -> summertÅr.put(key.getOpptjent(), summertÅr.getOrDefault(key.getOpptjent(), BigDecimal.ZERO).subtract(value.getVerdi())));
+
+        summert.entrySet().stream()
+            .filter(e -> erAvvik(e.getValue()))
+            .forEach(e -> LOG.info("{} andel {} saksnummer {} behandling {} år {} mottaker {} diff {} gammel {} ny {}",
+                AVVIK_KODE, erAvvik(summertÅr.get(e.getKey().getOpptjent())) ? "tilkjent-simulert" : "omfordelt",
+                saksnummer, behandlingId, e.getKey().getOpptjent(), e.getKey().getMottaker(), e.getValue().longValue(),
+                tilkjent.getOrDefault(e.getKey(), Beløp.ZERO).getVerdi().longValue(),
+                simulert.getOrDefault(e.getKey(), Beløp.ZERO).getVerdi().longValue()));
+
+        return summert.values().stream().anyMatch(SammenlignBeregningsresultatFeriepengerMedRegelResultat::erAvvik);
+    }
+
+    private static boolean erAvvik(BigDecimal diff) {
+        return Math.abs(diff.longValue()) > AKSEPTERT_AVVIK;
+    }
+
+    private static Map<AndelGruppering, Beløp> sorterteTilkjenteFeriepenger(List<BeregningsresultatFeriepengerPrÅr> feriepenger) {
+        return feriepenger.stream()
+            .collect(Collectors.groupingBy(AndelGruppering::new,
+                Collectors.reducing(new Beløp(BigDecimal.ZERO), BeregningsresultatFeriepengerPrÅr::getÅrsbeløp, Beløp::adder)));
+    }
+
+    private static Map<AndelGruppering, Beløp> sorterteTilkjenteRegelFeriepenger(List<no.nav.foreldrepenger.ytelse.beregning.regelmodell.feriepenger.BeregningsresultatFeriepengerPrÅr> feriepenger) {
+        return feriepenger.stream()
+            .collect(Collectors.groupingBy(AndelGruppering::new,
+                Collectors.reducing(new Beløp(BigDecimal.ZERO), prÅr -> new Beløp(prÅr.getÅrsbeløp()), Beløp::adder)));
+    }
+
+    private static class AndelGruppering {
+        Year opptjent;
+        String mottaker;
+
+        AndelGruppering(BeregningsresultatFeriepengerPrÅr andel) {
+            this.opptjent = Year.from(andel.getOpptjeningsår());
+            this.mottaker = andel.getBeregningsresultatAndel().erBrukerMottaker() ? BRUKER :
+                andel.getBeregningsresultatAndel().getArbeidsgiver().map(Arbeidsgiver::getIdentifikator).orElse(ARBGIVER);
+        }
+
+        AndelGruppering(no.nav.foreldrepenger.ytelse.beregning.regelmodell.feriepenger.BeregningsresultatFeriepengerPrÅr andel) {
+            this.opptjent = Year.from(andel.getOpptjeningÅr());
+            this.mottaker = andel.getBeregningsresultatAndel().erBrukerMottaker() ? BRUKER :
+                Optional.ofNullable(andel.getBeregningsresultatAndel().getArbeidsgiverId()).orElse(ARBGIVER);
+        }
+
+        public Year getOpptjent() {
+            return opptjent;
+        }
+
+        public String getMottaker() {
+            return mottaker;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            AndelGruppering that = (AndelGruppering) o;
+            return Objects.equals(opptjent, that.opptjent) && Objects.equals(mottaker, that.mottaker);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(opptjent, mottaker);
+        }
+
+        @Override
+        public String toString() {
+            return "AndelGruppering{" +
+                "år=" + opptjent +
+                ", mottaker='" + mottaker + '\'' +
+                '}';
+        }
+    }
+}

--- a/domenetjenester/beregning-ytelse/src/test/java/no/nav/foreldrepenger/ytelse/beregning/BeregnFeriepengerTjenesteTest.java
+++ b/domenetjenester/beregning-ytelse/src/test/java/no/nav/foreldrepenger/ytelse/beregning/BeregnFeriepengerTjenesteTest.java
@@ -80,6 +80,40 @@ public class BeregnFeriepengerTjenesteTest {
     }
 
     @Test
+    public void skalSjekkeFeriepengerMedAvvik() {
+        Behandling farsBehandling = lagBehandlingFar();
+        ScenarioMorSøkerForeldrepenger scenario = ScenarioMorSøkerForeldrepenger.forFødsel();
+        scenario.medDefaultOppgittDekningsgrad();
+        Behandling morsBehandling = scenario.lagre(repositoryProvider);
+        fagsakRelasjonRepository.opprettRelasjon(morsBehandling.getFagsak(), Dekningsgrad._100);
+        fagsakRelasjonRepository.kobleFagsaker(morsBehandling.getFagsak(), farsBehandling.getFagsak(), morsBehandling);
+        BeregningsresultatEntitet morsBeregningsresultatFP = lagBeregningsresultatFP(SKJÆRINGSTIDSPUNKT_MOR, SKJÆRINGSTIDSPUNKT_FAR,
+            Inntektskategori.ARBEIDSTAKER);
+
+        // Act
+        var avvik = tjeneste.avvikBeregnetFeriepengerBeregningsresultat(morsBehandling, morsBeregningsresultatFP, false);
+
+        // Assert
+        assertThat(avvik).isTrue();
+    }
+
+    @Test
+    public void skalSjekkeFeriepengerUtenAvvik() {
+        ScenarioMorSøkerForeldrepenger scenario = ScenarioMorSøkerForeldrepenger.forFødsel();
+        scenario.medDefaultOppgittDekningsgrad();
+        Behandling morsBehandling = scenario.lagre(repositoryProvider);
+        fagsakRelasjonRepository.opprettRelasjon(morsBehandling.getFagsak(), Dekningsgrad._100);
+        BeregningsresultatEntitet morsBeregningsresultatFP = lagBeregningsresultatFP(SKJÆRINGSTIDSPUNKT_MOR, SKJÆRINGSTIDSPUNKT_MOR.plusMonths(6),
+            Inntektskategori.ARBEIDSTAKER_UTEN_FERIEPENGER);
+
+        // Act
+        var avvik = tjeneste.avvikBeregnetFeriepengerBeregningsresultat(morsBehandling, morsBeregningsresultatFP,false);
+
+        // Assert
+        assertThat(avvik).isFalse();
+    }
+
+    @Test
     public void skalIkkeBeregneFeriepenger() {
         ScenarioMorSøkerForeldrepenger scenario = ScenarioMorSøkerForeldrepenger.forFødsel();
         scenario.medDefaultOppgittDekningsgrad();

--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/sakskompleks/BerørtBehandlingKontroller.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/sakskompleks/BerørtBehandlingKontroller.java
@@ -16,7 +16,6 @@ import no.nav.foreldrepenger.behandlingslager.behandling.Behandlingsresultat;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingsresultatRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingÅrsakType;
 import no.nav.foreldrepenger.behandlingslager.behandling.KonsekvensForYtelsen;
-import no.nav.foreldrepenger.behandlingslager.behandling.beregning.BeregningsresultatEntitet;
 import no.nav.foreldrepenger.behandlingslager.behandling.beregning.BeregningsresultatRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.historikk.HistorikkBegrunnelseType;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepository;
@@ -25,7 +24,6 @@ import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRe
 import no.nav.foreldrepenger.behandlingslager.fagsak.Fagsak;
 import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakLåsRepository;
 import no.nav.foreldrepenger.mottak.Behandlingsoppretter;
-import no.nav.foreldrepenger.ytelse.beregning.Feriepengesammenligner;
 import no.nav.foreldrepenger.ytelse.beregning.fp.BeregnFeriepenger;
 
 /*
@@ -140,9 +138,7 @@ public class BerørtBehandlingKontroller {
         if (!behandlingRepository.hentÅpneYtelseBehandlingerForFagsakId(fagsakMedforelder.getId()).isEmpty()) return false;
         var gjeldendeTilkjent = tilkjentRepository.hentUtbetBeregningsresultat(sisteVedtatteMedForelder.getId()).orElse(null);
         if (gjeldendeTilkjent == null) return false;
-        BeregningsresultatEntitet kopi = BeregningsresultatEntitet.builder(gjeldendeTilkjent).build();
-        beregnFeriepenger.beregnFeriepenger(sisteVedtatteMedForelder, kopi);
-        return new Feriepengesammenligner(sisteVedtatteMedForelder.getId(), fagsakMedforelder.getSaksnummer(), kopi, gjeldendeTilkjent).sjekkForAvvik();
+        return beregnFeriepenger.avvikBeregnetFeriepengerBeregningsresultat(sisteVedtatteMedForelder, gjeldendeTilkjent, false);
     }
 
     private void håndterKø(Fagsak fagsak) {

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/forvaltning/ForvaltningFeriepengerRestTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/forvaltning/ForvaltningFeriepengerRestTjeneste.java
@@ -63,7 +63,7 @@ public class ForvaltningFeriepengerRestTjeneste {
     @BeskyttetRessurs(action = CREATE, resource = FPSakBeskyttetRessursAttributt.DRIFT, sporingslogg = false)
     public Response reberegnFeriepenger(@BeanParam @Valid ForvaltningBehandlingIdDto dto) {
         long behandlingId = dto.getBehandlingId();
-        boolean avvikITilkjentYtelse = feriepengeRegeregnTjeneste.harDiff(behandlingId);
+        boolean avvikITilkjentYtelse = feriepengeRegeregnTjeneste.harDiffUtenomPeriode(behandlingId);
         String melding = "Finnes avvik i reberegnet feriepengegrunnlag: " + avvikITilkjentYtelse;
         return Response.ok(melding).build();
     }


### PR DESCRIPTION
Første forsøk gikk ikke så bra når vi forsøkte lagre en prosesstask og det lå løse feriepenge-entiteter.
Prøver med å sammenligne lagret tilkjent mot regelresultat - uten å mappe til BR-entiteter (de skal jo ikke lagres ifm simulering)