### PR TITLE
Feature/fikse refusjonsinfo

### DIFF
--- a/domenetjenester/okonomistotte/src/main/java/no/nav/foreldrepenger/økonomistøtte/ny/domene/Betalingsmottaker.java
+++ b/domenetjenester/okonomistotte/src/main/java/no/nav/foreldrepenger/økonomistøtte/ny/domene/Betalingsmottaker.java
@@ -21,6 +21,8 @@ public interface Betalingsmottaker {
         return ((ArbeidsgiverOrgnr) a).compareTo((ArbeidsgiverOrgnr) b);
     };
 
+    boolean erArbeidsgiver();
+
     default Betalingsmottaker bruker() {
         return BRUKER;
     }
@@ -39,6 +41,10 @@ public interface Betalingsmottaker {
             return "Bruker";
         }
 
+        @Override
+        public boolean erArbeidsgiver() {
+            return false;
+        }
     }
 
     class ArbeidsgiverOrgnr implements Betalingsmottaker, Comparable<ArbeidsgiverOrgnr> {
@@ -80,6 +86,11 @@ public interface Betalingsmottaker {
         @Override
         public int compareTo(ArbeidsgiverOrgnr o) {
             return orgnr.compareTo(o.orgnr);
+        }
+
+        @Override
+        public boolean erArbeidsgiver() {
+            return true;
         }
     }
 

--- a/domenetjenester/okonomistotte/src/main/java/no/nav/foreldrepenger/økonomistøtte/ny/mapper/OppdragMapper.java
+++ b/domenetjenester/okonomistotte/src/main/java/no/nav/foreldrepenger/økonomistøtte/ny/mapper/OppdragMapper.java
@@ -4,6 +4,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import no.nav.foreldrepenger.behandlingslager.økonomioppdrag.Avstemming;
 import no.nav.foreldrepenger.behandlingslager.økonomioppdrag.Ompostering116;
@@ -61,13 +62,26 @@ public class OppdragMapper {
 
         Oppdrag110 oppdrag110 = builder.build();
 
-        LocalDate maxdatoRefusjon = getMaxdatoRefusjon(oppdrag);
-
         for (Map.Entry<KjedeNøkkel, OppdragKjedeFortsettelse> entry : oppdrag.getKjeder().entrySet()) {
+            var kjedeNøkkel = entry.getKey();
+            var refusjonsinfoBuilder = byggRefusjonsinfoBuilderFor(oppdrag, kjedeNøkkel.getBetalingsmottaker());
             for (OppdragLinje oppdragLinje : entry.getValue().getOppdragslinjer()) {
-                mapTilOppdragslinje150(oppdrag110, entry.getKey(), oppdragLinje, maxdatoRefusjon, input.getVedtaksdato(), input.getBehandlingId());
+                var oppdragslinje150 = mapTilOppdragslinje150(oppdrag110, kjedeNøkkel, oppdragLinje, input.getVedtaksdato());
+                refusjonsinfoBuilder.map(o156Builder -> o156Builder.medOppdragslinje150(oppdragslinje150).build());
             }
         }
+    }
+
+    private Optional<Refusjonsinfo156.Builder> byggRefusjonsinfoBuilderFor(final Oppdrag oppdrag, final Betalingsmottaker betalingsmottaker) {
+        Refusjonsinfo156.Builder refusjonsinfoBuilder = null;
+        if (betalingsmottaker.erArbeidsgiver()) {
+            Betalingsmottaker.ArbeidsgiverOrgnr mottaker = (Betalingsmottaker.ArbeidsgiverOrgnr) betalingsmottaker;
+            refusjonsinfoBuilder = Refusjonsinfo156.builder()
+                .medDatoFom(hentFørsteUtbetalingsdato(oppdrag))
+                .medMaksDato(hentSisteUtbetalingsdato(oppdrag))
+                .medRefunderesId(OppdragOrgnrUtil.endreTilElleveSiffer(mottaker.getOrgnr()));
+        }
+        return Optional.ofNullable(refusjonsinfoBuilder);
     }
 
     private boolean oppdragErTilNyMottaker(Oppdrag oppdrag) {
@@ -81,7 +95,7 @@ public class OppdragMapper {
         return KodeEndring.ENDRING;
     }
 
-    Oppdragslinje150 mapTilOppdragslinje150(Oppdrag110 oppdrag110, KjedeNøkkel kjedeNøkkel, OppdragLinje linje, LocalDate maxdatoRefusjon, LocalDate vedtaksdato, Long behandlingId) {
+    Oppdragslinje150 mapTilOppdragslinje150(Oppdrag110 oppdrag110, KjedeNøkkel kjedeNøkkel, OppdragLinje linje, LocalDate vedtaksdato) {
         var builder = Oppdragslinje150.builder()
             .medOppdrag110(oppdrag110)
             .medDelytelseId(Long.valueOf(linje.getDelytelseId().toString()))
@@ -110,18 +124,7 @@ public class OppdragMapper {
             builder.medUtbetalingsgrad(Utbetalingsgrad.prosent(linje.getUtbetalingsgrad().getUtbetalingsgrad()));
         }
 
-        Oppdragslinje150 oppdragslinje150 = builder.build();
-
-        if (kjedeNøkkel.getBetalingsmottaker() instanceof Betalingsmottaker.ArbeidsgiverOrgnr) {
-            Betalingsmottaker.ArbeidsgiverOrgnr mottaker = (Betalingsmottaker.ArbeidsgiverOrgnr) kjedeNøkkel.getBetalingsmottaker();
-            Refusjonsinfo156.builder()
-                .medMaksDato(maxdatoRefusjon)
-                .medDatoFom(vedtaksdato)
-                .medRefunderesId(OppdragOrgnrUtil.endreTilElleveSiffer(mottaker.getOrgnr()))
-                .medOppdragslinje150(oppdragslinje150)
-                .build();
-        }
-        return oppdragslinje150;
+        return builder.build();
     }
 
     private Ompostering116 opprettOmpostering116(Oppdrag oppdrag, boolean brukInntrekk) {
@@ -136,13 +139,13 @@ public class OppdragMapper {
 
     private LocalDate finnDatoOmposterFom(Oppdrag oppdrag) {
         LocalDate endringsdato = oppdrag.getEndringsdato();
-        LocalDate korrigeringsdato = hentFørsteUttaksdato(oppdrag);
+        LocalDate korrigeringsdato = hentFørsteUtbetalingsdato(oppdrag);
         return korrigeringsdato.isAfter(endringsdato)
             ? korrigeringsdato
             : endringsdato;
     }
 
-    public LocalDate hentFørsteUttaksdato(Oppdrag nyttOppdrag) {
+    private LocalDate hentFørsteUtbetalingsdato(Oppdrag nyttOppdrag) {
         MottakerOppdragKjedeOversikt tidligerOppdragForMottaker = tidligereOppdrag.filter(nyttOppdrag.getBetalingsmottaker());
         MottakerOppdragKjedeOversikt utvidetMedNyttOppdrag = tidligerOppdragForMottaker.utvidMed(nyttOppdrag);
         LocalDate førsteUtbetalingsdato = hentFørsteUtbetalingsdato(tidligerOppdragForMottaker);
@@ -172,8 +175,7 @@ public class OppdragMapper {
         return førsteUtetalingsdato;
     }
 
-
-    private LocalDate getMaxdatoRefusjon(Oppdrag nyttOppdrag) {
+    private LocalDate hentSisteUtbetalingsdato(Oppdrag nyttOppdrag) {
         MottakerOppdragKjedeOversikt tidligerOppdragForMottaker = tidligereOppdrag.filter(nyttOppdrag.getBetalingsmottaker());
         MottakerOppdragKjedeOversikt utvidetMedNyttOppdrag = tidligerOppdragForMottaker.utvidMed(nyttOppdrag);
         LocalDate sisteUtbetalingsdato = hentSisteUtbetalingsdato(utvidetMedNyttOppdrag);

--- a/domenetjenester/okonomistotte/src/test/java/no/nav/foreldrepenger/økonomistøtte/ny/NyOppdragskontrollTjenesteOPPHTest.java
+++ b/domenetjenester/okonomistotte/src/test/java/no/nav/foreldrepenger/økonomistøtte/ny/NyOppdragskontrollTjenesteOPPHTest.java
@@ -332,6 +332,9 @@ public class NyOppdragskontrollTjenesteOPPHTest extends NyOppdragskontrollTjenes
     @Test
     public void retest_av_sak_fagsystem_160364_k27_opplyser_ikke_rett_refusjons_maksdato() {
         // Arrange
+        var stønadsdatoFom = LocalDate.now().plusDays(3);
+        var stønadsdatoTom = stønadsdatoFom.plusDays(10);
+
         var originaltOppdrag = Oppdragskontroll.builder().medBehandlingId(BEHANDLING_ID).medSaksnummer(SAKSNUMMER).medProsessTaskId(PROSESS_TASK_ID).medVenterKvittering(Boolean.FALSE).build();
         var oppdragAg = Oppdrag110.builder()
             .medKodeEndring(KodeEndring.NY)
@@ -345,21 +348,21 @@ public class NyOppdragskontrollTjenesteOPPHTest extends NyOppdragskontrollTjenes
         var oppdragLinjeAg = Oppdragslinje150.builder()
             .medKodeEndringLinje(KodeEndringLinje.NY)
             .medKodeKlassifik(KodeKlassifik.FPF_REFUSJON_AG)
-            .medVedtakFomOgTom(LocalDate.now(), LocalDate.now().plusDays(10))
+            .medVedtakFomOgTom(stønadsdatoFom, stønadsdatoTom)
             .medSats(Sats.på(1500))
             .medTypeSats(TypeSats.DAGLIG)
             .medDelytelseId(Long.parseLong(SAKSNUMMER.getVerdi() + "100100"))
             .medUtbetalingsgrad(Utbetalingsgrad._100)
             .medOppdrag110(oppdragAg).build();
 
-        Refusjonsinfo156.builder().medMaksDato(LocalDate.now().plusDays(10)).medDatoFom(LocalDate.now()).medRefunderesId(virksomhet).medOppdragslinje150(oppdragLinjeAg).build();
+        Refusjonsinfo156.builder().medMaksDato(stønadsdatoTom).medDatoFom(stønadsdatoFom).medRefunderesId(virksomhet).medOppdragslinje150(oppdragLinjeAg).build();
         OppdragKvitteringTestUtil.lagPositivKvitting(oppdragAg);
 
         // Tilkyent ytelse i revurdering
         BeregningsresultatEntitet beregningsresultatRevurderingFP = BeregningsresultatEntitet.builder().medRegelInput("clob1")
             .medRegelSporing("clob2").build();
 
-        BeregningsresultatPeriode brPeriode1 = buildBeregningsresultatPeriode(beregningsresultatRevurderingFP, 0, 7);
+        BeregningsresultatPeriode brPeriode1 = buildBeregningsresultatPeriode(beregningsresultatRevurderingFP, 3, 10);
         buildBeregningsresultatAndel(brPeriode1, false, 1500, BigDecimal.valueOf(100), virksomhet);
 
         TilkjentYtelseMapper mapper = new TilkjentYtelseMapper(FamilieYtelseType.FØDSEL);
@@ -378,7 +381,15 @@ public class NyOppdragskontrollTjenesteOPPHTest extends NyOppdragskontrollTjenes
             .map(BeregningsresultatPeriode::getBeregningsresultatPeriodeTom);
         assertThat(sisteOppdragsDatoTom).isPresent();
 
-        assertThat(oppdragslinje150Opphørt.get().getRefusjonsinfo156().getMaksDato()).isEqualTo(sisteOppdragsDatoTom.get());
+        var førsteOppdragsDatoFom = beregningsresultatRevurderingFP.getBeregningsresultatPerioder().stream().min(Comparator.comparing(BeregningsresultatPeriode::getBeregningsresultatPeriodeFom))
+            .map(BeregningsresultatPeriode::getBeregningsresultatPeriodeFom);
+        assertThat(førsteOppdragsDatoFom).isPresent();
+
+        var oppdragslinje150 = oppdragslinje150Opphørt.get();
+        var refusjonsinfo156 = oppdragslinje150.getRefusjonsinfo156();
+        assertThat(oppdragslinje150.getVedtakId()).isEqualTo(VEDTAKSDATO.toString());
+        assertThat(refusjonsinfo156.getMaksDato()).isEqualTo(sisteOppdragsDatoTom.get());
+        assertThat(refusjonsinfo156.getDatoFom()).isEqualTo(førsteOppdragsDatoFom.get());
     }
 
     @Test

--- a/domenetjenester/okonomistotte/src/test/java/no/nav/foreldrepenger/økonomistøtte/ny/NyOppdragskontrollTjenesteOPPHTest.java
+++ b/domenetjenester/okonomistotte/src/test/java/no/nav/foreldrepenger/økonomistøtte/ny/NyOppdragskontrollTjenesteOPPHTest.java
@@ -363,7 +363,10 @@ public class NyOppdragskontrollTjenesteOPPHTest extends NyOppdragskontrollTjenes
             .medRegelSporing("clob2").build();
 
         BeregningsresultatPeriode brPeriode1 = buildBeregningsresultatPeriode(beregningsresultatRevurderingFP, 3, 10);
-        buildBeregningsresultatAndel(brPeriode1, false, 1500, BigDecimal.valueOf(100), virksomhet);
+        var andelArb = buildBeregningsresultatAndel(brPeriode1, false, 1500, BigDecimal.valueOf(100), virksomhet);
+
+        BeregningsresultatFeriepenger feriepenger = buildBeregningsresultatFeriepenger(beregningsresultatRevurderingFP);
+        buildBeregningsresultatFeriepengerPrÅr(feriepenger, andelArb, 20000L, List.of(stønadsdatoFom));
 
         TilkjentYtelseMapper mapper = new TilkjentYtelseMapper(FamilieYtelseType.FØDSEL);
         GruppertYtelse gruppertYtelse2 = mapper.fordelPåNøkler(beregningsresultatRevurderingFP);
@@ -376,6 +379,10 @@ public class NyOppdragskontrollTjenesteOPPHTest extends NyOppdragskontrollTjenes
         var oppdragslinje150Opphørt = oppdragRevurdering.getOppdrag110Liste().stream().flatMap(oppdrag110 -> oppdrag110.getOppdragslinje150Liste()
             .stream()).filter(Oppdragslinje150::gjelderOpphør).findFirst();
         assertThat(oppdragslinje150Opphørt).isPresent();
+
+        var oppdragslinje150Feriepenger = oppdragRevurdering.getOppdrag110Liste().stream().flatMap(oppdrag110 -> oppdrag110.getOppdragslinje150Liste()
+            .stream()).filter(o150 -> !o150.gjelderOpphør()).findFirst();
+        assertThat(oppdragslinje150Feriepenger).isPresent();
 
         var sisteOppdragsDatoTom = beregningsresultatRevurderingFP.getBeregningsresultatPerioder().stream().max(Comparator.comparing(BeregningsresultatPeriode::getBeregningsresultatPeriodeTom))
             .map(BeregningsresultatPeriode::getBeregningsresultatPeriodeTom);
@@ -390,6 +397,14 @@ public class NyOppdragskontrollTjenesteOPPHTest extends NyOppdragskontrollTjenes
         assertThat(oppdragslinje150.getVedtakId()).isEqualTo(VEDTAKSDATO.toString());
         assertThat(refusjonsinfo156.getMaksDato()).isEqualTo(sisteOppdragsDatoTom.get());
         assertThat(refusjonsinfo156.getDatoFom()).isEqualTo(førsteOppdragsDatoFom.get());
+
+        var feriepengerFom = LocalDate.of(stønadsdatoFom.plusYears(1).getYear(), 5, 1);
+        var feriepengerTom = LocalDate.of(stønadsdatoFom.plusYears(1).getYear(), 5, 31);
+        var oppdragslinje150Ferie = oppdragslinje150Feriepenger.get();
+        assertThat(oppdragslinje150Ferie.getRefusjonsinfo156().getDatoFom()).isEqualTo(feriepengerFom);
+        assertThat(oppdragslinje150Ferie.getRefusjonsinfo156().getMaksDato()).isEqualTo(feriepengerTom);
+        assertThat(oppdragslinje150Ferie.getDatoVedtakFom()).isEqualTo(feriepengerFom);
+        assertThat(oppdragslinje150Ferie.getDatoVedtakTom()).isEqualTo(feriepengerTom);
     }
 
     @Test

--- a/domenetjenester/okonomistotte/src/test/java/no/nav/foreldrepenger/økonomistøtte/ny/mapper/EksisterendeOppdragMapperTest.java
+++ b/domenetjenester/okonomistotte/src/test/java/no/nav/foreldrepenger/økonomistøtte/ny/mapper/EksisterendeOppdragMapperTest.java
@@ -5,6 +5,8 @@ import static no.nav.foreldrepenger.behandlingslager.økonomioppdrag.koder.KodeK
 
 import java.time.LocalDate;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
 import org.assertj.core.api.Assertions;
@@ -44,8 +46,6 @@ public class EksisterendeOppdragMapperTest {
     DelytelseId delytelseId1 = DelytelseId.parse("1100100");
     DelytelseId delytelseId2 = delytelseId1.neste();
     DelytelseId delytelseId3 = delytelseId2.neste();
-    DelytelseId delytelseId4 = delytelseId3.neste();
-    DelytelseId delytelseId5 = delytelseId4.neste();
 
     @Test
     public void skal_mappe_eksisterende_oppdrag() {
@@ -71,7 +71,7 @@ public class EksisterendeOppdragMapperTest {
         lagOrdinærLinje(oppdrag110, delytelseId1, p1, Satsen.dagsats(100), null);
         lagOrdinærLinje(oppdrag110, delytelseId2, p2, Satsen.dagsats(150), null); // denne peker ikke til forrige, slik den egentlig skal
 
-        Map<KjedeNøkkel, OppdragKjede> kjeder = EksisterendeOppdragMapper.tilKjeder(Arrays.asList(oppdragskontroll));
+        Map<KjedeNøkkel, OppdragKjede> kjeder = EksisterendeOppdragMapper.tilKjeder(List.of(oppdragskontroll));
         KjedeNøkkel kjedeNøkkel = KjedeNøkkel.lag(FPF_ARBEIDSTAKER, Betalingsmottaker.BRUKER);
         KjedeNøkkel kjedeNøkkelKnektKjede = KjedeNøkkel.builder(FPF_ARBEIDSTAKER, Betalingsmottaker.BRUKER).medKnektKjedeDel(1).build();
         Assertions.assertThat(kjeder.keySet()).containsOnly(kjedeNøkkel, kjedeNøkkelKnektKjede);


### PR DESCRIPTION
Refusjonsinfo156 bør inneholde informasjon om første og siste stønadsdag. 
I dag sendes vedtaksdato og siste stønadsdag som er feil i de fleste tilfeller. 
Det sendes også samme periode for feriepenger utbetalinger som vi syns er feil også - her bør nok 01.05 - 31.05 sendes.