### PR TITLE
TFP-4217 ikke vent på inntektsregistrering for opptjening

### DIFF
--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/aksjonspunkt/AksjonspunktDefinisjon.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/aksjonspunkt/AksjonspunktDefinisjon.java
@@ -382,9 +382,6 @@ public enum AksjonspunktDefinisjon implements Kodeverdi {
     AUTO_SATT_PÅ_VENT_REVURDERING(AksjonspunktKodeDefinisjon.AUTO_SATT_PÅ_VENT_REVURDERING_KODE, AksjonspunktType.AUTOPUNKT,
             "Satt på vent etter varsel om revurdering", BehandlingStegType.VARSEL_REVURDERING, VurderingspunktType.UT, UTEN_VILKÅR, UTEN_SKJERMLENKE,
             ENTRINN, FORBLI, "P4W", EnumSet.of(ES, FP, SVP)),
-    AUTO_VENT_PÅ_OPPTJENINGSOPPLYSNINGER(AksjonspunktKodeDefinisjon.AUTO_VENT_PÅ_OPPTJENINGSOPPLYSNINGER_KODE, AksjonspunktType.AUTOPUNKT, "Venter på opptjeningsopplysninger",
-            BehandlingStegType.VURDER_OPPTJENINGSVILKÅR, VurderingspunktType.UT, VilkårType.OPPTJENINGSVILKÅRET, SkjermlenkeType.FAKTA_FOR_OPPTJENING,
-        ENTRINN, TILBAKE, "P2W", EnumSet.of(FP, SVP)),
     VENT_PÅ_SCANNING(AksjonspunktKodeDefinisjon.VENT_PÅ_SCANNING_KODE,
             AksjonspunktType.AUTOPUNKT, "Venter på scanning", BehandlingStegType.VURDER_INNSYN, VurderingspunktType.UT, UTEN_VILKÅR, UTEN_SKJERMLENKE, ENTRINN, TILBAKE,
             "P3D", EnumSet.of(ES, FP, SVP)),
@@ -474,6 +471,10 @@ public enum AksjonspunktDefinisjon implements Kodeverdi {
         AksjonspunktKodeDefinisjon.AVKLAR_FAKTA_FOR_PERSONSTATUS_KODE, AksjonspunktType.MANUELL, "Avklar fakta for status på person.",
         BehandlingStegType.KONTROLLER_FAKTA, VurderingspunktType.INN, VilkårType.MEDLEMSKAPSVILKÅRET, SkjermlenkeType.KONTROLL_AV_SAKSOPPLYSNINGER,
         ENTRINN, EnumSet.of(ES, FP, SVP)),
+    @Deprecated
+    AUTO_VENT_PÅ_OPPTJENINGSOPPLYSNINGER(AksjonspunktKodeDefinisjon.AUTO_VENT_PÅ_OPPTJENINGSOPPLYSNINGER_KODE, AksjonspunktType.AUTOPUNKT, "Venter på opptjeningsopplysninger",
+        BehandlingStegType.VURDER_OPPTJENINGSVILKÅR, VurderingspunktType.UT, VilkårType.OPPTJENINGSVILKÅRET, SkjermlenkeType.FAKTA_FOR_OPPTJENING,
+        ENTRINN, TILBAKE, "P2W", EnumSet.of(FP, SVP)),
     ;
 
     static final String KODEVERK = "AKSJONSPUNKT_DEF";

--- a/behandlingslager/domene/src/test/java/no/nav/foreldrepenger/behandlingslager/behandling/aksjonspunkt/BehandlingPåVentTest.java
+++ b/behandlingslager/domene/src/test/java/no/nav/foreldrepenger/behandlingslager/behandling/aksjonspunkt/BehandlingPåVentTest.java
@@ -1,7 +1,6 @@
 package no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt;
 
 import static no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.AksjonspunktDefinisjon.AUTO_MANUELT_SATT_PÅ_VENT;
-import static no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.AksjonspunktDefinisjon.AUTO_VENT_PÅ_OPPTJENINGSOPPLYSNINGER;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -43,13 +42,12 @@ public class BehandlingPåVentTest {
         assertFalse(behandling.isBehandlingPåVent());
     }
 
-    @Test // TODO PKMANTIS-1137 Har satt midlertidig frist, må endres når dynamisk frist
-          // er implementert
+    @Test
     public void testErPåVentNårVenterPåOpptjeningsopplysninger() {
         Behandling behandling = Behandling.forFørstegangssøknad(fagsak).build();
-        Aksjonspunkt aksjonspunkt = AksjonspunktTestSupport.leggTilAksjonspunkt(behandling, AUTO_VENT_PÅ_OPPTJENINGSOPPLYSNINGER);
+        Aksjonspunkt aksjonspunkt = AksjonspunktTestSupport.leggTilAksjonspunkt(behandling, AksjonspunktDefinisjon.AUTO_SATT_PÅ_VENT_REVURDERING);
         assertTrue(behandling.isBehandlingPåVent());
-        assertEquals(behandling.getOpprettetDato().plusWeeks(2).toLocalDate(), aksjonspunkt.getFristTid().toLocalDate());
+        assertEquals(behandling.getOpprettetDato().plusWeeks(4).toLocalDate(), aksjonspunkt.getFristTid().toLocalDate());
         AksjonspunktTestSupport.setTilUtført(aksjonspunkt, "");
         assertFalse(behandling.isBehandlingPåVent());
     }

--- a/behandlingsprosess/src/main/java/no/nav/foreldrepenger/behandling/steg/inngangsvilkår/opptjening/fp/VurderOpptjeningsvilkårSteg.java
+++ b/behandlingsprosess/src/main/java/no/nav/foreldrepenger/behandling/steg/inngangsvilkår/opptjening/fp/VurderOpptjeningsvilkårSteg.java
@@ -1,12 +1,7 @@
 package no.nav.foreldrepenger.behandling.steg.inngangsvilkår.opptjening.fp;
 
-import static java.time.LocalDateTime.of;
-
-import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
@@ -14,7 +9,6 @@ import javax.inject.Inject;
 import no.nav.foreldrepenger.behandling.steg.inngangsvilkår.InngangsvilkårFellesTjeneste;
 import no.nav.foreldrepenger.behandling.steg.inngangsvilkår.opptjening.MapTilOpptjeningAktiviteter;
 import no.nav.foreldrepenger.behandling.steg.inngangsvilkår.opptjening.felles.VurderOpptjeningsvilkårStegFelles;
-import no.nav.foreldrepenger.behandlingskontroll.AksjonspunktResultat;
 import no.nav.foreldrepenger.behandlingskontroll.BehandleStegResultat;
 import no.nav.foreldrepenger.behandlingskontroll.BehandlingStegRef;
 import no.nav.foreldrepenger.behandlingskontroll.BehandlingTypeRef;
@@ -22,10 +16,8 @@ import no.nav.foreldrepenger.behandlingskontroll.FagsakYtelseTypeRef;
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingStegType;
 import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.AksjonspunktDefinisjon;
-import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.Venteårsak;
 import no.nav.foreldrepenger.behandlingslager.behandling.opptjening.OpptjeningAktivitet;
 import no.nav.foreldrepenger.behandlingslager.behandling.opptjening.OpptjeningAktivitetKlassifisering;
-import no.nav.foreldrepenger.behandlingslager.behandling.opptjening.OpptjeningRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepositoryProvider;
 import no.nav.foreldrepenger.inngangsvilkaar.RegelResultat;
 import no.nav.foreldrepenger.inngangsvilkaar.regelmodell.opptjening.OpptjeningsvilkårResultat;
@@ -52,32 +44,8 @@ public class VurderOpptjeningsvilkårSteg extends VurderOpptjeningsvilkårStegFe
         return aktiviteter;
     }
 
-    /**
-     * Overstyr stegresultat og sett en frist dersom vi må vente på
-     * opptjeningsopplysninger.
-     */
-    @Override
-    protected BehandleStegResultat stegResultat(RegelResultat regelResultat) {
-        BehandleStegResultat stegResultat = super.stegResultat(regelResultat);
-        AksjonspunktDefinisjon apDef = AksjonspunktDefinisjon.AUTO_VENT_PÅ_OPPTJENINGSOPPLYSNINGER;
-
-        if (regelResultat.getAksjonspunktDefinisjoner().contains(apDef)) {
-            LocalDateTime frist = getVentPåOpptjeningsopplysningerFrist(regelResultat);
-            return stegResultat.medAksjonspunktResultat(
-                    AksjonspunktResultat.opprettForAksjonspunktMedFrist(apDef, Venteårsak.VENT_OPPTJENING_OPPLYSNINGER, frist));
-        }
-        return stegResultat;
-    }
-
     @Override
     protected BehandleStegResultat stegResultatVilkårIkkeOppfylt(RegelResultat regelResultat, Behandling behandling) {
         return BehandleStegResultat.utførtMedAksjonspunkter(List.of(AksjonspunktDefinisjon.VURDER_OPPTJENINGSVILKÅRET));
-    }
-
-    private LocalDateTime getVentPåOpptjeningsopplysningerFrist(RegelResultat regelResultat) {
-        Optional<OpptjeningsvilkårResultat> resultat = regelResultat.getEkstraResultat(OPPTJENINGSVILKÅRET);
-        LocalDate now = LocalDate.now();
-        LocalDate fristDato = resultat.isPresent() ? resultat.get().getFrist() : now;
-        return of(fristDato, LocalDateTime.now().toLocalTime());
     }
 }

--- a/behandlingsprosess/src/main/java/no/nav/foreldrepenger/behandling/steg/inngangsvilkår/opptjening/svp/VurderOpptjeningsvilkårSteg.java
+++ b/behandlingsprosess/src/main/java/no/nav/foreldrepenger/behandling/steg/inngangsvilkår/opptjening/svp/VurderOpptjeningsvilkårSteg.java
@@ -9,13 +9,17 @@ import javax.inject.Inject;
 import no.nav.foreldrepenger.behandling.steg.inngangsvilkår.InngangsvilkårFellesTjeneste;
 import no.nav.foreldrepenger.behandling.steg.inngangsvilkår.opptjening.MapTilOpptjeningAktiviteter;
 import no.nav.foreldrepenger.behandling.steg.inngangsvilkår.opptjening.felles.VurderOpptjeningsvilkårStegFelles;
+import no.nav.foreldrepenger.behandlingskontroll.BehandleStegResultat;
 import no.nav.foreldrepenger.behandlingskontroll.BehandlingStegRef;
 import no.nav.foreldrepenger.behandlingskontroll.BehandlingTypeRef;
 import no.nav.foreldrepenger.behandlingskontroll.FagsakYtelseTypeRef;
+import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingStegType;
+import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.AksjonspunktDefinisjon;
 import no.nav.foreldrepenger.behandlingslager.behandling.opptjening.OpptjeningAktivitet;
 import no.nav.foreldrepenger.behandlingslager.behandling.opptjening.OpptjeningAktivitetKlassifisering;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepositoryProvider;
+import no.nav.foreldrepenger.inngangsvilkaar.RegelResultat;
 import no.nav.foreldrepenger.inngangsvilkaar.regelmodell.opptjening.OpptjeningsvilkårResultat;
 
 @BehandlingStegRef(kode = "VURDER_OPPTJ")
@@ -37,5 +41,10 @@ public class VurderOpptjeningsvilkårSteg extends VurderOpptjeningsvilkårStegFe
         aktiviteter.addAll(mapper.map(oppResultat.getAntattGodkjentePerioder(), OpptjeningAktivitetKlassifisering.ANTATT_GODKJENT));
         aktiviteter.addAll(mapper.map(oppResultat.getUnderkjentePerioder(), OpptjeningAktivitetKlassifisering.BEKREFTET_AVVIST));
         return aktiviteter;
+    }
+
+    @Override
+    protected BehandleStegResultat stegResultatVilkårIkkeOppfylt(RegelResultat regelResultat, Behandling behandling) {
+        return BehandleStegResultat.utførtMedAksjonspunkter(List.of(AksjonspunktDefinisjon.VURDER_OPPTJENINGSVILKÅRET));
     }
 }

--- a/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/inngangsvilkår/InngangsvilkårStegImplTest.java
+++ b/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/inngangsvilkår/InngangsvilkårStegImplTest.java
@@ -165,7 +165,6 @@ public class InngangsvilkårStegImplTest {
         ekstra.setBekreftetGodkjentAktivitet(emptyMap());
         ekstra.setAntattGodkjentePerioder(emptyMap());
         ekstra.setAkseptertMellomliggendePerioder(emptyMap());
-        ekstra.setFrist(LocalDate.now().minusDays(1));
         return new RegelResultat(behandling.getBehandlingsresultat().getVilkårResultat(), emptyList(),
                 Map.of(VilkårType.OPPTJENINGSVILKÅRET, ekstra));
     }

--- a/domenetjenester/dokumentbestiller/src/main/java/no/nav/foreldrepenger/dokumentbestiller/observers/SendBrevForAutopunktEventObserver.java
+++ b/domenetjenester/dokumentbestiller/src/main/java/no/nav/foreldrepenger/dokumentbestiller/observers/SendBrevForAutopunktEventObserver.java
@@ -45,8 +45,6 @@ public class SendBrevForAutopunktEventObserver {
             .ifPresent(ap -> sendBrevForAutopunkt.sendBrevForTidligSøknad(behandling, ap));
         finnAksjonspunkerMedDef(aksjonspunkter, AksjonspunktDefinisjon.VENT_PÅ_FØDSEL)
             .ifPresent(ap -> sendBrevForAutopunkt.sendBrevForVenterPåFødsel(behandling, ap));
-        finnAksjonspunkerMedDef(aksjonspunkter, AksjonspunktDefinisjon.AUTO_VENT_PÅ_OPPTJENINGSOPPLYSNINGER)
-            .ifPresent(ap -> sendBrevForAutopunkt.oppdaterBehandlingsfristForVenterPåOpptjening(behandling, ap));
         finnAksjonspunkerMedDef(aksjonspunkter, AksjonspunktDefinisjon.AUTO_SATT_PÅ_VENT_REVURDERING)
             .ifPresent(ap -> sendBrevForAutopunkt.sendBrevForEtterkontroll(behandling));
     }

--- a/domenetjenester/dokumentbestiller/src/test/java/no/nav/foreldrepenger/dokumentbestiller/observers/SendBrevForAutopunktEventObserverTest.java
+++ b/domenetjenester/dokumentbestiller/src/test/java/no/nav/foreldrepenger/dokumentbestiller/observers/SendBrevForAutopunktEventObserverTest.java
@@ -54,7 +54,6 @@ public class SendBrevForAutopunktEventObserverTest {
         AksjonspunktDefinisjon autopunktDefinisjonIngenSøknad = AksjonspunktDefinisjon.VENT_PÅ_SØKNAD;
         AksjonspunktDefinisjon autopunktDefinisjonTidligSøknad = AksjonspunktDefinisjon.VENT_PGA_FOR_TIDLIG_SØKNAD;
         AksjonspunktDefinisjon autopunktDefinisjonVentFødsel = AksjonspunktDefinisjon.VENT_PÅ_FØDSEL;
-        AksjonspunktDefinisjon autopunktDefinisjonOpptjening = AksjonspunktDefinisjon.AUTO_VENT_PÅ_OPPTJENINGSOPPLYSNINGER;
         AksjonspunktDefinisjon autopunktDefinisjonEtterkontroll = AksjonspunktDefinisjon.AUTO_SATT_PÅ_VENT_REVURDERING;
 
         AksjonspunktDefinisjon manuellpunktDefinisjon = AksjonspunktDefinisjon.MANUELL_VURDERING_AV_OMSORGSVILKÅRET;
@@ -64,7 +63,6 @@ public class SendBrevForAutopunktEventObserverTest {
         lenient().when(autopunktIngenSøknad.getAksjonspunktDefinisjon()).thenReturn(autopunktDefinisjonIngenSøknad);
         lenient().when(autopunktVentFødsel.getAksjonspunktDefinisjon()).thenReturn(autopunktDefinisjonVentFødsel);
         lenient().when(autopunktTidligSøknad.getAksjonspunktDefinisjon()).thenReturn(autopunktDefinisjonTidligSøknad);
-        lenient().when(autopunktOpptjening.getAksjonspunktDefinisjon()).thenReturn(autopunktDefinisjonOpptjening);
         lenient().when(autopunktEtterkontroll.getAksjonspunktDefinisjon()).thenReturn(autopunktDefinisjonEtterkontroll);
 
         lenient().when(manuellpunkt.erOpprettet()).thenReturn(true);
@@ -111,13 +109,6 @@ public class SendBrevForAutopunktEventObserverTest {
         var event = new AksjonspunktStatusEvent(behandlingskontrollKontekst, List.of(autopunktVentFødsel), null);
         observer.sendBrevForAutopunkt(event);
         verify(sendBrevForAutopunkt, times(1)).sendBrevForVenterPåFødsel(any(), any());
-    }
-
-    @Test
-    public void skalOppdatereBehandlingsfristForVenterOpptjening() {
-        var event = new AksjonspunktStatusEvent(behandlingskontrollKontekst, List.of(autopunktOpptjening), null);
-        observer.sendBrevForAutopunkt(event);
-        verify(sendBrevForAutopunkt, times(1)).oppdaterBehandlingsfristForVenterPåOpptjening(any(), any());
     }
 
     @Test

--- a/domenetjenester/inngangsvilkar/regelmodell/src/main/java/no/nav/foreldrepenger/inngangsvilkaar/regelmodell/opptjening/Aktivitet.java
+++ b/domenetjenester/inngangsvilkar/regelmodell/src/main/java/no/nav/foreldrepenger/inngangsvilkaar/regelmodell/opptjening/Aktivitet.java
@@ -14,7 +14,7 @@ public class Aktivitet {
         AKTØRID;
     }
 
-    //OpptjeningAktivitetType.ARBEID
+    //OpptjeningAktivitetType.ARBEID , FRILOPP
     static private String ARBEID = OpptjeningsvilkårForeldrepenger.ARBEID;
     static private String FRILANSREG = OpptjeningsvilkårForeldrepenger.FRILANSREGISTER;
     static private String LØNN = OpptjeningsvilkårForeldrepenger.LØNN;
@@ -63,10 +63,6 @@ public class Aktivitet {
 
     public Aktivitet forInntekt() {
         return new Aktivitet(LØNN, aktivitetReferanse, referanseType);
-    }
-
-    public Aktivitet forArbeid() {
-        return new Aktivitet(ARBEID, aktivitetReferanse, referanseType);
     }
 
     @Override

--- a/domenetjenester/inngangsvilkar/regelmodell/src/main/java/no/nav/foreldrepenger/inngangsvilkaar/regelmodell/opptjening/Opptjeningsgrunnlag.java
+++ b/domenetjenester/inngangsvilkar/regelmodell/src/main/java/no/nav/foreldrepenger/inngangsvilkaar/regelmodell/opptjening/Opptjeningsgrunnlag.java
@@ -54,24 +54,10 @@ public class Opptjeningsgrunnlag implements VilkårGrunnlag {
     private Period minForegåendeForMellomliggendePeriodeForArbeidsforhold = Period.ofWeeks(4);
 
     /**
-     * Minste antall dager med bekreftet opptjening for å kunne legge på vent (sees i sammenheng med
-     * {@link #minsteAntallMånederForVent}.
-     */
-    @JsonIgnore
-    private int minsteAntallDagerForVent = 0;
-
-    /**
      * Minste antall dager som kreves godkjent dersom det er færre enn ({@link #minsteAntallMånederGodkjent}+1 måneder .
      */
     @JsonIgnore
     private int minsteAntallDagerGodkjent = 26;
-
-    /**
-     * Minste antall måneder med bekreftet opptjening for å kunne legge på vent (sees i sammenheng med
-     * {@link #minsteAntallDagerForVent}.
-     */
-    @JsonIgnore
-    private int minsteAntallMånederForVent = 4;
 
     /**
      * Minste antall måneder som kreves godkjent. Hvis eksakt samme, så sjekkes også {@link #minsteAntallDagerGodkjent}.
@@ -128,16 +114,8 @@ public class Opptjeningsgrunnlag implements VilkårGrunnlag {
         return minForegåendeForMellomliggendePeriodeForArbeidsforhold;
     }
 
-    public int getMinsteAntallDagerForVent() {
-        return minsteAntallDagerForVent;
-    }
-
     public int getMinsteAntallDagerGodkjent() {
         return minsteAntallDagerGodkjent;
-    }
-
-    public int getMinsteAntallMånederForVent() {
-        return minsteAntallMånederForVent;
     }
 
     public int getMinsteAntallMånederGodkjent() {
@@ -194,16 +172,8 @@ public class Opptjeningsgrunnlag implements VilkårGrunnlag {
         this.minForegåendeForMellomliggendePeriodeForArbeidsforhold = minForegåendeForMellomliggendePeriodeForArbeidsforhold;
     }
 
-    public void setMinsteAntallDagerForVent(int minsteAntallDagerForVent) {
-        this.minsteAntallDagerForVent = minsteAntallDagerForVent;
-    }
-
     public void setMinsteAntallDagerGodkjent(int minsteAntallDagerGodkjent) {
         this.minsteAntallDagerGodkjent = minsteAntallDagerGodkjent;
-    }
-
-    public void setMinsteAntallMånederForVent(int minsteAntallMånederForVent) {
-        this.minsteAntallMånederForVent = minsteAntallMånederForVent;
     }
 
     public void setMinsteAntallMånederGodkjent(int minsteAntallMånederGodkjent) {

--- a/domenetjenester/inngangsvilkar/regelmodell/src/main/java/no/nav/foreldrepenger/inngangsvilkaar/regelmodell/opptjening/OpptjeningsvilkårMellomregning.java
+++ b/domenetjenester/inngangsvilkar/regelmodell/src/main/java/no/nav/foreldrepenger/inngangsvilkaar/regelmodell/opptjening/OpptjeningsvilkårMellomregning.java
@@ -40,9 +40,6 @@ public class OpptjeningsvilkårMellomregning {
      */
     private Opptjeningsgrunnlag grunnlag;
 
-    /** Frist for å motta opptjening opplysninger (henger sammen med Aksjonspunkt 7006 "Venter på Opptjeningsopplysninger"). */
-    private LocalDate opptjeningOpplysningerFrist;
-
     public OpptjeningsvilkårMellomregning(Opptjeningsgrunnlag grunnlag) {
         this.grunnlag = grunnlag;
         LocalDateInterval maxIntervall = grunnlag.getOpptjeningPeriode();
@@ -198,15 +195,6 @@ public class OpptjeningsvilkårMellomregning {
 
         /* hvis Oppfylt/Ikke Oppfylt (men ikke "Ikke Vurdert"), så angis total opptjening som er kalkulert. */
         outputResultat.setTotalOpptjening(this.getTotalOpptjening());
-        outputResultat.setFrist(this.getOpptjeningOpplysningerFrist());
-    }
-
-    LocalDate getOpptjeningOpplysningerFrist() {
-        return opptjeningOpplysningerFrist;
-    }
-
-    void setOpptjeningOpplysningerFrist(LocalDate opptjeningOpplysningerFrist) {
-        this.opptjeningOpplysningerFrist = opptjeningOpplysningerFrist;
     }
 
     public void setAntattOpptjening(OpptjentTidslinje antattOpptjening) {
@@ -230,15 +218,6 @@ public class OpptjeningsvilkårMellomregning {
 
     void setUnderkjentePerioder(Map<Aktivitet, LocalDateTimeline<Boolean>> perioder) {
         perioder.forEach((key, value) -> mellomregning.get(key).setAktivitetUnderkjent(value));
-    }
-
-    /**
-     * Sjekker om opptjening er nok til å legge på vent ifht. konfigurert minste periode for vent.
-     */
-    boolean sjekkErInnenforMinsteGodkjentePeriodeForVent(Period opptjeningPeriode) {
-        int minsteAntallMåneder = grunnlag.getMinsteAntallMånederForVent();
-        int minsteAntallDager = grunnlag.getMinsteAntallDagerForVent();
-        return sjekkErErOverAntallPåkrevd(opptjeningPeriode, minsteAntallMåneder, minsteAntallDager);
     }
 
     /**

--- a/domenetjenester/inngangsvilkar/regelmodell/src/main/java/no/nav/foreldrepenger/inngangsvilkaar/regelmodell/opptjening/OpptjeningsvilkårResultat.java
+++ b/domenetjenester/inngangsvilkar/regelmodell/src/main/java/no/nav/foreldrepenger/inngangsvilkaar/regelmodell/opptjening/OpptjeningsvilkårResultat.java
@@ -1,6 +1,5 @@
 package no.nav.foreldrepenger.inngangsvilkaar.regelmodell.opptjening;
 
-import java.time.LocalDate;
 import java.time.Period;
 import java.util.Collections;
 import java.util.Map;
@@ -27,9 +26,6 @@ public class OpptjeningsvilkårResultat {
 
     /** Resultatstruktur - perioder underkjent i vurderingen, gruppert etter aktivitet. */
     private Map<Aktivitet, LocalDateTimeline<Boolean>> underkjentePerioder;
-
-    /** Frist for å vente på opptjeningsopplysninger, hvis nødvendig. */
-    private LocalDate frist;
 
     public OpptjeningsvilkårResultat() {
     }
@@ -79,12 +75,5 @@ public class OpptjeningsvilkårResultat {
         this.underkjentePerioder = underkjentePerioder;
     }
 
-    public void setFrist(LocalDate frist) {
-        this.frist = frist;
-    }
-
-    public LocalDate getFrist() {
-        return frist;
-    }
 
 }

--- a/domenetjenester/inngangsvilkar/regelmodell/src/main/java/no/nav/foreldrepenger/inngangsvilkaar/regelmodell/opptjening/SjekkInntektSamsvarerMedArbeidAktivitet.java
+++ b/domenetjenester/inngangsvilkar/regelmodell/src/main/java/no/nav/foreldrepenger/inngangsvilkaar/regelmodell/opptjening/SjekkInntektSamsvarerMedArbeidAktivitet.java
@@ -162,7 +162,7 @@ public class SjekkInntektSamsvarerMedArbeidAktivitet extends LeafSpecification<O
 
             // Denne er for å få med underkjente (aktiviteter)
             // Frilansperioder uten inntekt blir ikke antatt godkjent - inntil videre
-            // Obs på 1) ytelser som godkjenner antatt og 2) vent på inntektsreg (kon arbeid)
+            // Obs på 1) ytelser som godkjenner antatt o
             aktiviteter.entrySet().stream()
                 .filter(e -> FRILANSREGISTER.equals(e.getKey().getAktivitetType()))
                 .filter(e -> !e.getValue().isEmpty())

--- a/domenetjenester/inngangsvilkar/regelmodell/src/main/java/no/nav/foreldrepenger/inngangsvilkaar/regelmodell/opptjening/SjekkTilstrekkeligOpptjeningInklAntatt.java
+++ b/domenetjenester/inngangsvilkar/regelmodell/src/main/java/no/nav/foreldrepenger/inngangsvilkaar/regelmodell/opptjening/SjekkTilstrekkeligOpptjeningInklAntatt.java
@@ -2,9 +2,6 @@ package no.nav.foreldrepenger.inngangsvilkaar.regelmodell.opptjening;
 
 import java.time.LocalDate;
 import java.time.Period;
-import java.util.LinkedHashMap;
-import java.util.Map;
-import java.util.stream.Collectors;
 
 import no.nav.foreldrepenger.inngangsvilkaar.regelmodell.opptjening.fp.OpptjeningsvilkårForeldrepenger;
 import no.nav.fpsak.nare.doc.RuleDocumentation;
@@ -13,9 +10,7 @@ import no.nav.fpsak.nare.evaluation.Evaluation;
 import no.nav.fpsak.nare.evaluation.Resultat;
 import no.nav.fpsak.nare.evaluation.RuleReasonRefImpl;
 import no.nav.fpsak.nare.specification.LeafSpecification;
-import no.nav.fpsak.tidsserie.LocalDateInterval;
 import no.nav.fpsak.tidsserie.LocalDateTimeline;
-import no.nav.fpsak.tidsserie.StandardCombinators;
 
 /**
  * Sjekk om bruker har tilstrekkelig opptjening inklusiv antatt godkjente perioder for arbeidsforhold uten innrapportert
@@ -24,7 +19,6 @@ import no.nav.fpsak.tidsserie.StandardCombinators;
  * (antar at dersom bruker ikke trenger antatt godkjente perioder er det sjekket av tidligere regel)
  */
 @RuleDocumentation(value = "FP_VK_23.2.2", outcomes = {
-        @RuleOutcomeDocumentation(code = SjekkTilstrekkeligOpptjeningInklAntatt.LEGG_PÅ_VENT_ID, result = Resultat.IKKE_VURDERT, description = "Ikke tilstrekkelig opptjening, men kan oppnås hvis inntekt kommer for siste måneder senere."),
         @RuleOutcomeDocumentation(code = SjekkTilstrekkeligOpptjeningInklAntatt.IKKE_TILSTREKKELIG_OPPTJENING_ID, result = Resultat.NEI, description = "Ikke tilstrekkelig opptjening")
 })
 public class SjekkTilstrekkeligOpptjeningInklAntatt extends LeafSpecification<OpptjeningsvilkårMellomregning> {
@@ -36,11 +30,6 @@ public class SjekkTilstrekkeligOpptjeningInklAntatt extends LeafSpecification<Op
     static final String IKKE_TILSTREKKELIG_OPPTJENING_ID = "1035";
     public static final RuleReasonRefImpl IKKE_TILSTREKKELIG_OPPTJENING = new RuleReasonRefImpl(IKKE_TILSTREKKELIG_OPPTJENING_ID,
         "Ikke tilstrekkelig opptjening. Har opptjening: {0}");
-
-    static final String ARBEID = OpptjeningsvilkårForeldrepenger.ARBEID;
-    static final String LEGG_PÅ_VENT_ID = "7006";
-    static final RuleReasonRefImpl LEGG_PÅ_VENT = new RuleReasonRefImpl(LEGG_PÅ_VENT_ID,
-        "Ikke p.t. tilstrekkelig opptjening, men kan oppnå hvis det sjekkes senere. Har opptjening: {0}, frist for innsending: {1}");
 
     public SjekkTilstrekkeligOpptjeningInklAntatt() {
         super(ID);
@@ -60,7 +49,7 @@ public class SjekkTilstrekkeligOpptjeningInklAntatt extends LeafSpecification<Op
 
         //TODO(OJR) burde kanskje lage et egen regelsett for SVP, da det er store forskjeller
         if ((data.getGrunnlag().getSkalGodkjenneBasertPåAntatt())) {
-            // SVP godkjenner basert på antatt opptjening hvis behandling er før frist for inntektsrapportering. Legger ikke på vent
+            // SVP godkjenner basert på antatt opptjening hvis behandling er før frist for inntektsrapportering.
             LocalDate fristForInntektsrapportering = beregnFristForOpptjeningsopplysninger(data);
             boolean skalKreveRapportertInntekt = data.getGrunnlag().getBehandlingsTidspunkt().isAfter(fristForInntektsrapportering);
             OpptjentTidslinje antattOpptjeningTidsserie = data.getAntattTotalOpptjening();
@@ -81,22 +70,6 @@ public class SjekkTilstrekkeligOpptjeningInklAntatt extends LeafSpecification<Op
             }
         }
 
-        if (data.sjekkErInnenforMinstePeriodeGodkjent(antattTotalOpptjening)) {
-            // sjekk at bekreftet periode er minst 4 måneder
-            if (data.sjekkErInnenforMinsteGodkjentePeriodeForVent(bekreftetOpptjeningPeriode)) {
-                if (manglerInntektForSisteMånederIOpptjeningsperiodenINoenArbeidsforhold(data)) {
-                    LocalDate fristForOpptjeningsopplysninger = beregnFristForOpptjeningsopplysninger(data);
-                    if (fristForOpptjeningsopplysninger.isAfter(data.getGrunnlag().getBehandlingsTidspunkt())) {
-                        data.setOpptjeningOpplysningerFrist(fristForOpptjeningsopplysninger);
-
-                        Evaluation evaluation = kanIkkeVurdere(LEGG_PÅ_VENT, bekreftetOpptjeningPeriode, fristForOpptjeningsopplysninger);
-                        loggAntattOpptjeningPeriode(data, evaluation);
-                        return evaluation;
-                    }
-                }
-            }
-        }
-
         data.setTotalOpptjening(data.getBekreftetOpptjening());
 
         Evaluation evaluation = nei(IKKE_TILSTREKKELIG_OPPTJENING, bekreftetOpptjeningPeriode);
@@ -112,46 +85,9 @@ public class SjekkTilstrekkeligOpptjeningInklAntatt extends LeafSpecification<Op
         return frist;
     }
 
-    private boolean manglerInntektForSisteMånederIOpptjeningsperiodenINoenArbeidsforhold(OpptjeningsvilkårMellomregning data) {
-        LocalDate sisteDatoIOpptjening = data.getGrunnlag().getSisteDatoForOpptjening();
-
-        Map<Aktivitet, LocalDateTimeline<Boolean>> åpneArbeidsforhold;
-        åpneArbeidsforhold = data.getAktivitetTidslinjer(true, true)
-            .entrySet().stream()
-            .filter(e -> ARBEID.equals(e.getKey().getAktivitetType()))
-            .filter(e -> e.getValue().getMaxLocalDate().isAfter(sisteDatoIOpptjening))
-            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
-
-        boolean behandlesFørSkjæringstidspunkt = data.getGrunnlag().getBehandlingsTidspunkt().isBefore(data.getGrunnlag().getSisteDatoForOpptjening());
-        int justerMånedForInntektFilter = behandlesFørSkjæringstidspunkt && data.getGrunnlag().getBehandlingsTidspunkt().getDayOfMonth() < INNTEKT_RAPPORTERING_SENEST ? 0 : 1;
-        LocalDate startSiste2måneder = sisteDatoIOpptjening.minus(data.getGrunnlag().getPeriodeAntattGodkjentFørBehandlingstidspunkt())
-            .plusMonths(justerMånedForInntektFilter).withDayOfMonth(1);
-        LocalDateInterval sisteParMåneder = new LocalDateInterval(startSiste2måneder, sisteDatoIOpptjening);
-
-        LocalDateTimeline<Boolean> manglendeOpptjeningPerioder = new LocalDateTimeline<Boolean>(sisteParMåneder, Boolean.TRUE)
-            .disjoint(data.getBekreftetOpptjening().getTidslinje(), StandardCombinators::leftOnly);
-
-        Map<Aktivitet, LocalDateTimeline<Boolean>> mulighetForInntekt = new LinkedHashMap<>();
-        data.getInntektTidslinjer().entrySet()
-            .stream().filter(e -> åpneArbeidsforhold.containsKey(e.getKey().forArbeid()))
-            .forEach(e -> {
-                LocalDateTimeline<Long> inntektSisteTid = e.getValue().intersection(sisteParMåneder);
-                LocalDateTimeline<Boolean> muligInntektRapportering = manglendeOpptjeningPerioder.disjoint(inntektSisteTid, StandardCombinators::leftOnly);
-                if (!muligInntektRapportering.isEmpty()) {
-                    mulighetForInntekt.put(e.getKey(), muligInntektRapportering);
-                }
-            });
-
-            boolean manglerInntektRapportertSisteParMåneder = !mulighetForInntekt.isEmpty();
-            return manglerInntektRapportertSisteParMåneder;
-    }
-
     private void loggAntattOpptjeningPeriode(OpptjeningsvilkårMellomregning data, Evaluation ev) {
         OpptjentTidslinje antattTotalOpptjening = data.getAntattTotalOpptjening();
         ev.setEvaluationProperty(OpptjeningsvilkårForeldrepenger.EVAL_RESULT_ANTATT_AKTIVITET_TIDSLINJE, antattTotalOpptjening.getTidslinje());
         ev.setEvaluationProperty(OpptjeningsvilkårForeldrepenger.EVAL_RESULT_ANTATT_GODKJENT, antattTotalOpptjening.getOpptjentPeriode());
-        if (data.getOpptjeningOpplysningerFrist() != null) {
-            ev.setEvaluationProperty(OpptjeningsvilkårForeldrepenger.EVAL_RESULT_FRIST_FOR_OPPTJENING_OPPLYSNINGER, data.getOpptjeningOpplysningerFrist());
-        }
     }
 }

--- a/domenetjenester/inngangsvilkar/regelmodell/src/main/java/no/nav/foreldrepenger/inngangsvilkaar/regelmodell/opptjening/fp/OpptjeningsvilkårForeldrepenger.java
+++ b/domenetjenester/inngangsvilkar/regelmodell/src/main/java/no/nav/foreldrepenger/inngangsvilkaar/regelmodell/opptjening/fp/OpptjeningsvilkårForeldrepenger.java
@@ -80,9 +80,6 @@ public class OpptjeningsvilkårForeldrepenger implements RuleService<Opptjenings
     public static final String LØNN = "LØNN";
     public static final String UTLAND = "UTENLANDSK_ARBEIDSFORHOLD";
 
-    /** Evaluation property: Frist for innsending av opptjeningopplysninger (eks. Inntekt). */
-    public static final String EVAL_RESULT_FRIST_FOR_OPPTJENING_OPPLYSNINGER = "fristInnsendingOpptjeningopplysninger";
-
     @Override
     public Evaluation evaluer(Opptjeningsgrunnlag grunnlag, Object output) {
         OpptjeningsvilkårMellomregning grunnlagOgMellomregning = new OpptjeningsvilkårMellomregning(grunnlag);

--- a/domenetjenester/inngangsvilkar/regelmodell/src/test/java/no/nav/foreldrepenger/inngangsvilkaar/regelmodell/opptjening/OpptjeningVilkårBeregnetOpptjeningTest.java
+++ b/domenetjenester/inngangsvilkar/regelmodell/src/test/java/no/nav/foreldrepenger/inngangsvilkaar/regelmodell/opptjening/OpptjeningVilkårBeregnetOpptjeningTest.java
@@ -76,7 +76,7 @@ public class OpptjeningVilkårBeregnetOpptjeningTest {
     }
 
     @Test
-    public void skal_få_ikke_vurdert_og_lagt_på_vent_når_bekreftet_opptjening_er_5mnd_og_antatt_opptjening_er_6mnd() throws Exception {
+    public void skal_få_avslag_når_bekreftet_opptjening_er_5mnd_og_antatt_opptjening_er_6mnd() throws Exception {
         int maksMellomliggendeDager = 14;
         int minForegåendeDager = 4*7;
 
@@ -106,7 +106,7 @@ public class OpptjeningVilkårBeregnetOpptjeningTest {
         OpptjeningsvilkårResultat output = new OpptjeningsvilkårResultat();
         Evaluation evaluation = new OpptjeningsvilkårForeldrepenger().evaluer(grunnlag, output);
 
-        Resultat forventet = Resultat.IKKE_VURDERT;
+        Resultat forventet = Resultat.NEI;
         assertForventetResultat(evaluation, forventet);
 
         // Assert
@@ -120,8 +120,7 @@ public class OpptjeningVilkårBeregnetOpptjeningTest {
 
         assertThat(output.getAkseptertMellomliggendePerioder()).containsEntry(aktivitet, new LocalDateTimeline<>(dt2.plusDays(1), dt3.minusDays(1), Boolean.TRUE));
 
-        assertThat(output.getResultatTidslinje()).isNull();
-        assertThat(output.getResultatOpptjent()).isNull();
+        assertThat(output.getResultatTidslinje()).isEqualTo(new LocalDateTimeline<>(dt1, endOfInntekt, Boolean.TRUE));
 
     }
 

--- a/domenetjenester/inngangsvilkar/tjeneste/src/main/java/no/nav/foreldrepenger/inngangsvilkaar/opptjening/svp/OpptjeningsVilkårTjenesteImpl.java
+++ b/domenetjenester/inngangsvilkar/tjeneste/src/main/java/no/nav/foreldrepenger/inngangsvilkaar/opptjening/svp/OpptjeningsVilkårTjenesteImpl.java
@@ -59,8 +59,6 @@ public class OpptjeningsVilkårTjenesteImpl implements OpptjeningsVilkårTjenest
         //TODO(OJR) overstyrer konfig for fp... burde blitt flyttet ut til konfig verdier.. både for FP og for SVP???
         grunnlag.setMinsteAntallDagerGodkjent(28);
         grunnlag.setMinsteAntallMånederGodkjent(0);
-        grunnlag.setMinsteAntallDagerForVent(0);
-        grunnlag.setMinsteAntallMånederForVent(0);
         //TODO(OJR) denne burde kanskje endres til false i en revurdering-kontekts i etterkant?
         grunnlag.setSkalGodkjenneBasertPåAntatt(true);
 

--- a/domenetjenester/inngangsvilkar/tjeneste/src/test/java/no/nav/foreldrepenger/inngangsvilkaar/opptjening/svp/InngangsvilkårOpptjeningTest.java
+++ b/domenetjenester/inngangsvilkar/tjeneste/src/test/java/no/nav/foreldrepenger/inngangsvilkaar/opptjening/svp/InngangsvilkårOpptjeningTest.java
@@ -34,8 +34,6 @@ public class InngangsvilkårOpptjeningTest {
 
         grunnlag.setMinsteAntallDagerGodkjent(28);
         grunnlag.setMinsteAntallMånederGodkjent(0);
-        grunnlag.setMinsteAntallDagerForVent(0);
-        grunnlag.setMinsteAntallMånederForVent(0);
         grunnlag.setSkalGodkjenneBasertPåAntatt(true);
 
         OpptjeningsvilkårResultat output = new OpptjeningsvilkårResultat();
@@ -62,8 +60,6 @@ public class InngangsvilkårOpptjeningTest {
 
         grunnlag.setMinsteAntallDagerGodkjent(28);
         grunnlag.setMinsteAntallMånederGodkjent(0);
-        grunnlag.setMinsteAntallDagerForVent(0);
-        grunnlag.setMinsteAntallMånederForVent(0);
         grunnlag.setSkalGodkjenneBasertPåAntatt(true);
 
         OpptjeningsvilkårResultat output = new OpptjeningsvilkårResultat();
@@ -90,8 +86,6 @@ public class InngangsvilkårOpptjeningTest {
 
         grunnlag.setMinsteAntallDagerGodkjent(28);
         grunnlag.setMinsteAntallMånederGodkjent(0);
-        grunnlag.setMinsteAntallDagerForVent(0);
-        grunnlag.setMinsteAntallMånederForVent(0);
         grunnlag.setSkalGodkjenneBasertPåAntatt(true);
 
         OpptjeningsvilkårResultat output = new OpptjeningsvilkårResultat();
@@ -118,8 +112,6 @@ public class InngangsvilkårOpptjeningTest {
 
         grunnlag.setMinsteAntallDagerGodkjent(28);
         grunnlag.setMinsteAntallMånederGodkjent(0);
-        grunnlag.setMinsteAntallDagerForVent(0);
-        grunnlag.setMinsteAntallMånederForVent(0);
         grunnlag.setSkalGodkjenneBasertPåAntatt(true);
 
         OpptjeningsvilkårResultat output = new OpptjeningsvilkårResultat();
@@ -148,8 +140,6 @@ public class InngangsvilkårOpptjeningTest {
 
         grunnlag.setMinsteAntallDagerGodkjent(28);
         grunnlag.setMinsteAntallMånederGodkjent(0);
-        grunnlag.setMinsteAntallDagerForVent(0);
-        grunnlag.setMinsteAntallMånederForVent(0);
         grunnlag.setSkalGodkjenneBasertPåAntatt(true);
 
         OpptjeningsvilkårResultat output = new OpptjeningsvilkårResultat();

--- a/domenetjenester/vedtak/src/main/java/no/nav/foreldrepenger/domene/vedtak/fp/VilkårsgrunnlagXmlTjenesteImpl.java
+++ b/domenetjenester/vedtak/src/main/java/no/nav/foreldrepenger/domene/vedtak/fp/VilkårsgrunnlagXmlTjenesteImpl.java
@@ -183,7 +183,6 @@ public class VilkårsgrunnlagXmlTjenesteImpl extends VilkårsgrunnlagXmlTjeneste
         if (opptjeningsgrunnlag != null) {
             VedtakXmlUtil.lagDateOpplysning(opptjeningsgrunnlag.getBehandlingsTidspunkt()).ifPresent(vilkårgrunnlag::setBehandlingsDato);
 
-            vilkårgrunnlag.setMinsteAntallDagerForVent(VedtakXmlUtil.lagIntOpplysning(opptjeningsgrunnlag.getMinsteAntallDagerForVent()));
             vilkårgrunnlag.setMinsteAntallDagerGodkjent(VedtakXmlUtil.lagIntOpplysning(opptjeningsgrunnlag.getMinsteAntallDagerGodkjent()));
             vilkårgrunnlag.setMinsteAntallMånederGodkjent(VedtakXmlUtil.lagIntOpplysning(opptjeningsgrunnlag.getMinsteAntallMånederGodkjent()));
             LocalDateInterval opptjeningsperiode = opptjeningsgrunnlag.getOpptjeningPeriode();

--- a/domenetjenester/vedtak/src/main/java/no/nav/foreldrepenger/domene/vedtak/svp/VilkårsgrunnlagXmlTjenesteImpl.java
+++ b/domenetjenester/vedtak/src/main/java/no/nav/foreldrepenger/domene/vedtak/svp/VilkårsgrunnlagXmlTjenesteImpl.java
@@ -158,7 +158,6 @@ public class VilkårsgrunnlagXmlTjenesteImpl extends VilkårsgrunnlagXmlTjeneste
         if (opptjeningsgrunnlag != null) {
             VedtakXmlUtil.lagDateOpplysning(opptjeningsgrunnlag.getBehandlingsTidspunkt()).ifPresent(vilkårgrunnlag::setBehandlingsDato);
 
-            vilkårgrunnlag.setMinsteAntallDagerForVent(VedtakXmlUtil.lagIntOpplysning(opptjeningsgrunnlag.getMinsteAntallDagerForVent()));
             vilkårgrunnlag.setMinsteAntallDagerGodkjent(VedtakXmlUtil.lagIntOpplysning(opptjeningsgrunnlag.getMinsteAntallDagerGodkjent()));
             vilkårgrunnlag.setMinsteAntallMånederGodkjent(VedtakXmlUtil.lagIntOpplysning(opptjeningsgrunnlag.getMinsteAntallMånederGodkjent()));
             LocalDateInterval opptjeningsperiode = opptjeningsgrunnlag.getOpptjeningPeriode();

--- a/pom.xml
+++ b/pom.xml
@@ -576,7 +576,7 @@
             <dependency>
                 <groupId>com.fasterxml.woodstox</groupId>
                 <artifactId>woodstox-core</artifactId>
-                <version>6.2.4</version>
+                <version>6.2.5</version>
             </dependency>
             <dependency>
                 <groupId>com.google.code.findbugs</groupId>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -15,7 +15,7 @@
     <name>FPSAK :: Web - Webapp</name>
     <properties>
         <simpleclient.version>0.10.0</simpleclient.version>
-        <swagger-ui.version>3.45.0</swagger-ui.version>
+        <swagger-ui.version>3.46.0</swagger-ui.version>
         <resteasy.version>4.6.0.Final</resteasy.version>
     </properties>
     <dependencies>


### PR DESCRIPTION
Avslag / opptjening håndteres ved å opprette 5089 så det ikke blir automatisk avslag uten vurdering
Ikke lenger behov for denne ventelogikken