### PR TITLE
TFP-4219 redusere bruk av avklart førsteuttakdato og riktig G-dato

### DIFF
--- a/behandlingslager/testutil/pom.xml
+++ b/behandlingslager/testutil/pom.xml
@@ -17,7 +17,7 @@
             <dependency>
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-core</artifactId>
-                <version>3.8.0</version>
+                <version>3.9.0</version>
                 <scope>compile</scope>
             </dependency>
         </dependencies>

--- a/behandlingsprosess/src/main/java/no/nav/foreldrepenger/behandling/steg/avklarfakta/fp/KontrollerFaktaRevurderingStegImpl.java
+++ b/behandlingsprosess/src/main/java/no/nav/foreldrepenger/behandling/steg/avklarfakta/fp/KontrollerFaktaRevurderingStegImpl.java
@@ -218,7 +218,7 @@ class KontrollerFaktaRevurderingStegImpl implements KontrollerFaktaSteg {
             return finnStartpunktForGRegulering(revurdering);
         }
 
-        var grunnbeløp = beregningsgrunnlagKopierOgLagreTjeneste.finnEksaktSats(BeregningSatsType.GRUNNBELØP, ref.getFørsteUttaksdato());
+        var grunnbeløp = beregningsgrunnlagKopierOgLagreTjeneste.finnEksaktSats(BeregningSatsType.GRUNNBELØP, ref.getSkjæringstidspunkt().getGrunnbeløpdato());
         long satsIBeregning = forrigeBeregning.map(BeregningsgrunnlagEntitet::getGrunnbeløp).map(Beløp::getVerdi).map(BigDecimal::longValue)
                 .orElse(0L);
 

--- a/behandlingsprosess/src/main/java/no/nav/foreldrepenger/behandling/steg/avklarfakta/fp/KontrollerFaktaRevurderingStegImpl.java
+++ b/behandlingsprosess/src/main/java/no/nav/foreldrepenger/behandling/steg/avklarfakta/fp/KontrollerFaktaRevurderingStegImpl.java
@@ -218,7 +218,7 @@ class KontrollerFaktaRevurderingStegImpl implements KontrollerFaktaSteg {
             return finnStartpunktForGRegulering(revurdering);
         }
 
-        var grunnbeløp = beregningsgrunnlagKopierOgLagreTjeneste.finnEksaktSats(BeregningSatsType.GRUNNBELØP, ref.getSkjæringstidspunkt().getGrunnbeløpdato());
+        var grunnbeløp = beregningsgrunnlagKopierOgLagreTjeneste.finnEksaktSats(BeregningSatsType.GRUNNBELØP, ref.getSkjæringstidspunkt().getFørsteUttaksdatoGrunnbeløp());
         long satsIBeregning = forrigeBeregning.map(BeregningsgrunnlagEntitet::getGrunnbeløp).map(Beløp::getVerdi).map(BigDecimal::longValue)
                 .orElse(0L);
 

--- a/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/beregningsgrunnlag/ForeslåBeregningsgrunnlagStegTest.java
+++ b/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/beregningsgrunnlag/ForeslåBeregningsgrunnlagStegTest.java
@@ -69,6 +69,7 @@ public class ForeslåBeregningsgrunnlagStegTest {
         behandling = scenario.lagMocked();
         var stp = Skjæringstidspunkt.builder()
                 .medFørsteUttaksdato(LocalDate.now())
+                .medFørsteUttaksdatoGrunnbeløp(LocalDate.now())
                 .medSkjæringstidspunktOpptjening(LocalDate.now());
         var ref = BehandlingReferanse.fra(behandling, stp.build());
         var foreldrepengerGrunnlag = new ForeldrepengerGrunnlag(100, false, AktivitetGradering.INGEN_GRADERING);

--- a/domenetjenester/behandling/src/main/java/no/nav/foreldrepenger/behandling/BehandlingReferanse.java
+++ b/domenetjenester/behandling/src/main/java/no/nav/foreldrepenger/behandling/BehandlingReferanse.java
@@ -179,24 +179,6 @@ public class BehandlingReferanse {
         return skjæringstidspunkt;
     }
 
-    public LocalDate getSkjæringstidspunktBeregning() {
-        // precondition
-        sjekkSkjæringstidspunkt();
-        return skjæringstidspunkt.getSkjæringstidspunktBeregning();
-    }
-
-    public LocalDate getSkjæringstidspunktOpptjening() {
-        // precondition
-        sjekkSkjæringstidspunkt();
-        return skjæringstidspunkt.getSkjæringstidspunktOpptjening();
-    }
-
-    public LocalDate getFørsteUttaksdato() {
-        // precondition
-        sjekkSkjæringstidspunkt();
-        return skjæringstidspunkt.getFørsteUttaksdato();
-    }
-
     public RelasjonsRolleType getRelasjonsRolleType() {
         return relasjonRolle;
     }

--- a/domenetjenester/behandling/src/main/java/no/nav/foreldrepenger/behandling/Skjæringstidspunkt.java
+++ b/domenetjenester/behandling/src/main/java/no/nav/foreldrepenger/behandling/Skjæringstidspunkt.java
@@ -14,7 +14,8 @@ public class Skjæringstidspunkt {
     private LocalDate skjæringstidspunktOpptjening;
     private LocalDate skjæringstidspunktBeregning;
     private LocalDate førsteUttaksdato;
-    private LocalDate grunnbeløpdato;
+    private LocalDate førsteUttaksdatoGrunnbeløp;
+    private LocalDate førsteUttaksdatoFødseljustert;
     private LocalDateInterval utledetMedlemsintervall;
 
     private Skjæringstidspunkt() {
@@ -26,7 +27,8 @@ public class Skjæringstidspunkt {
         this.skjæringstidspunktOpptjening = other.skjæringstidspunktOpptjening;
         this.skjæringstidspunktBeregning = other.skjæringstidspunktBeregning;
         this.førsteUttaksdato = other.førsteUttaksdato;
-        this.grunnbeløpdato = other.grunnbeløpdato;
+        this.førsteUttaksdatoGrunnbeløp = other.førsteUttaksdatoGrunnbeløp;
+        this.førsteUttaksdatoFødseljustert = other.førsteUttaksdatoFødseljustert;
     }
 
     public Optional<LocalDate> getSkjæringstidspunktHvisUtledet() {
@@ -71,16 +73,22 @@ public class Skjæringstidspunkt {
         return skjæringstidspunktBeregning;
     }
 
-    /** Første uttaksdato er første dag stønadsperioden løper - dvs min(innvilget eller avslag søknadsfrist). */
+    /** Første uttaksdato er første dag stønadsperioden løper - dvs min(innvilget eller avslag søknadsfrist). Uten hensyn til tidlig fødsel */
     public LocalDate getFørsteUttaksdato() {
         Objects.requireNonNull(førsteUttaksdato, "Utvikler-feil: førsteUttaksdato er ikke satt. Sørg for at det er satt ifht. anvendelse");
         return førsteUttaksdato;
     }
 
     /** Grunnbeløpdato er første dag med innvilget uttak/utsettelse/overføring. */
-    public LocalDate getGrunnbeløpdato() {
-        Objects.requireNonNull(førsteUttaksdato, "Utvikler-feil: førsteUttaksdato er ikke satt. Sørg for at det er satt ifht. anvendelse");
-        return førsteUttaksdato;
+    public LocalDate getFørsteUttaksdatoGrunnbeløp() {
+        Objects.requireNonNull(førsteUttaksdatoGrunnbeløp, "Utvikler-feil: grunnbeløpdato er ikke satt. Sørg for at det er satt ifht. anvendelse");
+        return førsteUttaksdatoGrunnbeløp;
+    }
+
+    /** Første uttaksdato er første dag stønadsperioden løper - før evaluering av opptjeningsperiode. */
+    public LocalDate getFørsteUttaksdatoFødseljustert() {
+        Objects.requireNonNull(førsteUttaksdatoFødseljustert, "Utvikler-feil: grunnbeløpdato er ikke satt. Sørg for at det er satt ifht. anvendelse");
+        return førsteUttaksdatoFødseljustert;
     }
 
     @Override
@@ -152,8 +160,13 @@ public class Skjæringstidspunkt {
             return this;
         }
 
-        public Builder medGrunnbeløpdato(LocalDate dato) {
-            kladd.grunnbeløpdato = dato;
+        public Builder medFørsteUttaksdatoGrunnbeløp(LocalDate dato) {
+            kladd.førsteUttaksdatoGrunnbeløp = dato;
+            return this;
+        }
+
+        public Builder medFørsteUttaksdatoFødseljustert(LocalDate dato) {
+            kladd.førsteUttaksdatoFødseljustert = dato;
             return this;
         }
 

--- a/domenetjenester/behandling/src/main/java/no/nav/foreldrepenger/behandling/Skjæringstidspunkt.java
+++ b/domenetjenester/behandling/src/main/java/no/nav/foreldrepenger/behandling/Skjæringstidspunkt.java
@@ -14,6 +14,7 @@ public class Skjæringstidspunkt {
     private LocalDate skjæringstidspunktOpptjening;
     private LocalDate skjæringstidspunktBeregning;
     private LocalDate førsteUttaksdato;
+    private LocalDate grunnbeløpdato;
     private LocalDateInterval utledetMedlemsintervall;
 
     private Skjæringstidspunkt() {
@@ -25,6 +26,7 @@ public class Skjæringstidspunkt {
         this.skjæringstidspunktOpptjening = other.skjæringstidspunktOpptjening;
         this.skjæringstidspunktBeregning = other.skjæringstidspunktBeregning;
         this.førsteUttaksdato = other.førsteUttaksdato;
+        this.grunnbeløpdato = other.grunnbeløpdato;
     }
 
     public Optional<LocalDate> getSkjæringstidspunktHvisUtledet() {
@@ -38,10 +40,6 @@ public class Skjæringstidspunkt {
     public LocalDate getUtledetSkjæringstidspunkt() {
         Objects.requireNonNull(utledetSkjæringstidspunkt,
                 "Utvikler-feil: utledetSkjæringstidspunkt er ikke satt. Sørg for at det er satt ifht. anvendelse");
-        return utledetSkjæringstidspunkt;
-    }
-
-    public LocalDate getUtledetSkjæringstidspunktForKopieringTilKalkulus() {
         return utledetSkjæringstidspunkt;
     }
 
@@ -73,8 +71,14 @@ public class Skjæringstidspunkt {
         return skjæringstidspunktBeregning;
     }
 
-    /** Første uttaksdato er første dag bruker får utbetalt ytelse. */
+    /** Første uttaksdato er første dag stønadsperioden løper - dvs min(innvilget eller avslag søknadsfrist). */
     public LocalDate getFørsteUttaksdato() {
+        Objects.requireNonNull(førsteUttaksdato, "Utvikler-feil: førsteUttaksdato er ikke satt. Sørg for at det er satt ifht. anvendelse");
+        return førsteUttaksdato;
+    }
+
+    /** Grunnbeløpdato er første dag med innvilget uttak/utsettelse/overføring. */
+    public LocalDate getGrunnbeløpdato() {
         Objects.requireNonNull(førsteUttaksdato, "Utvikler-feil: førsteUttaksdato er ikke satt. Sørg for at det er satt ifht. anvendelse");
         return førsteUttaksdato;
     }
@@ -145,6 +149,11 @@ public class Skjæringstidspunkt {
 
         public Builder medFørsteUttaksdato(LocalDate dato) {
             kladd.førsteUttaksdato = dato;
+            return this;
+        }
+
+        public Builder medGrunnbeløpdato(LocalDate dato) {
+            kladd.grunnbeløpdato = dato;
             return this;
         }
 

--- a/domenetjenester/behandling/src/main/java/no/nav/foreldrepenger/behandling/Skjæringstidspunkt.java
+++ b/domenetjenester/behandling/src/main/java/no/nav/foreldrepenger/behandling/Skjæringstidspunkt.java
@@ -87,7 +87,7 @@ public class Skjæringstidspunkt {
 
     /** Første uttaksdato er første dag stønadsperioden løper - før evaluering av opptjeningsperiode. */
     public LocalDate getFørsteUttaksdatoFødseljustert() {
-        Objects.requireNonNull(førsteUttaksdatoFødseljustert, "Utvikler-feil: grunnbeløpdato er ikke satt. Sørg for at det er satt ifht. anvendelse");
+        Objects.requireNonNull(førsteUttaksdatoFødseljustert, "Utvikler-feil: fødselsjustert uttaksdato er ikke satt. Sørg for at det er satt ifht. anvendelse");
         return førsteUttaksdatoFødseljustert;
     }
 

--- a/domenetjenester/beregningsgrunnlag/src/main/java/no/nav/foreldrepenger/domene/fp/SykemeldingVentTjeneste.java
+++ b/domenetjenester/beregningsgrunnlag/src/main/java/no/nav/foreldrepenger/domene/fp/SykemeldingVentTjeneste.java
@@ -35,6 +35,6 @@ public class SykemeldingVentTjeneste {
 
         var iayGrunnlag = inntektArbeidYtelseTjeneste.hentGrunnlag(referanse.getBehandlingUuid());
         var filter = new YtelseFilter(iayGrunnlag.getAktørYtelseFraRegister(referanse.getAktørId()));
-        return VentPåSykemelding.utledVenteFrist(filter, referanse.getSkjæringstidspunktOpptjening(), LocalDate.now());
+        return VentPåSykemelding.utledVenteFrist(filter, referanse.getSkjæringstidspunkt().getSkjæringstidspunktOpptjening(), LocalDate.now());
     }
 }

--- a/domenetjenester/beregningsgrunnlag/src/main/java/no/nav/foreldrepenger/domene/mappers/til_kalkulus/MapBehandlingRef.java
+++ b/domenetjenester/beregningsgrunnlag/src/main/java/no/nav/foreldrepenger/domene/mappers/til_kalkulus/MapBehandlingRef.java
@@ -21,7 +21,7 @@ public class MapBehandlingRef {
         return Skjæringstidspunkt.builder()
             .medSkjæringstidspunktOpptjening(skjæringstidspunkt.getSkjæringstidspunktOpptjening())
             .medSkjæringstidspunktBeregning(skjæringstidspunkt.getSkjæringstidspunktBeregningForKopieringTilKalkulus())
-            .medFørsteUttaksdato(skjæringstidspunkt.getGrunnbeløpdato())
+            .medFørsteUttaksdato(skjæringstidspunkt.getFørsteUttaksdatoGrunnbeløp())
             .build();
     }
 }

--- a/domenetjenester/beregningsgrunnlag/src/main/java/no/nav/foreldrepenger/domene/mappers/til_kalkulus/MapBehandlingRef.java
+++ b/domenetjenester/beregningsgrunnlag/src/main/java/no/nav/foreldrepenger/domene/mappers/til_kalkulus/MapBehandlingRef.java
@@ -2,8 +2,8 @@ package no.nav.foreldrepenger.domene.mappers.til_kalkulus;
 
 import no.nav.folketrygdloven.kalkulator.modell.behandling.KoblingReferanse;
 import no.nav.folketrygdloven.kalkulator.modell.behandling.Skjæringstidspunkt;
-import no.nav.folketrygdloven.kalkulus.typer.AktørId;
 import no.nav.folketrygdloven.kalkulus.kodeverk.FagsakYtelseType;
+import no.nav.folketrygdloven.kalkulus.typer.AktørId;
 
 //TODO(OJR) skal fjernes
 public class MapBehandlingRef {
@@ -21,7 +21,7 @@ public class MapBehandlingRef {
         return Skjæringstidspunkt.builder()
             .medSkjæringstidspunktOpptjening(skjæringstidspunkt.getSkjæringstidspunktOpptjening())
             .medSkjæringstidspunktBeregning(skjæringstidspunkt.getSkjæringstidspunktBeregningForKopieringTilKalkulus())
-            .medFørsteUttaksdato(skjæringstidspunkt.getFørsteUttaksdato())
+            .medFørsteUttaksdato(skjæringstidspunkt.getGrunnbeløpdato())
             .build();
     }
 }

--- a/domenetjenester/beregningsgrunnlag/src/test/java/no/nav/foreldrepenger/domene/prosess/BeregningsgrunnlagKopierOgLagreTjenesteFastsettAktiviteterTest.java
+++ b/domenetjenester/beregningsgrunnlag/src/test/java/no/nav/foreldrepenger/domene/prosess/BeregningsgrunnlagKopierOgLagreTjenesteFastsettAktiviteterTest.java
@@ -322,6 +322,7 @@ public class BeregningsgrunnlagKopierOgLagreTjenesteFastsettAktiviteterTest {
         return BehandlingReferanse.fra(behandling)
             .medSkjæringstidspunkt(Skjæringstidspunkt.builder()
                 .medFørsteUttaksdato(SKJÆRINGSTIDSPUNKT)
+                .medFørsteUttaksdatoGrunnbeløp(SKJÆRINGSTIDSPUNKT)
                 .medSkjæringstidspunktOpptjening(SKJÆRINGSTIDSPUNKT)
                 .medSkjæringstidspunktBeregning(SKJÆRINGSTIDSPUNKT)
                 .medUtledetSkjæringstidspunkt(SKJÆRINGSTIDSPUNKT)

--- a/domenetjenester/beregningsgrunnlag/src/test/java/no/nav/foreldrepenger/domene/prosess/BeregningsgrunnlagKopierOgLagreTjenesteKontrollerFaktaTest.java
+++ b/domenetjenester/beregningsgrunnlag/src/test/java/no/nav/foreldrepenger/domene/prosess/BeregningsgrunnlagKopierOgLagreTjenesteKontrollerFaktaTest.java
@@ -194,6 +194,7 @@ public class BeregningsgrunnlagKopierOgLagreTjenesteKontrollerFaktaTest {
         return BehandlingReferanse.fra(behandling)
             .medSkjæringstidspunkt(Skjæringstidspunkt.builder()
                 .medFørsteUttaksdato(SKJÆRINGSTIDSPUNKT)
+                .medFørsteUttaksdatoGrunnbeløp(SKJÆRINGSTIDSPUNKT)
                 .medSkjæringstidspunktOpptjening(SKJÆRINGSTIDSPUNKT)
                 .medSkjæringstidspunktBeregning(SKJÆRINGSTIDSPUNKT)
                 .medUtledetSkjæringstidspunkt(SKJÆRINGSTIDSPUNKT)

--- a/domenetjenester/beregningsgrunnlag/src/test/java/no/nav/foreldrepenger/domene/prosess/FastsettBeregningAktiviteterOgStatuserTest.java
+++ b/domenetjenester/beregningsgrunnlag/src/test/java/no/nav/foreldrepenger/domene/prosess/FastsettBeregningAktiviteterOgStatuserTest.java
@@ -137,6 +137,7 @@ public class FastsettBeregningAktiviteterOgStatuserTest {
                 .medSkjæringstidspunkt(Skjæringstidspunkt.builder()
                         .medUtledetSkjæringstidspunkt(SKJÆRINGSTIDSPUNKT_OPPTJENING)
                         .medFørsteUttaksdato(FØRSTE_UTTAKSDAG)
+                        .medFørsteUttaksdatoGrunnbeløp(FØRSTE_UTTAKSDAG)
                         .medSkjæringstidspunktOpptjening(SKJÆRINGSTIDSPUNKT_OPPTJENING)
                         .build());
     }

--- a/domenetjenester/inngangsvilkar/tjeneste/src/main/java/no/nav/foreldrepenger/inngangsvilkaar/opptjening/fp/InngangsvilkårOpptjeningsperiode.java
+++ b/domenetjenester/inngangsvilkar/tjeneste/src/main/java/no/nav/foreldrepenger/inngangsvilkaar/opptjening/fp/InngangsvilkårOpptjeningsperiode.java
@@ -29,6 +29,6 @@ public class InngangsvilkårOpptjeningsperiode implements Inngangsvilkår {
 
     @Override
     public VilkårData vurderVilkår(BehandlingReferanse ref) {
-        return opptjeningsperiodeVilkårTjeneste.vurderOpptjeningsperiodeVilkår(ref, ref.getFørsteUttaksdato());
+        return opptjeningsperiodeVilkårTjeneste.vurderOpptjeningsperiodeVilkår(ref, ref.getSkjæringstidspunkt().getFørsteUttaksdato());
     }
 }

--- a/domenetjenester/inngangsvilkar/tjeneste/src/main/java/no/nav/foreldrepenger/inngangsvilkaar/opptjening/svp/InngangsvilkårOpptjeningsperiode.java
+++ b/domenetjenester/inngangsvilkar/tjeneste/src/main/java/no/nav/foreldrepenger/inngangsvilkaar/opptjening/svp/InngangsvilkårOpptjeningsperiode.java
@@ -29,6 +29,6 @@ public class InngangsvilkårOpptjeningsperiode implements Inngangsvilkår {
 
     @Override
     public VilkårData vurderVilkår(BehandlingReferanse ref) {
-        return opptjeningsperiodeVilkårTjeneste.vurderOpptjeningsperiodeVilkår(ref, ref.getFørsteUttaksdato());
+        return opptjeningsperiodeVilkårTjeneste.vurderOpptjeningsperiodeVilkår(ref, ref.getSkjæringstidspunkt().getFørsteUttaksdato());
     }
 }

--- a/domenetjenester/medlem/src/main/java/no/nav/foreldrepenger/domene/medlem/kontrollerfakta/AksjonspunktutlederForAvklarStartdatoForForeldrepengeperioden.java
+++ b/domenetjenester/medlem/src/main/java/no/nav/foreldrepenger/domene/medlem/kontrollerfakta/AksjonspunktutlederForAvklarStartdatoForForeldrepengeperioden.java
@@ -65,7 +65,7 @@ public class AksjonspunktutlederForAvklarStartdatoForForeldrepengeperioden imple
             return INGEN_AKSJONSPUNKTER;
         }
 
-        var skjæringstidspunkt = param.getSkjæringstidspunkt().getFørsteUttaksdato();
+        var skjæringstidspunkt = param.getSkjæringstidspunkt().getFørsteUttaksdatoFødseljustert();
 
         var filter = new YrkesaktivitetFilter(inntektArbeidYtelseGrunnlag.getArbeidsforholdInformasjon(), inntektArbeidYtelseGrunnlag.getAktørArbeidFraRegister(param.getAktørId()))
             .før(skjæringstidspunkt);

--- a/domenetjenester/medlem/src/test/java/no/nav/foreldrepenger/domene/medlem/kontrollerfakta/AksjonspunktutlederForAvklarStartdatoForForeldrepengeperiodenTest.java
+++ b/domenetjenester/medlem/src/test/java/no/nav/foreldrepenger/domene/medlem/kontrollerfakta/AksjonspunktutlederForAvklarStartdatoForForeldrepengeperiodenTest.java
@@ -62,7 +62,7 @@ public class AksjonspunktutlederForAvklarStartdatoForForeldrepengeperiodenTest e
     }
 
     private Skjæringstidspunkt lagSkjæringstidspunkt(LocalDate dato) {
-        return Skjæringstidspunkt.builder().medUtledetSkjæringstidspunkt(dato).medFørsteUttaksdato(dato).build();
+        return Skjæringstidspunkt.builder().medUtledetSkjæringstidspunkt(dato).medFørsteUttaksdato(dato).medFørsteUttaksdatoFødseljustert(dato).build();
     }
 
     @Test

--- a/domenetjenester/registerinnhenting/src/main/java/no/nav/foreldrepenger/domene/registerinnhenting/impl/startpunkt/StartpunktUtlederInntektsmelding.java
+++ b/domenetjenester/registerinnhenting/src/main/java/no/nav/foreldrepenger/domene/registerinnhenting/impl/startpunkt/StartpunktUtlederInntektsmelding.java
@@ -152,7 +152,7 @@ class StartpunktUtlederInntektsmelding {
 
     private boolean erStartdatoUlikFørsteUttaksdato(BehandlingReferanse ref, Inntektsmelding nyIm) {
         // Samme logikk som 5045 AksjonspunktutlederForAvklarStartdatoForForeldrepengeperioden
-        var førsteUttaksDato = endreDatoHvisLørdagEllerSøndag(ref.getFørsteUttaksdato());
+        var førsteUttaksDato = endreDatoHvisLørdagEllerSøndag(ref.getSkjæringstidspunkt().getFørsteUttaksdato());
         var startDatoIm = endreDatoHvisLørdagEllerSøndag(nyIm.getStartDatoPermisjon().orElse(Tid.TIDENES_BEGYNNELSE));
         return !førsteUttaksDato.equals(startDatoIm);
     }

--- a/domenetjenester/skjaeringstidspunkt/src/main/java/no/nav/foreldrepenger/skjæringstidspunkt/fp/SkjæringstidspunktTjenesteImpl.java
+++ b/domenetjenester/skjaeringstidspunkt/src/main/java/no/nav/foreldrepenger/skjæringstidspunkt/fp/SkjæringstidspunktTjenesteImpl.java
@@ -16,9 +16,12 @@ import no.nav.foreldrepenger.behandling.YtelseMaksdatoTjeneste;
 import no.nav.foreldrepenger.behandlingskontroll.FagsakYtelseTypeRef;
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingType;
+import no.nav.foreldrepenger.behandlingslager.behandling.familiehendelse.FamilieHendelseEntitet;
+import no.nav.foreldrepenger.behandlingslager.behandling.familiehendelse.FamilieHendelseGrunnlagEntitet;
 import no.nav.foreldrepenger.behandlingslager.behandling.familiehendelse.FamilieHendelseRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.opptjening.Opptjening;
 import no.nav.foreldrepenger.behandlingslager.behandling.opptjening.OpptjeningRepository;
+import no.nav.foreldrepenger.behandlingslager.behandling.personopplysning.RelasjonsRolleType;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepositoryProvider;
 import no.nav.foreldrepenger.behandlingslager.behandling.søknad.SøknadRepository;
@@ -32,6 +35,7 @@ import no.nav.foreldrepenger.behandlingslager.uttak.fp.FpUttakRepository;
 import no.nav.foreldrepenger.behandlingslager.uttak.fp.UttakResultatEntitet;
 import no.nav.foreldrepenger.behandlingslager.uttak.fp.UttakResultatPeriodeEntitet;
 import no.nav.foreldrepenger.behandlingslager.uttak.fp.UttakResultatPerioderEntitet;
+import no.nav.foreldrepenger.domene.tid.VirkedagUtil;
 import no.nav.foreldrepenger.skjæringstidspunkt.SkjæringstidspunktRegisterinnhentingTjeneste;
 import no.nav.foreldrepenger.skjæringstidspunkt.SkjæringstidspunktTjeneste;
 import no.nav.fpsak.tidsserie.LocalDateInterval;
@@ -80,10 +84,12 @@ public class SkjæringstidspunktTjenesteImpl implements SkjæringstidspunktTjene
     public Skjæringstidspunkt getSkjæringstidspunkter(Long behandlingId) {
         var behandling = behandlingRepository.hentBehandling(behandlingId);
 
-        var builder = Skjæringstidspunkt.builder();
+        var førsteUttaksdato = førsteDatoHensyntattTidligFødsel(behandling, førsteUttaksdag(behandling));
+        var førsteInnvilgetUttaksdato = førsteDatoHensyntattTidligFødsel(behandling, førsteInnvilgetUttaksdag(behandling));
 
-        var førsteUttaksdato = førsteUttaksdag(behandling);
-        builder.medFørsteUttaksdato(førsteUttaksdato);
+        var builder = Skjæringstidspunkt.builder()
+            .medFørsteUttaksdato(førsteUttaksdato)
+            .medGrunnbeløpdato(førsteInnvilgetUttaksdato);
 
         var opptjening = opptjeningRepository.finnOpptjening(behandlingId);
         if (opptjening.map(Opptjening::erOpptjeningPeriodeVilkårOppfylt).orElse(Boolean.FALSE)) {
@@ -109,20 +115,29 @@ public class SkjæringstidspunktTjenesteImpl implements SkjæringstidspunktTjene
         final var avklartStartDato = ytelseFordelingAggregat.flatMap(YtelseFordelingAggregat::getAvklarteDatoer)
             .map(AvklarteUttakDatoerEntitet::getFørsteUttaksdato);
 
-        return avklartStartDato.orElseGet(() -> førsteØnskedeUttaksdag(behandling, ytelseFordelingAggregat));
+        return avklartStartDato.orElseGet(() -> førsteØnskedeUttaksdag(behandling, ytelseFordelingAggregat, true));
+    }
+
+    private LocalDate førsteInnvilgetUttaksdag(Behandling behandling) {
+        final var ytelseFordelingAggregat = hentYtelseFordelingAggregatFor(behandling);
+
+        final var avklartStartDato = ytelseFordelingAggregat.flatMap(YtelseFordelingAggregat::getAvklarteDatoer)
+            .map(AvklarteUttakDatoerEntitet::getFørsteUttaksdato);
+
+        return avklartStartDato.orElseGet(() -> førsteØnskedeUttaksdag(behandling, ytelseFordelingAggregat, false));
     }
 
     private Optional<YtelseFordelingAggregat> hentYtelseFordelingAggregatFor(Behandling behandling) {
         return ytelsesFordelingRepository.hentAggregatHvisEksisterer(behandling.getId());
     }
 
-    private LocalDate førsteØnskedeUttaksdag(Behandling behandling, Optional<YtelseFordelingAggregat> ytelseFordelingAggregat) {
+    private LocalDate førsteØnskedeUttaksdag(Behandling behandling, Optional<YtelseFordelingAggregat> ytelseFordelingAggregat, boolean medAvslåttSøknadsfrist) {
         var oppgittFordeling = ytelseFordelingAggregat.map(YtelseFordelingAggregat::getOppgittFordeling);
 
         final var førsteØnskedeUttaksdagIBehandling = finnFørsteØnskedeUttaksdagFor(oppgittFordeling);
 
         if (behandling.erRevurdering()) {
-            final var førsteUttaksdagIForrigeVedtak = finnFørsteDatoIUttakResultat(behandling);
+            final var førsteUttaksdagIForrigeVedtak = finnFørsteDatoIUttakResultat(behandling, medAvslåttSøknadsfrist);
             if (førsteUttaksdagIForrigeVedtak.isEmpty() && førsteØnskedeUttaksdagIBehandling.isEmpty()) {
                 var ytelseFordelingForOriginalBehandling = hentYtelseFordelingAggregatFor(originalBehandling(behandling));
                 return finnFørsteØnskedeUttaksdagFor(ytelseFordelingForOriginalBehandling.map(YtelseFordelingAggregat::getOppgittFordeling))
@@ -203,7 +218,7 @@ public class SkjæringstidspunktTjenesteImpl implements SkjæringstidspunktTjene
         return behandlingRepository.hentBehandling(originalBehandlingId);
     }
 
-    private Optional<LocalDate> finnFørsteDatoIUttakResultat(Behandling behandling) {
+    private Optional<LocalDate> finnFørsteDatoIUttakResultat(Behandling behandling, boolean medAvslåttSøknadsfrist) {
         var uttakResultatPerioder = fpUttakRepository.hentUttakResultatHvisEksisterer(originalBehandling(behandling).getId())
             .map(UttakResultatEntitet::getGjeldendePerioder)
             .map(UttakResultatPerioderEntitet::getPerioder)
@@ -216,7 +231,7 @@ public class SkjæringstidspunktTjenesteImpl implements SkjæringstidspunktTjene
         }
         return uttakResultatPerioder
             .stream()
-            .filter(it -> it.isInnvilget() || SØKNADSFRIST.equals(it.getResultatÅrsak()))
+            .filter(it -> it.isInnvilget() || (medAvslåttSøknadsfrist && SØKNADSFRIST.equals(it.getResultatÅrsak())))
             .map(UttakResultatPeriodeEntitet::getFom)
             .min(Comparator.naturalOrder());
     }
@@ -235,5 +250,19 @@ public class SkjæringstidspunktTjenesteImpl implements SkjæringstidspunktTjene
     private boolean erAllePerioderAvslåttOgIngenAvslagPgaSøknadsfrist(List<UttakResultatPeriodeEntitet> uttakResultatPerioder) {
         return uttakResultatPerioder.stream().allMatch(ut -> PeriodeResultatType.AVSLÅTT.equals(ut.getResultatType())
             && !SØKNADSFRIST.equals(ut.getResultatÅrsak()));
+    }
+
+    private LocalDate førsteDatoHensyntattTidligFødsel(Behandling behandling, LocalDate førsteUttaksdato) {
+        // FAR/MEDMOR skal ikke vurderes
+        if (RelasjonsRolleType.MORA.equals(behandling.getFagsak().getRelasjonsRolleType())) {
+            // Uttak begynner virkedag på/etter fødsel dersom fødsel inntreffer før søkt uttak.
+            var registrertFødselsDato = familieGrunnlagRepository.hentAggregatHvisEksisterer(behandling.getId())
+                .flatMap(FamilieHendelseGrunnlagEntitet::getGjeldendeBekreftetVersjon)
+                .flatMap(FamilieHendelseEntitet::getFødselsdato)
+                .map(VirkedagUtil::fomVirkedag);
+            return registrertFødselsDato.filter(førsteUttaksdato::isAfter).orElse(førsteUttaksdato);
+        } else {
+            return førsteUttaksdato;
+        }
     }
 }

--- a/domenetjenester/skjaeringstidspunkt/src/main/java/no/nav/foreldrepenger/skjæringstidspunkt/fp/SkjæringstidspunktTjenesteImpl.java
+++ b/domenetjenester/skjaeringstidspunkt/src/main/java/no/nav/foreldrepenger/skjæringstidspunkt/fp/SkjæringstidspunktTjenesteImpl.java
@@ -84,12 +84,13 @@ public class SkjæringstidspunktTjenesteImpl implements SkjæringstidspunktTjene
     public Skjæringstidspunkt getSkjæringstidspunkter(Long behandlingId) {
         var behandling = behandlingRepository.hentBehandling(behandlingId);
 
-        var førsteUttaksdato = førsteDatoHensyntattTidligFødsel(behandling, førsteUttaksdag(behandling));
+        var førsteUttaksdato = førsteUttaksdag(behandling);
         var førsteInnvilgetUttaksdato = førsteDatoHensyntattTidligFødsel(behandling, førsteInnvilgetUttaksdag(behandling));
 
         var builder = Skjæringstidspunkt.builder()
             .medFørsteUttaksdato(førsteUttaksdato)
-            .medGrunnbeløpdato(førsteInnvilgetUttaksdato);
+            .medFørsteUttaksdatoFødseljustert(førsteDatoHensyntattTidligFødsel(behandling, førsteUttaksdato))
+            .medFørsteUttaksdatoGrunnbeløp(førsteInnvilgetUttaksdato);
 
         var opptjening = opptjeningRepository.finnOpptjening(behandlingId);
         if (opptjening.map(Opptjening::erOpptjeningPeriodeVilkårOppfylt).orElse(Boolean.FALSE)) {

--- a/domenetjenester/skjaeringstidspunkt/src/main/java/no/nav/foreldrepenger/skjæringstidspunkt/svp/SkjæringstidspunktTjenesteImpl.java
+++ b/domenetjenester/skjaeringstidspunkt/src/main/java/no/nav/foreldrepenger/skjæringstidspunkt/svp/SkjæringstidspunktTjenesteImpl.java
@@ -57,7 +57,7 @@ public class SkjæringstidspunktTjenesteImpl implements SkjæringstidspunktTjene
         var skjæringstidspunkt = utledSkjæringstidspunkt(behandlingId);
         return Skjæringstidspunkt.builder()
             .medFørsteUttaksdato(skjæringstidspunkt)
-            .medGrunnbeløpdato(skjæringstidspunkt)
+            .medFørsteUttaksdatoGrunnbeløp(skjæringstidspunkt)
             .medUtledetSkjæringstidspunkt(skjæringstidspunkt)
             .medSkjæringstidspunktOpptjening(skjæringstidspunkt)
             .medUtledetMedlemsintervall(utledYtelseintervall(behandlingId, skjæringstidspunkt))

--- a/domenetjenester/skjaeringstidspunkt/src/main/java/no/nav/foreldrepenger/skjæringstidspunkt/svp/SkjæringstidspunktTjenesteImpl.java
+++ b/domenetjenester/skjaeringstidspunkt/src/main/java/no/nav/foreldrepenger/skjæringstidspunkt/svp/SkjæringstidspunktTjenesteImpl.java
@@ -57,6 +57,7 @@ public class SkjæringstidspunktTjenesteImpl implements SkjæringstidspunktTjene
         var skjæringstidspunkt = utledSkjæringstidspunkt(behandlingId);
         return Skjæringstidspunkt.builder()
             .medFørsteUttaksdato(skjæringstidspunkt)
+            .medGrunnbeløpdato(skjæringstidspunkt)
             .medUtledetSkjæringstidspunkt(skjæringstidspunkt)
             .medSkjæringstidspunktOpptjening(skjæringstidspunkt)
             .medUtledetMedlemsintervall(utledYtelseintervall(behandlingId, skjæringstidspunkt))

--- a/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/KopierForeldrepengerUttaktjeneste.java
+++ b/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/KopierForeldrepengerUttaktjeneste.java
@@ -38,7 +38,7 @@ public class KopierForeldrepengerUttaktjeneste {
 
     public void kopierUttaksgrunnlagSøknadsfristResultatFraOriginalBehandling(BehandlingReferanse ref) {
         LOG.info("Kopierer yfgrunnlag fra behandling {}, til behandling {}", ref.getOriginalBehandlingId(), ref.getBehandlingId());
-        ytelsesFordelingRepository.kopierGrunnlagFraEksisterendeBehandling(ref.getOriginalBehandlingId().orElseThrow(), ref.getBehandlingId());
+        ytelsesFordelingRepository.kopierGrunnlagFraEksisterendeBehandlingForOverhoppUttak(ref.getOriginalBehandlingId().orElseThrow(), ref.getBehandlingId());
     }
 
     public void kopierUttaksresultatFraOriginalBehandling(BehandlingReferanse referanse) {

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
         <kalkulus.version>1.2.25</kalkulus.version>
         <abakus-kontrakt.version>1.3.2</abakus-kontrakt.version>
 
-        <swaggercore.version>2.1.7</swaggercore.version>
+        <swaggercore.version>2.1.8</swaggercore.version>
         <flyway.version>4.2.0</flyway.version>
         <!-- Hold samme som i felles -->
         <cxf.version>3.4.2</cxf.version>
@@ -522,12 +522,12 @@
             <dependency>
                 <groupId>org.apache.kafka</groupId>
                 <artifactId>kafka-clients</artifactId>
-                <version>2.7.0</version>
+                <version>2.8.0</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.kafka</groupId>
                 <artifactId>kafka-streams</artifactId>
-                <version>2.7.0</version>
+                <version>2.8.0</version>
             </dependency>
 
             <!-- SoB -->
@@ -576,7 +576,7 @@
             <dependency>
                 <groupId>com.fasterxml.woodstox</groupId>
                 <artifactId>woodstox-core</artifactId>
-                <version>6.2.5</version>
+                <version>6.2.6</version>
             </dependency>
             <dependency>
                 <groupId>com.google.code.findbugs</groupId>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -15,7 +15,7 @@
     <name>FPSAK :: Web - Webapp</name>
     <properties>
         <simpleclient.version>0.10.0</simpleclient.version>
-        <swagger-ui.version>3.46.0</swagger-ui.version>
+        <swagger-ui.version>3.47.1</swagger-ui.version>
         <resteasy.version>4.6.0.Final</resteasy.version>
     </properties>
     <dependencies>

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/medlem/aksjonspunkt/fp/AvklarStartdatoForPeriodenOppdaterer.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/medlem/aksjonspunkt/fp/AvklarStartdatoForPeriodenOppdaterer.java
@@ -50,7 +50,7 @@ public class AvklarStartdatoForPeriodenOppdaterer implements AksjonspunktOppdate
         avbrytOverflødigOverstyrAksjonpunkt(behandling)
             .ifPresent(a -> resultatBuilder.medEkstraAksjonspunktResultat(a.getAksjonspunktDefinisjon(), AksjonspunktStatus.AVBRUTT));
         var skjæringstidspunkt = param.getSkjæringstidspunkt().getUtledetSkjæringstidspunkt();
-        var førsteUttakDato = param.getSkjæringstidspunkt().getFørsteUttaksdato();
+        var førsteUttakDato = param.getSkjæringstidspunkt().getFørsteUttaksdatoFødseljustert();
         var startdatoFraSoknad = dto.getStartdatoFraSoknad();
         if (!startdatoFraSoknad.equals(førsteUttakDato) || harValgtStartdatoSomErSenereEnnDatoFraInntektsmelding(param.getRef(), startdatoFraSoknad, skjæringstidspunkt)) {
 


### PR DESCRIPTION
Tidlig fødsel (før uttak) vil nullstille avklart første uttaksdato
Skjæringstidspunkttjeneste sjekker for tidlig fødsel for mødre.
Skjæringstidspunkttjeneste tilbyr en Grunnbeløpdato til beregning.