### PR TITLE
TFP-4315 unntak for forenklet oppgjør uten aktivitetsavtaler

### DIFF
--- a/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/input/UttakYrkesaktiviteter.java
+++ b/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/input/UttakYrkesaktiviteter.java
@@ -13,6 +13,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import no.nav.foreldrepenger.behandling.Skjæringstidspunkt;
+import no.nav.foreldrepenger.behandlingslager.virksomhet.ArbeidType;
 import no.nav.foreldrepenger.behandlingslager.virksomhet.Arbeidsgiver;
 import no.nav.foreldrepenger.domene.iay.modell.AktivitetsAvtale;
 import no.nav.foreldrepenger.domene.iay.modell.Yrkesaktivitet;
@@ -96,6 +97,10 @@ public class UttakYrkesaktiviteter {
         var sum = BigDecimal.ZERO;
         for (var ya : filter.getAlleYrkesaktiviteter()) {
             var aktivitetsAvtaler = filter.getAktivitetsAvtalerForArbeid(ya);
+            if (ArbeidType.FORENKLET_OPPGJØRSORDNING.equals(ya.getArbeidType()) && aktivitetsAvtaler.isEmpty()) {
+                // Forekommer i halvparten av tilfellene pga rapportertingsmåte. Antar 0% i disse tilfellene.
+                continue;
+            }
             if (aktivitetsAvtaler.isEmpty()) {
                 var melding = "Forventer minst en aktivitetsavtale ved dato " + dato.toString() + " i yrkesaktivitet"
                     + ya.toString() + " med ansettelsesperioder " + filter.getAnsettelsesPerioder(ya).toString()


### PR DESCRIPTION
Har sjekket abakus 50/50 med/uten aktivitetsavtale (rettere sagt delvis hvordan abakus tolker sisteLønnsendring = null).
Alle tilfellene "uten aktivitetsavtale" har stillingsprosent 0 der det finnes en feiltolket aktivitetsavtale

Resultat 0 fra
select count(*) from iay_yrkesaktivitet y
where not exists(select * from iay_aktivitets_avtale aa where aa.yrkesaktivitet_id=y.id and aa.siste_loennsendringsdato is not null)
  and  exists(select * from iay_aktivitets_avtale aa where aa.yrkesaktivitet_id=y.id and aa.prosentsats is not null and aa.prosentsats > 0)
  and arbeid_type = 'FORENKLET_OPPGJØRSORDNING'
;
