### PR TITLE
TFP-4350 fri utsettelse konfig og del av STP

### DIFF
--- a/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/uttak/fp/FastsettUttaksgrunnlagOgVurderSøknadsfristStegTest.java
+++ b/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/uttak/fp/FastsettUttaksgrunnlagOgVurderSøknadsfristStegTest.java
@@ -53,6 +53,7 @@ import no.nav.foreldrepenger.domene.uttak.UttakRepositoryProvider;
 import no.nav.foreldrepenger.domene.uttak.uttaksgrunnlag.fp.EndringsdatoFørstegangsbehandlingUtleder;
 import no.nav.foreldrepenger.domene.uttak.uttaksgrunnlag.fp.EndringsdatoRevurderingUtlederImpl;
 import no.nav.foreldrepenger.domene.uttak.uttaksgrunnlag.fp.FastsettUttaksgrunnlagTjeneste;
+import no.nav.foreldrepenger.skjæringstidspunkt.Utsettelse2021;
 import no.nav.foreldrepenger.skjæringstidspunkt.fp.SkjæringstidspunktTjenesteImpl;
 import no.nav.foreldrepenger.skjæringstidspunkt.fp.SkjæringstidspunktUtils;
 
@@ -76,7 +77,7 @@ public class FastsettUttaksgrunnlagOgVurderSøknadsfristStegTest extends EntityM
         var beregningsgrunnlagTjeneste = new HentOgLagreBeregningsgrunnlagTjeneste(entityManager);
         var skjæringstidspunktTjeneste = new SkjæringstidspunktTjenesteImpl(behandlingRepositoryProvider,
                 new YtelseMaksdatoTjeneste(behandlingRepositoryProvider, new RelatertBehandlingTjeneste(behandlingRepositoryProvider)),
-                new SkjæringstidspunktUtils());
+                new SkjæringstidspunktUtils(), mock(Utsettelse2021.class));
         var uttakTjeneste = new ForeldrepengerUttakTjeneste(new FpUttakRepository(entityManager));
         var andelGraderingTjeneste = new BeregningUttakTjeneste(uttakTjeneste, ytelsesFordelingRepository);
         var iayTjeneste = new AbakusInMemoryInntektArbeidYtelseTjeneste();

--- a/domenetjenester/behandling-revurdering/src/test/java/no/nav/foreldrepenger/behandling/revurdering/ytelse/UttakInputTjenesteTest.java
+++ b/domenetjenester/behandling-revurdering/src/test/java/no/nav/foreldrepenger/behandling/revurdering/ytelse/UttakInputTjenesteTest.java
@@ -23,10 +23,11 @@ import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.Ytelses
 import no.nav.foreldrepenger.behandlingslager.testutilities.behandling.ScenarioMorSøkerForeldrepenger;
 import no.nav.foreldrepenger.behandlingslager.uttak.fp.FpUttakRepository;
 import no.nav.foreldrepenger.dbstoette.FPsakEntityManagerAwareExtension;
-import no.nav.foreldrepenger.domene.prosess.HentOgLagreBeregningsgrunnlagTjeneste;
 import no.nav.foreldrepenger.domene.abakus.AbakusInMemoryInntektArbeidYtelseTjeneste;
 import no.nav.foreldrepenger.domene.medlem.MedlemTjeneste;
+import no.nav.foreldrepenger.domene.prosess.HentOgLagreBeregningsgrunnlagTjeneste;
 import no.nav.foreldrepenger.domene.uttak.ForeldrepengerUttakTjeneste;
+import no.nav.foreldrepenger.skjæringstidspunkt.Utsettelse2021;
 import no.nav.foreldrepenger.skjæringstidspunkt.fp.SkjæringstidspunktTjenesteImpl;
 import no.nav.foreldrepenger.skjæringstidspunkt.fp.SkjæringstidspunktUtils;
 
@@ -45,7 +46,7 @@ public class UttakInputTjenesteTest {
         tjeneste = new UttakInputTjeneste(repositoryProvider, new HentOgLagreBeregningsgrunnlagTjeneste(entityManager),
                 new AbakusInMemoryInntektArbeidYtelseTjeneste(), new SkjæringstidspunktTjenesteImpl(repositoryProvider,
                         new YtelseMaksdatoTjeneste(repositoryProvider, new RelatertBehandlingTjeneste(repositoryProvider)),
-                        new SkjæringstidspunktUtils()),
+                        new SkjæringstidspunktUtils(), mock(Utsettelse2021.class)),
                 mock(MedlemTjeneste.class), andelGraderingTjeneste);
     }
 

--- a/domenetjenester/behandling/src/main/java/no/nav/foreldrepenger/behandling/Skjæringstidspunkt.java
+++ b/domenetjenester/behandling/src/main/java/no/nav/foreldrepenger/behandling/Skjæringstidspunkt.java
@@ -17,6 +17,7 @@ public class Skjæringstidspunkt {
     private LocalDate førsteUttaksdatoGrunnbeløp;
     private LocalDate førsteUttaksdatoFødseljustert;
     private LocalDateInterval utledetMedlemsintervall;
+    private boolean kvalifisertFriUtsettelse = false;
 
     private Skjæringstidspunkt() {
         // hide constructor
@@ -29,6 +30,7 @@ public class Skjæringstidspunkt {
         this.førsteUttaksdato = other.førsteUttaksdato;
         this.førsteUttaksdatoGrunnbeløp = other.førsteUttaksdatoGrunnbeløp;
         this.førsteUttaksdatoFødseljustert = other.førsteUttaksdatoFødseljustert;
+        this.kvalifisertFriUtsettelse = other.kvalifisertFriUtsettelse;
     }
 
     public Optional<LocalDate> getSkjæringstidspunktHvisUtledet() {
@@ -89,6 +91,11 @@ public class Skjæringstidspunkt {
     public LocalDate getFørsteUttaksdatoFødseljustert() {
         Objects.requireNonNull(førsteUttaksdatoFødseljustert, "Utvikler-feil: fødselsjustert uttaksdato er ikke satt. Sørg for at det er satt ifht. anvendelse");
         return førsteUttaksdatoFødseljustert;
+    }
+
+    /** Skal behandles etter nytt regelverk for uttak anno 2021. */
+    public boolean isKvalifisertFriUtsettelse() {
+        return kvalifisertFriUtsettelse;
     }
 
     @Override
@@ -167,6 +174,11 @@ public class Skjæringstidspunkt {
 
         public Builder medFørsteUttaksdatoFødseljustert(LocalDate dato) {
             kladd.førsteUttaksdatoFødseljustert = dato;
+            return this;
+        }
+
+        public Builder medKvalifisertFriUtsettelse(boolean erKvalifisert) {
+            kladd.kvalifisertFriUtsettelse = erKvalifisert;
             return this;
         }
 

--- a/domenetjenester/familie-hendelse/src/main/java/no/nav/foreldrepenger/familiehendelse/FamilieHendelseTjeneste.java
+++ b/domenetjenester/familie-hendelse/src/main/java/no/nav/foreldrepenger/familiehendelse/FamilieHendelseTjeneste.java
@@ -247,7 +247,7 @@ public class FamilieHendelseTjeneste {
     }
 
 
-    public boolean getManglerFødselsRegistreringFristUtløpt(FamilieHendelseGrunnlagEntitet grunnlag) {
+    public static boolean getManglerFødselsRegistreringFristUtløpt(FamilieHendelseGrunnlagEntitet grunnlag) {
         if (!grunnlag.getGjeldendeVersjon().getGjelderFødsel() || grunnlag.getBekreftetVersjon().isPresent() ||
             grunnlag.getOverstyrtVersjon().map(fh -> FØDSEL.equals(fh.getType()) && !fh.getBarna().isEmpty()).orElse(Boolean.FALSE)) {
             return false;

--- a/domenetjenester/familie-hendelse/src/main/java/no/nav/foreldrepenger/familiehendelse/aksjonspunkt/BekreftTerminbekreftelseOppdaterer.java
+++ b/domenetjenester/familie-hendelse/src/main/java/no/nav/foreldrepenger/familiehendelse/aksjonspunkt/BekreftTerminbekreftelseOppdaterer.java
@@ -108,7 +108,7 @@ public class BekreftTerminbekreftelseOppdaterer implements AksjonspunktOppdatere
         if (skalReinnhente) {
             builder.medOppdaterGrunnlag();
         }
-        if (familieHendelseTjeneste.getManglerFødselsRegistreringFristUtløpt(oppdatertGrunnlag)) {
+        if (FamilieHendelseTjeneste.getManglerFødselsRegistreringFristUtløpt(oppdatertGrunnlag)) {
             // Må kontrollere fakta på nytt for å sjekke om fødsel skulle ha inntruffet.
             // TODO: Vurder å fjerne denne (var tilbakehopp til kofak). APutleder/StpUtl tar hensyn til utløpt frist. Oppdateres når tas opp i gui.
             builder.medOppdaterGrunnlag();

--- a/domenetjenester/familie-hendelse/src/main/java/no/nav/foreldrepenger/familiehendelse/kontrollerfakta/fødsel/AksjonspunktUtlederForFødsel.java
+++ b/domenetjenester/familie-hendelse/src/main/java/no/nav/foreldrepenger/familiehendelse/kontrollerfakta/fødsel/AksjonspunktUtlederForFødsel.java
@@ -83,7 +83,7 @@ abstract class AksjonspunktUtlederForFødsel implements AksjonspunktUtleder {
     }
 
     Utfall erFristForRegistreringAvFødselPassert(FamilieHendelseGrunnlagEntitet grunnlag) {
-        return familieHendelseTjeneste.getManglerFødselsRegistreringFristUtløpt(grunnlag) ? JA : NEI;
+        return FamilieHendelseTjeneste.getManglerFødselsRegistreringFristUtløpt(grunnlag) ? JA : NEI;
     }
 
     LocalDateTime utledVentefrist(FamilieHendelseGrunnlagEntitet grunnlag) {

--- a/domenetjenester/inngangsvilkar/tjeneste/src/test/java/no/nav/foreldrepenger/inngangsvilkaar/fødsel/FødselsvilkårFarTest.java
+++ b/domenetjenester/inngangsvilkar/tjeneste/src/test/java/no/nav/foreldrepenger/inngangsvilkaar/fødsel/FødselsvilkårFarTest.java
@@ -1,6 +1,7 @@
 package no.nav.foreldrepenger.inngangsvilkaar.fødsel;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 
 import java.io.IOException;
 import java.time.LocalDate;
@@ -33,6 +34,7 @@ import no.nav.foreldrepenger.domene.personopplysning.PersonopplysningTjeneste;
 import no.nav.foreldrepenger.domene.typer.AktørId;
 import no.nav.foreldrepenger.inngangsvilkaar.impl.InngangsvilkårOversetter;
 import no.nav.foreldrepenger.skjæringstidspunkt.SkjæringstidspunktTjeneste;
+import no.nav.foreldrepenger.skjæringstidspunkt.Utsettelse2021;
 import no.nav.foreldrepenger.skjæringstidspunkt.fp.SkjæringstidspunktTjenesteImpl;
 import no.nav.foreldrepenger.skjæringstidspunkt.fp.SkjæringstidspunktUtils;
 
@@ -56,7 +58,7 @@ public class FødselsvilkårFarTest extends EntityManagerAwareTest {
             iayTjeneste, Period.parse("P6M"));
         var ytelseMaksdatoTjeneste = new YtelseMaksdatoTjeneste(repositoryProvider,
             new RelatertBehandlingTjeneste(repositoryProvider));
-        skjæringstidspunktTjeneste = new SkjæringstidspunktTjenesteImpl(repositoryProvider, ytelseMaksdatoTjeneste, stputil);
+        skjæringstidspunktTjeneste = new SkjæringstidspunktTjenesteImpl(repositoryProvider, ytelseMaksdatoTjeneste, stputil, mock(Utsettelse2021.class));
     }
 
     @Test // FP_VK 11.2 Vilkårsutfall oppfylt

--- a/domenetjenester/inngangsvilkar/tjeneste/src/test/java/no/nav/foreldrepenger/inngangsvilkaar/opptjening/OpptjeningsperiodeVilkårTest.java
+++ b/domenetjenester/inngangsvilkar/tjeneste/src/test/java/no/nav/foreldrepenger/inngangsvilkaar/opptjening/OpptjeningsperiodeVilkårTest.java
@@ -1,6 +1,7 @@
 package no.nav.foreldrepenger.inngangsvilkaar.opptjening;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 
 import java.time.LocalDate;
 import java.time.Period;
@@ -34,6 +35,7 @@ import no.nav.foreldrepenger.inngangsvilkaar.opptjening.fp.InngangsvilkårOpptje
 import no.nav.foreldrepenger.inngangsvilkaar.opptjening.fp.OpptjeningsperiodeVilkårTjenesteImpl;
 import no.nav.foreldrepenger.inngangsvilkaar.regelmodell.opptjening.OpptjeningsPeriode;
 import no.nav.foreldrepenger.skjæringstidspunkt.SkjæringstidspunktTjeneste;
+import no.nav.foreldrepenger.skjæringstidspunkt.Utsettelse2021;
 import no.nav.foreldrepenger.skjæringstidspunkt.fp.SkjæringstidspunktTjenesteImpl;
 import no.nav.foreldrepenger.skjæringstidspunkt.fp.SkjæringstidspunktUtils;
 
@@ -52,7 +54,7 @@ public class OpptjeningsperiodeVilkårTest extends EntityManagerAwareTest {
         var ytelseMaksdatoTjeneste = new YtelseMaksdatoTjeneste(repositoryProvider,
             new RelatertBehandlingTjeneste(repositoryProvider));
         skjæringstidspunktTjeneste = new SkjæringstidspunktTjenesteImpl(repositoryProvider, ytelseMaksdatoTjeneste,
-            stputil);
+            stputil, mock(Utsettelse2021.class));
         var personopplysningTjeneste = new PersonopplysningTjeneste(repositoryProvider.getPersonopplysningRepository());
         var beregnMorsMaksdatoTjeneste = new YtelseMaksdatoTjeneste(repositoryProvider,
             new RelatertBehandlingTjeneste(repositoryProvider));

--- a/domenetjenester/registerinnhenting/src/main/java/no/nav/foreldrepenger/domene/registerinnhenting/RegisterdataEndringshåndterer.java
+++ b/domenetjenester/registerinnhenting/src/main/java/no/nav/foreldrepenger/domene/registerinnhenting/RegisterdataEndringshåndterer.java
@@ -136,7 +136,7 @@ public class RegisterdataEndringshåndterer {
 
     private boolean isGåttOverTerminDatoOgIngenFødselsdato(Long behandlingId) {
         var fhGrunnlag = familieHendelseTjeneste.finnAggregat(behandlingId);
-        return fhGrunnlag.isEmpty() || familieHendelseTjeneste.getManglerFødselsRegistreringFristUtløpt(fhGrunnlag.get());
+        return fhGrunnlag.isEmpty() || FamilieHendelseTjeneste.getManglerFødselsRegistreringFristUtløpt(fhGrunnlag.get());
     }
 
     private EndringsresultatDiff opprettDiffUtenEndring() {

--- a/domenetjenester/registerinnhenting/src/main/java/no/nav/foreldrepenger/domene/registerinnhenting/es/StartpunktTjenesteImpl.java
+++ b/domenetjenester/registerinnhenting/src/main/java/no/nav/foreldrepenger/domene/registerinnhenting/es/StartpunktTjenesteImpl.java
@@ -101,7 +101,7 @@ public class StartpunktTjenesteImpl implements StartpunktTjeneste {
     }
 
     private boolean skalSjekkeForManglendeFødsel(FamilieHendelseGrunnlagEntitet grunnlagForBehandling) {
-        return familieHendelseTjeneste.getManglerFødselsRegistreringFristUtløpt(grunnlagForBehandling);
+        return FamilieHendelseTjeneste.getManglerFødselsRegistreringFristUtløpt(grunnlagForBehandling);
     }
 
 }

--- a/domenetjenester/registerinnhenting/src/main/java/no/nav/foreldrepenger/domene/registerinnhenting/fp/StartpunktTjenesteImpl.java
+++ b/domenetjenester/registerinnhenting/src/main/java/no/nav/foreldrepenger/domene/registerinnhenting/fp/StartpunktTjenesteImpl.java
@@ -86,6 +86,6 @@ public class StartpunktTjenesteImpl implements StartpunktTjeneste {
     }
 
     private boolean skalSjekkeForManglendeFødsel(FamilieHendelseGrunnlagEntitet grunnlagForBehandling) {
-        return familieHendelseTjeneste.getManglerFødselsRegistreringFristUtløpt(grunnlagForBehandling);
+        return FamilieHendelseTjeneste.getManglerFødselsRegistreringFristUtløpt(grunnlagForBehandling);
     }
 }

--- a/domenetjenester/skjaeringstidspunkt/src/main/java/no/nav/foreldrepenger/skjæringstidspunkt/Utsettelse2021.java
+++ b/domenetjenester/skjaeringstidspunkt/src/main/java/no/nav/foreldrepenger/skjæringstidspunkt/Utsettelse2021.java
@@ -1,0 +1,52 @@
+package no.nav.foreldrepenger.skjæringstidspunkt;
+
+import java.time.LocalDate;
+import java.util.Map;
+
+import no.nav.foreldrepenger.behandlingslager.behandling.familiehendelse.FamilieHendelseEntitet;
+import no.nav.foreldrepenger.behandlingslager.behandling.familiehendelse.FamilieHendelseGrunnlagEntitet;
+import no.nav.foreldrepenger.behandlingslager.behandling.familiehendelse.FamilieHendelseType;
+import no.nav.vedtak.util.env.Cluster;
+import no.nav.vedtak.util.env.Environment;
+
+/*
+ * Klasse for styring av ikrafttredelese nytt regelverk for uttak
+ * Metode for å gi ikrafttredelsesdato avhengig av miljø
+ * Metode for å vurdere om en Familiehendelse skal vurderes etter nye eller gamle regler. Vil bli oppdatert
+ */
+public class Utsettelse2021 {
+
+    private static final Cluster CURRENT_CLUSTER = Environment.current().getCluster();
+
+    private static final Map<Cluster, LocalDate> DATO_MAP = Map.of(
+        Cluster.PROD_FSS, LocalDate.of(2999,12,31),  // Nei, ikke endre denne før vi er klare
+        Cluster.DEV_FSS, LocalDate.of(2021, 10, 1), // Ja, denne kan tilpasses til testbehov
+        Cluster.LOCAL, LocalDate.of(2025,10,1) // Ja, endre denne når testklare
+    );
+
+    private static LocalDate DATO_LOKAL_TEST;
+
+    public static LocalDate ikrafttredelseDato() {
+        if (Cluster.LOCAL.equals(CURRENT_CLUSTER) && DATO_LOKAL_TEST != null) return DATO_LOKAL_TEST;
+        return DATO_MAP.get(CURRENT_CLUSTER);
+    }
+
+    public static boolean skalBehandlesEtterNyeReglerUttak(FamilieHendelseGrunnlagEntitet familieHendelseGrunnlag) {
+        if (familieHendelseGrunnlag == null) return false;
+        var bekreftetFamilieHendelse = familieHendelseGrunnlag.getGjeldendeBekreftetVersjon()
+            .filter(fh -> !FamilieHendelseType.TERMIN.equals(fh.getType()));
+        if (bekreftetFamilieHendelse.isPresent()) {
+            return bekreftetFamilieHendelse.map(FamilieHendelseEntitet::getSkjæringstidspunkt).filter(t -> !t.isBefore(ikrafttredelseDato())).isPresent();
+        }
+        var gjeldendeFH = familieHendelseGrunnlag.getGjeldendeVersjon();
+        if (gjeldendeFH == null) return false;
+        if (gjeldendeFH.getSkjæringstidspunkt().isBefore(Utsettelse2021.ikrafttredelseDato())) return false;
+        if (!gjeldendeFH.getGjelderFødsel()) return LocalDate.now().isAfter(ikrafttredelseDato());
+        return LocalDate.now().isAfter(ikrafttredelseDato().plusWeeks(2)); // Frist for registrering av fødsel i FREG
+    }
+
+    public static void setIkrafttredelseDatoEnhetstest(LocalDate testdato) {
+        DATO_LOKAL_TEST = testdato;
+    }
+
+}

--- a/domenetjenester/skjaeringstidspunkt/src/main/java/no/nav/foreldrepenger/skjæringstidspunkt/fp/SkjæringstidspunktTjenesteImpl.java
+++ b/domenetjenester/skjaeringstidspunkt/src/main/java/no/nav/foreldrepenger/skjæringstidspunkt/fp/SkjæringstidspunktTjenesteImpl.java
@@ -38,6 +38,7 @@ import no.nav.foreldrepenger.behandlingslager.uttak.fp.UttakResultatPerioderEnti
 import no.nav.foreldrepenger.domene.tid.VirkedagUtil;
 import no.nav.foreldrepenger.skjæringstidspunkt.SkjæringstidspunktRegisterinnhentingTjeneste;
 import no.nav.foreldrepenger.skjæringstidspunkt.SkjæringstidspunktTjeneste;
+import no.nav.foreldrepenger.skjæringstidspunkt.Utsettelse2021;
 import no.nav.fpsak.tidsserie.LocalDateInterval;
 import no.nav.vedtak.exception.TekniskException;
 import no.nav.vedtak.konfig.Tid;
@@ -88,6 +89,7 @@ public class SkjæringstidspunktTjenesteImpl implements SkjæringstidspunktTjene
         var førsteInnvilgetUttaksdato = førsteDatoHensyntattTidligFødsel(behandling, førsteInnvilgetUttaksdag(behandling));
 
         var builder = Skjæringstidspunkt.builder()
+            .medKvalifisertFriUtsettelse(skalBehandlesEtterNyeReglerUttak(behandling))
             .medFørsteUttaksdato(førsteUttaksdato)
             .medFørsteUttaksdatoFødseljustert(førsteDatoHensyntattTidligFødsel(behandling, førsteUttaksdato))
             .medFørsteUttaksdatoGrunnbeløp(førsteInnvilgetUttaksdato);
@@ -265,5 +267,10 @@ public class SkjæringstidspunktTjenesteImpl implements SkjæringstidspunktTjene
         } else {
             return førsteUttaksdato;
         }
+    }
+
+    private boolean skalBehandlesEtterNyeReglerUttak(Behandling behandling) {
+        return familieGrunnlagRepository.hentAggregatHvisEksisterer(behandling.getId())
+            .map(Utsettelse2021::skalBehandlesEtterNyeReglerUttak).orElse(false);
     }
 }

--- a/domenetjenester/skjaeringstidspunkt/src/main/java/no/nav/foreldrepenger/skjæringstidspunkt/fp/SkjæringstidspunktTjenesteImpl.java
+++ b/domenetjenester/skjaeringstidspunkt/src/main/java/no/nav/foreldrepenger/skjæringstidspunkt/fp/SkjæringstidspunktTjenesteImpl.java
@@ -55,6 +55,7 @@ public class SkjæringstidspunktTjenesteImpl implements SkjæringstidspunktTjene
     private SøknadRepository søknadRepository;
     private BehandlingRepository behandlingRepository;
     private YtelseMaksdatoTjeneste ytelseMaksdatoTjeneste;
+    private Utsettelse2021 utsettelse2021;
 
     SkjæringstidspunktTjenesteImpl() {
         // CDI
@@ -63,7 +64,8 @@ public class SkjæringstidspunktTjenesteImpl implements SkjæringstidspunktTjene
     @Inject
     public SkjæringstidspunktTjenesteImpl(BehandlingRepositoryProvider repositoryProvider,
                                           YtelseMaksdatoTjeneste ytelseMaksdatoTjeneste,
-                                          SkjæringstidspunktUtils utlederUtils) {
+                                          SkjæringstidspunktUtils utlederUtils,
+                                          Utsettelse2021 utsettelse2021) {
         this.behandlingRepository = repositoryProvider.getBehandlingRepository();
         this.ytelsesFordelingRepository = repositoryProvider.getYtelsesFordelingRepository();
         this.fpUttakRepository = repositoryProvider.getFpUttakRepository();
@@ -72,6 +74,7 @@ public class SkjæringstidspunktTjenesteImpl implements SkjæringstidspunktTjene
         this.familieGrunnlagRepository = repositoryProvider.getFamilieHendelseRepository();
         this.utlederUtils = utlederUtils;
         this.ytelseMaksdatoTjeneste = ytelseMaksdatoTjeneste;
+        this.utsettelse2021 = utsettelse2021;
     }
 
     @Override
@@ -271,6 +274,6 @@ public class SkjæringstidspunktTjenesteImpl implements SkjæringstidspunktTjene
 
     private boolean skalBehandlesEtterNyeReglerUttak(Behandling behandling) {
         return familieGrunnlagRepository.hentAggregatHvisEksisterer(behandling.getId())
-            .map(Utsettelse2021::skalBehandlesEtterNyeReglerUttak).orElse(false);
+            .map(utsettelse2021::skalBehandlesEtterNyeReglerUttak).orElse(false);
     }
 }

--- a/domenetjenester/skjaeringstidspunkt/src/test/java/no/nav/foreldrepenger/skjæringstidspunkt/fp/SkjæringstidspunktNyttUttakTest.java
+++ b/domenetjenester/skjaeringstidspunkt/src/test/java/no/nav/foreldrepenger/skjæringstidspunkt/fp/SkjæringstidspunktNyttUttakTest.java
@@ -15,9 +15,7 @@ public class SkjæringstidspunktNyttUttakTest {
     @Test
     public void skal_returnere_ikke_kvalifisert_hvis_bekreftet_hendelse_før_dato() {
         // Arrange
-        LocalDate ikraftredelse = LocalDate.of(2021, 10, 1);
-        Utsettelse2021.setIkrafttredelseDatoEnhetstest(ikraftredelse);
-
+        var ikraftredelse = LocalDate.of(2021, 10, 1);
         var skjæringsdato = ikraftredelse.minusWeeks(4);
         var bekreftetfødselsdato = skjæringsdato.plusWeeks(3);
 
@@ -25,20 +23,17 @@ public class SkjæringstidspunktNyttUttakTest {
             .medBehandlingType(BehandlingType.FØRSTEGANGSSØKNAD);
         førstegangScenario.medBekreftetHendelse().medFødselsDato(bekreftetfødselsdato);
         var mockprovider = førstegangScenario.mockBehandlingRepositoryProvider();
-
         var behandling = førstegangScenario.lagMocked();
 
         // Act/Assert
         var fhg = mockprovider.getFamilieHendelseRepository().hentAggregat(behandling.getId());
-        assertThat(Utsettelse2021.skalBehandlesEtterNyeReglerUttak(fhg)).isFalse();
+        assertThat(new Utsettelse2021(ikraftredelse).skalBehandlesEtterNyeReglerUttak(fhg)).isFalse();
     }
 
     @Test
     public void skal_returnere_kvalifisert_hvis_bekreftet_hendelse_etter_dato() {
         // Arrange
-        LocalDate ikraftredelse = LocalDate.of(2021, 10, 1);
-        Utsettelse2021.setIkrafttredelseDatoEnhetstest(ikraftredelse);
-
+        var ikraftredelse = LocalDate.of(2021, 10, 1);
         var skjæringsdato = ikraftredelse;
         var bekreftetfødselsdato = skjæringsdato.plusWeeks(3);
 
@@ -46,22 +41,18 @@ public class SkjæringstidspunktNyttUttakTest {
             .medBehandlingType(BehandlingType.FØRSTEGANGSSØKNAD);
         førstegangScenario.medBekreftetHendelse()
             .medAdopsjon(førstegangScenario.medBekreftetHendelse().getAdopsjonBuilder().medOmsorgsovertakelseDato(bekreftetfødselsdato));
-
         var mockprovider = førstegangScenario.mockBehandlingRepositoryProvider();
-
         var behandling = førstegangScenario.lagMocked();
 
         // Act/Assert
         var fhg = mockprovider.getFamilieHendelseRepository().hentAggregat(behandling.getId());
-        assertThat(Utsettelse2021.skalBehandlesEtterNyeReglerUttak(fhg)).isTrue();
+        assertThat(new Utsettelse2021(ikraftredelse).skalBehandlesEtterNyeReglerUttak(fhg)).isTrue();
     }
 
     @Test
     public void skal_returnere_kvalifisert_hvis_bekreftet_termin_20_dager_etter() {
         // Arrange
-        LocalDate ikraftredelse = LocalDate.now().minusDays(20);
-        Utsettelse2021.setIkrafttredelseDatoEnhetstest(ikraftredelse);
-
+        var ikraftredelse = LocalDate.now().minusDays(20);
         var skjæringsdato = ikraftredelse;
         var bekreftetfødselsdato = skjæringsdato.plusWeeks(3);
 
@@ -70,22 +61,18 @@ public class SkjæringstidspunktNyttUttakTest {
         førstegangScenario.medBekreftetHendelse()
             .medTerminbekreftelse(førstegangScenario.medBekreftetHendelse().getTerminbekreftelseBuilder()
                 .medTermindato(bekreftetfødselsdato));
-
         var mockprovider = førstegangScenario.mockBehandlingRepositoryProvider();
-
         var behandling = førstegangScenario.lagMocked();
 
         // Act/Assert
         var fhg = mockprovider.getFamilieHendelseRepository().hentAggregat(behandling.getId());
-        assertThat(Utsettelse2021.skalBehandlesEtterNyeReglerUttak(fhg)).isTrue();
+        assertThat(new Utsettelse2021(ikraftredelse).skalBehandlesEtterNyeReglerUttak(fhg)).isTrue();
     }
 
     @Test
     public void skal_returnere_ikke_kvalifisert_hvis_bekreftet_termin_2_dager_etter() {
         // Arrange
-        LocalDate ikraftredelse = LocalDate.now().minusDays(2);
-        Utsettelse2021.setIkrafttredelseDatoEnhetstest(ikraftredelse);
-
+        var ikraftredelse = LocalDate.now().minusDays(2);
         var skjæringsdato = ikraftredelse;
         var bekreftetfødselsdato = skjæringsdato.plusWeeks(3);
 
@@ -94,22 +81,18 @@ public class SkjæringstidspunktNyttUttakTest {
         førstegangScenario.medBekreftetHendelse()
             .medTerminbekreftelse(førstegangScenario.medBekreftetHendelse().getTerminbekreftelseBuilder()
                 .medTermindato(bekreftetfødselsdato));
-
         var mockprovider = førstegangScenario.mockBehandlingRepositoryProvider();
-
         var behandling = førstegangScenario.lagMocked();
 
         // Act/Assert
         var fhg = mockprovider.getFamilieHendelseRepository().hentAggregat(behandling.getId());
-        assertThat(Utsettelse2021.skalBehandlesEtterNyeReglerUttak(fhg)).isFalse();
+        assertThat(new Utsettelse2021(ikraftredelse).skalBehandlesEtterNyeReglerUttak(fhg)).isFalse();
     }
 
     @Test
     public void skal_returnere_kvalifisert_hvis_søkt_adopsjon_2_dager_etter() {
         // Arrange
-        LocalDate ikraftredelse = LocalDate.now().minusDays(2);
-        Utsettelse2021.setIkrafttredelseDatoEnhetstest(ikraftredelse);
-
+        var ikraftredelse = LocalDate.now().minusDays(2);
         var skjæringsdato = ikraftredelse;
         var bekreftetfødselsdato = skjæringsdato.plusWeeks(3);
 
@@ -118,22 +101,18 @@ public class SkjæringstidspunktNyttUttakTest {
         førstegangScenario.medSøknadHendelse()
             .medAdopsjon(førstegangScenario.medSøknadHendelse().getAdopsjonBuilder()
             .medOmsorgsovertakelseDato(bekreftetfødselsdato));
-
         var mockprovider = førstegangScenario.mockBehandlingRepositoryProvider();
-
         var behandling = førstegangScenario.lagMocked();
 
         // Act/Assert
         var fhg = mockprovider.getFamilieHendelseRepository().hentAggregat(behandling.getId());
-        assertThat(Utsettelse2021.skalBehandlesEtterNyeReglerUttak(fhg)).isTrue();
+        assertThat(new Utsettelse2021(ikraftredelse).skalBehandlesEtterNyeReglerUttak(fhg)).isTrue();
     }
 
     @Test
     public void skal_returnere_ikke_kvalifisert_hvis_søkt_fødsel_10_dager_etter() {
         // Arrange
-        LocalDate ikraftredelse = LocalDate.now().minusDays(10);
-        Utsettelse2021.setIkrafttredelseDatoEnhetstest(ikraftredelse);
-
+        var ikraftredelse = LocalDate.now().minusDays(10);
         var skjæringsdato = ikraftredelse;
         var bekreftetfødselsdato = skjæringsdato.plusWeeks(3);
 
@@ -141,22 +120,18 @@ public class SkjæringstidspunktNyttUttakTest {
             .medBehandlingType(BehandlingType.FØRSTEGANGSSØKNAD);
         førstegangScenario.medSøknadHendelse()
             .medFødselsDato(bekreftetfødselsdato);
-
         var mockprovider = førstegangScenario.mockBehandlingRepositoryProvider();
-
         var behandling = førstegangScenario.lagMocked();
 
         // Act/Assert
         var fhg = mockprovider.getFamilieHendelseRepository().hentAggregat(behandling.getId());
-        assertThat(Utsettelse2021.skalBehandlesEtterNyeReglerUttak(fhg)).isFalse();
+        assertThat(new Utsettelse2021(ikraftredelse).skalBehandlesEtterNyeReglerUttak(fhg)).isFalse();
     }
 
     @Test
     public void skal_returnere_kvalifisert_hvis_søkt_termin_30_dager_etter() {
         // Arrange
-        LocalDate ikraftredelse = LocalDate.now().minusDays(30);
-        Utsettelse2021.setIkrafttredelseDatoEnhetstest(ikraftredelse);
-
+        var ikraftredelse = LocalDate.now().minusDays(30);
         var skjæringsdato = ikraftredelse;
         var bekreftetfødselsdato = skjæringsdato.plusWeeks(3);
 
@@ -165,14 +140,11 @@ public class SkjæringstidspunktNyttUttakTest {
         førstegangScenario.medSøknadHendelse()
             .medTerminbekreftelse(førstegangScenario.medSøknadHendelse().getTerminbekreftelseBuilder()
                 .medTermindato(bekreftetfødselsdato));
-
         var mockprovider = førstegangScenario.mockBehandlingRepositoryProvider();
-
         var behandling = førstegangScenario.lagMocked();
-
         // Act/Assert
         var fhg = mockprovider.getFamilieHendelseRepository().hentAggregat(behandling.getId());
-        assertThat(Utsettelse2021.skalBehandlesEtterNyeReglerUttak(fhg)).isTrue();
+        assertThat(new Utsettelse2021(ikraftredelse).skalBehandlesEtterNyeReglerUttak(fhg)).isTrue();
     }
 
 }

--- a/domenetjenester/skjaeringstidspunkt/src/test/java/no/nav/foreldrepenger/skjæringstidspunkt/fp/SkjæringstidspunktNyttUttakTest.java
+++ b/domenetjenester/skjaeringstidspunkt/src/test/java/no/nav/foreldrepenger/skjæringstidspunkt/fp/SkjæringstidspunktNyttUttakTest.java
@@ -1,0 +1,178 @@
+package no.nav.foreldrepenger.skjæringstidspunkt.fp;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDate;
+
+import org.junit.jupiter.api.Test;
+
+import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingType;
+import no.nav.foreldrepenger.behandlingslager.testutilities.behandling.ScenarioMorSøkerForeldrepenger;
+import no.nav.foreldrepenger.skjæringstidspunkt.Utsettelse2021;
+
+public class SkjæringstidspunktNyttUttakTest {
+
+    @Test
+    public void skal_returnere_ikke_kvalifisert_hvis_bekreftet_hendelse_før_dato() {
+        // Arrange
+        LocalDate ikraftredelse = LocalDate.of(2021, 10, 1);
+        Utsettelse2021.setIkrafttredelseDatoEnhetstest(ikraftredelse);
+
+        var skjæringsdato = ikraftredelse.minusWeeks(4);
+        var bekreftetfødselsdato = skjæringsdato.plusWeeks(3);
+
+        var førstegangScenario = ScenarioMorSøkerForeldrepenger.forFødsel()
+            .medBehandlingType(BehandlingType.FØRSTEGANGSSØKNAD);
+        førstegangScenario.medBekreftetHendelse().medFødselsDato(bekreftetfødselsdato);
+        var mockprovider = førstegangScenario.mockBehandlingRepositoryProvider();
+
+        var behandling = førstegangScenario.lagMocked();
+
+        // Act/Assert
+        var fhg = mockprovider.getFamilieHendelseRepository().hentAggregat(behandling.getId());
+        assertThat(Utsettelse2021.skalBehandlesEtterNyeReglerUttak(fhg)).isFalse();
+    }
+
+    @Test
+    public void skal_returnere_kvalifisert_hvis_bekreftet_hendelse_etter_dato() {
+        // Arrange
+        LocalDate ikraftredelse = LocalDate.of(2021, 10, 1);
+        Utsettelse2021.setIkrafttredelseDatoEnhetstest(ikraftredelse);
+
+        var skjæringsdato = ikraftredelse;
+        var bekreftetfødselsdato = skjæringsdato.plusWeeks(3);
+
+        var førstegangScenario = ScenarioMorSøkerForeldrepenger.forAdopsjon()
+            .medBehandlingType(BehandlingType.FØRSTEGANGSSØKNAD);
+        førstegangScenario.medBekreftetHendelse()
+            .medAdopsjon(førstegangScenario.medBekreftetHendelse().getAdopsjonBuilder().medOmsorgsovertakelseDato(bekreftetfødselsdato));
+
+        var mockprovider = førstegangScenario.mockBehandlingRepositoryProvider();
+
+        var behandling = førstegangScenario.lagMocked();
+
+        // Act/Assert
+        var fhg = mockprovider.getFamilieHendelseRepository().hentAggregat(behandling.getId());
+        assertThat(Utsettelse2021.skalBehandlesEtterNyeReglerUttak(fhg)).isTrue();
+    }
+
+    @Test
+    public void skal_returnere_kvalifisert_hvis_bekreftet_termin_20_dager_etter() {
+        // Arrange
+        LocalDate ikraftredelse = LocalDate.now().minusDays(20);
+        Utsettelse2021.setIkrafttredelseDatoEnhetstest(ikraftredelse);
+
+        var skjæringsdato = ikraftredelse;
+        var bekreftetfødselsdato = skjæringsdato.plusWeeks(3);
+
+        var førstegangScenario = ScenarioMorSøkerForeldrepenger.forFødsel()
+            .medBehandlingType(BehandlingType.FØRSTEGANGSSØKNAD);
+        førstegangScenario.medBekreftetHendelse()
+            .medTerminbekreftelse(førstegangScenario.medBekreftetHendelse().getTerminbekreftelseBuilder()
+                .medTermindato(bekreftetfødselsdato));
+
+        var mockprovider = førstegangScenario.mockBehandlingRepositoryProvider();
+
+        var behandling = førstegangScenario.lagMocked();
+
+        // Act/Assert
+        var fhg = mockprovider.getFamilieHendelseRepository().hentAggregat(behandling.getId());
+        assertThat(Utsettelse2021.skalBehandlesEtterNyeReglerUttak(fhg)).isTrue();
+    }
+
+    @Test
+    public void skal_returnere_ikke_kvalifisert_hvis_bekreftet_termin_2_dager_etter() {
+        // Arrange
+        LocalDate ikraftredelse = LocalDate.now().minusDays(2);
+        Utsettelse2021.setIkrafttredelseDatoEnhetstest(ikraftredelse);
+
+        var skjæringsdato = ikraftredelse;
+        var bekreftetfødselsdato = skjæringsdato.plusWeeks(3);
+
+        var førstegangScenario = ScenarioMorSøkerForeldrepenger.forFødsel()
+            .medBehandlingType(BehandlingType.FØRSTEGANGSSØKNAD);
+        førstegangScenario.medBekreftetHendelse()
+            .medTerminbekreftelse(førstegangScenario.medBekreftetHendelse().getTerminbekreftelseBuilder()
+                .medTermindato(bekreftetfødselsdato));
+
+        var mockprovider = førstegangScenario.mockBehandlingRepositoryProvider();
+
+        var behandling = førstegangScenario.lagMocked();
+
+        // Act/Assert
+        var fhg = mockprovider.getFamilieHendelseRepository().hentAggregat(behandling.getId());
+        assertThat(Utsettelse2021.skalBehandlesEtterNyeReglerUttak(fhg)).isFalse();
+    }
+
+    @Test
+    public void skal_returnere_kvalifisert_hvis_søkt_adopsjon_2_dager_etter() {
+        // Arrange
+        LocalDate ikraftredelse = LocalDate.now().minusDays(2);
+        Utsettelse2021.setIkrafttredelseDatoEnhetstest(ikraftredelse);
+
+        var skjæringsdato = ikraftredelse;
+        var bekreftetfødselsdato = skjæringsdato.plusWeeks(3);
+
+        var førstegangScenario = ScenarioMorSøkerForeldrepenger.forAdopsjon()
+            .medBehandlingType(BehandlingType.FØRSTEGANGSSØKNAD);
+        førstegangScenario.medSøknadHendelse()
+            .medAdopsjon(førstegangScenario.medSøknadHendelse().getAdopsjonBuilder()
+            .medOmsorgsovertakelseDato(bekreftetfødselsdato));
+
+        var mockprovider = førstegangScenario.mockBehandlingRepositoryProvider();
+
+        var behandling = førstegangScenario.lagMocked();
+
+        // Act/Assert
+        var fhg = mockprovider.getFamilieHendelseRepository().hentAggregat(behandling.getId());
+        assertThat(Utsettelse2021.skalBehandlesEtterNyeReglerUttak(fhg)).isTrue();
+    }
+
+    @Test
+    public void skal_returnere_ikke_kvalifisert_hvis_søkt_fødsel_10_dager_etter() {
+        // Arrange
+        LocalDate ikraftredelse = LocalDate.now().minusDays(10);
+        Utsettelse2021.setIkrafttredelseDatoEnhetstest(ikraftredelse);
+
+        var skjæringsdato = ikraftredelse;
+        var bekreftetfødselsdato = skjæringsdato.plusWeeks(3);
+
+        var førstegangScenario = ScenarioMorSøkerForeldrepenger.forFødsel()
+            .medBehandlingType(BehandlingType.FØRSTEGANGSSØKNAD);
+        førstegangScenario.medSøknadHendelse()
+            .medFødselsDato(bekreftetfødselsdato);
+
+        var mockprovider = førstegangScenario.mockBehandlingRepositoryProvider();
+
+        var behandling = førstegangScenario.lagMocked();
+
+        // Act/Assert
+        var fhg = mockprovider.getFamilieHendelseRepository().hentAggregat(behandling.getId());
+        assertThat(Utsettelse2021.skalBehandlesEtterNyeReglerUttak(fhg)).isFalse();
+    }
+
+    @Test
+    public void skal_returnere_kvalifisert_hvis_søkt_termin_30_dager_etter() {
+        // Arrange
+        LocalDate ikraftredelse = LocalDate.now().minusDays(30);
+        Utsettelse2021.setIkrafttredelseDatoEnhetstest(ikraftredelse);
+
+        var skjæringsdato = ikraftredelse;
+        var bekreftetfødselsdato = skjæringsdato.plusWeeks(3);
+
+        var førstegangScenario = ScenarioMorSøkerForeldrepenger.forFødsel()
+            .medBehandlingType(BehandlingType.FØRSTEGANGSSØKNAD);
+        førstegangScenario.medSøknadHendelse()
+            .medTerminbekreftelse(førstegangScenario.medSøknadHendelse().getTerminbekreftelseBuilder()
+                .medTermindato(bekreftetfødselsdato));
+
+        var mockprovider = førstegangScenario.mockBehandlingRepositoryProvider();
+
+        var behandling = førstegangScenario.lagMocked();
+
+        // Act/Assert
+        var fhg = mockprovider.getFamilieHendelseRepository().hentAggregat(behandling.getId());
+        assertThat(Utsettelse2021.skalBehandlesEtterNyeReglerUttak(fhg)).isTrue();
+    }
+
+}

--- a/web/src/main/resources/application-dev-fss.properties
+++ b/web/src/main/resources/application-dev-fss.properties
@@ -17,7 +17,7 @@ behandling.default.ventefrist.periode = P4W
 dato.for.nye.beregningsregler = 2019-01-01
 
 # Dato for nye uttaksregler
-dato.for.nye.uttaksregler = 2999-12-31
+dato.for.nye.uttaksregler = 2021-05-01
 
 # Offset - for testing
 funksjonelt.tidsoffset.offset = P0D

--- a/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/BehandlingRestTjenesteTest.java
+++ b/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/BehandlingRestTjenesteTest.java
@@ -27,10 +27,11 @@ import no.nav.foreldrepenger.behandlingslager.testutilities.behandling.ScenarioF
 import no.nav.foreldrepenger.behandlingslager.testutilities.behandling.ScenarioMorSøkerForeldrepenger;
 import no.nav.foreldrepenger.behandlingsprosess.prosessering.BehandlingOpprettingTjeneste;
 import no.nav.foreldrepenger.dbstoette.FPsakEntityManagerAwareExtension;
-import no.nav.foreldrepenger.domene.prosess.HentOgLagreBeregningsgrunnlagTjeneste;
 import no.nav.foreldrepenger.domene.opptjening.aksjonspunkt.OpptjeningIUtlandDokStatusTjeneste;
+import no.nav.foreldrepenger.domene.prosess.HentOgLagreBeregningsgrunnlagTjeneste;
 import no.nav.foreldrepenger.domene.uttak.ForeldrepengerUttakTjeneste;
 import no.nav.foreldrepenger.produksjonsstyring.totrinn.TotrinnTjeneste;
+import no.nav.foreldrepenger.skjæringstidspunkt.Utsettelse2021;
 import no.nav.foreldrepenger.skjæringstidspunkt.fp.SkjæringstidspunktTjenesteImpl;
 import no.nav.foreldrepenger.skjæringstidspunkt.fp.SkjæringstidspunktUtils;
 import no.nav.foreldrepenger.web.app.tjenester.behandling.aksjonspunkt.BehandlingsoppretterTjeneste;
@@ -76,7 +77,7 @@ public class BehandlingRestTjenesteTest {
         var ytelseMaksdatoTjeneste = new YtelseMaksdatoTjeneste(repositoryProvider,
             new RelatertBehandlingTjeneste(repositoryProvider));
         var skjæringstidspunktTjeneste = new SkjæringstidspunktTjenesteImpl(repositoryProvider, ytelseMaksdatoTjeneste,
-            stputil);
+            stputil, mock(Utsettelse2021.class));
         var behandlingDtoTjeneste = new BehandlingDtoTjeneste(repositoryProvider, beregningsgrunnlagTjeneste,
             tilbakekrevingRepository, skjæringstidspunktTjeneste, opptjeningIUtlandDokStatusTjeneste,
             behandlingDokumentRepository, relatertBehandlingTjeneste,

--- a/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/BehandlingÅrsakDtoTest.java
+++ b/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/BehandlingÅrsakDtoTest.java
@@ -22,12 +22,13 @@ import no.nav.foreldrepenger.behandlingslager.behandling.tilbakekreving.Tilbakek
 import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.AvklarteUttakDatoerEntitet;
 import no.nav.foreldrepenger.behandlingslager.testutilities.behandling.ScenarioMorSøkerForeldrepenger;
 import no.nav.foreldrepenger.dbstoette.EntityManagerAwareTest;
-import no.nav.foreldrepenger.domene.prosess.HentOgLagreBeregningsgrunnlagTjeneste;
 import no.nav.foreldrepenger.domene.abakus.AbakusInMemoryInntektArbeidYtelseTjeneste;
 import no.nav.foreldrepenger.domene.medlem.MedlemTjeneste;
 import no.nav.foreldrepenger.domene.opptjening.aksjonspunkt.OpptjeningIUtlandDokStatusTjeneste;
+import no.nav.foreldrepenger.domene.prosess.HentOgLagreBeregningsgrunnlagTjeneste;
 import no.nav.foreldrepenger.domene.uttak.ForeldrepengerUttakTjeneste;
 import no.nav.foreldrepenger.domene.ytelsefordeling.YtelseFordelingTjeneste;
+import no.nav.foreldrepenger.skjæringstidspunkt.Utsettelse2021;
 import no.nav.foreldrepenger.skjæringstidspunkt.fp.SkjæringstidspunktTjenesteImpl;
 import no.nav.foreldrepenger.skjæringstidspunkt.fp.SkjæringstidspunktUtils;
 import no.nav.foreldrepenger.web.app.tjenester.behandling.dto.behandling.BehandlingDtoTjeneste;
@@ -46,7 +47,7 @@ public class BehandlingÅrsakDtoTest extends EntityManagerAwareTest {
         var ytelseMaksdatoTjeneste = new YtelseMaksdatoTjeneste(repositoryProvider,
             new RelatertBehandlingTjeneste(repositoryProvider));
         var skjæringstidspunktTjeneste = new SkjæringstidspunktTjenesteImpl(repositoryProvider, ytelseMaksdatoTjeneste,
-            stputil);
+            stputil, mock(Utsettelse2021.class));
         var beregningsgrunnlagTjeneste = new HentOgLagreBeregningsgrunnlagTjeneste(entityManager);
         var opptjeningIUtlandDokStatusTjeneste = new OpptjeningIUtlandDokStatusTjeneste(
             new OpptjeningIUtlandDokStatusRepository(entityManager));

--- a/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/uttak/app/KontrollerAktivitetskravDtoTjenesteTest.java
+++ b/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/uttak/app/KontrollerAktivitetskravDtoTjenesteTest.java
@@ -37,6 +37,7 @@ import no.nav.foreldrepenger.domene.medlem.MedlemTjeneste;
 import no.nav.foreldrepenger.domene.prosess.HentOgLagreBeregningsgrunnlagTjeneste;
 import no.nav.foreldrepenger.domene.uttak.ForeldrepengerUttakTjeneste;
 import no.nav.foreldrepenger.domene.ytelsefordeling.YtelseFordelingTjeneste;
+import no.nav.foreldrepenger.skjæringstidspunkt.Utsettelse2021;
 import no.nav.foreldrepenger.skjæringstidspunkt.fp.SkjæringstidspunktTjenesteImpl;
 import no.nav.foreldrepenger.skjæringstidspunkt.fp.SkjæringstidspunktUtils;
 import no.nav.foreldrepenger.web.app.tjenester.behandling.dto.UuidDto;
@@ -60,7 +61,7 @@ class KontrollerAktivitetskravDtoTjenesteTest {
         var uttakInputTjeneste = new UttakInputTjeneste(repositoryProvider, new HentOgLagreBeregningsgrunnlagTjeneste(entityManager),
             new AbakusInMemoryInntektArbeidYtelseTjeneste(), new SkjæringstidspunktTjenesteImpl(repositoryProvider,
             new YtelseMaksdatoTjeneste(repositoryProvider, new RelatertBehandlingTjeneste(repositoryProvider)),
-            new SkjæringstidspunktUtils()),
+            new SkjæringstidspunktUtils(), mock(Utsettelse2021.class)),
             mock(MedlemTjeneste.class), andelGraderingTjeneste);
         tjeneste = new KontrollerAktivitetskravDtoTjeneste(repositoryProvider.getBehandlingRepository(),
             ytelseFordelingTjeneste, uttakInputTjeneste, foreldrepengerUttakTjeneste);

--- a/web/src/test/resources/application-local.properties
+++ b/web/src/test/resources/application-local.properties
@@ -95,6 +95,9 @@ environment.name=devimg
 loadbalancer.url=http://localhost:8080
 dato.for.nye.beregningsregler=2010-01-01
 
+# Dato for nye uttaksregler
+dato.for.nye.uttaksregler = 2999-12-31
+
 # Auditlogger
 auditlogger.enabled=false
 auditlogger.vendor=fp


### PR DESCRIPTION
Enkelt startpunkt for å evaluere hvilke regler som skal brukes.
Velger å ikke bruke konfig-verdier for å kunne styre logikken fra enhetstester og ikke påvirke alle tester
