### PR TITLE
TFP-4382 uttaksdato sammenhengende, fri, samt beregning

### DIFF
--- a/domenetjenester/behandling/src/main/java/no/nav/foreldrepenger/behandling/Skjæringstidspunkt.java
+++ b/domenetjenester/behandling/src/main/java/no/nav/foreldrepenger/behandling/Skjæringstidspunkt.java
@@ -15,7 +15,6 @@ public class Skjæringstidspunkt {
     private LocalDate skjæringstidspunktBeregning;
     private LocalDate førsteUttaksdato;
     private LocalDate førsteUttaksdatoGrunnbeløp;
-    private LocalDate førsteUttaksdatoFødseljustert;
     private LocalDateInterval utledetMedlemsintervall;
     private boolean kreverSammenhengendeUttak = true; // Beholdes inntil lovendring avklart
 
@@ -29,7 +28,6 @@ public class Skjæringstidspunkt {
         this.skjæringstidspunktBeregning = other.skjæringstidspunktBeregning;
         this.førsteUttaksdato = other.førsteUttaksdato;
         this.førsteUttaksdatoGrunnbeløp = other.førsteUttaksdatoGrunnbeløp;
-        this.førsteUttaksdatoFødseljustert = other.førsteUttaksdatoFødseljustert;
         this.kreverSammenhengendeUttak = other.kreverSammenhengendeUttak;
     }
 
@@ -85,13 +83,6 @@ public class Skjæringstidspunkt {
     public LocalDate getFørsteUttaksdatoGrunnbeløp() {
         Objects.requireNonNull(førsteUttaksdatoGrunnbeløp, "Utvikler-feil: grunnbeløpdato er ikke satt. Sørg for at det er satt ifht. anvendelse");
         return førsteUttaksdatoGrunnbeløp;
-    }
-
-    /** Første uttaksdato er første dag stønadsperioden løper - før evaluering av opptjeningsperiode. */
-    public LocalDate getFørsteUttaksdatoFødseljustert() {
-        // TODO(jol) - fjerne ved sanering av 5045
-        Objects.requireNonNull(førsteUttaksdatoFødseljustert, "Utvikler-feil: fødselsjustert uttaksdato er ikke satt. Sørg for at det er satt ifht. anvendelse");
-        return førsteUttaksdatoFødseljustert;
     }
 
     /** Skal behandles etter nytt regelverk for uttak anno 2021. */
@@ -170,11 +161,6 @@ public class Skjæringstidspunkt {
 
         public Builder medFørsteUttaksdatoGrunnbeløp(LocalDate dato) {
             kladd.førsteUttaksdatoGrunnbeløp = dato;
-            return this;
-        }
-
-        public Builder medFørsteUttaksdatoFødseljustert(LocalDate dato) {
-            kladd.førsteUttaksdatoFødseljustert = dato;
             return this;
         }
 

--- a/domenetjenester/skjaeringstidspunkt/src/test/java/no/nav/foreldrepenger/skjæringstidspunkt/fp/SkjæringstidspunktTjenesteImplTest.java
+++ b/domenetjenester/skjaeringstidspunkt/src/test/java/no/nav/foreldrepenger/skjæringstidspunkt/fp/SkjæringstidspunktTjenesteImplTest.java
@@ -1,0 +1,183 @@
+package no.nav.foreldrepenger.skjæringstidspunkt.fp;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDate;
+import java.time.Period;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepositoryProvider;
+import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.periode.OppgittFordelingEntitet;
+import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.periode.OppgittPeriodeBuilder;
+import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.periode.UttakPeriodeType;
+import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.årsak.OverføringÅrsak;
+import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.årsak.UtsettelseÅrsak;
+import no.nav.foreldrepenger.behandlingslager.testutilities.behandling.ScenarioFarSøkerForeldrepenger;
+import no.nav.foreldrepenger.behandlingslager.testutilities.behandling.ScenarioMorSøkerForeldrepenger;
+import no.nav.foreldrepenger.dbstoette.EntityManagerAwareTest;
+import no.nav.foreldrepenger.domene.tid.VirkedagUtil;
+import no.nav.foreldrepenger.skjæringstidspunkt.SkjæringstidspunktTjeneste;
+import no.nav.foreldrepenger.skjæringstidspunkt.UtsettelseCore2021;
+
+public class SkjæringstidspunktTjenesteImplTest extends EntityManagerAwareTest {
+
+    private BehandlingRepositoryProvider repositoryProvider;
+    private SkjæringstidspunktTjeneste skjæringstidspunktTjeneste;
+    private SkjæringstidspunktUtils stputil = new SkjæringstidspunktUtils(Period.parse("P4M"), Period.parse("P1Y"));
+    private UtsettelseCore2021 utsettelseCore2021 = new UtsettelseCore2021(LocalDate.now().minusMonths(1));
+
+    @BeforeEach
+    void setUp() {
+        repositoryProvider = new BehandlingRepositoryProvider(getEntityManager());
+        skjæringstidspunktTjeneste = new SkjæringstidspunktTjenesteImpl(repositoryProvider, null, stputil, utsettelseCore2021);
+    }
+
+    @Test
+    public void skal_finne_fud_søkt_uttak_periode_mor() {
+        var skjæringstidspunkt = LocalDate.now().plusWeeks(1L).minusDays(1L);
+        var oppgittPeriodeBuilder = OppgittPeriodeBuilder.ny()
+            .medPeriode(skjæringstidspunkt, skjæringstidspunkt.plusWeeks(3).minusDays(1))
+            .medPeriodeType(UttakPeriodeType.FORELDREPENGER_FØR_FØDSEL);
+        var scenario = ScenarioMorSøkerForeldrepenger.forFødsel();
+        scenario.medFordeling(new OppgittFordelingEntitet(List.of(oppgittPeriodeBuilder.build()), true));
+        scenario.medSøknadHendelse()
+            .medTerminbekreftelse(scenario.medSøknadHendelse()
+                .getTerminbekreftelseBuilder()
+                .medTermindato(skjæringstidspunkt.plusWeeks(3))
+                .medUtstedtDato(LocalDate.now())
+                .medNavnPå("Doktor Dankel"));
+        scenario.medBekreftetHendelse()
+            .medTerminbekreftelse(scenario.medBekreftetHendelse()
+                .getTerminbekreftelseBuilder()
+                .medTermindato(skjæringstidspunkt.plusWeeks(3))
+                .medUtstedtDato(LocalDate.now())
+                .medNavnPå("Doktor Dankel"));
+        var behandling = scenario.lagre(repositoryProvider);
+
+        var stp = skjæringstidspunktTjeneste.getSkjæringstidspunkter(behandling.getId());
+        assertThat(stp.getFørsteUttaksdato()).isEqualTo(skjæringstidspunkt);
+        assertThat(stp.getFørsteUttaksdatoGrunnbeløp()).isEqualTo(VirkedagUtil.fomVirkedag(skjæringstidspunkt));
+        assertThat(stp.getUtledetSkjæringstidspunkt()).isEqualTo(skjæringstidspunkt);
+    }
+
+    @Test
+    public void skal_finne_fud_grunnbeløp_søkt_uttak_periode_mor() {
+        var skjæringstidspunkt = LocalDate.now().plusWeeks(1L).minusDays(1L);
+        var oppgittPeriodeBuilder = OppgittPeriodeBuilder.ny()
+            .medPeriode(skjæringstidspunkt.plusDays(5), skjæringstidspunkt.plusWeeks(3).minusDays(1))
+            .medPeriodeType(UttakPeriodeType.FORELDREPENGER_FØR_FØDSEL);
+        var scenario = ScenarioMorSøkerForeldrepenger.forFødsel();
+        scenario.medFordeling(new OppgittFordelingEntitet(List.of(oppgittPeriodeBuilder.build()), true));
+        scenario.medSøknadHendelse()
+            .medTerminbekreftelse(scenario.medSøknadHendelse()
+                .getTerminbekreftelseBuilder()
+                .medTermindato(skjæringstidspunkt.plusWeeks(3))
+                .medUtstedtDato(LocalDate.now())
+                .medNavnPå("Doktor Dankel"));
+        scenario.medBekreftetHendelse()
+            .medTerminbekreftelse(scenario.medBekreftetHendelse()
+                .getTerminbekreftelseBuilder()
+                .medTermindato(skjæringstidspunkt.plusWeeks(3))
+                .medUtstedtDato(LocalDate.now())
+                .medNavnPå("Doktor Dankel"));
+        var behandling = scenario.lagre(repositoryProvider);
+
+        var stp = skjæringstidspunktTjeneste.getSkjæringstidspunkter(behandling.getId());
+        assertThat(stp.getFørsteUttaksdato()).isEqualTo(skjæringstidspunkt.plusDays(5));
+        assertThat(stp.getFørsteUttaksdatoGrunnbeløp()).isEqualTo(VirkedagUtil.fomVirkedag(skjæringstidspunkt));
+        assertThat(stp.getUtledetSkjæringstidspunkt()).isEqualTo(skjæringstidspunkt);
+    }
+
+    @Test
+    public void skal_finne_fud_grunnbeløp_tidlig_fødsel() {
+        var skjæringstidspunkt = LocalDate.now().plusWeeks(1L).minusDays(1L);
+        var oppgittPeriodeBuilder = OppgittPeriodeBuilder.ny()
+            .medPeriode(skjæringstidspunkt, skjæringstidspunkt.plusWeeks(3).minusDays(1))
+            .medPeriodeType(UttakPeriodeType.FORELDREPENGER_FØR_FØDSEL);
+        var scenario = ScenarioMorSøkerForeldrepenger.forFødsel();
+        scenario.medFordeling(new OppgittFordelingEntitet(List.of(oppgittPeriodeBuilder.build()), true));
+        scenario.medSøknadHendelse()
+            .medTerminbekreftelse(scenario.medSøknadHendelse()
+                .getTerminbekreftelseBuilder()
+                .medTermindato(skjæringstidspunkt.plusWeeks(3))
+                .medUtstedtDato(LocalDate.now())
+                .medNavnPå("Doktor Dankel"));
+        scenario.medBekreftetHendelse()
+            .medFødselsDato(skjæringstidspunkt.minusWeeks(1), 1)
+            .medTerminbekreftelse(scenario.medBekreftetHendelse()
+                .getTerminbekreftelseBuilder()
+                .medTermindato(skjæringstidspunkt.plusWeeks(3))
+                .medUtstedtDato(LocalDate.now())
+                .medNavnPå("Doktor Dankel"));
+        var behandling = scenario.lagre(repositoryProvider);
+
+        var stp = skjæringstidspunktTjeneste.getSkjæringstidspunkter(behandling.getId());
+        assertThat(stp.getFørsteUttaksdato()).isEqualTo(skjæringstidspunkt);
+        assertThat(stp.getFørsteUttaksdatoGrunnbeløp()).isEqualTo(VirkedagUtil.fomVirkedag(skjæringstidspunkt.minusWeeks(1)));
+        assertThat(stp.getUtledetSkjæringstidspunkt()).isEqualTo(skjæringstidspunkt.minusWeeks(1));
+    }
+
+    @Test
+    public void skal_finne_fud_søkt_uttak_periode_far_overføring() {
+        var skjæringstidspunkt = LocalDate.now().plusWeeks(1L).minusDays(1L);
+        var oppgittPeriodeBuilder = OppgittPeriodeBuilder.ny()
+            .medPeriode(skjæringstidspunkt, skjæringstidspunkt.plusWeeks(3).minusDays(1))
+            .medPeriodeType(UttakPeriodeType.MØDREKVOTE)
+            .medÅrsak(OverføringÅrsak.INSTITUSJONSOPPHOLD_ANNEN_FORELDER);
+        var scenario = ScenarioFarSøkerForeldrepenger.forFødsel()
+            .medFordeling(new OppgittFordelingEntitet(List.of(oppgittPeriodeBuilder.build()), true));
+        scenario.medSøknadHendelse().medFødselsDato(skjæringstidspunkt, 1);
+        scenario.medBekreftetHendelse().medFødselsDato(skjæringstidspunkt, 1);
+        var behandling = scenario.lagre(repositoryProvider);
+
+        var stp = skjæringstidspunktTjeneste.getSkjæringstidspunkter(behandling.getId());
+        assertThat(stp.getFørsteUttaksdato()).isEqualTo(skjæringstidspunkt);
+        assertThat(stp.getFørsteUttaksdatoGrunnbeløp()).isEqualTo(VirkedagUtil.fomVirkedag(skjæringstidspunkt));
+        assertThat(stp.getUtledetSkjæringstidspunkt()).isEqualTo(skjæringstidspunkt);
+    }
+
+    @Test
+    public void skal_finne_fud_søkt_uttak_periode_far_utsettelse() {
+        var skjæringstidspunkt = LocalDate.now().plusWeeks(1L).minusDays(1L);
+        var oppgittPeriodeBuilder1 = OppgittPeriodeBuilder.ny()
+            .medPeriode(skjæringstidspunkt.plusWeeks(31), skjæringstidspunkt.plusWeeks(35).minusDays(1))
+            .medPeriodeType(UttakPeriodeType.FEDREKVOTE)
+            .medÅrsak(UtsettelseÅrsak.FERIE);
+        var oppgittPeriodeBuilder2 = OppgittPeriodeBuilder.ny()
+            .medPeriode(skjæringstidspunkt.plusWeeks(36), skjæringstidspunkt.plusWeeks(46).minusDays(1))
+            .medPeriodeType(UttakPeriodeType.FEDREKVOTE);
+        var scenario = ScenarioFarSøkerForeldrepenger.forFødsel()
+            .medFordeling(new OppgittFordelingEntitet(List.of(oppgittPeriodeBuilder1.build(), oppgittPeriodeBuilder2.build()), true));
+        scenario.medSøknadHendelse().medFødselsDato(skjæringstidspunkt, 1);
+        scenario.medBekreftetHendelse().medFødselsDato(skjæringstidspunkt, 1);
+        var behandling = scenario.lagre(repositoryProvider);
+
+        var stp = skjæringstidspunktTjeneste.getSkjæringstidspunkter(behandling.getId());
+        assertThat(stp.getFørsteUttaksdato()).isEqualTo(skjæringstidspunkt.plusWeeks(36));
+        assertThat(stp.getFørsteUttaksdatoGrunnbeløp()).isEqualTo(VirkedagUtil.fomVirkedag(skjæringstidspunkt.plusWeeks(36)));
+        assertThat(stp.getUtledetSkjæringstidspunkt()).isEqualTo(skjæringstidspunkt.plusWeeks(36));
+    }
+
+    @Test
+    public void skal_finne_fud_søkt_uttak_periode_far_før_fødsel() {
+        var skjæringstidspunkt = LocalDate.now().plusWeeks(1L).minusDays(1L);
+        var oppgittPeriodeBuilder = OppgittPeriodeBuilder.ny()
+            .medPeriode(skjæringstidspunkt.minusWeeks(2), skjæringstidspunkt.plusWeeks(8).minusDays(1))
+            .medPeriodeType(UttakPeriodeType.FEDREKVOTE);
+        var scenario = ScenarioFarSøkerForeldrepenger.forFødsel()
+            .medFordeling(new OppgittFordelingEntitet(List.of(oppgittPeriodeBuilder.build()), true));
+        scenario.medSøknadHendelse().medFødselsDato(skjæringstidspunkt, 1);
+        scenario.medBekreftetHendelse().medFødselsDato(skjæringstidspunkt, 1);
+        var behandling = scenario.lagre(repositoryProvider);
+
+        var stp = skjæringstidspunktTjeneste.getSkjæringstidspunkter(behandling.getId());
+        assertThat(stp.getFørsteUttaksdato()).isEqualTo(skjæringstidspunkt.minusWeeks(2));
+        assertThat(stp.getFørsteUttaksdatoGrunnbeløp()).isEqualTo(VirkedagUtil.fomVirkedag(skjæringstidspunkt));
+        assertThat(stp.getUtledetSkjæringstidspunkt()).isEqualTo(skjæringstidspunkt);
+    }
+
+
+}

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/forvaltning/ForvaltningBeregningRestTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/forvaltning/ForvaltningBeregningRestTjeneste.java
@@ -179,6 +179,7 @@ public class ForvaltningBeregningRestTjeneste {
         prosessTaskData.setFagsak(fagsak.getId(), fagsak.getAktørId().getId());
         prosessTaskData.setCallIdFraEksisterende();
         prosessTaskData.setPrioritet(50);
+        prosessTaskData.setProperty(AutomatiskGrunnbelopReguleringTask.MANUELL_KEY, "true");
         prosessTaskRepository.lagre(prosessTaskData);
         return Response.ok().build();
     }


### PR DESCRIPTION
Første Uttaksdato for fri utsettelse - utledning i Utsettelse2021Core - Anders ser du spesielt på UR og YF logikken?
Første Uttaksdato for beregning  - tolkning som i TFP-4382 (seneste datoer for mor + tidligste for far/medmor)
Finpuss G-regulering Prosesstask