### PR TITLE
TFP-3525: Nullstiller fritekstfeltet for vedtaksbrev når det ikke len…

### DIFF
--- a/behandlingsprosess/src/main/java/no/nav/foreldrepenger/behandling/steg/foreslåvedtak/ForeslåVedtakTjeneste.java
+++ b/behandlingsprosess/src/main/java/no/nav/foreldrepenger/behandling/steg/foreslåvedtak/ForeslåVedtakTjeneste.java
@@ -16,6 +16,7 @@ import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingÅrsakType;
 import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.AksjonspunktDefinisjon;
 import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakRepository;
 import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakYtelseType;
+import no.nav.foreldrepenger.dokumentbestiller.DokumentBehandlingTjeneste;
 import no.nav.foreldrepenger.domene.vedtak.impl.KlageAnkeVedtakTjeneste;
 
 @ApplicationScoped
@@ -26,6 +27,7 @@ class ForeslåVedtakTjeneste {
     private SjekkMotEksisterendeOppgaverTjeneste sjekkMotEksisterendeOppgaverTjeneste;
     private FagsakRepository fagsakRepository;
     private KlageAnkeVedtakTjeneste klageAnkeVedtakTjeneste;
+    private DokumentBehandlingTjeneste dokumentBehandlingTjeneste;
 
     protected ForeslåVedtakTjeneste() {
         // CDI proxy
@@ -33,11 +35,13 @@ class ForeslåVedtakTjeneste {
 
     @Inject
     ForeslåVedtakTjeneste(FagsakRepository fagsakRepository,
-            KlageAnkeVedtakTjeneste klageAnkeVedtakTjeneste,
-            SjekkMotEksisterendeOppgaverTjeneste sjekkMotEksisterendeOppgaverTjeneste) {
+                          KlageAnkeVedtakTjeneste klageAnkeVedtakTjeneste,
+                          SjekkMotEksisterendeOppgaverTjeneste sjekkMotEksisterendeOppgaverTjeneste,
+                          DokumentBehandlingTjeneste dokumentBehandlingTjeneste) {
         this.sjekkMotEksisterendeOppgaverTjeneste = sjekkMotEksisterendeOppgaverTjeneste;
         this.fagsakRepository = fagsakRepository;
         this.klageAnkeVedtakTjeneste = klageAnkeVedtakTjeneste;
+        this.dokumentBehandlingTjeneste = dokumentBehandlingTjeneste;
     }
 
     public BehandleStegResultat foreslåVedtak(Behandling behandling) {
@@ -84,6 +88,8 @@ class ForeslåVedtakTjeneste {
             LOG.info("To-trinn fjernet på behandling={}", behandling.getId());
             if (skalOppretteForeslåVedtakManuelt(behandling)) {
                 aksjonspunktDefinisjoner.add(AksjonspunktDefinisjon.FORESLÅ_VEDTAK_MANUELT);
+            } else {
+                dokumentBehandlingTjeneste.nullstillVedtakFritekstHvisFinnes(behandling.getId());
             }
         }
     }

--- a/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/foreslåvedtak/ForeslåVedtakTjenesteTest.java
+++ b/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/foreslåvedtak/ForeslåVedtakTjenesteTest.java
@@ -86,7 +86,7 @@ public class ForeslåVedtakTjenesteTest {
         var sjekkMotEksisterendeOppgaverTjeneste = new SjekkMotEksisterendeOppgaverTjeneste(historikkRepository,
                 oppgaveTjeneste);
         var klageAnke = new KlageAnkeVedtakTjeneste(klageRepository, ankeRepository);
-        tjeneste = new ForeslåVedtakTjeneste(fagsakRepository, klageAnke, sjekkMotEksisterendeOppgaverTjeneste);
+        tjeneste = new ForeslåVedtakTjeneste(fagsakRepository, klageAnke, sjekkMotEksisterendeOppgaverTjeneste, dokumentBehandlingTjeneste);
     }
 
     @Test
@@ -141,7 +141,7 @@ public class ForeslåVedtakTjenesteTest {
     }
 
     @Test
-    public void setterStegTilUtførtUtenAksjonspunktDersomIkkeTotorinnskontroll() {
+    public void setterStegTilUtførtUtenAksjonspunktDersomIkkeTotrinnskontroll() {
         // Act
         var stegResultat = tjeneste.foreslåVedtak(behandling);
 
@@ -158,6 +158,29 @@ public class ForeslåVedtakTjenesteTest {
         // Assert
         assertThat(stegResultat.getTransisjon()).isEqualTo(FellesTransisjoner.UTFØRT);
         assertThat(behandling.isToTrinnsBehandling()).isFalse();
+    }
+
+    @Test
+    public void nullstillerFritekstfeltetDersomIkkeTotrinnskontroll() {
+        // Act
+        var stegResultat = tjeneste.foreslåVedtak(behandling);
+
+        // Assert
+        assertThat(stegResultat.getTransisjon()).isEqualTo(FellesTransisjoner.UTFØRT);
+        verify(dokumentBehandlingTjeneste, times(1)).nullstillVedtakFritekstHvisFinnes(anyLong());
+    }
+
+    @Test
+    public void nullstillerIkkeFritekstfeltetDersomTotrinnskontroll() {
+        // Arrange
+        leggTilAksjonspunkt(AksjonspunktDefinisjon.AVKLAR_OM_ER_BOSATT, true);
+
+        // Act
+        var stegResultat = tjeneste.foreslåVedtak(behandling);
+
+        // Assert
+        assertThat(stegResultat.getTransisjon()).isEqualTo(FellesTransisjoner.UTFØRT);
+        verify(dokumentBehandlingTjeneste, times(0)).nullstillVedtakFritekstHvisFinnes(anyLong());
     }
 
     @Test

--- a/domenetjenester/dokumentbestiller/src/main/java/no/nav/foreldrepenger/dokumentbestiller/DokumentBehandlingTjeneste.java
+++ b/domenetjenester/dokumentbestiller/src/main/java/no/nav/foreldrepenger/dokumentbestiller/DokumentBehandlingTjeneste.java
@@ -66,12 +66,19 @@ public class DokumentBehandlingTjeneste {
     }
 
     public boolean erDokumentBestilt(Long behandlingId, DokumentMalType dokumentMalTypeKode) {
-
         var behandlingDokument = behandlingDokumentRepository.hentHvisEksisterer(behandlingId);
         return behandlingDokument.isPresent() && behandlingDokument.get().getBestilteDokumenter().stream()
                 .map(BehandlingDokumentBestiltEntitet::getDokumentMalType)
                 .collect(Collectors.toList())
                 .contains(dokumentMalTypeKode.getKode());
+    }
+
+    public void nullstillVedtakFritekstHvisFinnes(Long behandlingId) {
+        var behandlingDokument = behandlingDokumentRepository.hentHvisEksisterer(behandlingId);
+        behandlingDokument.ifPresent(behandlingDokumentEntitet -> behandlingDokumentRepository.lagreOgFlush(
+            BehandlingDokumentEntitet.Builder.fraEksisterende(behandlingDokumentEntitet)
+                .medVedtakFritekst(null)
+                .build()));
     }
 
     public void settBehandlingPåVent(Long behandlingId, Venteårsak venteårsak) {


### PR DESCRIPTION
…gre er totrinnskontroll på behandlingen, slik at evt. fritekst fra tidligere totrinnskontroll før tilbakehopp og bortfall av behov for totrinn, ikke lengre blir benyttet i vedtaksbrevet.