### PR TITLE
TFP-4443 Se bort fra perioder med dagsats=0

### DIFF
--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/vedtak/overlapp/VurderOpphørAvYtelser.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/vedtak/overlapp/VurderOpphørAvYtelser.java
@@ -151,7 +151,7 @@ public class VurderOpphørAvYtelser  {
     }
 
     private void vurderOpphørAvYtelserForSVP(Fagsak gjeldendeSVPsak, LocalDate startDatoIVB, Long behandlingId) {
-        var sisteDatoIVB = finnMaxDato(behandlingId);
+        var sisteDatoIVB = finnMaxDatoUtenAvslåtte(behandlingId);
         var overlapper = løpendeSakerSomOverlapperUttakNySakSVP(gjeldendeSVPsak.getAktørId(), gjeldendeSVPsak.getSaksnummer(), startDatoIVB, sisteDatoIVB);
         overlapper.forEach( fagsak -> {
             // Overlapp SVP-SVP - logger foreløpig


### PR DESCRIPTION
Når det kommer SVP-vedtak i periode med Foreldrepenger, men perioder på slutten av SVP har dagsats = 0 så unnlater vi å ta dem med i vurdering av overlapp.