### PR TITLE
FIX: Fjerner kode som frontend ikke bruker lengre.

### DIFF
--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/dto/behandling/BehandlingDto.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/dto/behandling/BehandlingDto.java
@@ -185,18 +185,12 @@ public class BehandlingDto {
         return toTrinnsBehandling;
     }
 
-    @Deprecated (forRemoval = true, since = "dato=26.01.2020") //TODO(TOR): Fjerne versjon uten å når frontend har byttet
-    @JsonProperty("behandlingArsaker")
-    public List<BehandlingÅrsakDto> getBehandlingArsaker() {
-        return behandlingÅrsaker;
-    }
-
     @JsonProperty("behandlingÅrsaker")
     public List<BehandlingÅrsakDto> getBehandlingÅrsaker() {
         return behandlingÅrsaker;
     }
 
-    void setBehandlingArsaker(List<BehandlingÅrsakDto> behandlingÅrsaker) {
+    void setBehandlingÅrsaker(List<BehandlingÅrsakDto> behandlingÅrsaker) {
         this.behandlingÅrsaker = behandlingÅrsaker;
     }
 

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/dto/behandling/BehandlingDtoTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/dto/behandling/BehandlingDtoTjeneste.java
@@ -346,17 +346,12 @@ public class BehandlingDtoTjeneste {
             dto.leggTil(get(PersonRestTjeneste.VERGE_BACKEND_PATH, "verge-backend", uuidDto));
         }
 
-        if (BehandlingType.REVURDERING.equals(behandling.getType()) && BehandlingStatus.UTREDES.equals(behandling.getStatus())) {
-            dto.leggTil(get(BrevRestTjeneste.VARSEL_REVURDERING_PATH, "sendt-varsel-om-revurdering", uuidDto));
-        }
-
         dto.leggTil(get(InntektArbeidYtelseRestTjeneste.INNTEKT_ARBEID_YTELSE_PATH, "inntekt-arbeid-ytelse", uuidDto));
         dto.leggTil(get(InntektArbeidYtelseRestTjeneste.ARBEIDSGIVERE_OPPLYSNINGER_PATH, "arbeidsgivere-oversikt", uuidDto));
 
         if (opptjeningIUtlandDokStatusTjeneste.hentStatus(behandling.getId()).isPresent()) {
             dto.leggTil(get(OpptjeningRestTjeneste.UTLAND_DOK_STATUS_PATH, "utland-dok-status", uuidDto));
         }
-
 
         if (FagsakYtelseType.ENGANGSTØNAD.equals(behandling.getFagsakYtelseType())) {
             dto.leggTil(get(BeregningsresultatRestTjeneste.ENGANGSTONAD_PATH, "beregningsresultat-engangsstonad", uuidDto));

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/dto/behandling/BehandlingDtoUtil.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/dto/behandling/BehandlingDtoUtil.java
@@ -76,7 +76,7 @@ public class BehandlingDtoUtil {
         dto.setBehandlingKøet(behandling.harÅpentAksjonspunktMedType(AksjonspunktDefinisjon.AUTO_KØET_BEHANDLING));
         dto.setAnsvarligSaksbehandler(behandling.getAnsvarligSaksbehandler());
         dto.setToTrinnsBehandling(behandling.isToTrinnsBehandling());
-        dto.setBehandlingArsaker(lagBehandlingÅrsakDto(behandling));
+        dto.setBehandlingÅrsaker(lagBehandlingÅrsakDto(behandling));
     }
 
     static void setStandardfelterMedGjeldendeVedtak(Behandling behandling,


### PR DESCRIPTION
I januar ble det endret fra behandlingArsaker til behandlingÅrsaker og behandlingArsaker ble gjort deprecated i Fpsak. Ble bruken av den gamle fjernet i alle applikasjoner slik at vi kan fjerne dette i Fpsak nå?

@palfi Ser det fortsatt er en referanse i Fplos BehandlingDto, men regner med nullsjekken gjør at det er greit å fjerne?
@tor-nav Mange treff på behandlingArsaker i frontend fortsatt, men regner med alt er lokale variabler?
@tendestad Ser du endret denne i BehandlingDto i Fptilbake, men hva med EksternBehandlingsinfoDto?