### PR TITLE
Samlet init yf for revurderinger

### DIFF
--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/aksjonspunkt/AksjonspunktDefinisjon.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/aksjonspunkt/AksjonspunktDefinisjon.java
@@ -417,16 +417,24 @@ public enum AksjonspunktDefinisjon implements Kodeverdi {
 
     UNDEFINED,
 
-    // Utgåtte aksjonspunktkoder - kun her for bakoverkompatibilitet. Finnes historisk i databasen til fpsak i P, Q, T
+    // Utgåtte aksjonspunktkoder - kun her for bakoverkompatibilitet. Finnes historisk i databasen til fpsak i PROD !
 
     @Deprecated
-    _7024("7024", AksjonspunktType.AUTOPUNKT, "Sett på vent - Arbeidsgiver krever refusjon 3 måneder tilbake i tid (UTGÅTT)"),
+    _5009("5009", AksjonspunktType.MANUELL, "Avklar tilleggsopplysninger"),
     @Deprecated
-    _7028("7028", AksjonspunktType.AUTOPUNKT, "Sett på vent - Søker har søkt SVP og hatt AAP eller DP siste 10 mnd (UTGÅTT)"),
-    @Deprecated
-    _7029("7029", AksjonspunktType.AUTOPUNKT, "Sett på vent - Støtter ikke FL/SN i svangerskapspenger (UTGÅTT)"),
+    _5022("5022", AksjonspunktType.MANUELL, "Avklar fakta for status på person."),
     @Deprecated
     _5024("5024", AksjonspunktType.MANUELL, "Saksbehandler må avklare hvilke verdier som er gjeldene, det er mismatch mellom register- og lokaldata (UTGÅTT)"),
+    @Deprecated
+    _5045("5045", AksjonspunktType.MANUELL, "Avklar startdato for foreldrepengeperioden"),
+    @Deprecated
+    _5072("5072", AksjonspunktType.MANUELL, "Søker er stortingsrepresentant/administrativt ansatt i Stortinget"),
+    @Deprecated
+    _5078("5078", AksjonspunktType.MANUELL, "Kontroller tilstøtende ytelser innvilget"),
+    @Deprecated
+    _5079("5079", AksjonspunktType.MANUELL, "Kontroller tilstøtende ytelser opphørt"),
+    @Deprecated
+    _7006("7006", AksjonspunktType.AUTOPUNKT, "Venter på opptjeningsopplysninger"),
     @Deprecated
     _7015("7015", AksjonspunktType.AUTOPUNKT, "Venter på regler for 80% dekningsgrad (UTGÅTT)"),
     @Deprecated
@@ -434,25 +442,17 @@ public enum AksjonspunktDefinisjon implements Kodeverdi {
     @Deprecated
     _7017("7017", AksjonspunktType.AUTOPUNKT, "Sett på vent - ventelønn/vartpenger og militær med flere aktiviteter (UTGÅTT)"),
     @Deprecated
-    _7021("7021", AksjonspunktType.AUTOPUNKT, "Endring i fordeling av ytelse bakover i tid (UTGÅTT)"),
-    @Deprecated
-    _5078("5078", AksjonspunktType.MANUELL, "Kontroller tilstøtende ytelser innvilget"),
-    @Deprecated
-    _5079("5079", AksjonspunktType.MANUELL, "Kontroller tilstøtende ytelser opphørt"),
-    @Deprecated
-    _5072("5072", AksjonspunktType.MANUELL, "Søker er stortingsrepresentant/administrativt ansatt i Stortinget"),
-    @Deprecated
-    _5022("5022", AksjonspunktType.MANUELL, "Avklar fakta for status på person."),
-    @Deprecated
-    _7006("7006", AksjonspunktType.AUTOPUNKT, "Venter på opptjeningsopplysninger"),
-    @Deprecated
     _7018("7018", AksjonspunktType.AUTOPUNKT, "Autopunkt dødfødsel 80% dekningsgrad."),
     @Deprecated
     _7019("7019", AksjonspunktType.AUTOPUNKT, "Autopunkt gradering uten beregningsgrunnlag."),
     @Deprecated
+    _7021("7021", AksjonspunktType.AUTOPUNKT, "Endring i fordeling av ytelse bakover i tid (UTGÅTT)"),
+    @Deprecated
     _7022("7022", AksjonspunktType.AUTOPUNKT, "Autopunkt vent på ny inntektsmelding med gyldig arbeidsforholdId."),
     @Deprecated
     _7023("7023", AksjonspunktType.AUTOPUNKT, "Autopunkt militær i opptjeningsperioden og beregninggrunnlag under 3G."),
+    @Deprecated
+    _7024("7024", AksjonspunktType.AUTOPUNKT, "Sett på vent - Arbeidsgiver krever refusjon 3 måneder tilbake i tid (UTGÅTT)"),
     @Deprecated
     _7025("7025", AksjonspunktType.AUTOPUNKT, "Autopunkt gradering flere arbeidsforhold."),
     @Deprecated
@@ -460,19 +460,15 @@ public enum AksjonspunktDefinisjon implements Kodeverdi {
     @Deprecated
     _7027("7027", AksjonspunktType.AUTOPUNKT, "Autopunkt vent delvis tilrettelegging og refusjon SVP."),
     @Deprecated
+    _7028("7028", AksjonspunktType.AUTOPUNKT, "Sett på vent - Søker har søkt SVP og hatt AAP eller DP siste 10 mnd (UTGÅTT)"),
+    @Deprecated
+    _7029("7029", AksjonspunktType.AUTOPUNKT, "Sett på vent - Støtter ikke FL/SN i svangerskapspenger (UTGÅTT)"),
+    @Deprecated
     _7034("7034", AksjonspunktType.AUTOPUNKT, "Autopunkt flere arbeidsforhold i samme virksomhet SVP"),
     @Deprecated
     _7035("7035", AksjonspunktType.AUTOPUNKT, "Autopunkt potensielt feil i endringssøknad, kontakt bruker"),
     @Deprecated
     _7036("7036", AksjonspunktType.AUTOPUNKT, "Autopunkt vent manglende arbeidsforhold ifm kommunereform 2020."),
-    @Deprecated
-    _5045("5045", AksjonspunktType.MANUELL, "Avklar startdato for foreldrepengeperioden",
-        BehandlingStegType.VURDER_MEDLEMSKAPVILKÅR, VurderingspunktType.INN, VilkårType.MEDLEMSKAPSVILKÅRET, SkjermlenkeType.FAKTA_OM_MEDLEMSKAP,
-        ENTRINN, EnumSet.of(ES, FP, SVP)),
-    @Deprecated
-    AVKLAR_TILLEGGSOPPLYSNINGER(
-        AksjonspunktKodeDefinisjon.AVKLAR_TILLEGGSOPPLYSNINGER_KODE, AksjonspunktType.MANUELL, "Avklar tilleggsopplysninger",
-        BehandlingStegType.KONTROLLER_FAKTA, VurderingspunktType.UT, UTEN_VILKÅR, UTEN_SKJERMLENKE, ENTRINN, EnumSet.of(ES, FP, SVP)),
 
     ;
 

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/aksjonspunkt/AksjonspunktKodeDefinisjon.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/aksjonspunkt/AksjonspunktKodeDefinisjon.java
@@ -30,7 +30,6 @@ public class AksjonspunktKodeDefinisjon {
     public static final String AVKLAR_OM_SØKER_ER_MANN_SOM_ADOPTERER_ALENE_KODE = "5006";
     public static final String AVKLAR_OPPHOLDSRETT_KODE = "5023";
     public static final String AVKLAR_TERMINBEKREFTELSE_KODE = "5001";
-    public static final String AVKLAR_TILLEGGSOPPLYSNINGER_KODE = "5009";
     public static final String AVKLAR_VILKÅR_FOR_OMSORGSOVERTAKELSE_KODE = "5008";
     public static final String AVKLAR_VILKÅR_FOR_FORELDREANSVAR_KODE = "5054";
     public static final String AVKLAR_VERGE_KODE = "5030";

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/ytelsefordeling/YtelsesFordelingRepository.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/ytelsefordeling/YtelsesFordelingRepository.java
@@ -203,8 +203,6 @@ public class YtelsesFordelingRepository {
     /**
      * Kopierer grunnlag fra en tidligere behandling. Nullstiller avklarte datoer.
      * Brukes ifm oppretting av revurdering
-     * TODO: Rydde i KOFAK-REVURDERING-FP når alle i kompletthet har passert KOFAK (2-4 uker). Behold oppgitte for endringssøknad
-     * Flytt innhold her + KOFAK-revurdering til RevurderingTjeneste der man fikser på akt.krav (tilpass for KøKontroller)
      */
     public void kopierGrunnlagFraEksisterendeBehandling(Long gammelBehandlingId, Long nyBehandlingId) {
         var origAggregat = hentAggregatHvisEksisterer(gammelBehandlingId);
@@ -213,7 +211,9 @@ public class YtelsesFordelingRepository {
                 .medAvklarteDatoer(null)
                 .medJustertFordeling(null)
                 .medPerioderUttakDokumentasjon(null)
-                .medOverstyrtFordeling(null);
+                .medOverstyrtFordeling(null)
+                .medSaksbehandledeAktivitetskravPerioder(null);
+            ytelseFordelingAggregat.getGjeldendeAktivitetskravPerioder().ifPresent(yfBuilder::medOpprinneligeAktivitetskravPerioder);
             lagreOgFlush(nyBehandlingId, yfBuilder.build());
         });
     }

--- a/behandlingsprosess/src/main/java/no/nav/foreldrepenger/behandling/steg/avklarfakta/fp/KontrollerFaktaRevurderingStegImpl.java
+++ b/behandlingsprosess/src/main/java/no/nav/foreldrepenger/behandling/steg/avklarfakta/fp/KontrollerFaktaRevurderingStegImpl.java
@@ -320,11 +320,9 @@ class KontrollerFaktaRevurderingStegImpl implements KontrollerFaktaSteg {
     }
 
     private void tilbakestillOppgittFordelingBasertPåBehandlingType(Behandling revurdering) {
-        tilbakestillFordeling(revurdering.getId());
         if (!erEndringssøknad(revurdering)) {
             var originalBehandling = revurdering.getOriginalBehandlingId().orElseThrow();
-            // Hvis original behandling har vært innom uttak så skal periodene fra uttaket
-            // brukes for å lage ny YF
+            // Hvis original behandling har vært innom uttak så skal periodene fra uttaket brukes for å lage ny YF
             // Se FastsettUttaksgrunnlagOgVurderSøknadsfristSteg
             if (harUttak(originalBehandling)) {
                 var ytelsesFordelingRepository = repositoryProvider.getYtelsesFordelingRepository();
@@ -336,17 +334,6 @@ class KontrollerFaktaRevurderingStegImpl implements KontrollerFaktaSteg {
                 ytelsesFordelingRepository.lagre(revurdering.getId(), yfBuilder.build());
             }
         }
-    }
-
-    private void tilbakestillFordeling(Long behandlingId) {
-        var ytelsesFordelingRepository = repositoryProvider.getYtelsesFordelingRepository();
-        var ytelseFordelingAggregat = ytelsesFordelingRepository.opprettBuilder(behandlingId)
-            .medAvklarteDatoer(null)
-            .medJustertFordeling(null)
-            .medPerioderUttakDokumentasjon(null)
-            .medOverstyrtFordeling(null)
-            .build();
-        ytelsesFordelingRepository.lagre(behandlingId, ytelseFordelingAggregat);
     }
 
     private boolean harUttak(Long behandlingId) {

--- a/domenetjenester/behandling-revurdering/src/main/java/no/nav/foreldrepenger/behandling/revurdering/ytelse/fp/RevurderingTjenesteImpl.java
+++ b/domenetjenester/behandling-revurdering/src/main/java/no/nav/foreldrepenger/behandling/revurdering/ytelse/fp/RevurderingTjenesteImpl.java
@@ -133,14 +133,6 @@ public class RevurderingTjenesteImpl implements RevurderingTjeneste {
         var ytelseFordelingAggregat = ytelsesFordelingRepository.hentAggregatHvisEksisterer(originalBehandlingId);
         if (BehandlingType.REVURDERING.equals(ny.getType())) {
             ytelsesFordelingRepository.kopierGrunnlagFraEksisterendeBehandling(originalBehandlingId, nyBehandlingId);
-            ytelseFordelingAggregat.flatMap(YtelseFordelingAggregat::getGjeldendeAktivitetskravPerioder)
-                .ifPresent(entitet -> {
-                    var yfa = ytelsesFordelingRepository.opprettBuilder(nyBehandlingId)
-                        .medOpprinneligeAktivitetskravPerioder(entitet)
-                        .medSaksbehandledeAktivitetskravPerioder(null)
-                        .build();
-                    ytelsesFordelingRepository.lagre(nyBehandlingId, yfa);
-                });
         } else {
             // Kopierer kun oppgitt for ny 1gang. Bør kanskje kopiere alt?
             ytelseFordelingAggregat.ifPresent(yfa -> {

--- a/domenetjenester/behandlingskontroll/src/test/java/no/nav/foreldrepenger/behandlingskontroll/impl/BehandlingModellTest.java
+++ b/domenetjenester/behandlingskontroll/src/test/java/no/nav/foreldrepenger/behandlingskontroll/impl/BehandlingModellTest.java
@@ -68,7 +68,7 @@ public class BehandlingModellTest {
         var a1_0 = AksjonspunktDefinisjon.AVKLAR_ADOPSJONSDOKUMENTAJON;
         var a1_1 = AksjonspunktDefinisjon.AVKLAR_LOVLIG_OPPHOLD;
         var a2_0 = AksjonspunktDefinisjon.AVKLAR_GYLDIG_MEDLEMSKAPSPERIODE;
-        var a2_1 = AksjonspunktDefinisjon.AVKLAR_TILLEGGSOPPLYSNINGER;
+        var a2_1 = AksjonspunktDefinisjon.AVKLAR_VERGE;
 
         var steg = new DummySteg();
         var steg0 = new DummySteg();

--- a/domenetjenester/behandlingskontroll/src/test/java/no/nav/foreldrepenger/behandlingskontroll/impl/BehandlingskontrollEventPublisererTest.java
+++ b/domenetjenester/behandlingskontroll/src/test/java/no/nav/foreldrepenger/behandlingskontroll/impl/BehandlingskontrollEventPublisererTest.java
@@ -195,7 +195,7 @@ public class BehandlingskontrollEventPublisererTest {
         var a1_0 = AksjonspunktDefinisjon.AVKLAR_ADOPSJONSDOKUMENTAJON;
         var a1_1 = AksjonspunktDefinisjon.AVKLAR_LOVLIG_OPPHOLD;
         var a2_0 = AksjonspunktDefinisjon.AVKLAR_GYLDIG_MEDLEMSKAPSPERIODE;
-        var a2_1 = AksjonspunktDefinisjon.AVKLAR_TILLEGGSOPPLYSNINGER;
+        var a2_1 = AksjonspunktDefinisjon.AVKLAR_VERGE;
 
         var steg = new DummySteg();
         var steg0 = new DummySteg(opprettForAksjonspunkt(a2_0));

--- a/domenetjenester/behandlingskontroll/src/test/java/no/nav/foreldrepenger/behandlingskontroll/impl/BehandlingskontrollTjenesteImplTest.java
+++ b/domenetjenester/behandlingskontroll/src/test/java/no/nav/foreldrepenger/behandlingskontroll/impl/BehandlingskontrollTjenesteImplTest.java
@@ -307,7 +307,7 @@ public class BehandlingskontrollTjenesteImplTest {
         when(kontekst.getBehandlingId()).thenReturn(behandling.getId());
         when(kontekst.getFagsakId()).thenReturn(behandling.getFagsakId());
         assertThat(kontrollTjeneste.skalAksjonspunktLøsesIEllerEtterSteg(behandling.getFagsakYtelseType(),
-                behandling.getType(), steg2, AksjonspunktDefinisjon.AVKLAR_TILLEGGSOPPLYSNINGER))
+                behandling.getType(), steg2, AksjonspunktDefinisjon.AVKLAR_VERGE))
                         .isTrue();
     }
 

--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/vurderfagsystem/svp/VurderFagsystemTjenesteImpl.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/vurderfagsystem/svp/VurderFagsystemTjenesteImpl.java
@@ -67,7 +67,8 @@ public class VurderFagsystemTjenesteImpl implements VurderFagsystemTjeneste {
             .collect(Collectors.toList());
 
         if (relevanteFagsaker.size() > 1) {
-            LOG.info("VurderFagsystem SV strukturert søknad flere relevante saker {} for {}", relevanteFagsaker.size(), vurderFagsystem.getAktørId());
+            var saksnumre = relevanteFagsaker.stream().map(Fagsak::getSaksnummer).collect(Collectors.toList());
+            LOG.info("VurderFagsystem SV strukturert søknad flere relevante saker {}", saksnumre);
             return new BehandlendeFagsystem(MANUELL_VURDERING);
         }
         if (relevanteFagsaker.isEmpty()) {
@@ -85,7 +86,8 @@ public class VurderFagsystemTjenesteImpl implements VurderFagsystemTjeneste {
 
         var åpneFagsaker = fellesUtils.finnÅpneSaker(sakerGittYtelseType);
         if (åpneFagsaker.size() > 1) {
-            LOG.info("VurderFagsystem SV inntektsmelding flere åpne saker {} for {}", åpneFagsaker.size(), vurderFagsystem.getAktørId());
+            var saksnumre = åpneFagsaker.stream().map(Fagsak::getSaksnummer).collect(Collectors.toList());
+            LOG.info("VurderFagsystem SV inntektsmelding flere åpne saker {}", saksnumre);
             return new BehandlendeFagsystem(MANUELL_VURDERING);
         }
         if (åpneFagsaker.size() == 1) {
@@ -96,7 +98,8 @@ public class VurderFagsystemTjenesteImpl implements VurderFagsystemTjeneste {
             .filter(f -> fellesUtils.finnGjeldendeFamilieHendelse(f).map(this::hendelseDatoIPeriode).orElse(Boolean.TRUE))
             .collect(Collectors.toList());
         if (aktuelleSakerForMatch.size() > 1) {
-            LOG.info("VurderFagsystem SV inntektsmelding flere aktuelle saker {} for {}", aktuelleSakerForMatch.size(), vurderFagsystem.getAktørId());
+            var saksnumre = aktuelleSakerForMatch.stream().map(Fagsak::getSaksnummer).collect(Collectors.toList());
+            LOG.info("VurderFagsystem SV inntektsmelding flere aktuelle saker {}", saksnumre);
             return new BehandlendeFagsystem(MANUELL_VURDERING);
         }
         if (aktuelleSakerForMatch.size() == 1) {
@@ -121,6 +124,8 @@ public class VurderFagsystemTjenesteImpl implements VurderFagsystemTjeneste {
 
         var åpneFagsaker = fellesUtils.finnÅpneSaker(sakerGittYtelseType);
         if (åpneFagsaker.size() > 1) {
+            var saksnumre = åpneFagsaker.stream().map(Fagsak::getSaksnummer).collect(Collectors.toList());
+            LOG.info("VurderFagsystem SV strukturert søknad gammel flere åpne saker {}", saksnumre);
             return new BehandlendeFagsystem(MANUELL_VURDERING);
         }
         if (åpneFagsaker.size() == 1) {
@@ -129,7 +134,11 @@ public class VurderFagsystemTjenesteImpl implements VurderFagsystemTjeneste {
 
         var aktuelleSakerForMatch = sakerGittYtelseType.stream()
             .filter(f -> fellesUtils.finnGjeldendeFamilieHendelse(f).map(this::hendelseDatoIPeriode).orElse(Boolean.TRUE))
+            .map(Fagsak::getSaksnummer)
             .collect(Collectors.toList());
+        if (!aktuelleSakerForMatch.isEmpty()) {
+            LOG.info("VurderFagsystem SV strukturert søknad gammel flere aktuelle saker {}", aktuelleSakerForMatch);
+        }
         return aktuelleSakerForMatch.isEmpty() ? new BehandlendeFagsystem(VEDTAKSLØSNING) : new BehandlendeFagsystem(MANUELL_VURDERING);
     }
 

--- a/domenetjenester/registerinnhenting/src/main/java/no/nav/foreldrepenger/domene/registerinnhenting/impl/ÅpneBehandlingForEndringerTask.java
+++ b/domenetjenester/registerinnhenting/src/main/java/no/nav/foreldrepenger/domene/registerinnhenting/impl/ÅpneBehandlingForEndringerTask.java
@@ -65,7 +65,7 @@ public class ÅpneBehandlingForEndringerTask extends BehandlingProsessTask {
             .finnAksjonspunktDefinisjonerFraOgMed(behandling, startpunkt.getBehandlingSteg(), true);
 
         behandling.getAksjonspunkter().stream()
-            .filter(ap -> !AksjonspunktDefinisjon._5045.equals(ap.getAksjonspunktDefinisjon()))
+            .filter(ap -> !ap.getAksjonspunktDefinisjon().erUtgått())
             .filter(ap -> aksjonspunkterFraOgMedStartpunkt.contains(ap.getAksjonspunktDefinisjon().getKode()))
             .filter(ap -> !AksjonspunktType.AUTOPUNKT.equals(ap.getAksjonspunktDefinisjon().getAksjonspunktType()))
             .forEach(ap -> behandlingskontrollTjeneste.lagreAksjonspunkterReåpnet(kontekst, List.of(ap), true, false));


### PR DESCRIPTION
Flytte init av YF for revurdering fra KOFAK_revurder til oppretting av revurdering
Sanere kode for aksjonspunkt 5009 + 5045
Bedre logging av dokument som ikke kan plasseres på sak