### PR TITLE
TFP-4488 Logger kun saksnummer som skal lanseres i InnvilgelseFpLanse…

### DIFF
--- a/domenetjenester/dokumentbestiller/src/main/java/no/nav/foreldrepenger/dokumentbestiller/vedtak/InnvilgelseFpLanseringTjeneste.java
+++ b/domenetjenester/dokumentbestiller/src/main/java/no/nav/foreldrepenger/dokumentbestiller/vedtak/InnvilgelseFpLanseringTjeneste.java
@@ -66,11 +66,24 @@ public class InnvilgelseFpLanseringTjeneste {
     }
 
     private void loggSaksnummerForNesteLansering(Behandling behandling) {
-        boolean kanBrukeDokgen = ikkeGraderingDødtBarnEllerSamtidigUttakOgharBokmål(behandling);
+        boolean kanBrukeDokgenVedNesteLansering = kanBrukeDokgenVedNesteLansering(behandling);
 
-        if (kanBrukeDokgen) {
-            LOGGER.info("Saksnummer {} kan bruke Dokgen ved neste lansering", behandling.getFagsak().getSaksnummer().getVerdi());
+        if (kanBrukeDokgenVedNesteLansering) {
+            LOGGER.info("Saksnummer {} vil bruke Dokgen ved neste lansering", behandling.getFagsak().getSaksnummer().getVerdi());
         }
+    }
+
+    private boolean kanBrukeDokgenVedNesteLansering(Behandling behandling) {
+        return ikkeGraderingDødtBarnEllerSamtidigUttakOgharBokmål(behandling)
+            && harAvslåttePerioder(behandling);
+    }
+
+    private boolean harAvslåttePerioder(Behandling behandling) {
+        return fpUttakRepository.hentUttakHvisEksisterer(behandling.getId())
+            .map(ForeldrepengerUttak::getGjeldendePerioder)
+            .orElse(Collections.emptyList())
+            .stream()
+            .anyMatch(p -> !p.isInnvilget());
     }
 
     private boolean ikkeGraderingDødtBarnEllerSamtidigUttakOgharBokmål(Behandling behandling) {


### PR DESCRIPTION
…ringTjeneste.

Tar kun med saksnummer som har avslåtte perioder(i tillegg FS, ikke gradering, ikke dødt barn og bokmål) når det logges saksnummer som vil slå til ved neste lansering.