### PR TITLE
TFP-4556 Riktig framhopp ved manuelt avslag vilkår

### DIFF
--- a/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/opptjening/aksjonspunkt/AvklarOpptjeningsvilkåretOppdaterer.java
+++ b/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/opptjening/aksjonspunkt/AvklarOpptjeningsvilkåretOppdaterer.java
@@ -54,7 +54,7 @@ public class AvklarOpptjeningsvilkåretOppdaterer implements AksjonspunktOppdate
                 .build();
         }
         return OppdateringResultat.utenTransisjon()
-            .medFremoverHopp(FellesTransisjoner.FREMHOPP_TIL_FORESLÅ_BEHANDLINGSRESULTAT)
+            .medFremoverHopp(FellesTransisjoner.FREMHOPP_VED_AVSLAG_VILKÅR)
             .leggTilAvslåttVilkårResultat(VilkårType.OPPTJENINGSVILKÅRET, Avslagsårsak.IKKE_TILSTREKKELIG_OPPTJENING)
             .medVilkårResultatType(VilkårResultatType.AVSLÅTT)
             .build();

--- a/domenetjenester/familie-hendelse/src/main/java/no/nav/foreldrepenger/familiehendelse/aksjonspunkt/OmsorgsvilkårAksjonspunktOppdaterer.java
+++ b/domenetjenester/familie-hendelse/src/main/java/no/nav/foreldrepenger/familiehendelse/aksjonspunkt/OmsorgsvilkårAksjonspunktOppdaterer.java
@@ -17,6 +17,7 @@ import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.Aksjonspun
 import no.nav.foreldrepenger.behandlingslager.behandling.historikk.HistorikkEndretFeltType;
 import no.nav.foreldrepenger.behandlingslager.behandling.historikk.HistorikkEndretFeltVerdiType;
 import no.nav.foreldrepenger.behandlingslager.behandling.vilkår.Avslagsårsak;
+import no.nav.foreldrepenger.behandlingslager.behandling.vilkår.VilkårResultatType;
 import no.nav.foreldrepenger.behandlingslager.behandling.vilkår.VilkårType;
 import no.nav.foreldrepenger.behandlingslager.behandling.vilkår.VilkårUtfallType;
 import no.nav.foreldrepenger.familiehendelse.aksjonspunkt.dto.Foreldreansvarsvilkår1AksjonspunktDto;
@@ -65,9 +66,12 @@ public abstract class OmsorgsvilkårAksjonspunktOppdaterer implements Aksjonspun
             resultatBuilder.leggTilVilkårResultat(vilkårType, VilkårUtfallType.OPPFYLT);
             return resultatBuilder.medTotrinn().build();
         }
-        resultatBuilder.leggTilAvslåttVilkårResultat(vilkårType, Avslagsårsak.fraKode(dto.getAvslagskode()));
 
-        return resultatBuilder.medFremoverHopp(FellesTransisjoner.FREMHOPP_VED_AVSLAG_VILKÅR).build();
+        return resultatBuilder
+            .medFremoverHopp(FellesTransisjoner.FREMHOPP_VED_AVSLAG_VILKÅR)
+            .leggTilAvslåttVilkårResultat(vilkårType, Avslagsårsak.fraKode(dto.getAvslagskode()))
+            .medVilkårResultatType(VilkårResultatType.AVSLÅTT)
+            .build();
     }
 
     protected abstract HistorikkEndretFeltType getTekstKode();

--- a/domenetjenester/familie-hendelse/src/main/java/no/nav/foreldrepenger/familiehendelse/aksjonspunkt/VurdereYtelseSammeBarnOppdaterer.java
+++ b/domenetjenester/familie-hendelse/src/main/java/no/nav/foreldrepenger/familiehendelse/aksjonspunkt/VurdereYtelseSammeBarnOppdaterer.java
@@ -19,6 +19,7 @@ import no.nav.foreldrepenger.behandlingslager.behandling.historikk.HistorikkEndr
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.vilkår.Avslagsårsak;
 import no.nav.foreldrepenger.behandlingslager.behandling.vilkår.Vilkår;
+import no.nav.foreldrepenger.behandlingslager.behandling.vilkår.VilkårResultatType;
 import no.nav.foreldrepenger.behandlingslager.behandling.vilkår.VilkårType;
 import no.nav.foreldrepenger.behandlingslager.behandling.vilkår.VilkårUtfallType;
 import no.nav.foreldrepenger.familiehendelse.aksjonspunkt.dto.VurdereYtelseSammeBarnAnnenForelderAksjonspunktDto;
@@ -61,8 +62,12 @@ public abstract class VurdereYtelseSammeBarnOppdaterer implements AksjonspunktOp
             }
             var resultatBuilder = OppdateringResultat.utenTransisjon();
             var avslagsårsak = dto.getAvslagskode() == null ? null : Avslagsårsak.fraKode(dto.getAvslagskode());
-            resultatBuilder.leggTilAvslåttVilkårResultat(vilkår.getVilkårType(), avslagsårsak);
-            return resultatBuilder.medFremoverHopp(FellesTransisjoner.FREMHOPP_VED_AVSLAG_VILKÅR).build();
+
+            return resultatBuilder
+                .medFremoverHopp(FellesTransisjoner.FREMHOPP_VED_AVSLAG_VILKÅR)
+                .leggTilAvslåttVilkårResultat(vilkår.getVilkårType(), avslagsårsak)
+                .medVilkårResultatType(VilkårResultatType.AVSLÅTT)
+                .build();
         }
         return OppdateringResultat.utenOveropp();
 

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/søknad/aksjonspunkt/BekreftSøkersOpplysningspliktManuellOppdaterer.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/søknad/aksjonspunkt/BekreftSøkersOpplysningspliktManuellOppdaterer.java
@@ -61,11 +61,10 @@ public class BekreftSøkersOpplysningspliktManuellOppdaterer implements Aksjonsp
             .filter(a -> !a.getAksjonspunktDefinisjon().getKode().equals(dto.getKode())) // Ikke seg selv
             .forEach(a -> resultatBuilder.medEkstraAksjonspunktResultat(a.getAksjonspunktDefinisjon(), AksjonspunktStatus.AVBRUTT));
 
-        resultatBuilder.leggTilAvslåttVilkårResultat(VilkårType.SØKERSOPPLYSNINGSPLIKT, avslagsårsak);
-        resultatBuilder.medVilkårResultatType(VilkårResultatType.AVSLÅTT);
-
         return resultatBuilder
             .medFremoverHopp(FellesTransisjoner.FREMHOPP_VED_AVSLAG_VILKÅR)
+            .leggTilAvslåttVilkårResultat(VilkårType.SØKERSOPPLYSNINGSPLIKT, avslagsårsak)
+            .medVilkårResultatType(VilkårResultatType.AVSLÅTT)
             .medEkstraAksjonspunktResultat(AksjonspunktDefinisjon.VEDTAK_UTEN_TOTRINNSKONTROLL, AksjonspunktStatus.OPPRETTET)
             .build();
     }

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/søknad/aksjonspunkt/SøknadsfristOppdaterer.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/søknad/aksjonspunkt/SøknadsfristOppdaterer.java
@@ -45,7 +45,7 @@ public class SøknadsfristOppdaterer implements AksjonspunktOppdaterer<Soknadsfr
                 .build();
         }
         return OppdateringResultat.utenTransisjon()
-            .medFremoverHopp(FellesTransisjoner.FREMHOPP_TIL_FORESLÅ_BEHANDLINGSRESULTAT)
+            .medFremoverHopp(FellesTransisjoner.FREMHOPP_VED_AVSLAG_VILKÅR)
             .leggTilAvslåttVilkårResultat(SØKNADSFRISTVILKÅRET,  Avslagsårsak.SØKT_FOR_SENT, VM_5007)
             .medVilkårResultatType(VilkårResultatType.AVSLÅTT)
             .build();


### PR DESCRIPTION
To tilfelle der man hoppet over uttak (opplysningsplikt 5017 og opptjening). Restrukturering øvrige

Petter: Kan du se på FastsettBeregningsAktiviteterSteg og VurderRefusjonBeregningsgrunnlagSteg som kan returnere FellesTransisjoner.FREMHOPP_TIL_FORESLÅ_BEHANDLINGSRESULTAT ?
Dersom disse kan brukes til å avslå VK41 for FP/Revurdering bør de innom uttak og få justert periodene. Se InngangsvilkårStegImpl . getBehandleStegResultatVedAvslag() for riktig håndtering.