### PR TITLE
TFP-4596 skriv om vilkårbuilder behold regelsporing

### DIFF
--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/vilkår/Vilkår.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/vilkår/Vilkår.java
@@ -110,11 +110,11 @@ public class Vilkår extends BaseEntitet implements IndexKey {
     }
 
     public boolean erManueltVurdert() {
-        return !asList(VilkårUtfallType.UDEFINERT, VilkårUtfallType.IKKE_VURDERT).contains(vilkårUtfallManuelt);
+        return !List.of(VilkårUtfallType.UDEFINERT, VilkårUtfallType.IKKE_VURDERT).contains(vilkårUtfallManuelt);
     }
 
     public boolean erOverstyrt() {
-        return !asList(VilkårUtfallType.UDEFINERT, VilkårUtfallType.IKKE_VURDERT).contains(vilkårUtfallOverstyrt);
+        return !List.of(VilkårUtfallType.UDEFINERT, VilkårUtfallType.IKKE_VURDERT).contains(vilkårUtfallOverstyrt);
     }
 
     public Avslagsårsak getAvslagsårsak() {
@@ -165,6 +165,11 @@ public class Vilkår extends BaseEntitet implements IndexKey {
         } if (!vilkårUtfallManuelt.equals(VilkårUtfallType.UDEFINERT)) {
             return vilkårUtfallManuelt;
         }
+        return vilkårUtfall;
+    }
+
+    // Kun for intern bruk i builders. Bruk getGjeldende forøvrig
+    VilkårUtfallType getVilkårUtfall() {
         return vilkårUtfall;
     }
 

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/vilkår/VilkårBuilder.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/vilkår/VilkårBuilder.java
@@ -1,76 +1,89 @@
 package no.nav.foreldrepenger.behandlingslager.behandling.vilkår;
 
-import java.util.Objects;
+import java.util.Optional;
 import java.util.Properties;
 
-class VilkårBuilder {
-    private VilkårType vilkårType;
-    private Avslagsårsak avslagsårsak;
-    private VilkårUtfallType vilkårUtfall;
-    private VilkårUtfallMerknad vilkårUtfallMerknad;
-    private Properties merknadParametere;
-    private VilkårUtfallType vilkårUtfallManuell;
-    private VilkårUtfallType vilkårUtfallOverstyrt;
-    private String regelEvaluering;
-    private String regelInput;
+public class VilkårBuilder {
+    private Vilkår kladd;
+    private boolean oppdatering;
 
-    VilkårBuilder medVilkårType(VilkårType vilkårType) {
-        this.vilkårType = vilkårType;
+    private VilkårBuilder(Vilkår vilkår, boolean oppdatering) {
+        this.kladd = vilkår;
+        this.oppdatering = oppdatering;
+    }
+
+    static VilkårBuilder ny() {
+        return new VilkårBuilder(new Vilkår(), false);
+    }
+
+    static VilkårBuilder oppdatere(Vilkår vilkår) {
+        return new VilkårBuilder(vilkår, true);
+    }
+
+    public static VilkårBuilder oppdatere(Optional<Vilkår> vilkår) {
+        return vilkår.map(VilkårBuilder::oppdatere).orElseGet(VilkårBuilder::ny);
+    }
+
+    public VilkårBuilder medVilkårType(VilkårType vilkårType) {
+        if (kladd.getVilkårType() != null && !vilkårType.equals(kladd.getVilkårType())) {
+            throw new IllegalArgumentException("Prøver endre vilkårtype på eksisterende vilkår");
+        }
+        kladd.setVilkårType(vilkårType);
         return this;
     }
 
-    VilkårBuilder medAvslagsårsak(Avslagsårsak avslagsårsak) {
-        this.avslagsårsak = avslagsårsak;
+    public VilkårBuilder medVilkårUtfall(VilkårUtfallType vilkårUtfall, Avslagsårsak avslagsårsak) {
+        kladd.setVilkårUtfall(vilkårUtfall);
+        if (!VilkårUtfallType.IKKE_OPPFYLT.equals(kladd.getVilkårUtfallOverstyrt())) {
+            kladd.setAvslagsårsak(avslagsårsak);
+        }
         return this;
     }
 
-    VilkårBuilder medVilkårUtfall(VilkårUtfallType vilkårUtfall) {
-        this.vilkårUtfall = vilkårUtfall;
+    public VilkårBuilder medUtfallManuell(VilkårUtfallType vilkårUtfallManuell, Avslagsårsak avslagsårsak) {
+        kladd.setVilkårUtfallManuelt(vilkårUtfallManuell);
+        if (!VilkårUtfallType.IKKE_OPPFYLT.equals(kladd.getVilkårUtfallOverstyrt())) {
+            kladd.setAvslagsårsak(avslagsårsak);
+        }
         return this;
     }
 
-    VilkårBuilder medVilkårUtfallMerknad(VilkårUtfallMerknad vilkårUtfallMerknad) {
-        this.vilkårUtfallMerknad = vilkårUtfallMerknad;
+    VilkårBuilder medUtfallOverstyrt(VilkårUtfallType vilkårUtfallOverstyrt, Avslagsårsak avslagsårsak) {
+        kladd.setVilkårUtfallOverstyrt(vilkårUtfallOverstyrt);
+        kladd.setAvslagsårsak(avslagsårsak);
         return this;
     }
 
-    VilkårBuilder medMerknadParametere(Properties merknadParametere) {
-        this.merknadParametere = merknadParametere;
+    public VilkårBuilder medVilkårUtfallMerknad(VilkårUtfallMerknad vilkårUtfallMerknad) {
+        kladd.setVilkårUtfallMerknad(vilkårUtfallMerknad != null ? vilkårUtfallMerknad : VilkårUtfallMerknad.UDEFINERT);
         return this;
     }
 
-    VilkårBuilder medUtfallManuell(VilkårUtfallType vilkårUtfallManuell) {
-        this.vilkårUtfallManuell = vilkårUtfallManuell;
+    public VilkårBuilder medMerknadParametere(Properties merknadParametere) {
+        if (merknadParametere != null && !merknadParametere.isEmpty())
+            kladd.setMerknadParametere(merknadParametere);
         return this;
     }
 
-    VilkårBuilder medUtfallOverstyrt(VilkårUtfallType vilkårUtfallOverstyrt) {
-        this.vilkårUtfallOverstyrt = vilkårUtfallOverstyrt;
+    public VilkårBuilder medRegelEvaluering(String regelEvaluering) {
+        kladd.setRegelEvaluering(regelEvaluering);
         return this;
     }
 
-    VilkårBuilder medRegelEvaluering(String regelEvaluering) {
-        this.regelEvaluering = regelEvaluering;
-        return this;
-    }
-
-    VilkårBuilder medRegelInput(String regelInput) {
-        this.regelInput = regelInput;
+    public VilkårBuilder medRegelInput(String regelInput) {
+        kladd.setRegelInput(regelInput);
         return this;
     }
 
     Vilkår build() {
-        var vilkår = new Vilkår();
-        Objects.requireNonNull(vilkårType, "vilkårType");
-        vilkår.setVilkårType(vilkårType);
-        vilkår.setVilkårUtfall(vilkårUtfall);
-        vilkår.setVilkårUtfallMerknad(vilkårUtfallMerknad);
-        vilkår.setAvslagsårsak(avslagsårsak);
-        vilkår.setMerknadParametere(merknadParametere);
-        vilkår.setVilkårUtfallManuelt(vilkårUtfallManuell);
-        vilkår.setVilkårUtfallOverstyrt(vilkårUtfallOverstyrt);
-        vilkår.setRegelEvaluering(regelEvaluering);
-        vilkår.setRegelInput(regelInput);
-        return vilkår;
+        if (VilkårType.UDEFINERT.equals(kladd.getVilkårType()) || VilkårUtfallType.UDEFINERT.equals(kladd.getGjeldendeVilkårUtfall())) {
+            throw new IllegalStateException("Mangler vilkårType");
+        }
+        return kladd;
     }
+
+    boolean erOppdatering() {
+        return oppdatering;
+    }
+
 }

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/vilkår/VilkårUtfallType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/vilkår/VilkårUtfallType.java
@@ -23,8 +23,6 @@ public enum VilkårUtfallType implements Kodeverdi {
     OPPFYLT("OPPFYLT", "Oppfylt"),
     IKKE_OPPFYLT("IKKE_OPPFYLT", "Ikke oppfylt"),
     IKKE_VURDERT("IKKE_VURDERT", "Ikke vurdert"),
-    IKKE_RELEVANT("IKKE_RELEVANT", "Ikke relevant"),
-    AVSLAAS_I_ANNET_VILKAAR("AVSLAAS_I_ANNET_VILKAAR", "Avslås i annet vilkår"),
 
     UDEFINERT("-", "Ikke definert"),
 

--- a/behandlingslager/domene/src/test/java/no/nav/foreldrepenger/behandlingslager/behandling/repository/BehandlingRevurderingRepositoryTest.java
+++ b/behandlingslager/domene/src/test/java/no/nav/foreldrepenger/behandlingslager/behandling/repository/BehandlingRevurderingRepositoryTest.java
@@ -3,7 +3,6 @@ package no.nav.foreldrepenger.behandlingslager.behandling.repository;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.LocalDateTime;
-import java.util.Properties;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -146,8 +145,7 @@ public class BehandlingRevurderingRepositoryTest extends EntityManagerAwareTest 
 
     private void oppdaterMedBehandlingsresultatAvslagOgLagre(Behandling behandling) {
         VilkårResultat.builder()
-            .leggTilVilkårResultat(VilkårType.FØDSELSVILKÅRET_MOR, VilkårUtfallType.IKKE_OPPFYLT,
-                null, new Properties(), null, false, false, null, null)
+            .leggTilVilkår(VilkårType.FØDSELSVILKÅRET_MOR, VilkårUtfallType.IKKE_OPPFYLT)
             .medVilkårResultatType(VilkårResultatType.AVSLÅTT)
             .buildFor(behandling);
 

--- a/behandlingslager/testutil/src/test/java/no/nav/foreldrepenger/behandlingslager/behandling/BehandlingRepositoryTest.java
+++ b/behandlingslager/testutil/src/test/java/no/nav/foreldrepenger/behandlingslager/behandling/BehandlingRepositoryTest.java
@@ -5,7 +5,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Properties;
 import java.util.UUID;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -746,8 +745,7 @@ public class BehandlingRepositoryTest extends EntityManagerAwareTest {
         behandlingRepository.lagre(behandling, lås);
 
         VilkårResultat.builder()
-            .leggTilVilkårResultat(VilkårType.FØDSELSVILKÅRET_MOR, innvilget ? VilkårUtfallType.OPPFYLT : VilkårUtfallType.IKKE_OPPFYLT,
-                null, new Properties(), null, false, false, null, null)
+            .leggTilVilkår(VilkårType.FØDSELSVILKÅRET_MOR, innvilget ? VilkårUtfallType.OPPFYLT : VilkårUtfallType.IKKE_OPPFYLT)
             .medVilkårResultatType(innvilget ? VilkårResultatType.INNVILGET : VilkårResultatType.AVSLÅTT)
             .buildFor(behandling);
         behandlingRepository.lagre(behandlingsresultat.getVilkårResultat(), lås);

--- a/behandlingslager/testutil/src/test/java/no/nav/foreldrepenger/behandlingslager/behandling/BeregningResultatTest.java
+++ b/behandlingslager/testutil/src/test/java/no/nav/foreldrepenger/behandlingslager/behandling/BeregningResultatTest.java
@@ -3,7 +3,6 @@ package no.nav.foreldrepenger.behandlingslager.behandling;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.LocalDateTime;
-import java.util.Properties;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -13,8 +12,8 @@ import no.nav.foreldrepenger.behandlingslager.behandling.beregning.LegacyESBereg
 import no.nav.foreldrepenger.behandlingslager.behandling.beregning.LegacyESBeregningsresultat;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.vilkår.VilkårResultat;
+import no.nav.foreldrepenger.behandlingslager.behandling.vilkår.VilkårResultatType;
 import no.nav.foreldrepenger.behandlingslager.behandling.vilkår.VilkårType;
-import no.nav.foreldrepenger.behandlingslager.behandling.vilkår.VilkårUtfallMerknad;
 import no.nav.foreldrepenger.behandlingslager.behandling.vilkår.VilkårUtfallType;
 import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakRepository;
 import no.nav.foreldrepenger.behandlingslager.testutilities.fagsak.FagsakBuilder;
@@ -225,7 +224,7 @@ public class BeregningResultatTest extends EntityManagerAwareTest {
         // TX_2: Oppdatere Behandlingsresultat med VilkårResultat
         behandling1 = behandlingRepository.hentBehandling(behandling1.getId());
         var vilkårResultat = VilkårResultat.builder()
-                .leggTilVilkårResultat(VilkårType.FØDSELSVILKÅRET_MOR, VilkårUtfallType.OPPFYLT, VilkårUtfallMerknad.VM_1001, new Properties(), null, false, false, null, null)
+                .leggTilVilkår(VilkårType.FØDSELSVILKÅRET_MOR, VilkårUtfallType.OPPFYLT)
                 .buildFor(behandling1);
 
         var lås = behandlingRepository.taSkriveLås(behandling1);

--- a/behandlingslager/testutil/src/test/java/no/nav/foreldrepenger/behandlingslager/behandling/VilkårResultatTest.java
+++ b/behandlingslager/testutil/src/test/java/no/nav/foreldrepenger/behandlingslager/behandling/VilkårResultatTest.java
@@ -2,8 +2,6 @@ package no.nav.foreldrepenger.behandlingslager.behandling;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.util.Properties;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -12,7 +10,6 @@ import no.nav.foreldrepenger.behandlingslager.behandling.vilkår.Avslagsårsak;
 import no.nav.foreldrepenger.behandlingslager.behandling.vilkår.VilkårResultat;
 import no.nav.foreldrepenger.behandlingslager.behandling.vilkår.VilkårResultatType;
 import no.nav.foreldrepenger.behandlingslager.behandling.vilkår.VilkårType;
-import no.nav.foreldrepenger.behandlingslager.behandling.vilkår.VilkårUtfallMerknad;
 import no.nav.foreldrepenger.behandlingslager.behandling.vilkår.VilkårUtfallType;
 import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakRepository;
 import no.nav.foreldrepenger.behandlingslager.testutilities.fagsak.FagsakBuilder;
@@ -35,7 +32,7 @@ public class VilkårResultatTest extends EntityManagerAwareTest {
         lagreBehandling(behandling);
 
         Behandlingsresultat.builderForInngangsvilkår().buildFor(behandling);
-        var behandlingsresultat1 = lagreOgGjenopphenteBehandlingsresultat(behandling);
+        var behandlingsresultat1 = lagreOgGjenopphenteBehandlingsresultat(behandling, VilkårResultatType.IKKE_FASTSATT);
 
         var id01 = behandlingsresultat1.getBehandlingId();
 
@@ -44,7 +41,7 @@ public class VilkårResultatTest extends EntityManagerAwareTest {
             .medKopiAvForrigeBehandlingsresultat()
             .build();
         lagreBehandling(behandling2);
-        var behandlingsresultat2 = lagreOgGjenopphenteBehandlingsresultat(behandling2);
+        var behandlingsresultat2 = lagreOgGjenopphenteBehandlingsresultat(behandling2, VilkårResultatType.IKKE_FASTSATT);
 
         // Assert
         assertThat(getBehandlingsresultat(behandling2)).isNotSameAs(getBehandlingsresultat(behandling));
@@ -70,7 +67,7 @@ public class VilkårResultatTest extends EntityManagerAwareTest {
         lagreBehandling(behandling);
 
         Behandlingsresultat.builderForInngangsvilkår().buildFor(behandling);
-        var behandlingsresultat1 = lagreOgGjenopphenteBehandlingsresultat(behandling);
+        var behandlingsresultat1 = lagreOgGjenopphenteBehandlingsresultat(behandling, VilkårResultatType.IKKE_FASTSATT);
 
         var id01 = behandlingsresultat1.getBehandlingId();
 
@@ -82,10 +79,11 @@ public class VilkårResultatTest extends EntityManagerAwareTest {
 
         // legg til et nytt vilkårsresultat
         VilkårResultat.builderFraEksisterende(getBehandlingsresultat(behandling2).getVilkårResultat())
-                .leggTilVilkårResultat(VilkårType.MEDLEMSKAPSVILKÅRET, VilkårUtfallType.OPPFYLT, VilkårUtfallMerknad.VM_1001, new Properties(), null, false, false, null, null)
+                .leggTilVilkår(VilkårType.MEDLEMSKAPSVILKÅRET, VilkårUtfallType.OPPFYLT)
+                .medVilkårResultatType(VilkårResultatType.INNVILGET)
                 .buildFor(behandling2);
 
-        var behandlingsresultat2 = lagreOgGjenopphenteBehandlingsresultat(behandling2);
+        var behandlingsresultat2 = lagreOgGjenopphenteBehandlingsresultat(behandling2, VilkårResultatType.INNVILGET);
         // Assert
         assertThat(getBehandlingsresultat(behandling2)).isNotSameAs(getBehandlingsresultat(behandling));
         assertThat(getBehandlingsresultat(behandling2).getVilkårResultat())
@@ -102,7 +100,7 @@ public class VilkårResultatTest extends EntityManagerAwareTest {
         lagreBehandling(behandling);
         var vilkårResultatBuilder = VilkårResultat.builder()
                 .medVilkårResultatType(VilkårResultatType.AVSLÅTT)
-                .leggTilVilkårResultat(VilkårType.OMSORGSVILKÅRET, VilkårUtfallType.IKKE_OPPFYLT, null, new Properties(), Avslagsårsak.SØKER_ER_IKKE_BARNETS_FAR_O, false, false, null, null);
+                .leggTilVilkår(VilkårType.OMSORGSVILKÅRET, VilkårUtfallType.IKKE_OPPFYLT, Avslagsårsak.SØKER_ER_IKKE_BARNETS_FAR_O);
         var behandlingsresultatBuilder = new Behandlingsresultat.Builder(vilkårResultatBuilder);
         var behandlingsresultat1 = behandlingsresultatBuilder.buildFor(behandling);
 
@@ -129,14 +127,14 @@ public class VilkårResultatTest extends EntityManagerAwareTest {
         // Arrange
         var behandling = lagBehandling();
         var opprinneligVilkårResultat = VilkårResultat.builder()
-            .medVilkårResultatType(VilkårResultatType.AVSLÅTT)
+            .medVilkårResultatType(VilkårResultatType.IKKE_FASTSATT)
             .leggTilVilkår(VilkårType.SØKNADSFRISTVILKÅRET, VilkårUtfallType.IKKE_VURDERT)
             .buildFor(behandling);
 
         // Act
         var oppdatertVilkårResultat = VilkårResultat.builderFraEksisterende(opprinneligVilkårResultat)
-            .medVilkårResultatType(VilkårResultatType.INNVILGET)
-            .leggTilVilkårResultat(VilkårType.FORELDREANSVARSVILKÅRET_4_LEDD, VilkårUtfallType.IKKE_OPPFYLT, null, new Properties(), Avslagsårsak.SØKER_ER_IKKE_BARNETS_FAR_F, true, false, null, null)
+            .medVilkårResultatType(VilkårResultatType.AVSLÅTT)
+            .manueltVilkår(VilkårType.FORELDREANSVARSVILKÅRET_4_LEDD, VilkårUtfallType.IKKE_OPPFYLT, Avslagsårsak.SØKER_ER_IKKE_BARNETS_FAR_F)
             .buildFor(behandling);
 
         // Assert
@@ -157,13 +155,13 @@ public class VilkårResultatTest extends EntityManagerAwareTest {
         var behandling = lagBehandling();
         var opprinneligVilkårResultat = VilkårResultat.builder()
             .medVilkårResultatType(VilkårResultatType.AVSLÅTT)
-            .leggTilVilkårResultat(VilkårType.FORELDREANSVARSVILKÅRET_2_LEDD, VilkårUtfallType.IKKE_OPPFYLT, null, new Properties(), Avslagsårsak.SØKER_HAR_IKKE_FORELDREANSVAR, true, false, null, null)
+            .manueltVilkår(VilkårType.FORELDREANSVARSVILKÅRET_2_LEDD, VilkårUtfallType.IKKE_OPPFYLT, Avslagsårsak.SØKER_HAR_IKKE_FORELDREANSVAR)
             .buildFor(behandling);
 
         // Act
         var oppdatertVilkårResultat = VilkårResultat.builderFraEksisterende(opprinneligVilkårResultat)
             .medVilkårResultatType(VilkårResultatType.INNVILGET)
-            .leggTilVilkårResultat(VilkårType.FORELDREANSVARSVILKÅRET_2_LEDD, VilkårUtfallType.OPPFYLT, null, new Properties(), null, true, false, null, null)
+            .manueltVilkår(VilkårType.FORELDREANSVARSVILKÅRET_2_LEDD, VilkårUtfallType.OPPFYLT, Avslagsårsak.UDEFINERT)
             .buildFor(behandling);
 
         // Assert
@@ -180,7 +178,7 @@ public class VilkårResultatTest extends EntityManagerAwareTest {
         var behandling = lagBehandling();
         var opprinneligVilkårResultat = VilkårResultat.builder()
             .medVilkårResultatType(VilkårResultatType.INNVILGET)
-            .leggTilVilkårResultat(VilkårType.MEDLEMSKAPSVILKÅRET, VilkårUtfallType.OPPFYLT, null, new Properties(), null, false, false, null, null)
+            .leggTilVilkår(VilkårType.MEDLEMSKAPSVILKÅRET, VilkårUtfallType.OPPFYLT)
             .buildFor(behandling);
 
         // Act 1: Ikke oppfylt (overstyrt)
@@ -202,7 +200,7 @@ public class VilkårResultatTest extends EntityManagerAwareTest {
         // Act 2: Oppfylt
         oppdatertVilkårResultat = VilkårResultat.builderFraEksisterende(oppdatertVilkårResultat)
             .medVilkårResultatType(VilkårResultatType.INNVILGET)
-            .overstyrVilkår(VilkårType.MEDLEMSKAPSVILKÅRET, VilkårUtfallType.OPPFYLT, null)
+            .overstyrVilkår(VilkårType.MEDLEMSKAPSVILKÅRET, VilkårUtfallType.OPPFYLT, Avslagsårsak.UDEFINERT)
             .buildFor(behandling);
 
         // Assert
@@ -222,7 +220,7 @@ public class VilkårResultatTest extends EntityManagerAwareTest {
         var behandling = lagBehandling();
         var opprinneligVilkårResultat = VilkårResultat.builder()
             .medVilkårResultatType(VilkårResultatType.INNVILGET)
-            .leggTilVilkårResultat(VilkårType.MEDLEMSKAPSVILKÅRET, VilkårUtfallType.OPPFYLT, null, new Properties(), null, false, false, null, null)
+            .leggTilVilkår(VilkårType.MEDLEMSKAPSVILKÅRET, VilkårUtfallType.OPPFYLT)
             .buildFor(behandling);
         var overstyrtVilkårResultat = VilkårResultat.builderFraEksisterende(opprinneligVilkårResultat)
             .medVilkårResultatType(VilkårResultatType.AVSLÅTT)
@@ -231,8 +229,8 @@ public class VilkårResultatTest extends EntityManagerAwareTest {
 
         // Act
         var oppdatertVilkårResultat = VilkårResultat.builderFraEksisterende(overstyrtVilkårResultat)
-            .medVilkårResultatType(VilkårResultatType.INNVILGET)
-            .leggTilVilkårResultat(VilkårType.MEDLEMSKAPSVILKÅRET, VilkårUtfallType.OPPFYLT, null, new Properties(), null, true, false, null, null)
+            .medVilkårResultatType(VilkårResultatType.AVSLÅTT) // Overstyring teller
+            .manueltVilkår(VilkårType.MEDLEMSKAPSVILKÅRET, VilkårUtfallType.OPPFYLT, Avslagsårsak.UDEFINERT)
             .buildFor(behandling);
 
         // Assert
@@ -252,12 +250,13 @@ public class VilkårResultatTest extends EntityManagerAwareTest {
         var opprinneligVilkårResultat = VilkårResultat.builder()
             .medVilkårResultatType(VilkårResultatType.AVSLÅTT)
             .leggTilVilkår(VilkårType.SØKNADSFRISTVILKÅRET, VilkårUtfallType.IKKE_VURDERT)
-            .leggTilVilkårResultat(VilkårType.FORELDREANSVARSVILKÅRET_4_LEDD, VilkårUtfallType.IKKE_OPPFYLT, null, new Properties(), Avslagsårsak.SØKER_ER_IKKE_BARNETS_FAR_F, true, false, null, null)
+            .manueltVilkår(VilkårType.FORELDREANSVARSVILKÅRET_4_LEDD, VilkårUtfallType.IKKE_OPPFYLT, Avslagsårsak.SØKER_ER_IKKE_BARNETS_FAR_F)
             .buildFor(behandling);
 
         // Act
         var oppdatertVilkårResultat = VilkårResultat.builderFraEksisterende(opprinneligVilkårResultat)
             .fjernVilkår(VilkårType.FORELDREANSVARSVILKÅRET_4_LEDD)
+            .medVilkårResultatType(VilkårResultatType.IKKE_FASTSATT)
             .buildFor(behandling);
 
         // Assert
@@ -267,12 +266,12 @@ public class VilkårResultatTest extends EntityManagerAwareTest {
         assertThat(vilkår.getGjeldendeVilkårUtfall()).isEqualTo(VilkårUtfallType.IKKE_VURDERT);
     }
 
-    private Behandlingsresultat lagreOgGjenopphenteBehandlingsresultat(Behandling behandling) {
+    private Behandlingsresultat lagreOgGjenopphenteBehandlingsresultat(Behandling behandling, VilkårResultatType forventet) {
         var behandlingsresultat = getBehandlingsresultat(behandling);
 
         assertThat(behandlingsresultat.getBehandlingId()).isNotNull();
         assertThat(behandlingsresultat.getVilkårResultat().getOriginalBehandlingId()).isNotNull();
-        assertThat(behandlingsresultat.getVilkårResultat().getVilkårResultatType()).isEqualTo(VilkårResultatType.IKKE_FASTSATT);
+        assertThat(behandlingsresultat.getVilkårResultat().getVilkårResultatType()).isEqualTo(forventet);
 
         var lås = behandlingRepository.taSkriveLås(behandling);
         behandlingRepository.lagre(behandlingsresultat.getVilkårResultat(), lås);

--- a/behandlingsprosess/src/main/java/no/nav/foreldrepenger/behandling/steg/avklarfakta/fp/KontrollerFaktaRevurderingStegImpl.java
+++ b/behandlingsprosess/src/main/java/no/nav/foreldrepenger/behandling/steg/avklarfakta/fp/KontrollerFaktaRevurderingStegImpl.java
@@ -399,11 +399,6 @@ class KontrollerFaktaRevurderingStegImpl implements KontrollerFaktaSteg {
     }
 
     private void kopierVilkår(VilkårResultat.Builder vilkårBuilder, Set<Vilkår> vilkårne) {
-        vilkårne
-                .forEach(vilkår -> vilkårBuilder.leggTilVilkårResultat(vilkår.getVilkårType(), vilkår.getGjeldendeVilkårUtfall(),
-                        vilkår.getVilkårUtfallMerknad(),
-                        vilkår.getMerknadParametere(), vilkår.getAvslagsårsak(), vilkår.erManueltVurdert(), vilkår.erOverstyrt(),
-                        vilkår.getRegelEvaluering(),
-                        vilkår.getRegelInput()));
+        vilkårne.forEach(vilkår -> vilkårBuilder.kopierVilkårFraAnnenBehandling(vilkår, false));
     }
 }

--- a/behandlingsprosess/src/main/java/no/nav/foreldrepenger/behandling/steg/medlemskap/VurderLøpendeMedlemskapSteg.java
+++ b/behandlingsprosess/src/main/java/no/nav/foreldrepenger/behandling/steg/medlemskap/VurderLøpendeMedlemskapSteg.java
@@ -69,17 +69,18 @@ public class VurderLøpendeMedlemskapSteg implements BehandlingSteg {
                 medlemskapVilkårPeriodeRepository.lagreMedlemskapsvilkår(behandling, builder);
 
                 var resultat = medlemskapVilkårPeriodeRepository.utledeVilkårStatus(behandling);
-                var vilkårBuilder = VilkårResultat
+                var vilkårResultatBuilder = VilkårResultat
                         .builderFraEksisterende(getBehandlingsresultat(behandlingId).getVilkårResultat());
-                Avslagsårsak avslagsårsak = null;
+                var vilkårBuilder = vilkårResultatBuilder.getVilkårBuilderFor(VilkårType.MEDLEMSKAPSVILKÅRET_LØPENDE);
                 if (VilkårUtfallType.IKKE_OPPFYLT.equals(resultat.vilkårUtfallType())) {
-                    avslagsårsak = Avslagsårsak.fraKode(resultat.vilkårUtfallMerknad().getKode());
+                    var avslagsårsak = Avslagsårsak.fraKode(resultat.vilkårUtfallMerknad().getKode());
+                    vilkårBuilder.medVilkårUtfall(resultat.vilkårUtfallType(), avslagsårsak).medVilkårUtfallMerknad(resultat.vilkårUtfallMerknad());
+                } else {
+                    vilkårBuilder.medVilkårUtfall(resultat.vilkårUtfallType(), Avslagsårsak.UDEFINERT);
                 }
-                vilkårBuilder.leggTilVilkårResultat(VilkårType.MEDLEMSKAPSVILKÅRET_LØPENDE, resultat.vilkårUtfallType(), resultat.vilkårUtfallMerknad(), null,
-                        avslagsårsak, false, false, null, null);
-
+                vilkårResultatBuilder.leggTilVilkår(vilkårBuilder);
                 var lås = kontekst.getSkriveLås();
-                behandlingRepository.lagre(vilkårBuilder.buildFor(behandling), lås);
+                behandlingRepository.lagre(vilkårResultatBuilder.buildFor(behandling), lås);
             }
         }
         return BehandleStegResultat.utførtUtenAksjonspunkter();

--- a/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/foreslåresultat/fp/ForeslåBehandlingsresultatTjenesteTest.java
+++ b/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/foreslåresultat/fp/ForeslåBehandlingsresultatTjenesteTest.java
@@ -273,10 +273,11 @@ public class ForeslåBehandlingsresultatTjenesteTest extends EntityManagerAwareT
         if (vilkårUtfallType.equals(VilkårUtfallType.OPPFYLT)) {
             vilkårsresultatBuilder.leggTilVilkår(VilkårType.FØDSELSVILKÅRET_MOR, vilkårUtfallType);
             vilkårsresultatBuilder.leggTilVilkår(VilkårType.MEDLEMSKAPSVILKÅRET, vilkårUtfallType);
+            vilkårsresultatBuilder.medVilkårResultatType(VilkårResultatType.INNVILGET);
         } else {
-            vilkårsresultatBuilder.leggTilVilkårResultatManueltIkkeOppfylt(
-                    VilkårType.FØDSELSVILKÅRET_MOR,
+            vilkårsresultatBuilder.manueltVilkår(VilkårType.FØDSELSVILKÅRET_MOR, VilkårUtfallType.IKKE_OPPFYLT,
                     Avslagsårsak.FØDSELSDATO_IKKE_OPPGITT_ELLER_REGISTRERT);
+            vilkårsresultatBuilder.medVilkårResultatType(VilkårResultatType.AVSLÅTT);
         }
         behandlingRepository.lagre(vilkårsresultatBuilder.buildFor(behandling), lås);
         behandlingRepository.lagre(behandling, lås);

--- a/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/foreslåresultat/svp/ForeslåBehandlingsresultatTjenesteTest.java
+++ b/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/foreslåresultat/svp/ForeslåBehandlingsresultatTjenesteTest.java
@@ -252,10 +252,11 @@ public class ForeslåBehandlingsresultatTjenesteTest extends EntityManagerAwareT
         if (vilkårUtfallType.equals(VilkårUtfallType.OPPFYLT)) {
             vilkårsresultatBuilder.leggTilVilkår(VilkårType.OPPTJENINGSVILKÅRET, vilkårUtfallType);
             vilkårsresultatBuilder.leggTilVilkår(VilkårType.MEDLEMSKAPSVILKÅRET, vilkårUtfallType);
+            vilkårsresultatBuilder.medVilkårResultatType(VilkårResultatType.INNVILGET);
         } else {
-            vilkårsresultatBuilder.leggTilVilkårResultatManueltIkkeOppfylt(
-                    VilkårType.OPPTJENINGSVILKÅRET,
+            vilkårsresultatBuilder.manueltVilkår(VilkårType.OPPTJENINGSVILKÅRET, VilkårUtfallType.IKKE_OPPFYLT,
                     Avslagsårsak.IKKE_TILSTREKKELIG_OPPTJENING);
+            vilkårsresultatBuilder.medVilkårResultatType(VilkårResultatType.AVSLÅTT);
         }
         behandlingRepository.lagre(vilkårsresultatBuilder.buildFor(behandling), lås);
         behandlingRepository.lagre(behandling, lås);

--- a/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/inngangsvilkår/InngangsvilkårStegImplTest.java
+++ b/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/inngangsvilkår/InngangsvilkårStegImplTest.java
@@ -65,7 +65,7 @@ public class InngangsvilkårStegImplTest {
         // Arrange
         var scenario = ScenarioMorSøkerForeldrepenger.forFødsel()
                 .medBehandlingType(BehandlingType.REVURDERING)
-                .medVilkårResultatType(VilkårResultatType.IKKE_FASTSATT)
+                .medVilkårResultatType(VilkårResultatType.AVSLÅTT)
                 .leggTilVilkår(medlVilkårType, VilkårUtfallType.IKKE_OPPFYLT);
         var behandling = scenario.lagMocked();
 
@@ -85,7 +85,7 @@ public class InngangsvilkårStegImplTest {
         assertThat(stegResultat.getTransisjon()).isEqualTo(TransisjonIdentifikator.forId(FREMHOPP_TIL_UTTAKSPLAN.getId()));
 
         var vilkårResultat = behandling.getBehandlingsresultat().getVilkårResultat();
-        assertThat(vilkårResultat.getVilkårResultatType()).isEqualTo(VilkårResultatType.IKKE_FASTSATT);
+        assertThat(vilkårResultat.getVilkårResultatType()).isEqualTo(VilkårResultatType.AVSLÅTT);
         assertThat(vilkårResultat.getVilkårene().stream().map(Vilkår::getGjeldendeVilkårUtfall).collect(toList()))
                 .containsExactly(VilkårUtfallType.IKKE_OPPFYLT);
     }
@@ -95,7 +95,7 @@ public class InngangsvilkårStegImplTest {
         // Arrange
         var scenario = ScenarioMorSøkerForeldrepenger.forFødsel()
                 .medBehandlingType(BehandlingType.FØRSTEGANGSSØKNAD)
-                .medVilkårResultatType(VilkårResultatType.IKKE_FASTSATT)
+                .medVilkårResultatType(VilkårResultatType.AVSLÅTT)
                 .leggTilVilkår(oppVilkårType, VilkårUtfallType.IKKE_OPPFYLT);
         var behandling = scenario.lagMocked();
 
@@ -116,7 +116,7 @@ public class InngangsvilkårStegImplTest {
         assertThat(stegResultat.getAksjonspunktListe()).contains(AksjonspunktDefinisjon.VURDER_OPPTJENINGSVILKÅRET);
 
         var vilkårResultat = behandling.getBehandlingsresultat().getVilkårResultat();
-        assertThat(vilkårResultat.getVilkårResultatType()).isEqualTo(VilkårResultatType.IKKE_FASTSATT);
+        assertThat(vilkårResultat.getVilkårResultatType()).isEqualTo(VilkårResultatType.AVSLÅTT);
         assertThat(vilkårResultat.getVilkårene().stream().map(Vilkår::getGjeldendeVilkårUtfall).collect(toList()))
                 .containsExactly(VilkårUtfallType.IKKE_OPPFYLT);
     }
@@ -134,7 +134,7 @@ public class InngangsvilkårStegImplTest {
 
         var revurderingsscenario = ScenarioMorSøkerForeldrepenger.forFødsel()
                 .medBehandlingType(BehandlingType.REVURDERING)
-                .medVilkårResultatType(VilkårResultatType.IKKE_FASTSATT)
+                .medVilkårResultatType(VilkårResultatType.AVSLÅTT)
                 .leggTilVilkår(oppVilkårType, VilkårUtfallType.IKKE_OPPFYLT)
                 .medOriginalBehandling(førstegangsbehandling, BehandlingÅrsakType.RE_HENDELSE_FØDSEL);
         var revurdering = revurderingsscenario.lagMocked();
@@ -179,7 +179,7 @@ public class InngangsvilkårStegImplTest {
 
         var revurderingsscenario = ScenarioMorSøkerForeldrepenger.forFødsel()
                 .medBehandlingType(BehandlingType.REVURDERING)
-                .medVilkårResultatType(VilkårResultatType.IKKE_FASTSATT)
+                .medVilkårResultatType(VilkårResultatType.AVSLÅTT)
                 .leggTilVilkår(medlVilkårType, VilkårUtfallType.IKKE_OPPFYLT)
                 .leggTilVilkår(oppVilkårType, VilkårUtfallType.OPPFYLT)
                 .medOriginalBehandling(førstegangsbehandling, BehandlingÅrsakType.RE_HENDELSE_FØDSEL);
@@ -206,7 +206,7 @@ public class InngangsvilkårStegImplTest {
         // Arrange
         var førstegangsscenario = ScenarioMorSøkerForeldrepenger.forFødsel()
                 .medBehandlingType(BehandlingType.FØRSTEGANGSSØKNAD)
-                .medVilkårResultatType(VilkårResultatType.IKKE_FASTSATT)
+                .medVilkårResultatType(VilkårResultatType.AVSLÅTT)
                 .leggTilVilkår(oppVilkårType, VilkårUtfallType.IKKE_OPPFYLT)
                 .medBehandlingsresultat(Behandlingsresultat.builder().medBehandlingResultatType(BehandlingResultatType.AVSLÅTT));
         var førstegangsbehandling = førstegangsscenario.lagMocked();
@@ -214,7 +214,7 @@ public class InngangsvilkårStegImplTest {
 
         var revurderingsscenario = ScenarioMorSøkerForeldrepenger.forFødsel()
                 .medBehandlingType(BehandlingType.REVURDERING)
-                .medVilkårResultatType(VilkårResultatType.IKKE_FASTSATT)
+                .medVilkårResultatType(VilkårResultatType.AVSLÅTT)
                 .leggTilVilkår(medlVilkårType, VilkårUtfallType.IKKE_OPPFYLT)
                 .leggTilVilkår(oppVilkårType, VilkårUtfallType.OPPFYLT)
                 .medOriginalBehandling(førstegangsbehandling, BehandlingÅrsakType.RE_HENDELSE_FØDSEL);
@@ -243,7 +243,7 @@ public class InngangsvilkårStegImplTest {
         // Arrange
         var førstegangsscenario = ScenarioMorSøkerForeldrepenger.forFødsel()
                 .medBehandlingType(BehandlingType.FØRSTEGANGSSØKNAD)
-                .medVilkårResultatType(VilkårResultatType.IKKE_FASTSATT)
+                .medVilkårResultatType(VilkårResultatType.AVSLÅTT)
                 .leggTilVilkår(oppVilkårType, VilkårUtfallType.IKKE_OPPFYLT)
                 .medBehandlingsresultat(Behandlingsresultat.builder().medBehandlingResultatType(BehandlingResultatType.AVSLÅTT));
         var førstegangsbehandling = førstegangsscenario.lagMocked();
@@ -251,7 +251,7 @@ public class InngangsvilkårStegImplTest {
 
         var førsteRevurderingsscenario = ScenarioMorSøkerForeldrepenger.forFødsel()
                 .medBehandlingType(BehandlingType.REVURDERING)
-                .medVilkårResultatType(VilkårResultatType.IKKE_FASTSATT)
+                .medVilkårResultatType(VilkårResultatType.AVSLÅTT)
                 .leggTilVilkår(oppVilkårType, VilkårUtfallType.IKKE_OPPFYLT)
                 .medOriginalBehandling(førstegangsbehandling, BehandlingÅrsakType.RE_HENDELSE_FØDSEL)
                 .medBehandlingsresultat(Behandlingsresultat.builder().medBehandlingResultatType(BehandlingResultatType.INGEN_ENDRING));
@@ -259,7 +259,7 @@ public class InngangsvilkårStegImplTest {
 
         var andreRevurderingsscenario = ScenarioMorSøkerForeldrepenger.forFødsel()
                 .medBehandlingType(BehandlingType.REVURDERING)
-                .medVilkårResultatType(VilkårResultatType.IKKE_FASTSATT)
+                .medVilkårResultatType(VilkårResultatType.AVSLÅTT)
                 .leggTilVilkår(medlVilkårType, VilkårUtfallType.IKKE_OPPFYLT)
                 .leggTilVilkår(oppVilkårType, VilkårUtfallType.OPPFYLT)
                 .medOriginalBehandling(revurdering1, BehandlingÅrsakType.RE_HENDELSE_FØDSEL);

--- a/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/inngangsvilkår/SamletInngangsvilkårStegImplTest.java
+++ b/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/inngangsvilkår/SamletInngangsvilkårStegImplTest.java
@@ -55,7 +55,7 @@ public class SamletInngangsvilkårStegImplTest {
         // Arrange
         var scenario = ScenarioMorSøkerForeldrepenger.forFødsel()
                 .medBehandlingType(BehandlingType.REVURDERING)
-                .medVilkårResultatType(VilkårResultatType.IKKE_FASTSATT)
+                .medVilkårResultatType(VilkårResultatType.AVSLÅTT)
                 .leggTilVilkår(VilkårType.SØKERSOPPLYSNINGSPLIKT, VilkårUtfallType.IKKE_OPPFYLT)
                 .leggTilVilkår(VilkårType.FØDSELSVILKÅRET_MOR, VilkårUtfallType.IKKE_VURDERT)
                 .leggTilVilkår(VilkårType.MEDLEMSKAPSVILKÅRET, VilkårUtfallType.IKKE_VURDERT)
@@ -79,7 +79,7 @@ public class SamletInngangsvilkårStegImplTest {
         assertThat(stegResultat.getTransisjon()).isEqualTo(TransisjonIdentifikator.forId(FREMHOPP_TIL_UTTAKSPLAN.getId()));
 
         var vilkårResultat = behandling.getBehandlingsresultat().getVilkårResultat();
-        assertThat(vilkårResultat.getVilkårResultatType()).isEqualTo(VilkårResultatType.IKKE_FASTSATT);
+        assertThat(vilkårResultat.getVilkårResultatType()).isEqualTo(VilkårResultatType.AVSLÅTT);
     }
 
     @Test
@@ -87,7 +87,7 @@ public class SamletInngangsvilkårStegImplTest {
         // Arrange
         var scenario = ScenarioMorSøkerForeldrepenger.forFødsel()
                 .medBehandlingType(BehandlingType.REVURDERING)
-                .medVilkårResultatType(VilkårResultatType.IKKE_FASTSATT)
+                .medVilkårResultatType(VilkårResultatType.INNVILGET)
                 .leggTilVilkår(VilkårType.SØKERSOPPLYSNINGSPLIKT, VilkårUtfallType.OPPFYLT)
                 .leggTilVilkår(VilkårType.FØDSELSVILKÅRET_MOR, VilkårUtfallType.OPPFYLT)
                 .leggTilVilkår(VilkårType.MEDLEMSKAPSVILKÅRET, VilkårUtfallType.OPPFYLT)

--- a/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/vedtak/BehandlingVedtakTjenesteTest.java
+++ b/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/vedtak/BehandlingVedtakTjenesteTest.java
@@ -5,7 +5,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
 import java.time.LocalDate;
-import java.util.Properties;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -125,8 +124,7 @@ public class BehandlingVedtakTjenesteTest extends EntityManagerAwareTest {
                 .buildFor(behandling);
         var ikkeAvslått = !behandlingResultatType.equals(BehandlingResultatType.AVSLÅTT);
         VilkårResultat.builder()
-                .leggTilVilkårResultat(VilkårType.FØDSELSVILKÅRET_MOR, ikkeAvslått ? VilkårUtfallType.OPPFYLT : VilkårUtfallType.IKKE_OPPFYLT,
-                        null, new Properties(), null, false, false, null, null)
+                .leggTilVilkår(VilkårType.FØDSELSVILKÅRET_MOR, ikkeAvslått ? VilkårUtfallType.OPPFYLT : VilkårUtfallType.IKKE_OPPFYLT)
                 .medVilkårResultatType(ikkeAvslått ? VilkårResultatType.INNVILGET : VilkårResultatType.AVSLÅTT)
                 .buildFor(behandling);
 

--- a/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/vedtak/FatteVedtakStegTest.java
+++ b/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/vedtak/FatteVedtakStegTest.java
@@ -17,7 +17,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
-import java.util.Properties;
 
 import javax.inject.Inject;
 import javax.persistence.EntityManager;
@@ -554,8 +553,7 @@ public class FatteVedtakStegTest {
         var behandling = behandlingRepository.hentBehandling(kontekst.getBehandlingId());
 
         var vilkårResultat = VilkårResultat.builder()
-                .leggTilVilkårResultat(VilkårType.FØDSELSVILKÅRET_MOR, innvilget ? VilkårUtfallType.OPPFYLT : VilkårUtfallType.IKKE_OPPFYLT,
-                        null, new Properties(), null, false, false, null, null)
+                .leggTilVilkår(VilkårType.FØDSELSVILKÅRET_MOR, innvilget ? VilkårUtfallType.OPPFYLT : VilkårUtfallType.IKKE_OPPFYLT)
                 .medVilkårResultatType(innvilget ? VilkårResultatType.INNVILGET : VilkårResultatType.AVSLÅTT)
                 .buildFor(behandling);
 

--- a/domenetjenester/behandling-revurdering/src/main/java/no/nav/foreldrepenger/behandling/revurdering/RevurderingTjenesteFelles.java
+++ b/domenetjenester/behandling-revurdering/src/main/java/no/nav/foreldrepenger/behandling/revurdering/RevurderingTjenesteFelles.java
@@ -25,7 +25,6 @@ import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRe
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRevurderingRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.vilkår.VilkårResultat;
 import no.nav.foreldrepenger.behandlingslager.behandling.vilkår.VilkårResultatType;
-import no.nav.foreldrepenger.behandlingslager.behandling.vilkår.VilkårUtfallType;
 import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.periode.OppgittFordelingEntitet;
 import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.periode.OppgittPeriodeBuilder;
 import no.nav.foreldrepenger.behandlingslager.fagsak.Fagsak;
@@ -98,13 +97,7 @@ public class RevurderingTjenesteFelles {
 
         var vilkårBuilder = VilkårResultat.builder();
         origVilkårResultat.getVilkårene().stream()
-                .forEach(vilkår -> vilkårBuilder
-                        .medUtfallManuelt(vilkår.getVilkårUtfallManuelt())
-                        .medUtfallOverstyrt(vilkår.getVilkårUtfallOverstyrt())
-                        .leggTilVilkårResultat(vilkår.getVilkårType(), VilkårUtfallType.IKKE_VURDERT, vilkår.getVilkårUtfallMerknad(),
-                                vilkår.getMerknadParametere(), vilkår.getAvslagsårsak(), vilkår.erManueltVurdert(), vilkår.erOverstyrt(),
-                                vilkår.getRegelEvaluering(),
-                                vilkår.getRegelInput()));
+                .forEach(vilkår -> vilkårBuilder.kopierVilkårFraAnnenBehandling(vilkår, true));
         vilkårBuilder.medVilkårResultatType(VilkårResultatType.IKKE_FASTSATT);
         var vilkårResultat = vilkårBuilder.buildFor(revurdering);
         behandlingRepository.lagre(vilkårResultat, kontekst.getSkriveLås());

--- a/domenetjenester/behandling-revurdering/src/test/java/no/nav/foreldrepenger/behandling/revurdering/FagsakRevurderingTest.java
+++ b/domenetjenester/behandling-revurdering/src/test/java/no/nav/foreldrepenger/behandling/revurdering/FagsakRevurderingTest.java
@@ -25,7 +25,6 @@ import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRe
 import no.nav.foreldrepenger.behandlingslager.behandling.vilkår.Avslagsårsak;
 import no.nav.foreldrepenger.behandlingslager.behandling.vilkår.VilkårResultat;
 import no.nav.foreldrepenger.behandlingslager.behandling.vilkår.VilkårType;
-import no.nav.foreldrepenger.behandlingslager.behandling.vilkår.VilkårUtfallMerknad;
 import no.nav.foreldrepenger.behandlingslager.behandling.vilkår.VilkårUtfallType;
 import no.nav.foreldrepenger.behandlingslager.fagsak.Fagsak;
 import no.nav.foreldrepenger.behandlingslager.testutilities.fagsak.FagsakBuilder;
@@ -78,9 +77,8 @@ public class FagsakRevurderingTest {
     public void kanOppretteRevurderingNårÅpenKlage() {
         behandling.avsluttBehandling();
         Behandlingsresultat.builder().medBehandlingResultatType(BehandlingResultatType.AVSLÅTT).buildFor(behandling);
-        VilkårResultat.builder().leggTilVilkårResultat(VilkårType.FØDSELSVILKÅRET_MOR,
-                VilkårUtfallType.IKKE_OPPFYLT, VilkårUtfallMerknad.VM_1005, null,
-                Avslagsårsak.SØKER_ER_IKKE_BARNETS_FAR_O, false, false, null, null).buildFor(behandling);
+        VilkårResultat.builder().leggTilVilkår(VilkårType.FØDSELSVILKÅRET_MOR,
+                VilkårUtfallType.IKKE_OPPFYLT, Avslagsårsak.SØKER_ER_IKKE_BARNETS_FAR_O).buildFor(behandling);
         when(behandlingRepository.hentÅpneYtelseBehandlingerForFagsakId(fagsak.getId())).thenReturn(
                 Collections.emptyList());
 
@@ -93,9 +91,8 @@ public class FagsakRevurderingTest {
     public void kanOppretteRevurderingNårÅpentInnsyn() {
         behandling.avsluttBehandling();
         Behandlingsresultat.builder().medBehandlingResultatType(BehandlingResultatType.AVSLÅTT).buildFor(behandling);
-        VilkårResultat.builder().leggTilVilkårResultat(VilkårType.FØDSELSVILKÅRET_MOR,
-                VilkårUtfallType.IKKE_OPPFYLT, VilkårUtfallMerknad.VM_1005, null,
-                Avslagsårsak.SØKER_ER_IKKE_BARNETS_FAR_O, false, false, null, null).buildFor(behandling);
+        VilkårResultat.builder().leggTilVilkår(VilkårType.FØDSELSVILKÅRET_MOR,
+            VilkårUtfallType.IKKE_OPPFYLT, Avslagsårsak.SØKER_ER_IKKE_BARNETS_FAR_O).buildFor(behandling);
         when(behandlingRepository.hentÅpneYtelseBehandlingerForFagsakId(fagsak.getId())).thenReturn(
                 Collections.emptyList());
 
@@ -121,9 +118,8 @@ public class FagsakRevurderingTest {
     public void kanOppretteRevurderingDersomBehandlingErVedtatt() {
         behandling.avsluttBehandling();
         Behandlingsresultat.builder().medBehandlingResultatType(BehandlingResultatType.AVSLÅTT).buildFor(behandling);
-        VilkårResultat.builder().leggTilVilkårResultat(VilkårType.FØDSELSVILKÅRET_MOR,
-                VilkårUtfallType.IKKE_OPPFYLT, VilkårUtfallMerknad.VM_1005, null,
-                Avslagsårsak.SØKER_ER_IKKE_BARNETS_FAR_O, false, false, null, null).buildFor(behandling);
+        VilkårResultat.builder().leggTilVilkår(VilkårType.FØDSELSVILKÅRET_MOR,
+            VilkårUtfallType.IKKE_OPPFYLT, Avslagsårsak.SØKER_ER_IKKE_BARNETS_FAR_O).buildFor(behandling);
 
         var tjeneste = new FagsakRevurdering(behandlingRepository);
         var kanRevurderingOpprettes = tjeneste.kanRevurderingOpprettes(fagsak);
@@ -135,9 +131,8 @@ public class FagsakRevurderingTest {
     public void kanIkkeOppretteRevurderingDersomAvlagPåSøkersOpplysningsplikt() {
         behandling.avsluttBehandling();
         Behandlingsresultat.builder().medBehandlingResultatType(BehandlingResultatType.AVSLÅTT).buildFor(behandling);
-        VilkårResultat.builder().leggTilVilkårResultat(VilkårType.SØKERSOPPLYSNINGSPLIKT,
-                VilkårUtfallType.IKKE_OPPFYLT, VilkårUtfallMerknad.VM_1005, null,
-                Avslagsårsak.SØKER_ER_IKKE_BARNETS_FAR_O, false, false, null, null).buildFor(behandling);
+        VilkårResultat.builder().leggTilVilkår(VilkårType.SØKERSOPPLYSNINGSPLIKT,
+                VilkårUtfallType.IKKE_OPPFYLT, Avslagsårsak.SØKER_ER_IKKE_BARNETS_FAR_O).buildFor(behandling);
 
         var tjeneste = new FagsakRevurdering(behandlingRepository);
         var kanRevurderingOpprettes = tjeneste.kanRevurderingOpprettes(fagsak);
@@ -155,9 +150,8 @@ public class FagsakRevurderingTest {
                 .medBehandlingResultatType(BehandlingResultatType.INNVILGET)
                 .buildFor(eldreBehandling);
 
-        VilkårResultat.builder().leggTilVilkårResultat(VilkårType.SØKERSOPPLYSNINGSPLIKT,
-                VilkårUtfallType.OPPFYLT, null, null,
-                null, false, false, null, null).buildFor(eldreBehandling);
+        VilkårResultat.builder().leggTilVilkår(VilkårType.SØKERSOPPLYSNINGSPLIKT,
+                VilkårUtfallType.OPPFYLT).buildFor(eldreBehandling);
         lenient().when(behandlingRepository.finnSisteIkkeHenlagteYtelseBehandlingFor(any()))
                 .thenReturn(Optional.of(eldreBehandling));
         var tjeneste = new FagsakRevurdering(behandlingRepository);
@@ -173,16 +167,12 @@ public class FagsakRevurderingTest {
         Behandlingsresultat.builder()
                 .medBehandlingResultatType(BehandlingResultatType.AVSLÅTT)
                 .buildFor(eldreBehandling);
-        VilkårResultat.builder().leggTilVilkårResultat(VilkårType.SØKERSOPPLYSNINGSPLIKT,
-                VilkårUtfallType.IKKE_OPPFYLT, null, null,
-                null, false, false, null, null).buildFor(eldreBehandling);
+        VilkårResultat.builder().leggTilVilkår(VilkårType.SØKERSOPPLYSNINGSPLIKT, VilkårUtfallType.IKKE_OPPFYLT).buildFor(eldreBehandling);
 
         Behandlingsresultat.builder()
                 .medBehandlingResultatType(BehandlingResultatType.AVSLÅTT)
                 .buildFor(nyesteBehandling);
-        VilkårResultat.builder().leggTilVilkårResultat(VilkårType.SØKERSOPPLYSNINGSPLIKT,
-                VilkårUtfallType.OPPFYLT, null, null,
-                null, false, false, null, null).buildFor(nyesteBehandling);
+        VilkårResultat.builder().leggTilVilkår(VilkårType.SØKERSOPPLYSNINGSPLIKT, VilkårUtfallType.OPPFYLT).buildFor(nyesteBehandling);
         lenient().when(behandlingRepository.finnSisteIkkeHenlagteYtelseBehandlingFor(any()))
                 .thenReturn(Optional.of(nyesteBehandling));
         var tjeneste = new FagsakRevurdering(behandlingRepository);
@@ -196,16 +186,12 @@ public class FagsakRevurderingTest {
         Behandlingsresultat.builder()
                 .medBehandlingResultatType(BehandlingResultatType.AVSLÅTT)
                 .buildFor(nyesteBehandling);
-        VilkårResultat.builder().leggTilVilkårResultat(VilkårType.SØKERSOPPLYSNINGSPLIKT,
-                VilkårUtfallType.IKKE_OPPFYLT, null, null,
-                null, false, false, null, null).buildFor(nyesteBehandling);
+        VilkårResultat.builder().leggTilVilkår(VilkårType.SØKERSOPPLYSNINGSPLIKT, VilkårUtfallType.IKKE_OPPFYLT).buildFor(nyesteBehandling);
 
         Behandlingsresultat.builder()
                 .medBehandlingResultatType(BehandlingResultatType.AVSLÅTT)
                 .buildFor(eldreBehandling);
-        VilkårResultat.builder().leggTilVilkårResultat(VilkårType.SØKERSOPPLYSNINGSPLIKT,
-                VilkårUtfallType.OPPFYLT, null, null,
-                null, false, false, null, null).buildFor(eldreBehandling);
+        VilkårResultat.builder().leggTilVilkår(VilkårType.SØKERSOPPLYSNINGSPLIKT, VilkårUtfallType.OPPFYLT).buildFor(eldreBehandling);
         lenient().when(behandlingRepository.finnSisteIkkeHenlagteYtelseBehandlingFor(any()))
                 .thenReturn(Optional.of(nyesteBehandling));
         var tjeneste = new FagsakRevurdering(behandlingRepository);

--- a/domenetjenester/behandling-revurdering/src/test/java/no/nav/foreldrepenger/behandling/revurdering/felles/OppfyllerIkkeInngangsvilkårPåSkjæringstidsspunktTest.java
+++ b/domenetjenester/behandling-revurdering/src/test/java/no/nav/foreldrepenger/behandling/revurdering/felles/OppfyllerIkkeInngangsvilkårPåSkjæringstidsspunktTest.java
@@ -181,7 +181,7 @@ public class OppfyllerIkkeInngangsvilkårPåSkjæringstidsspunktTest {
     public void skal_teste_at_behandlingsresultatet_fastsettes_korrekt_for_saker_som_skal_behandles_i_infotrygd() {
         // Arrange
         VilkårResultat.builder()
-                .leggTilVilkårResultatManueltIkkeOppfylt(VilkårType.BEREGNINGSGRUNNLAGVILKÅR,
+                .manueltVilkår(VilkårType.BEREGNINGSGRUNNLAGVILKÅR, VilkårUtfallType.IKKE_OPPFYLT,
                         Avslagsårsak.INGEN_BEREGNINGSREGLER_TILGJENGELIG_I_LØSNINGEN)
                 .buildFor(revurdering);
 
@@ -203,7 +203,7 @@ public class OppfyllerIkkeInngangsvilkårPåSkjæringstidsspunktTest {
     public void skal_teste_at_behandlingsresultatet_fastsettes_korrekt_for_saker_med_avslagsårsak_null() {
         // Arrange
         VilkårResultat.builder()
-                .leggTilVilkårResultatManueltIkkeOppfylt(VilkårType.BEREGNINGSGRUNNLAGVILKÅR, Avslagsårsak.UDEFINERT)
+                .manueltVilkår(VilkårType.BEREGNINGSGRUNNLAGVILKÅR, VilkårUtfallType.IKKE_OPPFYLT, Avslagsårsak.UDEFINERT)
                 .buildFor(revurdering);
 
         // Act

--- a/domenetjenester/behandling-revurdering/src/test/java/no/nav/foreldrepenger/behandling/revurdering/ytelse/fp/RevurderingBehandlingsresultatutlederTest.java
+++ b/domenetjenester/behandling-revurdering/src/test/java/no/nav/foreldrepenger/behandling/revurdering/ytelse/fp/RevurderingBehandlingsresultatutlederTest.java
@@ -197,14 +197,16 @@ public class RevurderingBehandlingsresultatutlederTest {
         lagUttakResultatPlanForBehandling(revurdering, revurderingPerioder, StønadskontoType.FEDREKVOTE);
 
         // Oppfylt inngangsvilkår på skjæringstidspunkt
-        var vilkårResultat = VilkårResultat.builder()
+        var vilkårResultatBuilder = VilkårResultat.builder()
                 .leggTilVilkår(VilkårType.FORELDREANSVARSVILKÅRET_2_LEDD, VilkårUtfallType.OPPFYLT)
                 .leggTilVilkår(VilkårType.OPPTJENINGSVILKÅRET, VilkårUtfallType.OPPFYLT)
                 .leggTilVilkår(VilkårType.SØKERSOPPLYSNINGSPLIKT, VilkårUtfallType.OPPFYLT)
-                .leggTilVilkår(VilkårType.MEDLEMSKAPSVILKÅRET, VilkårUtfallType.OPPFYLT)
-                .leggTilVilkårResultatManueltIkkeOppfylt(VilkårType.MEDLEMSKAPSVILKÅRET_LØPENDE,
-                        VilkårUtfallMerknad.VM_1020, Avslagsårsak.SØKER_ER_IKKE_MEDLEM)
-                .buildFor(revurdering);
+                .leggTilVilkår(VilkårType.MEDLEMSKAPSVILKÅRET, VilkårUtfallType.OPPFYLT);
+        var vilkårBuilder =  vilkårResultatBuilder.getVilkårBuilderFor(VilkårType.MEDLEMSKAPSVILKÅRET_LØPENDE)
+                .medUtfallManuell(VilkårUtfallType.IKKE_OPPFYLT, Avslagsårsak.SØKER_ER_IKKE_MEDLEM)
+                .medVilkårUtfallMerknad(VilkårUtfallMerknad.VM_1020);
+        var vilkårResultat = vilkårResultatBuilder.leggTilVilkår(vilkårBuilder)
+            .buildFor(revurdering);
 
         var lås = behandlingRepository.taSkriveLås(revurdering);
         behandlingRepository.lagre(vilkårResultat, lås);

--- a/domenetjenester/behandling/src/main/java/no/nav/foreldrepenger/behandling/aksjonspunkt/OppdateringResultat.java
+++ b/domenetjenester/behandling/src/main/java/no/nav/foreldrepenger/behandling/aksjonspunkt/OppdateringResultat.java
@@ -18,6 +18,8 @@ import no.nav.foreldrepenger.behandlingslager.behandling.vilkår.VilkårUtfallTy
 
 public class OppdateringResultat {
 
+    private static final String MULTI_ENDRING = "Kan ikke fjerne vilkårtype med resultat som er lagt til i samme transisjon";
+
     private BehandlingStegType nesteSteg;
     private final List<VilkårOppdateringResultat> vilkårResultatSomSkalLeggesTil = new ArrayList<>();
     private final List<VilkårType> vilkårTyperSomSkalFjernes = new ArrayList<>(); // Eksisterer for å håndtere vilkåropprydding for Omsorg
@@ -147,6 +149,7 @@ public class OppdateringResultat {
         }
 
         public Builder medVilkårResultatType(VilkårResultatType vilkårResultatType) {
+            Objects.requireNonNull(vilkårResultatType);
             resultat.vilkårResultatType = vilkårResultatType;
             return this;
         }
@@ -154,8 +157,11 @@ public class OppdateringResultat {
         public Builder leggTilVilkårResultat(VilkårType vilkårType, VilkårUtfallType vilkårUtfallType) {
             Objects.requireNonNull(vilkårType);
             Objects.requireNonNull(vilkårUtfallType);
+            if (VilkårUtfallType.IKKE_OPPFYLT.equals(vilkårUtfallType)) {
+                throw new IllegalArgumentException("Mangler avslagsårsak");
+            }
             if (resultat.vilkårTyperSomSkalFjernes.stream().anyMatch(type -> type.equals(vilkårType))) {
-                throw new IllegalStateException("Kan ikke fjerne vilkårtype med resultat som er lagt til i samme transisjon");
+                throw new IllegalStateException(MULTI_ENDRING);
             }
             resultat.vilkårResultatSomSkalLeggesTil.add(new VilkårOppdateringResultat(vilkårType, vilkårUtfallType));
             return this;
@@ -163,8 +169,9 @@ public class OppdateringResultat {
 
         public Builder leggTilAvslåttVilkårResultat(VilkårType vilkårType, Avslagsårsak avslagsårsak) {
             Objects.requireNonNull(vilkårType);
+            Objects.requireNonNull(avslagsårsak);
             if (resultat.vilkårTyperSomSkalFjernes.stream().anyMatch(type -> type.equals(vilkårType))) {
-                throw new IllegalStateException("Kan ikke fjerne vilkårtype med resultat som er lagt til i samme transisjon");
+                throw new IllegalStateException(MULTI_ENDRING);
             }
             resultat.vilkårResultatSomSkalLeggesTil.add(new VilkårOppdateringResultat(vilkårType, avslagsårsak));
             return this;
@@ -172,19 +179,19 @@ public class OppdateringResultat {
 
         public Builder leggTilAvslåttVilkårResultat(VilkårType vilkårType, Avslagsårsak avslagsårsak, VilkårUtfallMerknad merknad) {
             Objects.requireNonNull(vilkårType);
+            Objects.requireNonNull(avslagsårsak);
+            Objects.requireNonNull(merknad);
             if (resultat.vilkårTyperSomSkalFjernes.stream().anyMatch(type -> type.equals(vilkårType))) {
-                throw new IllegalStateException("Kan ikke fjerne vilkårtype med resultat som er lagt til i samme transisjon");
+                throw new IllegalStateException(MULTI_ENDRING);
             }
             resultat.vilkårResultatSomSkalLeggesTil.add(new VilkårOppdateringResultat(vilkårType, avslagsårsak, merknad));
             return this;
         }
 
-
-
         public Builder fjernVilkårType(VilkårType vilkårType) {
             Objects.requireNonNull(vilkårType);
             if (resultat.vilkårResultatSomSkalLeggesTil.stream().anyMatch(v -> v.getVilkårType().equals(vilkårType))) {
-                throw new IllegalStateException("Kan ikke fjerne vilkårtype med resultat som er lagt til i samme transisjon");
+                throw new IllegalStateException(MULTI_ENDRING);
             }
             resultat.vilkårTyperSomSkalFjernes.add(vilkårType);
             return this;

--- a/domenetjenester/behandling/src/main/java/no/nav/foreldrepenger/behandling/aksjonspunkt/VilkårOppdateringResultat.java
+++ b/domenetjenester/behandling/src/main/java/no/nav/foreldrepenger/behandling/aksjonspunkt/VilkårOppdateringResultat.java
@@ -15,12 +15,15 @@ public class VilkårOppdateringResultat {
     public VilkårOppdateringResultat(VilkårType vilkårType, VilkårUtfallType vilkårUtfallType) {
         this.vilkårType = vilkårType;
         this.vilkårUtfallType = vilkårUtfallType;
+        this.avslagsårsak = Avslagsårsak.UDEFINERT;
+        this.vilkårUtfallMerknad = VilkårUtfallMerknad.UDEFINERT;
     }
 
     public VilkårOppdateringResultat(VilkårType vilkårType, Avslagsårsak avslagsårsak) {
         this.vilkårType = vilkårType;
         this.vilkårUtfallType = VilkårUtfallType.IKKE_OPPFYLT;
         this.avslagsårsak = avslagsårsak;
+        this.vilkårUtfallMerknad = VilkårUtfallMerknad.UDEFINERT;
     }
 
     public VilkårOppdateringResultat(VilkårType vilkårType,

--- a/domenetjenester/datavarehus/src/test/java/no/nav/foreldrepenger/datavarehus/xml/DvhVedtakXmlTjenesteEngangsstønadTest.java
+++ b/domenetjenester/datavarehus/src/test/java/no/nav/foreldrepenger/datavarehus/xml/DvhVedtakXmlTjenesteEngangsstønadTest.java
@@ -5,7 +5,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.Month;
-import java.util.Properties;
 
 import javax.inject.Inject;
 import javax.persistence.EntityManager;
@@ -242,8 +241,7 @@ public class DvhVedtakXmlTjenesteEngangsstønadTest {
 
     private void oppdaterMedBehandlingsresultat(EntityManager em, Behandling behandling, boolean innvilget) {
         var vilkårResultat = VilkårResultat.builder()
-                .leggTilVilkårResultat(VilkårType.FØDSELSVILKÅRET_MOR, innvilget ? VilkårUtfallType.OPPFYLT : VilkårUtfallType.IKKE_OPPFYLT, null,
-                        new Properties(), null, false, false, null, null)
+                .leggTilVilkår(VilkårType.FØDSELSVILKÅRET_MOR, innvilget ? VilkårUtfallType.OPPFYLT : VilkårUtfallType.IKKE_OPPFYLT)
                 .medVilkårResultatType(innvilget ? VilkårResultatType.INNVILGET : VilkårResultatType.AVSLÅTT)
                 .buildFor(behandling);
         em.persist(vilkårResultat);

--- a/domenetjenester/familie-hendelse/src/test/java/no/nav/foreldrepenger/familiehendelse/aksjonspunkt/VurdereYtelseSammeBarnAnnenForelderOppdatererTest.java
+++ b/domenetjenester/familie-hendelse/src/test/java/no/nav/foreldrepenger/familiehendelse/aksjonspunkt/VurdereYtelseSammeBarnAnnenForelderOppdatererTest.java
@@ -3,8 +3,6 @@ package no.nav.foreldrepenger.familiehendelse.aksjonspunkt;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
-import java.util.Properties;
-
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
@@ -103,15 +101,8 @@ public class VurdereYtelseSammeBarnAnnenForelderOppdatererTest {
     }
 
     private void byggVilkårResultat(VilkårResultat.Builder vilkårBuilder, OppdateringResultat delresultat) {
-        delresultat.getVilkårResultatSomSkalLeggesTil().forEach(v -> vilkårBuilder.leggTilVilkårResultat(
-            v.getVilkårType(),
-            v.getVilkårUtfallType(),
-            v.getVilkårUtfallMerknad(),
-            new Properties(),
-            v.getAvslagsårsak(),
-            true,
-            false,
-            null, null));
+        delresultat.getVilkårResultatSomSkalLeggesTil()
+            .forEach(v -> vilkårBuilder.leggTilVilkår(v.getVilkårType(), v.getVilkårUtfallType(), v.getAvslagsårsak()));
         delresultat.getVilkårTyperSomSkalFjernes().forEach(vilkårBuilder::fjernVilkår); // TODO: Vilkår burde ryddes på ein annen måte enn dette
         if (delresultat.getVilkårResultatType() != null) {
             vilkårBuilder.medVilkårResultatType(delresultat.getVilkårResultatType());

--- a/domenetjenester/familie-hendelse/src/test/java/no/nav/foreldrepenger/familiehendelse/omsorg/AvklarOmsorgOgForeldreansvarOppdatererTest.java
+++ b/domenetjenester/familie-hendelse/src/test/java/no/nav/foreldrepenger/familiehendelse/omsorg/AvklarOmsorgOgForeldreansvarOppdatererTest.java
@@ -6,7 +6,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.time.LocalDate;
 import java.time.Period;
 import java.util.Objects;
-import java.util.Properties;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -108,15 +107,8 @@ public class AvklarOmsorgOgForeldreansvarOppdatererTest extends EntityManagerAwa
     }
 
     private void byggVilkårResultat(VilkårResultat.Builder vilkårBuilder, OppdateringResultat delresultat) {
-        delresultat.getVilkårResultatSomSkalLeggesTil().forEach(v -> vilkårBuilder.leggTilVilkårResultat(
-            v.getVilkårType(),
-            v.getVilkårUtfallType(),
-            v.getVilkårUtfallMerknad(),
-            new Properties(),
-            v.getAvslagsårsak(),
-            true,
-            false,
-            null, null));
+        delresultat.getVilkårResultatSomSkalLeggesTil()
+            .forEach(v -> vilkårBuilder.leggTilVilkår(v.getVilkårType(), v.getVilkårUtfallType(), v.getAvslagsårsak()));
         delresultat.getVilkårTyperSomSkalFjernes().forEach(vilkårBuilder::fjernVilkår); // TODO: Vilkår burde ryddes på ein annen måte enn dette
         if (delresultat.getVilkårResultatType() != null) {
             vilkårBuilder.medVilkårResultatType(delresultat.getVilkårResultatType());

--- a/domenetjenester/inngangsvilkar/tjeneste/src/main/java/no/nav/foreldrepenger/inngangsvilkaar/InngangsvilkårTjeneste.java
+++ b/domenetjenester/inngangsvilkar/tjeneste/src/main/java/no/nav/foreldrepenger/inngangsvilkaar/InngangsvilkårTjeneste.java
@@ -95,7 +95,7 @@ public class InngangsvilkårTjeneste {
         var builder = VilkårResultat.builderFraEksisterende(vilkårResultat);
 
         if (Objects.equals(VilkårUtfallType.OPPFYLT, utfall)) {
-            builder.overstyrVilkår(vilkårType, utfall, null);
+            builder.overstyrVilkår(vilkårType, utfall, Avslagsårsak.UDEFINERT);
             if (!finnesOverstyrteAvviste(vilkårResultat, vilkårType)) {
                 builder.medVilkårResultatType(VilkårResultatType.IKKE_FASTSATT);
             }

--- a/domenetjenester/inngangsvilkar/tjeneste/src/main/java/no/nav/foreldrepenger/inngangsvilkaar/VilkårData.java
+++ b/domenetjenester/inngangsvilkar/tjeneste/src/main/java/no/nav/foreldrepenger/inngangsvilkaar/VilkårData.java
@@ -18,13 +18,12 @@ public class VilkårData {
     private Avslagsårsak avslagsårsak;
     private String regelEvaluering;
     private String regelInput;
-    private boolean erOverstyrt;
     private Object data;
 
     /** Ctor som tar alle parametere inkl. regel input og evaluering. */
     public VilkårData(VilkårType vilkårType, VilkårUtfallType utfallType, Properties merknadParametere,
             List<AksjonspunktDefinisjon> apDefinisjoner, VilkårUtfallMerknad vilkårUtfallMerknad,
-            Avslagsårsak avslagsårsak, String regelEvaluering, String regelInput, boolean erOverstyrt) {
+            Avslagsårsak avslagsårsak, String regelEvaluering, String regelInput) {
 
         this.vilkårType = vilkårType;
         this.utfallType = utfallType;
@@ -34,12 +33,11 @@ public class VilkårData {
         this.avslagsårsak = avslagsårsak;
         this.regelEvaluering = regelEvaluering;
         this.regelInput = regelInput;
-        this.erOverstyrt = erOverstyrt;
     }
 
     /** Ctor som tar minimum av parametere, og ingen regel evaluering og input data.  Vil heller aldri være overstyrt. */
     public VilkårData(VilkårType vilkårType, VilkårUtfallType utfallType, List<AksjonspunktDefinisjon> apDefinisjoner) {
-        this(vilkårType, utfallType, new Properties(), apDefinisjoner, null, null, null, null, false);
+        this(vilkårType, utfallType, new Properties(), apDefinisjoner, null, null, null, null);
     }
 
     /** (Optional) ekstra resultat data. */
@@ -81,9 +79,5 @@ public class VilkårData {
 
     public String getRegelInput() {
         return regelInput;
-    }
-
-    public boolean erOverstyrt() {
-        return erOverstyrt;
     }
 }

--- a/domenetjenester/inngangsvilkar/tjeneste/src/main/java/no/nav/foreldrepenger/inngangsvilkaar/impl/VilkårUtfallOversetter.java
+++ b/domenetjenester/inngangsvilkar/tjeneste/src/main/java/no/nav/foreldrepenger/inngangsvilkaar/impl/VilkårUtfallOversetter.java
@@ -41,7 +41,7 @@ public class VilkårUtfallOversetter {
         var vilkårUtfallMerknad = getVilkårUtfallMerknad(summary);
 
         return new VilkårData(vilkårType, vilkårUtfallType, merknadParametere, apDefinisjoner, vilkårUtfallMerknad, null,
-            regelEvalueringJson, jsonGrunnlag, false);
+            regelEvalueringJson, jsonGrunnlag);
 
     }
 

--- a/domenetjenester/inngangsvilkar/tjeneste/src/main/java/no/nav/foreldrepenger/inngangsvilkaar/medlemskap/VurderLøpendeMedlemskap.java
+++ b/domenetjenester/inngangsvilkar/tjeneste/src/main/java/no/nav/foreldrepenger/inngangsvilkaar/medlemskap/VurderLøpendeMedlemskap.java
@@ -28,6 +28,7 @@ import no.nav.foreldrepenger.behandlingslager.behandling.personopplysning.Person
 import no.nav.foreldrepenger.behandlingslager.behandling.personopplysning.PersonstatusEntitet;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.vilkår.VilkårType;
+import no.nav.foreldrepenger.behandlingslager.behandling.vilkår.VilkårUtfallMerknad;
 import no.nav.foreldrepenger.behandlingslager.behandling.vilkår.VilkårUtfallType;
 import no.nav.foreldrepenger.behandlingslager.geografisk.Region;
 import no.nav.foreldrepenger.behandlingslager.virksomhet.Arbeidsgiver;

--- a/domenetjenester/medlem/src/test/java/no/nav/foreldrepenger/domene/medlem/impl/MedlemTjenesteTest.java
+++ b/domenetjenester/medlem/src/test/java/no/nav/foreldrepenger/domene/medlem/impl/MedlemTjenesteTest.java
@@ -14,6 +14,7 @@ import no.nav.foreldrepenger.behandlingslager.behandling.Behandlingsresultat;
 import no.nav.foreldrepenger.behandlingslager.behandling.medlemskap.MedlemskapVilkårPeriodeRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepositoryProvider;
+import no.nav.foreldrepenger.behandlingslager.behandling.vilkår.Avslagsårsak;
 import no.nav.foreldrepenger.behandlingslager.behandling.vilkår.VilkårResultat;
 import no.nav.foreldrepenger.behandlingslager.behandling.vilkår.VilkårType;
 import no.nav.foreldrepenger.behandlingslager.behandling.vilkår.VilkårUtfallType;
@@ -58,7 +59,7 @@ public class MedlemTjenesteTest {
 
         var vilkår = VilkårResultat.builderFraEksisterende(behandlingsresultat.getVilkårResultat());
         vilkår.leggTilVilkår(VilkårType.MEDLEMSKAPSVILKÅRET, VilkårUtfallType.IKKE_OPPFYLT);
-        vilkår.overstyrVilkår(VilkårType.MEDLEMSKAPSVILKÅRET, VilkårUtfallType.OPPFYLT, null);
+        vilkår.overstyrVilkår(VilkårType.MEDLEMSKAPSVILKÅRET, VilkårUtfallType.OPPFYLT, Avslagsårsak.UDEFINERT);
 
         var vilkårResultat = vilkår.buildFor(behandling);
         behandlingRepository.lagre(vilkårResultat, lås);

--- a/domenetjenester/mottak/src/test/java/no/nav/foreldrepenger/mottak/dokumentmottak/impl/DokumentmottakerKlageTest.java
+++ b/domenetjenester/mottak/src/test/java/no/nav/foreldrepenger/mottak/dokumentmottak/impl/DokumentmottakerKlageTest.java
@@ -8,7 +8,6 @@ import static org.mockito.Mockito.verify;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.util.Properties;
 
 import javax.inject.Inject;
 
@@ -212,8 +211,7 @@ public class DokumentmottakerKlageTest {
                 .medBehandlingResultatType(BehandlingResultatType.INNVILGET)
                 .buildFor(behandling);
         VilkårResultat.builder()
-                .leggTilVilkårResultat(VilkårType.FØDSELSVILKÅRET_MOR, VilkårUtfallType.OPPFYLT,
-                        null, new Properties(), null, false, false, "", "")
+                .leggTilVilkår(VilkårType.FØDSELSVILKÅRET_MOR, VilkårUtfallType.OPPFYLT)
                 .medVilkårResultatType(VilkårResultatType.INNVILGET)
                 .buildFor(behandling);
         var behandlingsresultat = behandling.getBehandlingsresultat();

--- a/domenetjenester/uttak/src/test/java/no/nav/foreldrepenger/domene/uttak/fastsetteperioder/grunnlagbyggere/InngangsvilkårGrunnlagByggerTest.java
+++ b/domenetjenester/uttak/src/test/java/no/nav/foreldrepenger/domene/uttak/fastsetteperioder/grunnlagbyggere/InngangsvilkårGrunnlagByggerTest.java
@@ -7,10 +7,8 @@ import org.junit.jupiter.api.Test;
 import no.nav.foreldrepenger.behandling.BehandlingReferanse;
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandlingsresultat;
-import no.nav.foreldrepenger.behandlingslager.behandling.vilkår.Avslagsårsak;
 import no.nav.foreldrepenger.behandlingslager.behandling.vilkår.VilkårResultat;
 import no.nav.foreldrepenger.behandlingslager.behandling.vilkår.VilkårType;
-import no.nav.foreldrepenger.behandlingslager.behandling.vilkår.VilkårUtfallMerknad;
 import no.nav.foreldrepenger.behandlingslager.behandling.vilkår.VilkårUtfallType;
 import no.nav.foreldrepenger.domene.uttak.UttakRepositoryProvider;
 import no.nav.foreldrepenger.domene.uttak.input.UttakInput;
@@ -30,14 +28,10 @@ public class InngangsvilkårGrunnlagByggerTest {
         var behandling = scenario.lagre(repositoryProvider);
 
         var vilkårBuilder = VilkårResultat.builder();
-        vilkårBuilder.leggTilVilkårResultat(VilkårType.FØDSELSVILKÅRET_MOR, VilkårUtfallType.OPPFYLT, VilkårUtfallMerknad.UDEFINERT,
-                null, Avslagsårsak.UDEFINERT, false, false, null, null);
-        vilkårBuilder.leggTilVilkårResultat(VilkårType.OPPTJENINGSVILKÅRET, VilkårUtfallType.OPPFYLT, VilkårUtfallMerknad.UDEFINERT,
-                null, Avslagsårsak.UDEFINERT, false, false, null, null);
-        vilkårBuilder.leggTilVilkårResultat(VilkårType.FORELDREANSVARSVILKÅRET_2_LEDD, VilkårUtfallType.OPPFYLT, VilkårUtfallMerknad.UDEFINERT,
-                null, Avslagsårsak.UDEFINERT, false, false, null, null);
-        vilkårBuilder.leggTilVilkårResultat(VilkårType.ADOPSJONSVILKARET_FORELDREPENGER, VilkårUtfallType.OPPFYLT, VilkårUtfallMerknad.UDEFINERT,
-                null, Avslagsårsak.UDEFINERT, false, false, null, null);
+        vilkårBuilder.leggTilVilkår(VilkårType.FØDSELSVILKÅRET_MOR, VilkårUtfallType.OPPFYLT);
+        vilkårBuilder.leggTilVilkår(VilkårType.OPPTJENINGSVILKÅRET, VilkårUtfallType.OPPFYLT);
+        vilkårBuilder.leggTilVilkår(VilkårType.FORELDREANSVARSVILKÅRET_2_LEDD, VilkårUtfallType.OPPFYLT);
+        vilkårBuilder.leggTilVilkår(VilkårType.ADOPSJONSVILKARET_FORELDREPENGER, VilkårUtfallType.OPPFYLT);
         lagreVilkår(behandling, vilkårBuilder);
 
         var grunnlag = bygger.byggGrunnlag(input(behandling)).build();
@@ -66,14 +60,10 @@ public class InngangsvilkårGrunnlagByggerTest {
         var behandling = scenario.lagre(repositoryProvider);
 
         var vilkårBuilder = VilkårResultat.builder();
-        vilkårBuilder.leggTilVilkårResultat(VilkårType.FØDSELSVILKÅRET_MOR, VilkårUtfallType.IKKE_OPPFYLT, VilkårUtfallMerknad.UDEFINERT,
-                null, Avslagsårsak.UDEFINERT, false, false, null, null);
-        vilkårBuilder.leggTilVilkårResultat(VilkårType.OPPTJENINGSVILKÅRET, VilkårUtfallType.IKKE_OPPFYLT, VilkårUtfallMerknad.UDEFINERT,
-                null, Avslagsårsak.UDEFINERT, false, false, null, null);
-        vilkårBuilder.leggTilVilkårResultat(VilkårType.FORELDREANSVARSVILKÅRET_2_LEDD, VilkårUtfallType.IKKE_OPPFYLT, VilkårUtfallMerknad.UDEFINERT,
-                null, Avslagsårsak.UDEFINERT, false, false, null, null);
-        vilkårBuilder.leggTilVilkårResultat(VilkårType.ADOPSJONSVILKARET_FORELDREPENGER, VilkårUtfallType.IKKE_OPPFYLT, VilkårUtfallMerknad.UDEFINERT,
-                null, Avslagsårsak.UDEFINERT, false, false, null, null);
+        vilkårBuilder.leggTilVilkår(VilkårType.FØDSELSVILKÅRET_MOR, VilkårUtfallType.IKKE_OPPFYLT);
+        vilkårBuilder.leggTilVilkår(VilkårType.OPPTJENINGSVILKÅRET, VilkårUtfallType.IKKE_OPPFYLT);
+        vilkårBuilder.leggTilVilkår(VilkårType.FORELDREANSVARSVILKÅRET_2_LEDD, VilkårUtfallType.IKKE_OPPFYLT);
+        vilkårBuilder.leggTilVilkår(VilkårType.ADOPSJONSVILKARET_FORELDREPENGER, VilkårUtfallType.IKKE_OPPFYLT);
         lagreVilkår(behandling, vilkårBuilder);
 
         var grunnlag = bygger.byggGrunnlag(input(behandling)).build();

--- a/domenetjenester/uttak/src/test/java/no/nav/foreldrepenger/domene/uttak/fastsetteperioder/grunnlagbyggere/RettOgOmsorgGrunnlagByggerTest.java
+++ b/domenetjenester/uttak/src/test/java/no/nav/foreldrepenger/domene/uttak/fastsetteperioder/grunnlagbyggere/RettOgOmsorgGrunnlagByggerTest.java
@@ -9,11 +9,9 @@ import org.junit.jupiter.api.Test;
 import no.nav.foreldrepenger.behandling.BehandlingReferanse;
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandlingsresultat;
-import no.nav.foreldrepenger.behandlingslager.behandling.vilkår.Avslagsårsak;
 import no.nav.foreldrepenger.behandlingslager.behandling.vilkår.VilkårResultat;
 import no.nav.foreldrepenger.behandlingslager.behandling.vilkår.VilkårResultatType;
 import no.nav.foreldrepenger.behandlingslager.behandling.vilkår.VilkårType;
-import no.nav.foreldrepenger.behandlingslager.behandling.vilkår.VilkårUtfallMerknad;
 import no.nav.foreldrepenger.behandlingslager.behandling.vilkår.VilkårUtfallType;
 import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.OppgittRettighetEntitet;
 import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.PerioderAleneOmsorgEntitet;
@@ -160,9 +158,7 @@ public class RettOgOmsorgGrunnlagByggerTest {
 
     private Behandlingsresultat behandlingsresultatMedAvslåttVilkår() {
         var vilkårBuilder = VilkårResultat.builder().medVilkårResultatType(VilkårResultatType.AVSLÅTT);
-        vilkårBuilder.leggTilVilkårResultat(VilkårType.ADOPSJONSVILKARET_FORELDREPENGER,
-            VilkårUtfallType.IKKE_OPPFYLT, VilkårUtfallMerknad.UDEFINERT, null, Avslagsårsak.UDEFINERT, false,
-            false, null, null);
+        vilkårBuilder.leggTilVilkår(VilkårType.ADOPSJONSVILKARET_FORELDREPENGER, VilkårUtfallType.IKKE_OPPFYLT);
         var behandlingsresultat = Behandlingsresultat.builderForInngangsvilkår().build();
         behandlingsresultat.medOppdatertVilkårResultat(vilkårBuilder.build());
         return behandlingsresultat;

--- a/domenetjenester/vedtak/src/test/java/no/nav/foreldrepenger/domene/vedtak/es/VedtakXmlTest.java
+++ b/domenetjenester/vedtak/src/test/java/no/nav/foreldrepenger/domene/vedtak/es/VedtakXmlTest.java
@@ -15,7 +15,6 @@ import java.util.Calendar;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Properties;
 
 import javax.inject.Inject;
 import javax.persistence.EntityManager;
@@ -267,9 +266,7 @@ public class VedtakXmlTest {
 
     private void oppdaterMedBehandlingsresultat(Behandling behandling, boolean innvilget) {
         VilkårResultat.builder()
-                .leggTilVilkårResultat(VilkårType.FØDSELSVILKÅRET_MOR, innvilget ? VilkårUtfallType.OPPFYLT : VilkårUtfallType.IKKE_OPPFYLT, null,
-                        new Properties(),
-                        null, false, false, null, null)
+                .leggTilVilkår(VilkårType.FØDSELSVILKÅRET_MOR, innvilget ? VilkårUtfallType.OPPFYLT : VilkårUtfallType.IKKE_OPPFYLT)
                 .medVilkårResultatType(innvilget ? VilkårResultatType.INNVILGET : VilkårResultatType.AVSLÅTT)
                 .buildFor(behandling);
         if (innvilget) {

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/medlem/aksjonspunkt/MedlemskapsvilkåretLøpendeOverstyringshåndterer.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/medlem/aksjonspunkt/MedlemskapsvilkåretLøpendeOverstyringshåndterer.java
@@ -60,20 +60,19 @@ public class MedlemskapsvilkåretLøpendeOverstyringshåndterer extends Abstract
         var grBuilder = medlemskapVilkårPeriodeRepository.hentBuilderFor(behandling);
         var periodeBuilder = grBuilder.getPeriodeBuilder();
 
-        var vilkårBuilder = VilkårResultat.builderFraEksisterende(behandling.getBehandlingsresultat().getVilkårResultat());
+        var vilkårResultatBuilder = VilkårResultat.builderFraEksisterende(behandling.getBehandlingsresultat().getVilkårResultat());
         if (dto.getErVilkarOk()) {
             periodeBuilder.opprettOverstryingOppfylt(dto.getOverstryingsdato());
-            vilkårBuilder.leggTilVilkårResultat(VilkårType.MEDLEMSKAPSVILKÅRET_LØPENDE, VilkårUtfallType.OPPFYLT, null, null, null, false, true, null, null);
+            vilkårResultatBuilder.overstyrVilkår(VilkårType.MEDLEMSKAPSVILKÅRET_LØPENDE, VilkårUtfallType.OPPFYLT, Avslagsårsak.UDEFINERT);
         } else {
             var avslagsårsak = Avslagsårsak.fraKode(dto.getAvslagskode());
             periodeBuilder.opprettOverstryingAvslag(dto.getOverstryingsdato(), avslagsårsak);
-            vilkårBuilder.leggTilVilkårResultat(VilkårType.MEDLEMSKAPSVILKÅRET_LØPENDE, VilkårUtfallType.IKKE_OPPFYLT, null, null, avslagsårsak, false, true,
-                null, null);
+            vilkårResultatBuilder.overstyrVilkår(VilkårType.MEDLEMSKAPSVILKÅRET_LØPENDE, VilkårUtfallType.IKKE_OPPFYLT, avslagsårsak);
         }
         var lås = kontekst.getSkriveLås();
         grBuilder.medMedlemskapsvilkårPeriode(periodeBuilder);
         medlemskapVilkårPeriodeRepository.lagreMedlemskapsvilkår(behandling, grBuilder);
-        behandlingRepository.lagre(vilkårBuilder.buildFor(behandling), lås);
+        behandlingRepository.lagre(vilkårResultatBuilder.buildFor(behandling), lås);
         return OppdateringResultat.utenOveropp();
     }
 }

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/forvaltning/ForvaltningStegRestTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/forvaltning/ForvaltningStegRestTjeneste.java
@@ -30,6 +30,7 @@ import no.nav.foreldrepenger.behandlingslager.behandling.historikk.HistorikkAkt�
 import no.nav.foreldrepenger.behandlingslager.behandling.historikk.HistorikkRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.historikk.Historikkinnslag;
 import no.nav.foreldrepenger.behandlingslager.behandling.historikk.HistorikkinnslagType;
+import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepositoryProvider;
 import no.nav.foreldrepenger.behandlingslager.behandling.vilkår.Vilkår;
 import no.nav.foreldrepenger.behandlingslager.behandling.vilkår.VilkårResultat;
@@ -57,6 +58,7 @@ public class ForvaltningStegRestTjeneste {
     private FamilieHendelseRepository familieHendelseRepository;
     private InntektsmeldingTjeneste inntektsmeldingTjeneste;
     private VilkårResultatRepository vilkårResultatRepository;
+    private BehandlingRepository behandlingRepository;
 
     @Inject
     public ForvaltningStegRestTjeneste(BehandlingsprosessTjeneste behandlingsprosessTjeneste,
@@ -71,6 +73,7 @@ public class ForvaltningStegRestTjeneste {
         this.historikkRepository = repositoryProvider.getHistorikkRepository();
         this.familieHendelseRepository = repositoryProvider.getFamilieHendelseRepository();
         this.vilkårResultatRepository = vilkårResultatRepository;
+        this.behandlingRepository = repositoryProvider.getBehandlingRepository();
     }
 
     public ForvaltningStegRestTjeneste() {
@@ -138,11 +141,13 @@ public class ForvaltningStegRestTjeneste {
                     .findFirst();
 
             if (opptjeningsvilkåretOpt.isPresent()) {
+                var kontekst = behandlingskontrollTjeneste.initBehandlingskontroll(behandling);
                 var builder = VilkårResultat.builderFraEksisterende(vilkårResultat);
                 builder.fjernVilkår(VilkårType.OPPTJENINGSVILKÅRET);
 
-                var nyttVilkårResulatat = builder.build();
-                vilkårResultatRepository.lagre(behandlingId, nyttVilkårResulatat);
+                var nyttVilkårResulatat = builder.buildFor(behandling);
+                behandlingRepository.lagre(nyttVilkårResulatat, kontekst.getSkriveLås());
+                behandlingRepository.lagre(behandling, kontekst.getSkriveLås());
 
                 if (behandling.erRevurdering()) {
                     hoppTilbake(dto, KONTROLLERER_SØKERS_OPPLYSNINGSPLIKT);

--- a/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/svp/BekreftSvangerskapspengervilkårOppdatererTest.java
+++ b/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/svp/BekreftSvangerskapspengervilkårOppdatererTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
 import java.util.Optional;
-import java.util.Properties;
 
 import javax.persistence.EntityManager;
 
@@ -80,8 +79,7 @@ public class BekreftSvangerskapspengervilkårOppdatererTest {
 
         var builder = VilkårResultat.builder();
         resultat.getVilkårResultatSomSkalLeggesTil()
-            .forEach(v -> builder.leggTilVilkårResultat(v.getVilkårType(), v.getVilkårUtfallType(),
-                v.getVilkårUtfallMerknad(), new Properties(), v.getAvslagsårsak(), true, false, null, null));
+            .forEach(v -> builder.leggTilVilkår(v.getVilkårType(), v.getVilkårUtfallType(), v.getAvslagsårsak()));
 
         assertThat(builder.buildFor(behandling).getVilkårene().get(0).getGjeldendeVilkårUtfall()).isEqualTo(
             VilkårUtfallType.IKKE_OPPFYLT);
@@ -101,8 +99,7 @@ public class BekreftSvangerskapspengervilkårOppdatererTest {
 
         var builder = VilkårResultat.builder();
         resultat.getVilkårResultatSomSkalLeggesTil()
-            .forEach(v -> builder.leggTilVilkårResultat(v.getVilkårType(), v.getVilkårUtfallType(),
-                v.getVilkårUtfallMerknad(), new Properties(), v.getAvslagsårsak(), true, false, null, null));
+            .forEach(v -> builder.leggTilVilkår(v.getVilkårType(), v.getVilkårUtfallType(), v.getAvslagsårsak()));
 
 
         assertThat(builder.buildFor(behandling).getVilkårene().get(0).getGjeldendeVilkårUtfall()).isEqualTo(

--- a/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/vedtak/TotrinnskontrollAksjonspunkterTjenesteTest.java
+++ b/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/vedtak/TotrinnskontrollAksjonspunkterTjenesteTest.java
@@ -165,14 +165,14 @@ public class TotrinnskontrollAksjonspunkterTjenesteTest {
         var ttvGodkjent = false;
         var apAvbrutt = false;
 
-        Map<VilkårType, SkjermlenkeType> vilkårTypeSkjermlenkeTypeMap = new HashMap<>();
-        vilkårTypeSkjermlenkeTypeMap.put(VilkårType.FØDSELSVILKÅRET_MOR, SkjermlenkeType.PUNKT_FOR_FOEDSEL);
-        vilkårTypeSkjermlenkeTypeMap.put(VilkårType.FØDSELSVILKÅRET_FAR_MEDMOR, SkjermlenkeType.PUNKT_FOR_FOEDSEL);
-        vilkårTypeSkjermlenkeTypeMap.put(VilkårType.ADOPSJONSVILKÅRET_ENGANGSSTØNAD, SkjermlenkeType.PUNKT_FOR_ADOPSJON);
-        vilkårTypeSkjermlenkeTypeMap.put(VilkårType.ADOPSJONSVILKARET_FORELDREPENGER, SkjermlenkeType.PUNKT_FOR_ADOPSJON);
-        vilkårTypeSkjermlenkeTypeMap.put(VilkårType.OMSORGSVILKÅRET, SkjermlenkeType.PUNKT_FOR_OMSORG);
-        vilkårTypeSkjermlenkeTypeMap.put(VilkårType.FORELDREANSVARSVILKÅRET_2_LEDD, SkjermlenkeType.PUNKT_FOR_FORELDREANSVAR);
-        vilkårTypeSkjermlenkeTypeMap.put(VilkårType.FORELDREANSVARSVILKÅRET_4_LEDD, SkjermlenkeType.PUNKT_FOR_FORELDREANSVAR);
+        Map<VilkårType, SkjermlenkeType> vilkårTypeSkjermlenkeTypeMap = Map.of(
+            VilkårType.FØDSELSVILKÅRET_MOR, SkjermlenkeType.PUNKT_FOR_FOEDSEL,
+            VilkårType.FØDSELSVILKÅRET_FAR_MEDMOR, SkjermlenkeType.PUNKT_FOR_FOEDSEL,
+            VilkårType.ADOPSJONSVILKÅRET_ENGANGSSTØNAD, SkjermlenkeType.PUNKT_FOR_ADOPSJON,
+            VilkårType.ADOPSJONSVILKARET_FORELDREPENGER, SkjermlenkeType.PUNKT_FOR_ADOPSJON,
+            VilkårType.OMSORGSVILKÅRET, SkjermlenkeType.PUNKT_FOR_OMSORG,
+            VilkårType.FORELDREANSVARSVILKÅRET_2_LEDD, SkjermlenkeType.PUNKT_FOR_FORELDREANSVAR,
+            VilkårType.FORELDREANSVARSVILKÅRET_4_LEDD, SkjermlenkeType.PUNKT_FOR_FORELDREANSVAR);
 
         for (var aksjonspunktDefinisjon : aksjonspunktDefinisjons) {
             vilkårTypeSkjermlenkeTypeMap.keySet().forEach(vilkårType -> {
@@ -262,14 +262,13 @@ public class TotrinnskontrollAksjonspunkterTjenesteTest {
         var ttvGodkjent = false;
         var apAvbrutt = false;
 
-        Map<VilkårType, SkjermlenkeType> vilkårTypeSkjermlenkeTypeMap = new HashMap<>();
-        vilkårTypeSkjermlenkeTypeMap.put(VilkårType.SØKERSOPPLYSNINGSPLIKT, SkjermlenkeType.UDEFINERT);
-        vilkårTypeSkjermlenkeTypeMap.put(VilkårType.MEDLEMSKAPSVILKÅRET, SkjermlenkeType.UDEFINERT);
-        vilkårTypeSkjermlenkeTypeMap.put(VilkårType.UDEFINERT, SkjermlenkeType.UDEFINERT);
-        vilkårTypeSkjermlenkeTypeMap.put(VilkårType.SØKNADSFRISTVILKÅRET, SkjermlenkeType.UDEFINERT);
-        vilkårTypeSkjermlenkeTypeMap.put(VilkårType.OPPTJENINGSVILKÅRET, SkjermlenkeType.UDEFINERT);
-        vilkårTypeSkjermlenkeTypeMap.put(VilkårType.OPPTJENINGSPERIODEVILKÅR, SkjermlenkeType.UDEFINERT);
-        vilkårTypeSkjermlenkeTypeMap.put(VilkårType.BEREGNINGSGRUNNLAGVILKÅR, SkjermlenkeType.UDEFINERT);
+        Map<VilkårType, SkjermlenkeType> vilkårTypeSkjermlenkeTypeMap = Map.of(
+            VilkårType.SØKERSOPPLYSNINGSPLIKT, SkjermlenkeType.UDEFINERT,
+            VilkårType.MEDLEMSKAPSVILKÅRET, SkjermlenkeType.UDEFINERT,
+            VilkårType.SØKNADSFRISTVILKÅRET, SkjermlenkeType.UDEFINERT,
+            VilkårType.OPPTJENINGSVILKÅRET, SkjermlenkeType.UDEFINERT,
+            VilkårType.OPPTJENINGSPERIODEVILKÅR, SkjermlenkeType.UDEFINERT,
+            VilkårType.BEREGNINGSGRUNNLAGVILKÅR, SkjermlenkeType.UDEFINERT);
 
         for (var aksjonspunktDefinisjon : aksjonspunktDefinisjons) {
             vilkårTypeSkjermlenkeTypeMap.keySet().forEach(vilkårType -> {
@@ -474,7 +473,7 @@ public class TotrinnskontrollAksjonspunkterTjenesteTest {
 
     private void opprettBehandlingForFP(Optional<VilkårType> vilkårTypeOpt) {
         var scenario = ScenarioMorSøkerForeldrepenger.forFødsel();
-        vilkårTypeOpt.ifPresent(vt -> scenario.leggTilVilkår(vt, VilkårUtfallType.UDEFINERT));
+        vilkårTypeOpt.ifPresent(vt -> scenario.leggTilVilkår(vt, VilkårUtfallType.IKKE_VURDERT));
         behandling = scenario.lagMocked();
     }
 


### PR DESCRIPTION
Problem: manuell vurdering og overstyring har fjernet regelsporing siden dag 1
Antar: regelkjøring gir utfall, merknader, regelsporing. Manuell+Overstyring gir kun utfall+avslagsårsak (et par tilfelle av merknad)

Skriver om struktur på vilkårresultatbuilder og vilkårbuilder til å støtte hovedregelen + et par unntak.
VilkårResultat og Vilkår er fortsatt mutable. Kan diskutere å endre det senere.

Senere steg i prosessen: 
* Erstatte String i regler med enumer og innføre eksplisitt mapping regelmerknad->merknad (regelap->ap) (ikke string)
* Fikse denne originalBehandling-referansen i VilkårResultat: Pek opp til BR, ikke fra BehRes ned til VilkRes (exp,migrer,contract).
* Vurdere buildFor-pattern
* Flytte inngangsvilkårregler til eget repo
