### PR TITLE
Endret dato for nye uttaksregler til 01012020 slik at det blir fritt …

### DIFF
--- a/web/src/test/resources/application-local.properties
+++ b/web/src/test/resources/application-local.properties
@@ -94,7 +94,7 @@ loadbalancer.url=http://localhost:8080
 dato.for.nye.beregningsregler=2010-01-01
 
 # Dato for nye uttaksregler
-dato.for.nye.uttaksregler = 2999-12-31
+dato.for.nye.uttaksregler = 2020-01-01
 
 # Auditlogger
 auditlogger.enabled=false


### PR DESCRIPTION
…uttak når man kjører verdikjedetester lokalt