### PR TITLE
TFP-4585: Implementert batch BVL011 som bestiller infobrev annen fore…

### DIFF
--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/BehandlingÅrsakType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/BehandlingÅrsakType.java
@@ -62,6 +62,7 @@ public enum BehandlingÅrsakType implements Kodeverdi {
     //For automatiske informasjonsbrev
     INFOBREV_BEHANDLING("INFOBREV_BEHANDLING", "Informasjonsbrev uttak"),
     INFOBREV_OPPHOLD("INFOBREV_OPPHOLD", "Informasjonsbrev opphold"),
+    INFOBREV_PÅMINNELSE("INFOBREV_PÅMINNELSE", "Informasjonsbrev påminnelse"),
 
     //For å vurdere opphør av ytelse
     OPPHØR_YTELSE_NYTT_BARN("OPPHØR-NYTT-BARN", "Nytt barn/stønadsperiode"),

--- a/behandlingsprosess/src/main/java/no/nav/foreldrepenger/behandling/steg/registrersøknad/RegistrerSøknadSteg.java
+++ b/behandlingsprosess/src/main/java/no/nav/foreldrepenger/behandling/steg/registrersøknad/RegistrerSøknadSteg.java
@@ -140,7 +140,8 @@ public class RegistrerSøknadSteg implements BehandlingSteg {
 
     private BehandleStegResultat resultatVedIngenMottatteDokument(Behandling behandling) {
         if (behandling.harBehandlingÅrsak(BehandlingÅrsakType.INFOBREV_BEHANDLING)
-                || behandling.harBehandlingÅrsak(BehandlingÅrsakType.INFOBREV_OPPHOLD)) {
+                || behandling.harBehandlingÅrsak(BehandlingÅrsakType.INFOBREV_OPPHOLD)
+                || behandling.harBehandlingÅrsak(BehandlingÅrsakType.INFOBREV_PÅMINNELSE)) {
             var kResultat = KompletthetResultat.ikkeOppfylt(LocalDate.now().plus(VENT_PÅ_SØKNAD_PERIODE).atStartOfDay(),
                     Venteårsak.VENT_SØKNAD_SENDT_INFORMASJONSBREV);
             return evaluerSøknadMottattUoppfylt(behandling, kResultat, VENT_PÅ_SØKNAD);

--- a/domenetjenester/behandling-prosessering/pom.xml
+++ b/domenetjenester/behandling-prosessering/pom.xml
@@ -26,6 +26,11 @@
             <groupId>no.nav.foreldrepenger</groupId>
             <artifactId>registerinnhenting</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>no.nav.foreldrepenger</groupId>
+            <artifactId>dokumentbestiller</artifactId>
+        </dependency>
         
         <!-- Test dependencies -->
         <dependency>

--- a/domenetjenester/behandling-prosessering/src/main/java/no/nav/foreldrepenger/behandlingsprosess/dagligejobber/infobrev/SendInformasjonsbrevBatchArguments.java
+++ b/domenetjenester/behandling-prosessering/src/main/java/no/nav/foreldrepenger/behandlingsprosess/dagligejobber/infobrev/SendInformasjonsbrevBatchArguments.java
@@ -18,7 +18,6 @@ public class SendInformasjonsbrevBatchArguments extends BatchArguments {
     static final String DATE_PATTERN = "dd-MM-yyyy";
     private static final String ANTALL_DAGER_KEY = "antallDager";
     private static final Integer MAX_PERIOD = 365;
-    private static final Integer UKER_FRAMOVER = 4;
 
     @BatchArgument(beskrivelse = "Antall dager tilbake i tid det skal genereres rapport for.")
     private Integer antallDager;
@@ -28,8 +27,11 @@ public class SendInformasjonsbrevBatchArguments extends BatchArguments {
     private LocalDate tom;
     private boolean harGenerertDatoer = false;
 
-    SendInformasjonsbrevBatchArguments(Map<String, String> arguments) {
+    private Integer antallUkerFremover;
+
+    SendInformasjonsbrevBatchArguments(Map<String, String> arguments, Integer antallUkerFremover) {
         super(arguments);
+        this.antallUkerFremover = antallUkerFremover;
         if ((antallDager != null) && (tom == null) && (fom == null)) { // NOSONAR
             beregneFomOgTomDato();
             harGenerertDatoer = true;
@@ -59,8 +61,8 @@ public class SendInformasjonsbrevBatchArguments extends BatchArguments {
     }
 
     private void beregneFomOgTomDato() {
-        fom = LocalDate.now().minusDays(antallDager).plusWeeks(UKER_FRAMOVER);
-        tom = LocalDate.now().minusDays(1).plusWeeks(UKER_FRAMOVER);
+        fom = LocalDate.now().minusDays(antallDager).plusWeeks(antallUkerFremover);
+        tom = LocalDate.now().minusDays(1).plusWeeks(antallUkerFremover);
     }
 
     private LocalDate parsedato(String datoString) {

--- a/domenetjenester/behandling-prosessering/src/main/java/no/nav/foreldrepenger/behandlingsprosess/dagligejobber/infobrev/SendInformasjonsbrevOppholdBatchTjeneste.java
+++ b/domenetjenester/behandling-prosessering/src/main/java/no/nav/foreldrepenger/behandlingsprosess/dagligejobber/infobrev/SendInformasjonsbrevOppholdBatchTjeneste.java
@@ -34,7 +34,7 @@ public class SendInformasjonsbrevOppholdBatchTjeneste implements BatchTjeneste {
 
     @Override
     public SendInformasjonsbrevBatchArguments createArguments(Map<String, String> jobArguments) {
-        return new SendInformasjonsbrevBatchArguments(jobArguments);
+        return new SendInformasjonsbrevBatchArguments(jobArguments, 4);
     }
 
     @Override

--- a/domenetjenester/behandling-prosessering/src/main/java/no/nav/foreldrepenger/behandlingsprosess/dagligejobber/infobrev/SendInformasjonsbrevPåminnelseBatchTjeneste.java
+++ b/domenetjenester/behandling-prosessering/src/main/java/no/nav/foreldrepenger/behandlingsprosess/dagligejobber/infobrev/SendInformasjonsbrevPåminnelseBatchTjeneste.java
@@ -13,48 +13,45 @@ import org.slf4j.LoggerFactory;
 
 import no.nav.foreldrepenger.batch.BatchArguments;
 import no.nav.foreldrepenger.batch.BatchTjeneste;
-import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingÅrsakType;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTaskData;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTaskTjeneste;
 
 @ApplicationScoped
-public class SendInformasjonsbrevBatchTjeneste implements BatchTjeneste {
+public class SendInformasjonsbrevPåminnelseBatchTjeneste implements BatchTjeneste {
 
-    static final String BATCHNAVN = "BVL008";
-    private static final Logger LOG = LoggerFactory.getLogger(SendInformasjonsbrevBatchTjeneste.class);
+    static final String BATCHNAVN = "BVL011";
+    private static final Logger LOG = LoggerFactory.getLogger(SendInformasjonsbrevPåminnelseBatchTjeneste.class);
     private InformasjonssakRepository informasjonssakRepository;
     private ProsessTaskTjeneste taskTjeneste;
 
     @Inject
-    public SendInformasjonsbrevBatchTjeneste(InformasjonssakRepository informasjonssakRepository, ProsessTaskTjeneste taskTjeneste) {
+    public SendInformasjonsbrevPåminnelseBatchTjeneste(InformasjonssakRepository informasjonssakRepository, ProsessTaskTjeneste taskTjeneste) {
         this.informasjonssakRepository = informasjonssakRepository;
         this.taskTjeneste = taskTjeneste;
     }
 
     @Override
     public SendInformasjonsbrevBatchArguments createArguments(Map<String, String> jobArguments) {
-        return new SendInformasjonsbrevBatchArguments(jobArguments, 4);
+        return new SendInformasjonsbrevBatchArguments(jobArguments, -130); // Ser etter fødsler som skjedde 130 uker tilbake (ca 2.5 år)
     }
 
     @Override
     public String launch(BatchArguments arguments) {
         var batchArguments = (SendInformasjonsbrevBatchArguments) arguments; // NOSONAR
-        var saker = informasjonssakRepository.finnSakerMedInnvilgetMaksdatoInnenIntervall(batchArguments.getFom(),
-                batchArguments.getTom());
+        LOG.info("Ser etter aktuelle saker med barn født mellom {} og {}", batchArguments.getFom(), batchArguments.getTom());
+        var saker = informasjonssakRepository.finnSakerDerMedforelderIkkeHarSøktOgBarnetBleFødtInnenforIntervall(
+            batchArguments.getFom(), batchArguments.getTom());
         var baseline = LocalTime.now();
         saker.forEach(sak -> {
-            LOG.info("Oppretter informasjonssak-task for {}", sak.getAktørId().getId());
-            var data = ProsessTaskData.forProsessTask(OpprettInformasjonsFagsakTask.class);
+            LOG.info("Oppretter informasjonsbrev-påminnelse task for {}", sak.getAktørId().getId());
+            var data = ProsessTaskData.forProsessTask(SendInformasjonsbrevPåminnelseTask.class);
             data.setAktørId(sak.getAktørId().getId());
             data.setCallIdFraEksisterende();
             data.setNesteKjøringEtter(LocalDateTime.of(LocalDate.now(), baseline.plusSeconds(LocalDateTime.now().getNano() % 419)));
             data.setPrioritet(100);
-            data.setProperty(OpprettInformasjonsFagsakTask.OPPRETTET_DATO_KEY, sak.getKildesakOpprettetDato().toString());
-            data.setProperty(OpprettInformasjonsFagsakTask.FH_DATO_KEY, sak.getFamilieHndelseDato().toString());
-            data.setProperty(OpprettInformasjonsFagsakTask.BEH_ENHET_ID_KEY, sak.getEnhet());
-            data.setProperty(OpprettInformasjonsFagsakTask.BEH_ENHET_NAVN_KEY, sak.getEnhetNavn());
-            data.setProperty(OpprettInformasjonsFagsakTask.BEHANDLING_AARSAK, BehandlingÅrsakType.INFOBREV_BEHANDLING.getKode());
-            data.setProperty(OpprettInformasjonsFagsakTask.FAGSAK_ID_MOR_KEY, sak.getKildeFagsakId().toString());
+            data.setProperty(SendInformasjonsbrevPåminnelseTask.BEH_ENHET_ID_KEY, sak.getEnhet());
+            data.setProperty(SendInformasjonsbrevPåminnelseTask.BEH_ENHET_NAVN_KEY, sak.getEnhetNavn());
+            data.setProperty(SendInformasjonsbrevPåminnelseTask.FAGSAK_ID_KEY, sak.getKildeFagsakId().toString());
             taskTjeneste.lagre(data);
         });
         return BATCHNAVN + "-" + saker.size();

--- a/domenetjenester/behandling-prosessering/src/main/java/no/nav/foreldrepenger/behandlingsprosess/dagligejobber/infobrev/SendInformasjonsbrevPåminnelseTask.java
+++ b/domenetjenester/behandling-prosessering/src/main/java/no/nav/foreldrepenger/behandlingsprosess/dagligejobber/infobrev/SendInformasjonsbrevPåminnelseTask.java
@@ -1,0 +1,101 @@
+package no.nav.foreldrepenger.behandlingsprosess.dagligejobber.infobrev;
+
+import java.util.Optional;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import no.nav.foreldrepenger.behandlingslager.aktør.OrganisasjonsEnhet;
+import no.nav.foreldrepenger.behandlingslager.aktør.PersoninfoBasis;
+import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
+import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingType;
+import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingÅrsakType;
+import no.nav.foreldrepenger.behandlingslager.behandling.historikk.HistorikkAktør;
+import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepository;
+import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepositoryProvider;
+import no.nav.foreldrepenger.behandlingslager.fagsak.Fagsak;
+import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakProsesstaskRekkefølge;
+import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakRepository;
+import no.nav.foreldrepenger.behandlingsprosess.prosessering.BehandlingOpprettingTjeneste;
+import no.nav.foreldrepenger.dokumentbestiller.DokumentBestillerTjeneste;
+import no.nav.foreldrepenger.dokumentbestiller.DokumentMalType;
+import no.nav.foreldrepenger.dokumentbestiller.dto.BestillBrevDto;
+import no.nav.foreldrepenger.domene.person.PersoninfoAdapter;
+import no.nav.foreldrepenger.domene.typer.AktørId;
+import no.nav.foreldrepenger.produksjonsstyring.behandlingenhet.BehandlendeEnhetTjeneste;
+import no.nav.vedtak.exception.TekniskException;
+import no.nav.vedtak.felles.prosesstask.api.ProsessTask;
+import no.nav.vedtak.felles.prosesstask.api.ProsessTaskData;
+import no.nav.vedtak.felles.prosesstask.api.ProsessTaskHandler;
+
+@ApplicationScoped
+@ProsessTask("opprettsak.informasjonsbrevPåminnelse")
+@FagsakProsesstaskRekkefølge(gruppeSekvens = true)
+public class SendInformasjonsbrevPåminnelseTask implements ProsessTaskHandler {
+
+    public static final String BEH_ENHET_ID_KEY = "enhetId";
+    public static final String BEH_ENHET_NAVN_KEY = "enhetNavn";
+    public static final String FAGSAK_ID_KEY = "fagsakId";
+
+    private static final Logger LOG = LoggerFactory.getLogger(SendInformasjonsbrevPåminnelseTask.class);
+
+    private BehandlingOpprettingTjeneste behandlingOpprettingTjeneste;
+    private PersoninfoAdapter personinfoAdapter;
+    private FagsakRepository fagsakRepository;
+    private BehandlingRepository behandlingRepository;
+    private BehandlendeEnhetTjeneste behandlendeEnhetTjeneste;
+    private DokumentBestillerTjeneste dokumentBestillerTjeneste;
+
+    SendInformasjonsbrevPåminnelseTask() {
+        // for CDI proxy
+    }
+
+    @Inject
+    public SendInformasjonsbrevPåminnelseTask(BehandlingRepositoryProvider repositoryProvider,
+                                              BehandlingOpprettingTjeneste behandlingOpprettingTjeneste,
+                                              PersoninfoAdapter personinfoAdapter,
+                                              BehandlendeEnhetTjeneste behandlendeEnhetTjeneste,
+                                              DokumentBestillerTjeneste dokumentBestillerTjeneste) {
+        this.behandlingOpprettingTjeneste = behandlingOpprettingTjeneste;
+        this.behandlendeEnhetTjeneste = behandlendeEnhetTjeneste;
+        this.personinfoAdapter = personinfoAdapter;
+        this.fagsakRepository = repositoryProvider.getFagsakRepository();
+        this.behandlingRepository = repositoryProvider.getBehandlingRepository();
+        this.dokumentBestillerTjeneste = dokumentBestillerTjeneste;
+    }
+
+    @Override
+    public void doTask(ProsessTaskData prosessTaskData) {
+        var aktørId = new AktørId(prosessTaskData.getAktørId());
+        var bruker = hentPersonInfo(aktørId);
+        if (bruker.dødsdato() != null) {
+            return; // Unngå brev til død bruker
+        }
+
+        var fagsak = fagsakRepository.finnEksaktFagsakReadOnly(Long.parseLong(prosessTaskData.getPropertyValue(FAGSAK_ID_KEY)));
+        var enhet = new OrganisasjonsEnhet(prosessTaskData.getPropertyValue(BEH_ENHET_ID_KEY), prosessTaskData.getPropertyValue(BEH_ENHET_NAVN_KEY));
+        var brukEnhet = behandlendeEnhetTjeneste.finnBehandlendeEnhetFor(fagsak);
+
+        Optional<Behandling> eksisterendeBehandling = behandlingRepository.hentSisteYtelsesBehandlingForFagsakId(fagsak.getId());
+        if (eksisterendeBehandling.isPresent() && !eksisterendeBehandling.get().erAvsluttet()) {
+            var bestillBrevDto = new BestillBrevDto(eksisterendeBehandling.get().getId(), eksisterendeBehandling.get().getUuid(), DokumentMalType.FORELDREPENGER_INFO_TIL_ANNEN_FORELDER);
+            dokumentBestillerTjeneste.bestillDokument(bestillBrevDto, HistorikkAktør.VEDTAKSLØSNINGEN, false);
+        } else {
+            var behandling = opprettFørstegangsbehandlingTilInfobrev(fagsak, brukEnhet);
+            behandlingOpprettingTjeneste.asynkStartBehandlingsprosess(behandling);
+            LOG.info("Opprettet informasjonsbehandling {} på fagsak {}", behandling.getId(), fagsak.getSaksnummer().getVerdi()); // NOSONAR
+        }
+    }
+
+    private Behandling opprettFørstegangsbehandlingTilInfobrev(Fagsak fagsak, OrganisasjonsEnhet enhet) {
+        return behandlingOpprettingTjeneste.opprettBehandling(fagsak, BehandlingType.FØRSTEGANGSSØKNAD, enhet, BehandlingÅrsakType.INFOBREV_PÅMINNELSE);
+    }
+
+    private PersoninfoBasis hentPersonInfo(AktørId aktørId) {
+        return personinfoAdapter.hentBrukerBasisForAktør(aktørId)
+            .orElseThrow(() -> new TekniskException("FP-442142", String.format("Fant ingen ident for aktør %s.", aktørId)));
+    }
+}

--- a/domenetjenester/behandling-prosessering/src/test/java/no/nav/foreldrepenger/behandlingsprosess/dagligejobber/infobrev/SendInformasjonsbrevBatchTjenesteTest.java
+++ b/domenetjenester/behandling-prosessering/src/test/java/no/nav/foreldrepenger/behandlingsprosess/dagligejobber/infobrev/SendInformasjonsbrevBatchTjenesteTest.java
@@ -74,13 +74,13 @@ public class SendInformasjonsbrevBatchTjenesteTest {
         Map<String, String> arguments = new HashMap<>();
         arguments.put(SendInformasjonsbrevBatchArguments.FOM_KEY, fom.format(ofPattern(DATE_PATTERN)));
         arguments.put(SendInformasjonsbrevBatchArguments.TOM_KEY, tom.format(ofPattern(DATE_PATTERN)));
-        batchArgs = new SendInformasjonsbrevBatchArguments(arguments);
+        batchArgs = new SendInformasjonsbrevBatchArguments(arguments, 4);
 
         tjenesteOpphold = new SendInformasjonsbrevOppholdBatchTjeneste(repository, taskTjenesteMock);
         Map<String, String> argumentsOpphold = new HashMap<>();
         argumentsOpphold.put(SendInformasjonsbrevBatchArguments.FOM_KEY, fomOpphold.format((ofPattern(DATE_PATTERN))));
         argumentsOpphold.put(SendInformasjonsbrevBatchArguments.TOM_KEY, tomOpphold.format((ofPattern(DATE_PATTERN))));
-        batchArgs = new SendInformasjonsbrevBatchArguments(argumentsOpphold);
+        batchArgs = new SendInformasjonsbrevBatchArguments(argumentsOpphold, 4);
     }
 
     @Test

--- a/domenetjenester/behandling-prosessering/src/test/java/no/nav/foreldrepenger/behandlingsprosess/dagligejobber/infobrev/SendInformasjonsbrevPåminnelseBatchTjenesteTest.java
+++ b/domenetjenester/behandling-prosessering/src/test/java/no/nav/foreldrepenger/behandlingsprosess/dagligejobber/infobrev/SendInformasjonsbrevPåminnelseBatchTjenesteTest.java
@@ -1,0 +1,194 @@
+package no.nav.foreldrepenger.behandlingsprosess.dagligejobber.infobrev;
+
+import static java.time.format.DateTimeFormatter.ofPattern;
+import static java.util.List.of;
+import static no.nav.foreldrepenger.behandlingsprosess.dagligejobber.infobrev.SendInformasjonsbrevBatchArguments.DATE_PATTERN;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDate;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.inject.Inject;
+import javax.persistence.EntityManager;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import no.nav.foreldrepenger.behandlingslager.aktør.FødtBarnInfo;
+import no.nav.foreldrepenger.behandlingslager.aktør.NavBruker;
+import no.nav.foreldrepenger.behandlingslager.aktør.OrganisasjonsEnhet;
+import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
+import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingResultatType;
+import no.nav.foreldrepenger.behandlingslager.behandling.Behandlingsresultat;
+import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepository;
+import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepositoryProvider;
+import no.nav.foreldrepenger.behandlingslager.behandling.søknad.SøknadEntitet;
+import no.nav.foreldrepenger.behandlingslager.fagsak.Dekningsgrad;
+import no.nav.foreldrepenger.behandlingslager.fagsak.Fagsak;
+import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakYtelseType;
+import no.nav.foreldrepenger.behandlingslager.testutilities.behandling.ScenarioMorSøkerForeldrepenger;
+import no.nav.foreldrepenger.behandlingslager.uttak.fp.Stønadskonto;
+import no.nav.foreldrepenger.behandlingslager.uttak.fp.StønadskontoType;
+import no.nav.foreldrepenger.behandlingslager.uttak.fp.Stønadskontoberegning;
+import no.nav.foreldrepenger.dbstoette.CdiDbAwareTest;
+import no.nav.foreldrepenger.domene.typer.AktørId;
+import no.nav.foreldrepenger.domene.typer.PersonIdent;
+import no.nav.foreldrepenger.familiehendelse.FamilieHendelseTjeneste;
+import no.nav.vedtak.felles.prosesstask.api.ProsessTaskTjeneste;
+
+@CdiDbAwareTest
+public class SendInformasjonsbrevPåminnelseBatchTjenesteTest {
+
+    @Inject
+    private BehandlingRepository behandlingRepository;
+
+    @Inject
+    private ProsessTaskTjeneste taskTjenesteMock;
+
+    @Inject
+    private BehandlingRepositoryProvider repositoryProvider;
+
+    @Inject
+    private InformasjonssakRepository repository;
+
+    @Inject
+    private FamilieHendelseTjeneste familieHendelseTjeneste;
+
+    private SendInformasjonsbrevPåminnelseBatchTjeneste tjeneste;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        tjeneste = new SendInformasjonsbrevPåminnelseBatchTjeneste(repository, taskTjenesteMock);
+    }
+
+    @Test
+    public void skal_finne_en_sak_som_trenger_påminnelse_når_fødselsdatoen_er_innenfor_intervallet(EntityManager em) {
+        opprettTestdata(em, LocalDate.now().plusDays(2));
+        var resultat = tjeneste.launch(settOppBatchArguments(LocalDate.now(), LocalDate.now().plusDays(3)));
+        assertThat(resultat).isEqualTo(SendInformasjonsbrevPåminnelseBatchTjeneste.BATCHNAVN + "-1");
+    }
+
+    @Test
+    public void skal_ikke_finne_en_sak_som_trenger_påminnelse_når_fødselsdatoen_er_utenfor_intervallet(EntityManager em) {
+        opprettTestdata(em, LocalDate.now().plusDays(20));
+        var resultat = tjeneste.launch(settOppBatchArguments(LocalDate.now(), LocalDate.now().plusDays(3)));
+        assertThat(resultat).isEqualTo(SendInformasjonsbrevPåminnelseBatchTjeneste.BATCHNAVN + "-0");
+    }
+
+    @Test
+    public void skal_ikke_finne_en_sak_som_trenger_påminnelse_når_fødselsdatoen_er_før_første_oktober_2021(EntityManager em) {
+        opprettTestdata(em, LocalDate.of(2021, 6, 2));
+        var resultat = tjeneste.launch(settOppBatchArguments(LocalDate.of(2021, 6, 1), LocalDate.of(2021, 6, 3)));
+        assertThat(resultat).isEqualTo(SendInformasjonsbrevPåminnelseBatchTjeneste.BATCHNAVN + "-0");
+    }
+
+    @Test
+    public void skal_ikke_finne_en_sak_som_trenger_påminnelse_når_barnet_er_dødt(EntityManager em) {
+        // Arrange
+        Behandling behandlingMor = opprettTestdata(em, LocalDate.now().plusDays(2)).behandlingMor;
+        FødtBarnInfo fødtBarnInfo = new FødtBarnInfo.Builder()
+            .medIdent(new PersonIdent("11"))
+            .medFødselsdato(LocalDate.now().plusDays(2))
+            .medDødsdato(LocalDate.now().plusDays(2))
+            .build();
+        familieHendelseTjeneste.oppdaterFødselPåGrunnlag(behandlingMor, of(fødtBarnInfo));
+
+        // Act
+        var resultat = tjeneste.launch(settOppBatchArguments(LocalDate.now(), LocalDate.now().plusDays(3)));
+
+        // Assert
+        assertThat(resultat).isEqualTo(SendInformasjonsbrevPåminnelseBatchTjeneste.BATCHNAVN + "-0");
+    }
+
+    @Test
+    public void skal_ikke_finne_en_sak_som_trenger_påminnelse_når_far_har_søkt(EntityManager em) {
+        // Arrange
+        Behandling behandlingFar = opprettTestdata(em, LocalDate.now().plusDays(2)).behandlingFar;
+        SøknadEntitet søknad = new SøknadEntitet.Builder().medSøknadsdato(LocalDate.now()).build();
+        repositoryProvider.getSøknadRepository().lagreOgFlush(behandlingFar, søknad);
+
+        // Act
+        var resultat = tjeneste.launch(settOppBatchArguments(LocalDate.now(), LocalDate.now().plusDays(3)));
+
+        // Assert
+        assertThat(resultat).isEqualTo(SendInformasjonsbrevPåminnelseBatchTjeneste.BATCHNAVN + "-0");
+    }
+
+    @Test
+    public void skal_ikke_finne_en_sak_som_trenger_påminnelse_når_mor_har_en_nyere_sak(EntityManager em) {
+        // Arrange
+        Behandling behandlingMor = opprettTestdata(em, LocalDate.now().plusDays(2)).behandlingMor;
+        var nyFagsakMor = Fagsak.opprettNy(FagsakYtelseType.FORELDREPENGER, behandlingMor.getFagsak().getNavBruker());
+        repositoryProvider.getFagsakRepository().opprettNy(nyFagsakMor);
+
+        // Act
+        var resultat = tjeneste.launch(settOppBatchArguments(LocalDate.now(), LocalDate.now().plusDays(3)));
+
+        // Assert
+        assertThat(resultat).isEqualTo(SendInformasjonsbrevPåminnelseBatchTjeneste.BATCHNAVN + "-0");
+    }
+
+    @Test
+    public void skal_ikke_finne_en_sak_som_trenger_påminnelse_når_far_har_en_nyere_sak(EntityManager em) {
+        // Arrange
+        Behandling behandlingFar = opprettTestdata(em, LocalDate.now().plusDays(2)).behandlingFar;
+        var nyFagsakFar = Fagsak.opprettNy(FagsakYtelseType.FORELDREPENGER, behandlingFar.getFagsak().getNavBruker());
+        repositoryProvider.getFagsakRepository().opprettNy(nyFagsakFar);
+
+        // Act
+        var resultat = tjeneste.launch(settOppBatchArguments(LocalDate.now(), LocalDate.now().plusDays(3)));
+
+        // Assert
+        assertThat(resultat).isEqualTo(SendInformasjonsbrevPåminnelseBatchTjeneste.BATCHNAVN + "-0");
+    }
+
+    private SendInformasjonsbrevBatchArguments settOppBatchArguments(LocalDate fom, LocalDate tom) {
+        Map<String, String> arguments = new HashMap<>();
+        arguments.put(SendInformasjonsbrevBatchArguments.FOM_KEY, fom.format(ofPattern(DATE_PATTERN)));
+        arguments.put(SendInformasjonsbrevBatchArguments.TOM_KEY, tom.format(ofPattern(DATE_PATTERN)));
+        return new SendInformasjonsbrevBatchArguments(arguments, -130);
+    }
+
+    private MorOgFarBehandling opprettTestdata(EntityManager em, LocalDate fødselsdato) {
+        var scenarioMor = ScenarioMorSøkerForeldrepenger.forFødsel()
+            .medSøknadDato(fødselsdato.minusDays(40));
+        AktørId aktørIdFar = new AktørId("1111111111111");
+        scenarioMor.medSøknadAnnenPart().medAktørId(aktørIdFar).medNavn("Bruker Brukersen").build();
+
+        scenarioMor.medBekreftetHendelse()
+            .medFødselsDato(fødselsdato)
+            .medAntallBarn(1);
+
+        scenarioMor.medBehandlingsresultat(Behandlingsresultat.builder().medBehandlingResultatType(BehandlingResultatType.INNVILGET));
+        var behandlingMor = scenarioMor.lagre(repositoryProvider);
+        behandlingMor.avsluttBehandling();
+        var lås = behandlingRepository.taSkriveLås(behandlingMor);
+        behandlingRepository.lagre(behandlingMor, lås);
+
+        var kontoMor = Stønadskontoberegning.builder()
+            .medStønadskonto(Stønadskonto.builder().medStønadskontoType(StønadskontoType.MØDREKVOTE).medMaxDager(75).build())
+            .medRegelInput("{ blablabla }").medRegelEvaluering("{ blablabla }");
+
+        repositoryProvider.getFagsakRelasjonRepository().opprettRelasjon(behandlingMor.getFagsak(), Dekningsgrad._100);
+        repositoryProvider.getFagsakRelasjonRepository().lagre(behandlingMor.getFagsak(), behandlingMor.getId(), kontoMor.build());
+
+        var fagsakFar = Fagsak.opprettNy(FagsakYtelseType.FORELDREPENGER, NavBruker.opprettNyNB(aktørIdFar));
+        repositoryProvider.getFagsakRepository().opprettNy(fagsakFar);
+        var behandlingFar = Behandling.forFørstegangssøknad(fagsakFar).medBehandlendeEnhet(new OrganisasjonsEnhet("1000", "Enheten")).build();
+        lås = behandlingRepository.taSkriveLås(behandlingFar);
+        repositoryProvider.getBehandlingRepository().lagre(behandlingFar, lås);
+        repositoryProvider.getFagsakRelasjonRepository().kobleFagsaker(behandlingMor.getFagsak(), fagsakFar, behandlingMor);
+
+        var kontoFar = Stønadskontoberegning.builder()
+            .medStønadskonto(Stønadskonto.builder().medStønadskontoType(StønadskontoType.FEDREKVOTE).medMaxDager(75).build())
+            .medRegelInput("{ blablabla }").medRegelEvaluering("{ blablabla }");
+        repositoryProvider.getFagsakRelasjonRepository().lagre(fagsakFar, behandlingFar.getId(), kontoFar.build());
+
+        em.flush();
+        em.clear();
+        return new MorOgFarBehandling(em.find(Behandling.class, behandlingMor.getId()), em.find(Behandling.class, behandlingFar.getId()));
+    }
+
+    private record MorOgFarBehandling(Behandling behandlingMor, Behandling behandlingFar) {}
+}

--- a/domenetjenester/dokumentbestiller/src/main/java/no/nav/foreldrepenger/dokumentbestiller/autopunkt/SendBrevForAutopunkt.java
+++ b/domenetjenester/dokumentbestiller/src/main/java/no/nav/foreldrepenger/dokumentbestiller/autopunkt/SendBrevForAutopunkt.java
@@ -1,6 +1,7 @@
 package no.nav.foreldrepenger.dokumentbestiller.autopunkt;
 
 import static no.nav.foreldrepenger.behandlingslager.behandling.BehandlingÅrsakType.INFOBREV_OPPHOLD;
+import static no.nav.foreldrepenger.behandlingslager.behandling.BehandlingÅrsakType.INFOBREV_PÅMINNELSE;
 
 import java.time.LocalDate;
 
@@ -44,7 +45,8 @@ public class SendBrevForAutopunkt {
 
     public void sendBrevForSøknadIkkeMottatt(Behandling behandling, Aksjonspunkt ap) {
         var dokumentMalType = DokumentMalType.IKKE_SØKT;
-        if (behandling.harBehandlingÅrsak(BehandlingÅrsakType.INFOBREV_BEHANDLING) || behandling.harBehandlingÅrsak(INFOBREV_OPPHOLD)) {
+        if (behandling.harBehandlingÅrsak(BehandlingÅrsakType.INFOBREV_BEHANDLING)
+            || behandling.harBehandlingÅrsak(INFOBREV_OPPHOLD) || behandling.harBehandlingÅrsak(INFOBREV_PÅMINNELSE)) {
             dokumentMalType = DokumentMalType.FORELDREPENGER_INFO_TIL_ANNEN_FORELDER;
         }
         if ((DokumentMalType.IKKE_SØKT.equals(dokumentMalType) && !harSendtBrevForMal(behandling.getId(), dokumentMalType) && !harSendtBrevForMal(behandling.getId(), DokumentMalType.INNTEKTSMELDING_FOR_TIDLIG_DOK))

--- a/infrastrukturtjenester/batch/src/main/java/no/nav/foreldrepenger/batch/task/BatchSchedulerTask.java
+++ b/infrastrukturtjenester/batch/src/main/java/no/nav/foreldrepenger/batch/task/BatchSchedulerTask.java
@@ -52,7 +52,8 @@ public class BatchSchedulerTask implements ProsessTaskHandler {
             new BatchConfig(6, 48, AVSTEMMING, "fagomrade=FP, antallDager="),
             new BatchConfig(6, 49, AVSTEMMING, "fagomrade=FPREF, antallDager="),
             new BatchConfig(7, 3, "BVL008", ANT_DAGER), // Infobrev far - 7min spread
-            new BatchConfig(7, 10, "BVL009", ANT_DAGER) // Infobrev opphold far - 3 min spread
+            new BatchConfig(7, 10, "BVL009", ANT_DAGER), // Infobrev opphold far - 3 min spread
+            new BatchConfig(7, 13, "BVL011", ANT_DAGER) // Infobrev far påminnelse - 7min spread
     );
 
     private static final List<BatchConfig> BATCH_OPPSETT_VIRKEDAGER = Arrays.asList(
@@ -62,7 +63,7 @@ public class BatchSchedulerTask implements ProsessTaskHandler {
             new BatchConfig(7, 0, "BVL002", null), // Etterkontroll
             new BatchConfig(7, 2, "BVL003", null), // Forlengelsesbrev må kjøre noe etter Gjenoppta
             new BatchConfig(7, 1, "BVL006", null), // Fagsakavslutning
-            new BatchConfig(7, 15, "BVL007", null), // Oppdatering dagsgamle oppgaver - 24 min spread
+            new BatchConfig(7, 20, "BVL007", null), // Oppdatering dagsgamle oppgaver - 24 min spread
             new BatchConfig(7, 45, BatchRunnerTask.BATCH_NAME_RETRY_TASKS, null) // Siste steg
     );
 

--- a/infrastrukturtjenester/batch/src/test/java/no/nav/foreldrepenger/batch/task/BatchSchedulerTaskTest.java
+++ b/infrastrukturtjenester/batch/src/test/java/no/nav/foreldrepenger/batch/task/BatchSchedulerTaskTest.java
@@ -28,7 +28,7 @@ public class BatchSchedulerTaskTest {
     }
 
     @Test
-    public void normal_dag_skal_ha_7_tasks_med_antalldager() {
+    public void normal_dag_skal_ha_8_tasks_med_antalldager() {
         // Arrange
         task.doTask(taskData);
         var props = testsupport.getTaskDataList();
@@ -39,7 +39,7 @@ public class BatchSchedulerTaskTest {
                 .collect(Collectors.toList());
         if (props.size() > 1) {
             System.out.println(matches);
-            assertThat(matches).hasSize(7); // Antall dagsensitive batcher.
+            assertThat(matches).hasSize(8); // Antall dagsensitive batcher.
         }
     }
 


### PR DESCRIPTION
…lder når det har gått 2.5 år siden barnet ble født og far ikke har søkt.

Det er tricky å teste dette ordentlig, men jeg har foruten enhetstestene som dekker SQLen ganske godt, testet batchen lokalt ved å:
1. Endre så InformasjonssakRepository.QUERY_INFORMASJONSBREV_PÅMINNELSE ikke har kriterie om fødsel etter 01.10.2021.
2. Endre så InformasjonssakRepository.QUERY_INFORMASJONSBREV_VANLIG ikke har noe tidsintervall for når vanlig infobrev sendes.
3. Kjøre en autotest som gir mors sak ferdigbehandlet, men ingen sak på far.
4. Kjøre BVL008 via Swagger for å få infobrevsak på far.
5. Endre fødselsdatoen i databasen på mors sak til at barnet ble født for 2.5 år siden, slik at intervallet for BVL011 treffer (21.04.2019 i dag 18.10.2021).
6. Kjøre BVL011 via Swagger, som gir nytt infobrev på samme åpne behandling.
7. Gjentatt steg 3 til 5, men så henlagt den åpne behandlingen før steg 6, og ser da at det blir opprettet ny behandling før nytt infobrev sendes.