### PR TITLE
TFP-4659: Økt tillatt størrelse på fritekst-felt når brev bestilles f…

### DIFF
--- a/domenetjenester/dokumentbestiller/src/main/java/no/nav/foreldrepenger/dokumentbestiller/dto/BestillBrevDto.java
+++ b/domenetjenester/dokumentbestiller/src/main/java/no/nav/foreldrepenger/dokumentbestiller/dto/BestillBrevDto.java
@@ -31,7 +31,7 @@ public class BestillBrevDto {
     @Pattern(regexp = InputValideringRegex.KODEVERK)
     private String brevmalkode;
 
-    @Size(max = 4000)
+    @Size(max = 6000)
     @Pattern(regexp = InputValideringRegex.FRITEKST)
     public String fritekst;
 


### PR DESCRIPTION
…ra fp-frontend fra 4000 til 6000 tegn, slik at det samsvarer med endringen som er gjort i fp-frontend.