### PR TITLE
Oppdatert til team namespace saf url.

### DIFF
--- a/.deploy/dev-fss-teamforeldrepenger.json
+++ b/.deploy/dev-fss-teamforeldrepenger.json
@@ -58,7 +58,7 @@
     "DKIF_RS_URL": "http://dkif.default/api/v1/personer/kontaktinformasjon",
     "ARBEIDSFORDELING_RS_URL": "http://norg2.default/norg2/api/v1/arbeidsfordeling/enheter",
     "PDL_BASE_URL" : "http://pdl-api.pdl/graphql",
-    "SAF_BASE_URL" : "http://saf.q1",
+    "SAF_BASE_URL" : "http://saf-q1.teamdokumenthandtering",
     "KODEVERK_V2_URL": "https://kodeverk.nais.preprod.local/ws/kodeverk/v2"
   }
 }

--- a/.deploy/prod-fss-teamforeldrepenger.json
+++ b/.deploy/prod-fss-teamforeldrepenger.json
@@ -55,7 +55,7 @@
     "DKIF_RS_URL": "http://dkif.default/api/v1/personer/kontaktinformasjon",
     "ARBEIDSFORDELING_RS_URL": "https://app.adeo.no/norg2/api/v1/arbeidsfordeling/enheter",
     "PDL_BASE_URL" : "http://pdl-api.pdl/graphql",
-    "SAF_BASE_URL" : "https://saf.nais.adeo.no",
+    "SAF_BASE_URL" : "https://saf.intern.nav.no",
     "KODEVERK_V2_URL": "https://kodeverk.nais.adeo.no/ws/kodeverk/v2",
     "AZURE_HTTP_PROXY": "http://webproxy.nais:8088",
     "SPOKELSE_GRUNNLAG_SCOPES": "api://prod-fss.tbd.spokelse/.default",


### PR DESCRIPTION
**saf har migrert til team namespaces**
Det er ikke tillatt å lage apper i andre namespace enn ditt eget teams namespace lenger på NAIS.
Vi har da opprettet saf apper i test på team namespace `teamdokumenthandtering`. `saf-q0`, `saf-q1`, `saf-q4`
Ingresser skal da rute mot disse nye appene.
:warning:
Appen deres bruker kubernetes service discovery!
Denne PR endrer kubernetes service discovery url:
* Fra `http://saf.q1` til `http://saf-q1.teamdokumenthandtering` på `dev-fss`.
* Fra `http://saf.default` til til `http://saf.teamdokumenthandtering` på `prod-fss`.