### PR TITLE
TFP-4436 TFP-4437 endring som utsetter startdato

### DIFF
--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/Behandling.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/Behandling.java
@@ -321,6 +321,12 @@ public class Behandling extends BaseEntitet {
                 .anyMatch(behandlingÅrsak::equals);
     }
 
+    public boolean harNoenBehandlingÅrsaker(Set<BehandlingÅrsakType> behandlingÅrsaker) {
+        return getBehandlingÅrsaker().stream()
+            .map(BehandlingÅrsak::getBehandlingÅrsakType)
+            .anyMatch(behandlingÅrsaker::contains);
+    }
+
     public Optional<Long> getOriginalBehandlingId() {
         return getBehandlingÅrsaker().stream()
                 .map(BehandlingÅrsak::getOriginalBehandlingId)

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/BehandlingResultatType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/BehandlingResultatType.java
@@ -34,6 +34,7 @@ public enum BehandlingResultatType implements Kodeverdi {
     MERGET_OG_HENLAGT("MERGET_OG_HENLAGT", "Mottatt ny søknad"),
     HENLAGT_SØKNAD_MANGLER("HENLAGT_SØKNAD_MANGLER", "Henlagt søknad mangler"),
     FORELDREPENGER_ENDRET("FORELDREPENGER_ENDRET", "Sak er endret"),
+    FORELDREPENGER_SENERE("FORELDREPENGER_SENERE", "Sak er endret"),
     INGEN_ENDRING("INGEN_ENDRING", "Ingen endring"),
     MANGLER_BEREGNINGSREGLER("MANGLER_BEREGNINGSREGLER", "Mangler beregningsregler"),
 
@@ -66,8 +67,7 @@ public enum BehandlingResultatType implements Kodeverdi {
     private static final Set<BehandlingResultatType> KLAGE_KODER = Set.of(KLAGE_MEDHOLD, KLAGE_YTELSESVEDTAK_STADFESTET, KLAGE_YTELSESVEDTAK_OPPHEVET, KLAGE_AVVIST, HJEMSENDE_UTEN_OPPHEVE);
     private static final Set<BehandlingResultatType> ANKE_KODER = Set.of(ANKE_AVVIST, ANKE_OMGJOER, ANKE_OPPHEVE_OG_HJEMSENDE, ANKE_HJEMSENDE_UTEN_OPPHEV, ANKE_YTELSESVEDTAK_STADFESTET);
     private static final Set<BehandlingResultatType> INNSYN_KODER = Set.of(INNSYN_INNVILGET, INNSYN_DELVIS_INNVILGET, INNSYN_AVVIST);
-    private static final Set<BehandlingResultatType> INNVILGET_KODER = Set.of(INNVILGET, FORELDREPENGER_ENDRET);
-    private static final Set<BehandlingResultatType> ALLE_INNVILGET_KODER = Set.of(INNVILGET, FORELDREPENGER_ENDRET, INGEN_ENDRING);
+    private static final Set<BehandlingResultatType> ALLE_INNVILGET_KODER = Set.of(INNVILGET, FORELDREPENGER_ENDRET, FORELDREPENGER_SENERE, INGEN_ENDRING);
 
     private static final Map<AnkeVurdering, BehandlingResultatType> ANKE_RESULTAT = Map.ofEntries(
         Map.entry(AnkeVurdering.ANKE_AVVIS, BehandlingResultatType.ANKE_AVVIST),
@@ -162,10 +162,6 @@ public enum BehandlingResultatType implements Kodeverdi {
 
     public static Set<BehandlingResultatType> getInnsynKoder() {
         return INNSYN_KODER;
-    }
-
-    public static Set<BehandlingResultatType> getInnvilgetKoder() {
-        return INNVILGET_KODER;
     }
 
     public static Set<BehandlingResultatType> getAlleInnvilgetKoder() {

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/BehandlingÅrsakType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/BehandlingÅrsakType.java
@@ -50,9 +50,11 @@ public enum BehandlingÅrsakType implements Kodeverdi {
     RE_MANGLER_FØDSEL_I_PERIODE("RE-MFIP", "Mangler fødselsreg. u26-29"),
     RE_AVVIK_ANTALL_BARN("RE-AVAB", "Avvik antall barn"),
 
-    // Mottak + varianter av berørte behandlinger (tekniske behandlinger)
+    // Mottak
     RE_ENDRING_FRA_BRUKER("RE-END-FRA-BRUKER", "Søknad"),
     RE_ENDRET_INNTEKTSMELDING("RE-END-INNTEKTSMELD", "Inntektsmelding"),
+
+    // Tekniske behandlinger som skal spesialbehandles i prosessen
     BERØRT_BEHANDLING("BERØRT-BEHANDLING", "Berørt behandling"),
     REBEREGN_FERIEPENGER("REBEREGN-FERIEPENGER", "Omfordel feriepenger"),
     RE_UTSATT_START("RE-UTSATT-START", "Senere startdato"),
@@ -100,6 +102,9 @@ public enum BehandlingÅrsakType implements Kodeverdi {
     ;
 
     public static final String KODEVERK = "BEHANDLING_AARSAK"; //$NON-NLS-1$
+
+    private static final Set<BehandlingÅrsakType> SPESIELLE_BEHANDLINGER = Set.of(BehandlingÅrsakType.BERØRT_BEHANDLING,
+        BehandlingÅrsakType.REBEREGN_FERIEPENGER, BehandlingÅrsakType.RE_UTSATT_START);
 
     private static final Map<String, BehandlingÅrsakType> KODER = new LinkedHashMap<>();
 
@@ -186,5 +191,13 @@ public enum BehandlingÅrsakType implements Kodeverdi {
 
     public static Set<BehandlingÅrsakType> årsakerRelatertTilDød() {
         return Set.of(RE_OPPLYSNINGER_OM_DØD, RE_HENDELSE_DØD_BARN, RE_HENDELSE_DØD_FORELDER, RE_HENDELSE_DØDFØDSEL);
+    }
+
+    public static Set<BehandlingÅrsakType> årsakerForRelatertVedtak() {
+        return Set.of(BERØRT_BEHANDLING, REBEREGN_FERIEPENGER);
+    }
+
+    public static Set<BehandlingÅrsakType> alleTekniskeÅrsaker() {
+        return SPESIELLE_BEHANDLINGER;
     }
 }

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/BehandlingÅrsakType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/BehandlingÅrsakType.java
@@ -32,7 +32,7 @@ public enum BehandlingÅrsakType implements Kodeverdi {
 
     RE_OPPLYSNINGER_OM_MEDLEMSKAP("RE-MDL", "Opplysninger medlemskap"),
     RE_OPPLYSNINGER_OM_OPPTJENING("RE-OPTJ", "Opplysninger opptjening"),
-    RE_OPPLYSNINGER_OM_FORDELING("RE-FRDLING", "Opplysninger fordeling"),
+    RE_OPPLYSNINGER_OM_FORDELING("RE-FRDLING", "Opplysninger uttak"),
     RE_OPPLYSNINGER_OM_INNTEKT("RE-INNTK", "Opplysninger inntekt"),
     RE_OPPLYSNINGER_OM_FØDSEL("RE-FØDSEL", "Fødsel"),
     RE_OPPLYSNINGER_OM_DØD("RE-DØD", "Opplysninger død"),
@@ -50,11 +50,12 @@ public enum BehandlingÅrsakType implements Kodeverdi {
     RE_MANGLER_FØDSEL_I_PERIODE("RE-MFIP", "Mangler fødselsreg. u26-29"),
     RE_AVVIK_ANTALL_BARN("RE-AVAB", "Avvik antall barn"),
 
-    // Mottak
+    // Mottak + varianter av berørte behandlinger (tekniske behandlinger)
     RE_ENDRING_FRA_BRUKER("RE-END-FRA-BRUKER", "Søknad"),
     RE_ENDRET_INNTEKTSMELDING("RE-END-INNTEKTSMELD", "Inntektsmelding"),
     BERØRT_BEHANDLING("BERØRT-BEHANDLING", "Berørt behandling"),
     REBEREGN_FERIEPENGER("REBEREGN-FERIEPENGER", "Omfordel feriepenger"),
+    RE_UTSATT_START("RE-UTSATT-START", "Senere startdato"),
 
     // G-regulering
     RE_SATS_REGULERING("RE-SATS-REGULERING", "Regulering grunnbeløp"),

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/DokumentTypeId.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/DokumentTypeId.java
@@ -233,6 +233,11 @@ public enum DokumentTypeId implements Kodeverdi, MedOffisiellKode {
         return ENDRING_SØKNAD_TYPER.contains(this);
     }
 
+    public boolean erForeldrepengeSøknad() {
+        return Set.of(SØKNAD_FORELDREPENGER_FØDSEL, SØKNAD_FORELDREPENGER_ADOPSJON,
+            FORELDREPENGER_ENDRING_SØKNAD, FLEKSIBELT_UTTAK_FORELDREPENGER).contains(this);
+    }
+
     public boolean erInntektsmelding() {
         return INNTEKTSMELDING.equals(this);
     }

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/SpesialBehandling.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/SpesialBehandling.java
@@ -1,0 +1,59 @@
+package no.nav.foreldrepenger.behandlingslager.behandling;
+
+import java.util.Set;
+
+/*
+ * Metoder knyttet til tekniske behandlinger pga vedtak i relatert fagsak eller senerelagt uttak
+ * Disse skal typisk ikke gjennom vilkår eller beregning - men oppdatere uttak eller tilkjent ytelse.
+ */
+public final class SpesialBehandling {
+
+    private static final Set<BehandlingÅrsakType> BEHOLD_GRUNNLAG = BehandlingÅrsakType.alleTekniskeÅrsaker();
+
+    private static final Set<BehandlingÅrsakType> BEHOLD_UTTAK = Set.of(BehandlingÅrsakType.REBEREGN_FERIEPENGER, BehandlingÅrsakType.RE_UTSATT_START);
+
+    public static boolean erSpesialBehandling(Behandling behandling) {
+        return behandling.harNoenBehandlingÅrsaker(BEHOLD_GRUNNLAG);
+    }
+
+    public static boolean erIkkeSpesialBehandling(Behandling behandling) {
+        return !behandling.harNoenBehandlingÅrsaker(BEHOLD_GRUNNLAG);
+    }
+
+    public static boolean erBerørtBehandling(Behandling behandling) {
+        return behandling.harBehandlingÅrsak(BehandlingÅrsakType.BERØRT_BEHANDLING);
+    }
+
+    public static boolean erJusterFeriepenger(Behandling behandling) {
+        return behandling.harBehandlingÅrsak(BehandlingÅrsakType.REBEREGN_FERIEPENGER);
+    }
+
+    public static boolean erOppsagtUttak(Behandling behandling) {
+        return behandling.harBehandlingÅrsak(BehandlingÅrsakType.RE_UTSATT_START);
+    }
+
+    public static boolean skalGrunnlagBeholdes(Behandling behandling) {
+        return behandling.harNoenBehandlingÅrsaker(BEHOLD_GRUNNLAG);
+    }
+
+    public static boolean skalUttakVurderes(Behandling behandling) {
+        return !behandling.harNoenBehandlingÅrsaker(BEHOLD_UTTAK);
+    }
+
+    public static boolean skalKøes(Behandling behandling) {
+        return !behandling.harNoenBehandlingÅrsaker(BEHOLD_GRUNNLAG);
+    }
+
+    public static boolean skalIkkeKøes(Behandling behandling) {
+        return behandling.harNoenBehandlingÅrsaker(BEHOLD_GRUNNLAG);
+    }
+
+    public static boolean kanIkkeOverstyres(Behandling behandling) {
+        return behandling.harNoenBehandlingÅrsaker(BEHOLD_UTTAK);
+    }
+
+    public static boolean kanHenlegges(Behandling behandling) {
+        return !behandling.harNoenBehandlingÅrsaker(BEHOLD_UTTAK);
+    }
+
+}

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/familiehendelse/FamilieHendelseRepository.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/familiehendelse/FamilieHendelseRepository.java
@@ -222,7 +222,7 @@ public class FamilieHendelseRepository {
      * @param gammelBehandling behandlingen det opprettes revurdering på
      * @param nyBehandling revurderings behandlingen
      */
-    public void kopierGrunnlagFraEksisterendeBehandlingForRevurdering(Long gammelBehandlingId, Long nyBehandlingId) {
+    public void kopierGrunnlagFraEksisterendeBehandlingUtenVurderinger(Long gammelBehandlingId, Long nyBehandlingId) {
         final var familieHendelseGrunnlag = getAktivtFamilieHendelseGrunnlag(gammelBehandlingId);
         if (familieHendelseGrunnlag.isPresent()) {
             final var entitet = new FamilieHendelseGrunnlagEntitet(familieHendelseGrunnlag.get());

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/medlemskap/MedlemskapRepository.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/medlemskap/MedlemskapRepository.java
@@ -75,7 +75,7 @@ public class MedlemskapRepository {
         oppdaterLås(nyLås);
     }
 
-    public void kopierGrunnlagFraEksisterendeBehandlingForRevurdering(Long eksisterendeBehandlingId, Long nyBehandlingId) {
+    public void kopierGrunnlagFraEksisterendeBehandlingUtenVurderinger(Long eksisterendeBehandlingId, Long nyBehandlingId) {
         final var nyLås = taLås(nyBehandlingId);
         var eksisterendeGrunnlag = getAktivtBehandlingsgrunnlag(eksisterendeBehandlingId);
 

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/personopplysning/PersonopplysningRepository.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/personopplysning/PersonopplysningRepository.java
@@ -61,7 +61,7 @@ public class PersonopplysningRepository {
     }
 
 
-    public void kopierGrunnlagFraEksisterendeBehandlingForRevurdering(Long eksisterendeBehandlingId, Long nyBehandlingId) {
+    public void kopierGrunnlagFraEksisterendeBehandlingUtenVurderinger(Long eksisterendeBehandlingId, Long nyBehandlingId) {
         var eksisterendeGrunnlag = getAktivtGrunnlag(eksisterendeBehandlingId);
 
         final var builder = PersonopplysningGrunnlagBuilder.oppdatere(eksisterendeGrunnlag);

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/repository/BehandlingRepository.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/repository/BehandlingRepository.java
@@ -27,6 +27,7 @@ import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingType;
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandlingsresultat;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingÅrsak;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingÅrsakType;
+import no.nav.foreldrepenger.behandlingslager.behandling.SpesialBehandling;
 import no.nav.foreldrepenger.behandlingslager.behandling.vilkår.VilkårResultat;
 import no.nav.foreldrepenger.behandlingslager.fagsak.Fagsak;
 import no.nav.foreldrepenger.domene.typer.Saksnummer;
@@ -210,7 +211,7 @@ public class BehandlingRepository {
 
     public boolean harÅpenOrdinærYtelseBehandlingerForFagsakId(Long fagsakId) {
         return hentÅpneYtelseBehandlingerForFagsakId(fagsakId).stream()
-                .anyMatch(b -> !b.harBehandlingÅrsak(BehandlingÅrsakType.BERØRT_BEHANDLING));
+                .anyMatch(SpesialBehandling::erIkkeSpesialBehandling);
     }
 
     public List<Behandling> hentÅpneYtelseBehandlingerForFagsakId(Long fagsakId) {

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/uttak/fp/FpUttakRepository.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/uttak/fp/FpUttakRepository.java
@@ -38,6 +38,7 @@ public class FpUttakRepository {
 
     public void lagreOpprinneligUttakResultatPerioder(Long behandlingId,
                                                       UttakResultatPerioderEntitet opprinneligPerioder) {
+        // Nullstilling er forventet - fjerner evt overstyring
         lagreUttaksresultat(behandlingId, builder -> builder.nullstill().medOpprinneligPerioder(opprinneligPerioder));
     }
 

--- a/behandlingslager/testutil/src/main/java/no/nav/foreldrepenger/behandlingslager/testutilities/behandling/AbstractTestScenario.java
+++ b/behandlingslager/testutil/src/main/java/no/nav/foreldrepenger/behandlingslager/testutilities/behandling/AbstractTestScenario.java
@@ -462,7 +462,7 @@ public abstract class AbstractTestScenario<S extends AbstractTestScenario<S>> {
             }
 
             @Override
-            public void kopierGrunnlagFraEksisterendeBehandlingForRevurdering(Long gammelBehandlingId, Long nyBehandlingId) {
+            public void kopierGrunnlagFraEksisterendeBehandlingUtenVurderinger(Long gammelBehandlingId, Long nyBehandlingId) {
                 final var familieHendelseAggregat = hentAggregatHvisEksisterer(gammelBehandlingId);
                 final var oppdatere = FamilieHendelseGrunnlagBuilder.oppdatere(familieHendelseAggregat);
                 oppdatere.medOverstyrtVersjon(null);
@@ -1408,7 +1408,7 @@ public abstract class AbstractTestScenario<S extends AbstractTestScenario<S>> {
 
     private final class MockPersonopplysningRepository extends PersonopplysningRepository {
         @Override
-        public void kopierGrunnlagFraEksisterendeBehandlingForRevurdering(Long eksisterendeBehandlingId, Long nyBehandlingId) {
+        public void kopierGrunnlagFraEksisterendeBehandlingUtenVurderinger(Long eksisterendeBehandlingId, Long nyBehandlingId) {
             final var oppdatere = PersonopplysningGrunnlagBuilder.oppdatere(
                     Optional.ofNullable(personopplysningMap.getOrDefault(eksisterendeBehandlingId, null)));
 

--- a/behandlingsprosess/src/main/java/no/nav/foreldrepenger/behandling/steg/avklarfakta/AksjonspunktUtlederForVurderArbeidsforhold.java
+++ b/behandlingsprosess/src/main/java/no/nav/foreldrepenger/behandling/steg/avklarfakta/AksjonspunktUtlederForVurderArbeidsforhold.java
@@ -16,7 +16,7 @@ import no.nav.foreldrepenger.behandling.aksjonspunkt.AksjonspunktUtleder;
 import no.nav.foreldrepenger.behandling.aksjonspunkt.AksjonspunktUtlederInput;
 import no.nav.foreldrepenger.behandlingskontroll.AksjonspunktResultat;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingType;
-import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingÅrsakType;
+import no.nav.foreldrepenger.behandlingslager.behandling.SpesialBehandling;
 import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.AksjonspunktDefinisjon;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepository;
 import no.nav.foreldrepenger.behandlingslager.virksomhet.Arbeidsgiver;
@@ -50,7 +50,7 @@ public class AksjonspunktUtlederForVurderArbeidsforhold implements AksjonspunktU
     @Override
     public List<AksjonspunktResultat> utledAksjonspunkterFor(AksjonspunktUtlederInput param) {
         var behandling = behandlingRepository.hentBehandling(param.getBehandlingId());
-        if (behandling.harBehandlingÅrsak(BehandlingÅrsakType.BERØRT_BEHANDLING)) {
+        if (SpesialBehandling.skalGrunnlagBeholdes(behandling)) {
             return INGEN_AKSJONSPUNKTER;
         }
 

--- a/behandlingsprosess/src/main/java/no/nav/foreldrepenger/behandling/steg/avklarfakta/fp/KontrollerFaktaRevurderingStegImpl.java
+++ b/behandlingsprosess/src/main/java/no/nav/foreldrepenger/behandling/steg/avklarfakta/fp/KontrollerFaktaRevurderingStegImpl.java
@@ -35,6 +35,7 @@ import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingsresultatRepo
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingÅrsak;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingÅrsakType;
 import no.nav.foreldrepenger.behandlingslager.behandling.DokumentTypeId;
+import no.nav.foreldrepenger.behandlingslager.behandling.SpesialBehandling;
 import no.nav.foreldrepenger.behandlingslager.behandling.beregning.BeregningSatsType;
 import no.nav.foreldrepenger.behandlingslager.behandling.beregning.BeregningsresultatRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepository;
@@ -130,10 +131,9 @@ class KontrollerFaktaRevurderingStegImpl implements KontrollerFaktaSteg {
             return BehandleStegResultat.utførtUtenAksjonspunkter();
         }
         // Spesialhåndtering for enkelte behandlinger
-        if (behandling.harBehandlingÅrsak(BehandlingÅrsakType.BERØRT_BEHANDLING)) {
-            var startpunkt = behandling.harBehandlingÅrsak(BehandlingÅrsakType.REBEREGN_FERIEPENGER) ||
-                behandling.harBehandlingÅrsak(BehandlingÅrsakType.RE_UTSATT_START) ?
-                StartpunktType.TILKJENT_YTELSE : StartpunktType.UTTAKSVILKÅR;
+        if (SpesialBehandling.erSpesialBehandling(behandling)) {
+            var startpunkt = SpesialBehandling.skalUttakVurderes(behandling) ?
+                StartpunktType.UTTAKSVILKÅR : StartpunktType.TILKJENT_YTELSE;
             behandling.setStartpunkt(startpunkt);
             kopierResultaterAvhengigAvStartpunkt(behandling, kontekst);
             return utledStegResultat(startpunkt, List.of());
@@ -305,7 +305,7 @@ class KontrollerFaktaRevurderingStegImpl implements KontrollerFaktaSteg {
         }
 
         if (StartpunktType.TILKJENT_YTELSE.equals(revurdering.getStartpunkt())) {
-            if (revurdering.harBehandlingÅrsak(BehandlingÅrsakType.RE_UTSATT_START)) {
+            if (SpesialBehandling.erOppsagtUttak(revurdering)) {
                 kopierForeldrepengerUttaktjeneste.lagreTomtUttakResultat(revurdering.getId());
             } else {
                 kopierForeldrepengerUttaktjeneste.kopierUttakFraOriginalBehandling(origBehandling.getId(), revurdering.getId());

--- a/behandlingsprosess/src/main/java/no/nav/foreldrepenger/behandling/steg/beregnytelse/fp/VurderTilbaketrekkSteg.java
+++ b/behandlingsprosess/src/main/java/no/nav/foreldrepenger/behandling/steg/beregnytelse/fp/VurderTilbaketrekkSteg.java
@@ -3,6 +3,9 @@ package no.nav.foreldrepenger.behandling.steg.beregnytelse.fp;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import no.nav.foreldrepenger.behandling.BehandlingReferanse;
 import no.nav.foreldrepenger.behandling.aksjonspunkt.AksjonspunktUtlederInput;
 import no.nav.foreldrepenger.behandlingskontroll.BehandleStegResultat;
@@ -11,7 +14,7 @@ import no.nav.foreldrepenger.behandlingskontroll.BehandlingStegRef;
 import no.nav.foreldrepenger.behandlingskontroll.BehandlingTypeRef;
 import no.nav.foreldrepenger.behandlingskontroll.BehandlingskontrollKontekst;
 import no.nav.foreldrepenger.behandlingskontroll.FagsakYtelseTypeRef;
-import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingÅrsakType;
+import no.nav.foreldrepenger.behandlingslager.behandling.SpesialBehandling;
 import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.Aksjonspunkt;
 import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.AksjonspunktDefinisjon;
 import no.nav.foreldrepenger.behandlingslager.behandling.beregning.BehandlingBeregningsresultatEntitet;
@@ -20,8 +23,6 @@ import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRe
 import no.nav.foreldrepenger.skjæringstidspunkt.SkjæringstidspunktTjeneste;
 import no.nav.foreldrepenger.ytelse.beregning.tilbaketrekk.AksjonspunktutlederTilbaketrekk;
 import no.nav.foreldrepenger.ytelse.beregning.tilbaketrekk.KopierUtbetResultatTjeneste;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @BehandlingStegRef(kode = "VURDER_TILBAKETREKK")
 @BehandlingTypeRef("BT-004")
@@ -70,11 +71,10 @@ public class VurderTilbaketrekkSteg implements BehandlingSteg {
         var aksjonspunkter = aksjonspunktutlederTilbaketrekk.utledAksjonspunkterFor(new AksjonspunktUtlederInput(ref));
 
         if (aksjonspunkter.isEmpty()) {
-            // I saker som er opprettet pga feriepenger må reberegnes kan det komme tilfeller der vi ikke kan
-            // omfordele igjen pga tilkommede arbeidsforhold, i slike tilfeller må vi sjekke om foreslått
-            // resultat er likt og om det finnes et utbet. resultat vi kan kopiere, og isåfall kopiere dette
+            // I saker som er opprettet pga feriepenger må reberegnes kan det komme tilfeller der vi ikke kan omfordele igjen pga tilkommede arbeidsforhold,
+            // i slike tilfeller må vi sjekke om foreslått resultat er likt og om det finnes et utbet. resultat vi kan kopiere, og isåfall kopiere dette
             // TFP-4279
-            if (behandling.harBehandlingÅrsak(BehandlingÅrsakType.REBEREGN_FERIEPENGER)
+            if (SpesialBehandling.erJusterFeriepenger(behandling)
                 && kopierUtbetResultatTjeneste.kanKopiereForrigeUtbetResultat(ref)) {
                 kopierUtbetResultatTjeneste.kopierOgLagreUtbetBeregningsresultat(ref);
             }

--- a/behandlingsprosess/src/main/java/no/nav/foreldrepenger/behandling/steg/foreslåvedtak/SjekkMotEksisterendeOppgaverTjeneste.java
+++ b/behandlingsprosess/src/main/java/no/nav/foreldrepenger/behandling/steg/foreslåvedtak/SjekkMotEksisterendeOppgaverTjeneste.java
@@ -51,7 +51,8 @@ public class SjekkMotEksisterendeOppgaverTjeneste {
         List<AksjonspunktDefinisjon> aksjonspunktliste = new ArrayList<>();
 
         if (oppgaveTjeneste.harÅpneOppgaverAvType(aktørid, Oppgavetyper.VURDER_KONSEKVENS_YTELSE)) {
-            if (behandling.harBehandlingÅrsak(BehandlingÅrsakType.REBEREGN_FERIEPENGER)) {
+            if (behandling.harBehandlingÅrsak(BehandlingÅrsakType.REBEREGN_FERIEPENGER) ||
+                behandling.harBehandlingÅrsak(BehandlingÅrsakType.RE_UTSATT_START)) {
                 LOG.info("REBEREGN OPPGAVE fant Vurder Konsekvens for sak {}", behandling.getFagsak().getSaksnummer());
             } else {
                 aksjonspunktliste.add(AksjonspunktDefinisjon.VURDERE_ANNEN_YTELSE_FØR_VEDTAK);
@@ -59,7 +60,8 @@ public class SjekkMotEksisterendeOppgaverTjeneste {
             }
         }
         if (oppgaveTjeneste.harÅpneOppgaverAvType(aktørid, Oppgavetyper.VURDER_DOKUMENT_VL)) {
-            if (behandling.harBehandlingÅrsak(BehandlingÅrsakType.REBEREGN_FERIEPENGER)) {
+            if (behandling.harBehandlingÅrsak(BehandlingÅrsakType.REBEREGN_FERIEPENGER) ||
+                behandling.harBehandlingÅrsak(BehandlingÅrsakType.RE_UTSATT_START)) {
                 LOG.info("REBEREGN OPPGAVE fant Vurder Dokument for sak {}", behandling.getFagsak().getSaksnummer());
             } else {
                 aksjonspunktliste.add(AksjonspunktDefinisjon.VURDERE_DOKUMENT_FØR_VEDTAK);

--- a/behandlingsprosess/src/main/java/no/nav/foreldrepenger/behandling/steg/foreslåvedtak/SjekkMotEksisterendeOppgaverTjeneste.java
+++ b/behandlingsprosess/src/main/java/no/nav/foreldrepenger/behandling/steg/foreslåvedtak/SjekkMotEksisterendeOppgaverTjeneste.java
@@ -11,7 +11,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
-import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingÅrsakType;
+import no.nav.foreldrepenger.behandlingslager.behandling.SpesialBehandling;
 import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.AksjonspunktDefinisjon;
 import no.nav.foreldrepenger.behandlingslager.behandling.historikk.HistorikkAktør;
 import no.nav.foreldrepenger.behandlingslager.behandling.historikk.HistorikkRepository;
@@ -51,8 +51,7 @@ public class SjekkMotEksisterendeOppgaverTjeneste {
         List<AksjonspunktDefinisjon> aksjonspunktliste = new ArrayList<>();
 
         if (oppgaveTjeneste.harÅpneOppgaverAvType(aktørid, Oppgavetyper.VURDER_KONSEKVENS_YTELSE)) {
-            if (behandling.harBehandlingÅrsak(BehandlingÅrsakType.REBEREGN_FERIEPENGER) ||
-                behandling.harBehandlingÅrsak(BehandlingÅrsakType.RE_UTSATT_START)) {
+            if (!SpesialBehandling.skalUttakVurderes(behandling)) {
                 LOG.info("REBEREGN OPPGAVE fant Vurder Konsekvens for sak {}", behandling.getFagsak().getSaksnummer());
             } else {
                 aksjonspunktliste.add(AksjonspunktDefinisjon.VURDERE_ANNEN_YTELSE_FØR_VEDTAK);
@@ -60,8 +59,7 @@ public class SjekkMotEksisterendeOppgaverTjeneste {
             }
         }
         if (oppgaveTjeneste.harÅpneOppgaverAvType(aktørid, Oppgavetyper.VURDER_DOKUMENT_VL)) {
-            if (behandling.harBehandlingÅrsak(BehandlingÅrsakType.REBEREGN_FERIEPENGER) ||
-                behandling.harBehandlingÅrsak(BehandlingÅrsakType.RE_UTSATT_START)) {
+            if (!SpesialBehandling.skalUttakVurderes(behandling)) {
                 LOG.info("REBEREGN OPPGAVE fant Vurder Dokument for sak {}", behandling.getFagsak().getSaksnummer());
             } else {
                 aksjonspunktliste.add(AksjonspunktDefinisjon.VURDERE_DOKUMENT_FØR_VEDTAK);

--- a/behandlingsprosess/src/main/java/no/nav/foreldrepenger/behandling/steg/søknadsfrist/fp/FastsettUttaksgrunnlagOgVurderSøknadsfristSteg.java
+++ b/behandlingsprosess/src/main/java/no/nav/foreldrepenger/behandling/steg/søknadsfrist/fp/FastsettUttaksgrunnlagOgVurderSøknadsfristSteg.java
@@ -105,7 +105,7 @@ public class FastsettUttaksgrunnlagOgVurderSøknadsfristSteg implements Behandli
         var uttakInput = uttakInputTjeneste.lagInput(kontekst.getBehandlingId());
         if (skalKopiereUttakTjeneste.skalKopiereStegResultat(uttakInput)) {
             var ref = uttakInput.getBehandlingReferanse();
-            kopierForeldrepengerUttaktjeneste.kopierUttaksgrunnlagSøknadsfristResultatFraOriginalBehandling(ref);
+            kopierForeldrepengerUttaktjeneste.kopierUttaksgrunnlagSøknadsfristResultatFraOriginalBehandling(ref.getOriginalBehandlingId().orElseThrow(), ref.getBehandlingId());
         }
     }
 

--- a/behandlingsprosess/src/main/java/no/nav/foreldrepenger/behandling/steg/uttak/fp/UttakStegImpl.java
+++ b/behandlingsprosess/src/main/java/no/nav/foreldrepenger/behandling/steg/uttak/fp/UttakStegImpl.java
@@ -13,7 +13,6 @@ import no.nav.foreldrepenger.behandlingskontroll.BehandlingStegRef;
 import no.nav.foreldrepenger.behandlingskontroll.BehandlingTypeRef;
 import no.nav.foreldrepenger.behandlingskontroll.BehandlingskontrollKontekst;
 import no.nav.foreldrepenger.behandlingskontroll.FagsakYtelseTypeRef;
-import no.nav.foreldrepenger.behandlingskontroll.transisjoner.FellesTransisjoner;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingStegType;
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandlingsresultat;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingsresultatRepository;
@@ -99,7 +98,8 @@ public class UttakStegImpl implements UttakSteg {
         }
         var uttakInput = uttakInputTjeneste.lagInput(kontekst.getBehandlingId());
         if (skalKopiereUttakTjeneste.skalKopiereStegResultat(uttakInput)) {
-            kopierUttaktjeneste.kopierUttaksresultatFraOriginalBehandling(uttakInput.getBehandlingReferanse());
+            kopierUttaktjeneste.kopierUttaksresultatFraOriginalBehandling(uttakInput.getBehandlingReferanse().getOriginalBehandlingId().orElseThrow(),
+                uttakInput.getBehandlingReferanse().getBehandlingId());
         } else {
             ryddUttak(kontekst.getBehandlingId());
             ryddStønadskontoberegning(kontekst.getBehandlingId(), kontekst.getFagsakId());

--- a/behandlingsprosess/src/main/java/no/nav/foreldrepenger/behandling/steg/varselrevurdering/fp/VarselRevurderingStegImpl.java
+++ b/behandlingsprosess/src/main/java/no/nav/foreldrepenger/behandling/steg/varselrevurdering/fp/VarselRevurderingStegImpl.java
@@ -23,7 +23,7 @@ import no.nav.foreldrepenger.behandlingskontroll.transisjoner.FellesTransisjoner
 import no.nav.foreldrepenger.behandlingskontroll.transisjoner.TransisjonIdentifikator;
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingStegType;
-import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingÅrsakType;
+import no.nav.foreldrepenger.behandlingslager.behandling.SpesialBehandling;
 import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.Aksjonspunkt;
 import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.Venteårsak;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepository;
@@ -46,7 +46,7 @@ public class VarselRevurderingStegImpl implements VarselRevurderingSteg {
 
         var behandling = behandlingRepository.hentBehandling(kontekst.getBehandlingId());
 
-        if (behandling.harBehandlingÅrsak(BehandlingÅrsakType.BERØRT_BEHANDLING)) {
+        if (SpesialBehandling.skalGrunnlagBeholdes(behandling)) {
             var transisjon = TransisjonIdentifikator
                     .forId(FellesTransisjoner.SPOLFREM_PREFIX + BehandlingStegType.KONTROLLER_FAKTA.getKode());
             return BehandleStegResultat.fremoverførtMedAksjonspunktResultater(transisjon, Collections.emptyList());

--- a/behandlingsprosess/src/main/java/no/nav/foreldrepenger/behandling/steg/vedtak/FatteVedtakTjeneste.java
+++ b/behandlingsprosess/src/main/java/no/nav/foreldrepenger/behandling/steg/vedtak/FatteVedtakTjeneste.java
@@ -43,7 +43,7 @@ public class FatteVedtakTjeneste {
     private static final AksjonspunktDefinisjon VENT_MERKNADER = AksjonspunktDefinisjon.AUTO_VENT_ANKE_MERKNADER_FRA_BRUKER;
 
     private static final Set<BehandlingResultatType> VEDTAKSTILSTANDER_REVURDERING = Set.of(BehandlingResultatType.AVSLÅTT,
-            BehandlingResultatType.INNVILGET,
+            BehandlingResultatType.INNVILGET, BehandlingResultatType.FORELDREPENGER_SENERE,
             BehandlingResultatType.OPPHØR, BehandlingResultatType.FORELDREPENGER_ENDRET, BehandlingResultatType.INGEN_ENDRING);
     private static final Set<BehandlingResultatType> VEDTAKSTILSTANDER = Set.of(BehandlingResultatType.AVSLÅTT, BehandlingResultatType.INNVILGET);
     private static final Set<BehandlingResultatType> VEDTAKSTILSTANDER_KLAGE = Set.of(BehandlingResultatType.KLAGE_AVVIST,

--- a/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/avklarfakta/fp/KontrollerFaktaRevurderingStegImplTest.java
+++ b/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/avklarfakta/fp/KontrollerFaktaRevurderingStegImplTest.java
@@ -200,7 +200,7 @@ public class KontrollerFaktaRevurderingStegImplTest {
 
     @Test
     public void feriepenge_berørt_hopper_til_tilkjent() {
-        var behandling = opprettRevurdering(List.of(BehandlingÅrsakType.BERØRT_BEHANDLING, BehandlingÅrsakType.REBEREGN_FERIEPENGER));
+        var behandling = opprettRevurdering(BehandlingÅrsakType.REBEREGN_FERIEPENGER);
         var fagsak = behandling.getFagsak();
         // Arrange
         var lås = behandlingRepository.taSkriveLås(behandling);
@@ -351,10 +351,10 @@ public class KontrollerFaktaRevurderingStegImplTest {
     }
 
     private Behandling opprettRevurdering() {
-        return opprettRevurdering(List.of(BehandlingÅrsakType.RE_MANGLER_FØDSEL));
+        return opprettRevurdering(BehandlingÅrsakType.RE_MANGLER_FØDSEL);
     }
 
-    private Behandling opprettRevurdering(List<BehandlingÅrsakType> årsaker) {
+    private Behandling opprettRevurdering(BehandlingÅrsakType årsak) {
         var fødselsdato = LocalDate.now().minusYears(20);
         var aktørId = AktørId.dummy();
 
@@ -422,7 +422,7 @@ public class KontrollerFaktaRevurderingStegImplTest {
         var revurderingScenario = ScenarioMorSøkerForeldrepenger.forFødsel()
                 .medBehandlingType(BehandlingType.REVURDERING)
                 .medRegisterOpplysninger(personopplysningBuilder.build())
-                .medOriginalBehandling(originalBehandling, årsaker, false);
+                .medOriginalBehandling(originalBehandling, årsak);
         revurderingScenario.medDefaultOppgittTilknytning();
 
         revurderingScenario.medAvklarteUttakDatoer(new AvklarteUttakDatoerEntitet.Builder().medFørsteUttaksdato(LocalDate.now()).build());

--- a/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/medlemskap/KontrollerFaktaLøpendeMedlemskapStegRevurderingTest.java
+++ b/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/medlemskap/KontrollerFaktaLøpendeMedlemskapStegRevurderingTest.java
@@ -217,8 +217,8 @@ public class KontrollerFaktaLøpendeMedlemskapStegRevurderingTest {
 
         medlemskapRepository.kopierGrunnlagFraEksisterendeBehandling(behandlingId, revurderingId);
         iayTjeneste.kopierGrunnlagFraEksisterendeBehandling(behandlingId, revurderingId);
-        personopplysningRepository.kopierGrunnlagFraEksisterendeBehandlingForRevurdering(behandlingId, revurderingId);
-        familieHendelseRepository.kopierGrunnlagFraEksisterendeBehandlingForRevurdering(behandlingId, revurderingId);
+        personopplysningRepository.kopierGrunnlagFraEksisterendeBehandlingUtenVurderinger(behandlingId, revurderingId);
+        familieHendelseRepository.kopierGrunnlagFraEksisterendeBehandlingUtenVurderinger(behandlingId, revurderingId);
         return revudering;
     }
 

--- a/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/medlemskap/VurderLøpendeMedlemskapStegTest.java
+++ b/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/medlemskap/VurderLøpendeMedlemskapStegTest.java
@@ -188,8 +188,8 @@ public class VurderLøpendeMedlemskapStegTest {
 
         medlemskapRepository.kopierGrunnlagFraEksisterendeBehandling(behandlingId, revurderingId);
         iayTjeneste.kopierGrunnlagFraEksisterendeBehandling(behandlingId, revurderingId);
-        personopplysningRepository.kopierGrunnlagFraEksisterendeBehandlingForRevurdering(behandlingId, revurderingId);
-        familieHendelseRepository.kopierGrunnlagFraEksisterendeBehandlingForRevurdering(behandlingId, revurderingId);
+        personopplysningRepository.kopierGrunnlagFraEksisterendeBehandlingUtenVurderinger(behandlingId, revurderingId);
+        familieHendelseRepository.kopierGrunnlagFraEksisterendeBehandlingUtenVurderinger(behandlingId, revurderingId);
 
         return revudering;
     }

--- a/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/uttak/fp/FastsettUttaksgrunnlagOgVurderSøknadsfristStegTest.java
+++ b/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/uttak/fp/FastsettUttaksgrunnlagOgVurderSøknadsfristStegTest.java
@@ -57,7 +57,7 @@ import no.nav.foreldrepenger.domene.uttak.uttaksgrunnlag.fp.EndringsdatoFørsteg
 import no.nav.foreldrepenger.domene.uttak.uttaksgrunnlag.fp.EndringsdatoRevurderingUtlederImpl;
 import no.nav.foreldrepenger.domene.uttak.uttaksgrunnlag.fp.FastsettUttaksgrunnlagTjeneste;
 import no.nav.foreldrepenger.domene.ytelsefordeling.YtelseFordelingTjeneste;
-import no.nav.foreldrepenger.skjæringstidspunkt.UtsettelseCore2021;
+import no.nav.foreldrepenger.skjæringstidspunkt.UtsettelseBehandling2021;
 import no.nav.foreldrepenger.skjæringstidspunkt.fp.SkjæringstidspunktTjenesteImpl;
 import no.nav.foreldrepenger.skjæringstidspunkt.fp.SkjæringstidspunktUtils;
 
@@ -82,7 +82,7 @@ public class FastsettUttaksgrunnlagOgVurderSøknadsfristStegTest extends EntityM
         var beregningsgrunnlagTjeneste = new HentOgLagreBeregningsgrunnlagTjeneste(entityManager);
         var skjæringstidspunktTjeneste = new SkjæringstidspunktTjenesteImpl(behandlingRepositoryProvider,
                 new YtelseMaksdatoTjeneste(behandlingRepositoryProvider, new RelatertBehandlingTjeneste(behandlingRepositoryProvider)),
-                new SkjæringstidspunktUtils(), mock(UtsettelseCore2021.class));
+                new SkjæringstidspunktUtils(), mock(UtsettelseBehandling2021.class));
         var uttakTjeneste = new ForeldrepengerUttakTjeneste(new FpUttakRepository(entityManager));
         var andelGraderingTjeneste = new BeregningUttakTjeneste(uttakTjeneste, ytelsesFordelingRepository);
         iayTjeneste = new AbakusInMemoryInntektArbeidYtelseTjeneste();

--- a/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/abakus/AbakusInMemoryInntektArbeidYtelseTjeneste.java
+++ b/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/abakus/AbakusInMemoryInntektArbeidYtelseTjeneste.java
@@ -115,6 +115,15 @@ public class AbakusInMemoryInntektArbeidYtelseTjeneste implements InntektArbeidY
     }
 
     @Override
+    public void kopierGrunnlagFraEksisterendeBehandlingUtenVurderinger(Long fraBehandlingId, Long tilBehandlingId) {
+        var origAggregat = hentInntektArbeidYtelseGrunnlagForBehandling(fraBehandlingId);
+        origAggregat.ifPresent(orig -> {
+            var entitet = new InntektArbeidYtelseGrunnlag(orig);
+            lagreOgFlush(tilBehandlingId, entitet);
+        });
+    }
+
+    @Override
     public List<Inntektsmelding> hentUnikeInntektsmeldingerForSak(Saksnummer saksnummer) {
         return new ArrayList<>(hentInntektsmeldinger(saksnummer).getAlleInntektsmeldinger());
     }

--- a/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/arbeidsforhold/InntektArbeidYtelseTjeneste.java
+++ b/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/arbeidsforhold/InntektArbeidYtelseTjeneste.java
@@ -4,7 +4,6 @@ import java.time.LocalDateTime;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 import java.util.UUID;
 
 import no.nav.abakus.iaygrunnlag.v1.InntektArbeidYtelseGrunnlagDto;
@@ -18,7 +17,6 @@ import no.nav.foreldrepenger.domene.iay.modell.InntektsmeldingBuilder;
 import no.nav.foreldrepenger.domene.iay.modell.OppgittOpptjeningBuilder;
 import no.nav.foreldrepenger.domene.iay.modell.RefusjonskravDato;
 import no.nav.foreldrepenger.domene.typer.AktørId;
-import no.nav.foreldrepenger.domene.typer.JournalpostId;
 import no.nav.foreldrepenger.domene.typer.Saksnummer;
 
 public interface InntektArbeidYtelseTjeneste {
@@ -137,6 +135,9 @@ public interface InntektArbeidYtelseTjeneste {
      * @param tilBehandlingId - Ny behandling
      */
     void kopierGrunnlagFraEksisterendeBehandling(Long fraBehandlingId, Long tilBehandlingId);
+
+    // Kun Oppgitt opptjening og inntektsmeldinger - ikke register eller overstyrt
+    void kopierGrunnlagFraEksisterendeBehandlingUtenVurderinger(Long fraBehandlingId, Long tilBehandlingId);
 
     List<Inntektsmelding> hentUnikeInntektsmeldingerForSak(Saksnummer saksnummer);
 

--- a/domenetjenester/arbeidsforhold/src/test/java/no/nav/foreldrepenger/domene/arbeidsforhold/testutilities/behandling/AbstractIAYTestScenario.java
+++ b/domenetjenester/arbeidsforhold/src/test/java/no/nav/foreldrepenger/domene/arbeidsforhold/testutilities/behandling/AbstractIAYTestScenario.java
@@ -235,7 +235,7 @@ abstract class AbstractIAYTestScenario<S extends AbstractIAYTestScenario<S>> {
             }
 
             @Override
-            public void kopierGrunnlagFraEksisterendeBehandlingForRevurdering(Long gammelBehandlingId, Long nyBehandlingId) {
+            public void kopierGrunnlagFraEksisterendeBehandlingUtenVurderinger(Long gammelBehandlingId, Long nyBehandlingId) {
                 throw new UnsupportedOperationException();
             }
 
@@ -520,7 +520,7 @@ abstract class AbstractIAYTestScenario<S extends AbstractIAYTestScenario<S>> {
 
     private final class MockPersonopplysningRepository extends PersonopplysningRepository {
         @Override
-        public void kopierGrunnlagFraEksisterendeBehandlingForRevurdering(Long eksisterendeBehandlingId, Long nyBehandlingId) {
+        public void kopierGrunnlagFraEksisterendeBehandlingUtenVurderinger(Long eksisterendeBehandlingId, Long nyBehandlingId) {
             final var oppdatere = PersonopplysningGrunnlagBuilder.oppdatere(
                     Optional.ofNullable(personopplysningMap.getOrDefault(eksisterendeBehandlingId, null)));
 

--- a/domenetjenester/behandling-prosessering/src/main/java/no/nav/foreldrepenger/behandlingsprosess/dagligejobber/infobrev/InformasjonssakRepository.java
+++ b/domenetjenester/behandling-prosessering/src/main/java/no/nav/foreldrepenger/behandlingsprosess/dagligejobber/infobrev/InformasjonssakRepository.java
@@ -36,7 +36,7 @@ public class InformasjonssakRepository {
             BehandlingResultatType.FORELDREPENGER_ENDRET.getKode(),
             BehandlingResultatType.INGEN_ENDRING.getKode());
     private static final List<String> SENERE_TYPER = List.of(BehandlingResultatType.INNVILGET.getKode(),
-            BehandlingResultatType.FORELDREPENGER_ENDRET.getKode(),
+            BehandlingResultatType.FORELDREPENGER_ENDRET.getKode(), BehandlingResultatType.FORELDREPENGER_SENERE.getKode(),
             BehandlingResultatType.INGEN_ENDRING.getKode(), BehandlingResultatType.OPPHØR.getKode());
 
     // Query-resultat posisjon
@@ -321,8 +321,8 @@ public class InformasjonssakRepository {
         }
         query.setParameter("foreldrepenger", List.of(FagsakYtelseType.FORELDREPENGER.getKode(), FagsakYtelseType.SVANGERSKAPSPENGER.getKode())); //$NON-NLS-1$
         query.setParameter("restyper", List.of(BehandlingResultatType.INNVILGET.getKode(), BehandlingResultatType.INGEN_ENDRING.getKode(),
-                BehandlingResultatType.FORELDREPENGER_ENDRET.getKode(), BehandlingResultatType.AVSLÅTT.getKode(),
-                BehandlingResultatType.OPPHØR.getKode()));
+                BehandlingResultatType.FORELDREPENGER_ENDRET.getKode(), BehandlingResultatType.FORELDREPENGER_SENERE.getKode(),
+            BehandlingResultatType.AVSLÅTT.getKode(), BehandlingResultatType.OPPHØR.getKode()));
         query.setParameter("innvilgetyper", INNVILGET_TYPER); //$NON-NLS-1$
         query.setParameter("avsluttet", avsluttendeStatus); //$NON-NLS-1$
         query.setParameter("behtyper", List.of(BehandlingType.FØRSTEGANGSSØKNAD.getKode(), BehandlingType.REVURDERING.getKode())); //$NON-NLS-1$
@@ -385,8 +385,8 @@ public class InformasjonssakRepository {
         }
         query.setParameter("foreldrepenger", List.of(FagsakYtelseType.FORELDREPENGER.getKode(), FagsakYtelseType.SVANGERSKAPSPENGER.getKode())); //$NON-NLS-1$
         query.setParameter("restyper", List.of(BehandlingResultatType.INNVILGET.getKode(), BehandlingResultatType.INGEN_ENDRING.getKode(),
-                BehandlingResultatType.FORELDREPENGER_ENDRET.getKode(), BehandlingResultatType.AVSLÅTT.getKode(),
-                BehandlingResultatType.OPPHØR.getKode()));
+            BehandlingResultatType.FORELDREPENGER_ENDRET.getKode(), BehandlingResultatType.FORELDREPENGER_SENERE,
+            BehandlingResultatType.AVSLÅTT.getKode(),  BehandlingResultatType.OPPHØR.getKode()));
         query.setParameter("avsluttet", avsluttendeStatus); //$NON-NLS-1$
         query.setParameter("behtyper", List.of(BehandlingType.FØRSTEGANGSSØKNAD.getKode(), BehandlingType.REVURDERING.getKode())); //$NON-NLS-1$
         @SuppressWarnings("unchecked")

--- a/domenetjenester/behandling-revurdering/src/main/java/no/nav/foreldrepenger/behandling/revurdering/BerørtBehandlingTjeneste.java
+++ b/domenetjenester/behandling-revurdering/src/main/java/no/nav/foreldrepenger/behandling/revurdering/BerørtBehandlingTjeneste.java
@@ -10,6 +10,7 @@ import javax.inject.Inject;
 
 import no.nav.foreldrepenger.behandling.revurdering.ytelse.UttakInputTjeneste;
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
+import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingResultatType;
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandlingsresultat;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingÅrsakType;
 import no.nav.foreldrepenger.behandlingslager.behandling.KonsekvensForYtelsen;
@@ -66,6 +67,10 @@ public class BerørtBehandlingTjeneste {
     public boolean skalBerørtBehandlingOpprettes(Behandlingsresultat brukersGjeldendeBehandlingsresultat,
                                                  Long behandlingId,
                                                  Long behandlingIdAnnenPart) {
+        // Skal ikke lage berørt dersom siste behandling har tømt uttaket.
+        if (BehandlingResultatType.FORELDREPENGER_SENERE.equals(brukersGjeldendeBehandlingsresultat.getBehandlingResultatType())) {
+            return false;
+        }
         //Må sjekke konsekvens pga overlapp med samtidig uttak
         if (brukersGjeldendeBehandlingsresultat.isBehandlingHenlagt() || harKonsekvens(
             brukersGjeldendeBehandlingsresultat, KonsekvensForYtelsen.INGEN_ENDRING)) {

--- a/domenetjenester/behandling-revurdering/src/main/java/no/nav/foreldrepenger/behandling/revurdering/RevurderingHistorikk.java
+++ b/domenetjenester/behandling-revurdering/src/main/java/no/nav/foreldrepenger/behandling/revurdering/RevurderingHistorikk.java
@@ -29,8 +29,8 @@ public class RevurderingHistorikk {
         this.historikkRepository = historikkRepository;
     }
 
-    public void opprettHistorikkinnslagOmRevurdering(Behandling behandling, List<BehandlingÅrsakType> revurderingÅrsaker, boolean manueltOpprettet) {
-        if (revurderingÅrsaker.contains(BehandlingÅrsakType.BERØRT_BEHANDLING)) {
+    public void opprettHistorikkinnslagOmRevurdering(Behandling behandling, BehandlingÅrsakType revurderingsÅrsak, boolean manueltOpprettet) {
+        if (BehandlingÅrsakType.alleTekniskeÅrsaker().contains(revurderingsÅrsak)) {
             return;
         }
 
@@ -42,7 +42,7 @@ public class RevurderingHistorikk {
         revurderingsInnslag.setAktør(historikkAktør);
         var historiebygger = new HistorikkInnslagTekstBuilder()
                 .medHendelse(HistorikkinnslagType.REVURD_OPPR)
-                .medBegrunnelse(revurderingÅrsaker.stream().findFirst().orElse(BehandlingÅrsakType.UDEFINERT));
+                .medBegrunnelse(revurderingsÅrsak);
         historiebygger.build(revurderingsInnslag);
 
         historikkRepository.lagre(revurderingsInnslag);

--- a/domenetjenester/behandling-revurdering/src/main/java/no/nav/foreldrepenger/behandling/revurdering/RevurderingTjeneste.java
+++ b/domenetjenester/behandling-revurdering/src/main/java/no/nav/foreldrepenger/behandling/revurdering/RevurderingTjeneste.java
@@ -19,6 +19,10 @@ public interface RevurderingTjeneste {
 
     void kopierAlleGrunnlagFraTidligereBehandling(Behandling original, Behandling ny);
 
+    default void kopierAlleGrunnlagFraTidligereBehandlingTilUtsattSøknad(Behandling original, Behandling ny) {
+        throw new IllegalStateException("Skal ikke kalles for ytelse type " + ny.getFagsakYtelseType().getKode());
+    }
+
     Boolean kanRevurderingOpprettes(Fagsak fagsak);
 
     boolean erRevurderingMedUendretUtfall(Behandling behandling);

--- a/domenetjenester/behandling-revurdering/src/main/java/no/nav/foreldrepenger/behandling/revurdering/RevurderingTjenesteFelles.java
+++ b/domenetjenester/behandling-revurdering/src/main/java/no/nav/foreldrepenger/behandling/revurdering/RevurderingTjenesteFelles.java
@@ -1,7 +1,6 @@
 package no.nav.foreldrepenger.behandling.revurdering;
 
 import java.time.LocalDate;
-import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -59,14 +58,14 @@ public class RevurderingTjenesteFelles {
         this.revurderingHistorikk = new RevurderingHistorikk(repositoryProvider.getHistorikkRepository());
     }
 
-    public Behandling opprettRevurderingsbehandling(List<BehandlingÅrsakType> revurderingÅrsakTyper, Behandling opprinneligBehandling,
+    public Behandling opprettRevurderingsbehandling(BehandlingÅrsakType revurderingsÅrsak, Behandling opprinneligBehandling,
             boolean manueltOpprettet,
             OrganisasjonsEnhet enhet) {
         var behandlingType = BehandlingType.REVURDERING;
-        var revurderingÅrsak = BehandlingÅrsak.builder(revurderingÅrsakTyper)
+        var revurderingÅrsak = BehandlingÅrsak.builder(revurderingsÅrsak)
                 .medOriginalBehandlingId(opprinneligBehandling.getId())
                 .medManueltOpprettet(manueltOpprettet);
-        if (revurderingÅrsakTyper.contains(BehandlingÅrsakType.BERØRT_BEHANDLING)) {
+        if (BehandlingÅrsakType.årsakerForRelatertVedtak().contains(revurderingsÅrsak)) {
             var basis = behandlingRevurderingRepository.finnSisteVedtatteIkkeHenlagteBehandlingForMedforelder(opprinneligBehandling.getFagsak())
                     .orElseThrow(() -> new IllegalStateException(
                             "Berørt behandling må ha en tilhørende avlsuttet behandling for medforelder - skal ikke skje")); // NOSONAR
@@ -78,7 +77,7 @@ public class RevurderingTjenesteFelles {
                 .medBehandlendeEnhet(enhet)
                 .medBehandlingstidFrist(LocalDate.now().plusWeeks(behandlingType.getBehandlingstidFristUker()))
                 .medBehandlingÅrsak(revurderingÅrsak).build();
-        revurderingHistorikk.opprettHistorikkinnslagOmRevurdering(revurdering, revurderingÅrsakTyper, manueltOpprettet);
+        revurderingHistorikk.opprettHistorikkinnslagOmRevurdering(revurdering, revurderingsÅrsak, manueltOpprettet);
         return revurdering;
     }
 

--- a/domenetjenester/behandling-revurdering/src/main/java/no/nav/foreldrepenger/behandling/revurdering/felles/ErKunEndringIFordelingAvYtelsen.java
+++ b/domenetjenester/behandling-revurdering/src/main/java/no/nav/foreldrepenger/behandling/revurdering/felles/ErKunEndringIFordelingAvYtelsen.java
@@ -30,12 +30,9 @@ class ErKunEndringIFordelingAvYtelsen {
 
     public static Behandlingsresultat fastsett(Behandling revurdering, Behandlingsresultat behandlingsresultat, boolean erVarselOmRevurderingSendt) {
         var vedtaksbrev = utledVedtaksbrev(erVarselOmRevurderingSendt);
-        var behandlingsresultatBuilder = Behandlingsresultat.builderEndreEksisterende(behandlingsresultat);
-        behandlingsresultatBuilder.medBehandlingResultatType(BehandlingResultatType.FORELDREPENGER_ENDRET);
-        behandlingsresultatBuilder.medVedtaksbrev(vedtaksbrev);
-        behandlingsresultatBuilder.medRettenTil(RettenTil.HAR_RETT_TIL_FP);
-        behandlingsresultatBuilder.leggTilKonsekvensForYtelsen(KonsekvensForYtelsen.ENDRING_I_FORDELING_AV_YTELSEN);
-        return behandlingsresultatBuilder.buildFor(revurdering);
+        return RevurderingBehandlingsresultatutlederFelles.buildBehandlingsresultat(revurdering, behandlingsresultat,
+            BehandlingResultatType.FORELDREPENGER_ENDRET, RettenTil.HAR_RETT_TIL_FP,
+            vedtaksbrev, List.of(KonsekvensForYtelsen.ENDRING_I_FORDELING_AV_YTELSEN));
     }
 
     private static boolean kontrollerEndringIFordelingAvYtelsen(Optional<BeregningsgrunnlagEntitet> revurderingsGrunnlagOpt,

--- a/domenetjenester/behandling-revurdering/src/main/java/no/nav/foreldrepenger/behandling/revurdering/felles/FastsettBehandlingsresultatVedAvslagPåAvslag.java
+++ b/domenetjenester/behandling-revurdering/src/main/java/no/nav/foreldrepenger/behandling/revurdering/felles/FastsettBehandlingsresultatVedAvslagPåAvslag.java
@@ -8,6 +8,7 @@ import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingResultatType;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingType;
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandlingsresultat;
 import no.nav.foreldrepenger.behandlingslager.behandling.KonsekvensForYtelsen;
+import no.nav.foreldrepenger.behandlingslager.behandling.RettenTil;
 import no.nav.foreldrepenger.behandlingslager.behandling.vedtak.Vedtaksbrev;
 
 class FastsettBehandlingsresultatVedAvslagPåAvslag {
@@ -27,8 +28,8 @@ class FastsettBehandlingsresultatVedAvslagPåAvslag {
 
     public static Behandlingsresultat fastsett(Behandling revurdering, Behandlingsresultat behandlingsresultat) {
         return RevurderingBehandlingsresultatutlederFelles.buildBehandlingsresultat(revurdering, behandlingsresultat,
-                BehandlingResultatType.INGEN_ENDRING,
-                List.of(KonsekvensForYtelsen.INGEN_ENDRING), Vedtaksbrev.INGEN);
+            BehandlingResultatType.INGEN_ENDRING, RettenTil.HAR_RETT_TIL_FP,
+            Vedtaksbrev.INGEN, List.of(KonsekvensForYtelsen.INGEN_ENDRING));
     }
 
     private static boolean erAvslagPåAvslag(Behandlingsresultat resRevurdering, Behandlingsresultat resOriginal) {

--- a/domenetjenester/behandling-revurdering/src/main/java/no/nav/foreldrepenger/behandling/revurdering/felles/RevurderingBehandlingsresultatutlederFelles.java
+++ b/domenetjenester/behandling-revurdering/src/main/java/no/nav/foreldrepenger/behandling/revurdering/felles/RevurderingBehandlingsresultatutlederFelles.java
@@ -16,6 +16,7 @@ import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingResultatType;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingType;
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandlingsresultat;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingsresultatRepository;
+import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingÅrsakType;
 import no.nav.foreldrepenger.behandlingslager.behandling.KonsekvensForYtelsen;
 import no.nav.foreldrepenger.behandlingslager.behandling.RettenTil;
 import no.nav.foreldrepenger.behandlingslager.behandling.beregning.BeregningsresultatRepository;
@@ -94,6 +95,13 @@ public abstract class RevurderingBehandlingsresultatutlederFelles {
 
         var behandlingsresultatRevurdering = behandlingsresultatRepository.hentHvisEksisterer(behandlingId);
         var behandlingsresultatOriginal = finnBehandlingsresultatPåOriginalBehandling(originalBehandling.getId());
+
+        if (revurdering.harBehandlingÅrsak(BehandlingÅrsakType.RE_UTSATT_START)) {
+            return buildBehandlingsresultat(revurdering, behandlingsresultatRevurdering.orElse(null),
+                BehandlingResultatType.FORELDREPENGER_SENERE, RettenTil.HAR_RETT_TIL_FP,
+                Vedtaksbrev.AUTOMATISK, List.of(KonsekvensForYtelsen.ENDRING_I_UTTAK));
+        }
+
         if (FastsettBehandlingsresultatVedAvslagPåAvslag.vurder(behandlingsresultatRevurdering,
             behandlingsresultatOriginal, originalBehandling.getType())) {
             /* 2b */
@@ -110,13 +118,10 @@ public abstract class RevurderingBehandlingsresultatutlederFelles {
         var utfall = medlemTjeneste.utledVilkårUtfall(revurdering);
         if (!utfall.vilkårUtfallType().equals(VilkårUtfallType.OPPFYLT)) {
             var behandlingsresultat = behandlingsresultatRepository.hent(behandlingId);
-            var behandlingsresultatBuilder = Behandlingsresultat.builderEndreEksisterende(behandlingsresultat);
-            behandlingsresultatBuilder.medBehandlingResultatType(BehandlingResultatType.OPPHØR);
-            behandlingsresultatBuilder.medRettenTil(RettenTil.HAR_IKKE_RETT_TIL_FP);
-            behandlingsresultatBuilder.leggTilKonsekvensForYtelsen(KonsekvensForYtelsen.FORELDREPENGER_OPPHØRER);
-            behandlingsresultatBuilder.medVedtaksbrev(Vedtaksbrev.AUTOMATISK);
             behandlingsresultat.setAvslagsårsak(utfall.avslagsårsak());
-            return behandlingsresultatBuilder.buildFor(revurdering);
+            return buildBehandlingsresultat(revurdering, behandlingsresultat,
+                BehandlingResultatType.OPPHØR, RettenTil.HAR_IKKE_RETT_TIL_FP,
+                Vedtaksbrev.AUTOMATISK, List.of(KonsekvensForYtelsen.FORELDREPENGER_OPPHØRER));
         }
 
         var erEndringIUttakFraEndringstidspunkt = uttakresultatOriginalOpt.harUlikUttaksplan(
@@ -246,8 +251,7 @@ public abstract class RevurderingBehandlingsresultatutlederFelles {
             return fastsettForIkkeEtablertYtelse(revurdering, konsekvenserForYtelsen);
         }
 
-        if (!harEtablertYtelse(revurdering, erMinstEnInnvilgetBehandlingUtenPåfølgendeOpphør,
-            uttakresultatFraOriginalBehandling)) {
+        if (!harEtablertYtelse(revurdering, erMinstEnInnvilgetBehandlingUtenPåfølgendeOpphør, uttakresultatFraOriginalBehandling)) {
             return fastsettForIkkeEtablertYtelse(revurdering, konsekvenserForYtelsen);
         }
 
@@ -258,7 +262,7 @@ public abstract class RevurderingBehandlingsresultatutlederFelles {
         var vedtaksbrev = utledVedtaksbrev(konsekvenserForYtelsen, erVarselOmRevurderingSendt);
         var behandlingResultatType = utledBehandlingResultatType(konsekvenserForYtelsen);
         return buildBehandlingsresultat(revurdering, behandlingsresultatRepository.hent(revurdering.getId()),
-            behandlingResultatType, konsekvenserForYtelsen, vedtaksbrev);
+            behandlingResultatType, RettenTil.HAR_RETT_TIL_FP, vedtaksbrev, konsekvenserForYtelsen);
     }
 
     private boolean harUttakIkkeOpphørt(UttakResultatHolder uttakResultatHolder,
@@ -279,12 +283,9 @@ public abstract class RevurderingBehandlingsresultatutlederFelles {
     private Behandlingsresultat fastsettForIkkeEtablertYtelse(Behandling revurdering,
                                                               List<KonsekvensForYtelsen> konsekvenserForYtelsen) {
         var behandlingsresultat = behandlingsresultatRepository.hentHvisEksisterer(revurdering.getId()).orElse(null);
-        var behandlingsresultatBuilder = Behandlingsresultat.builderEndreEksisterende(behandlingsresultat);
-        konsekvenserForYtelsen.forEach(behandlingsresultatBuilder::leggTilKonsekvensForYtelsen);
-        behandlingsresultatBuilder.medBehandlingResultatType(BehandlingResultatType.INNVILGET);
-        behandlingsresultatBuilder.medRettenTil(RettenTil.HAR_RETT_TIL_FP);
-        behandlingsresultatBuilder.medVedtaksbrev(Vedtaksbrev.AUTOMATISK);
-        return behandlingsresultatBuilder.buildFor(revurdering);
+        return buildBehandlingsresultat(revurdering, behandlingsresultat,
+            BehandlingResultatType.INNVILGET, RettenTil.HAR_RETT_TIL_FP,
+            Vedtaksbrev.AUTOMATISK, konsekvenserForYtelsen);
     }
 
     private Vedtaksbrev utledVedtaksbrev(List<KonsekvensForYtelsen> konsekvenserForYtelsen,
@@ -321,14 +322,16 @@ public abstract class RevurderingBehandlingsresultatutlederFelles {
     static Behandlingsresultat buildBehandlingsresultat(Behandling revurdering,
                                                         Behandlingsresultat behandlingsresultat,
                                                         BehandlingResultatType behandlingResultatType,
-                                                        List<KonsekvensForYtelsen> konsekvenserForYtelsen,
-                                                        Vedtaksbrev vedtaksbrev) {
+                                                        RettenTil rettenTil,
+                                                        Vedtaksbrev vedtaksbrev,
+                                                        List<KonsekvensForYtelsen> konsekvenserForYtelsen) {
         var behandlingsresultatBuilder = Behandlingsresultat.builderEndreEksisterende(behandlingsresultat);
         behandlingsresultatBuilder.medBehandlingResultatType(behandlingResultatType);
         behandlingsresultatBuilder.medVedtaksbrev(vedtaksbrev);
-        behandlingsresultatBuilder.medRettenTil(RettenTil.HAR_RETT_TIL_FP);
+        behandlingsresultatBuilder.medRettenTil(rettenTil);
         konsekvenserForYtelsen.forEach(behandlingsresultatBuilder::leggTilKonsekvensForYtelsen);
         return behandlingsresultatBuilder.buildFor(revurdering);
     }
+
 
 }

--- a/domenetjenester/behandling-revurdering/src/main/java/no/nav/foreldrepenger/behandling/revurdering/felles/RevurderingBehandlingsresultatutlederFelles.java
+++ b/domenetjenester/behandling-revurdering/src/main/java/no/nav/foreldrepenger/behandling/revurdering/felles/RevurderingBehandlingsresultatutlederFelles.java
@@ -16,9 +16,9 @@ import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingResultatType;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingType;
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandlingsresultat;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingsresultatRepository;
-import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingÅrsakType;
 import no.nav.foreldrepenger.behandlingslager.behandling.KonsekvensForYtelsen;
 import no.nav.foreldrepenger.behandlingslager.behandling.RettenTil;
+import no.nav.foreldrepenger.behandlingslager.behandling.SpesialBehandling;
 import no.nav.foreldrepenger.behandlingslager.behandling.beregning.BeregningsresultatRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepositoryProvider;
@@ -96,7 +96,7 @@ public abstract class RevurderingBehandlingsresultatutlederFelles {
         var behandlingsresultatRevurdering = behandlingsresultatRepository.hentHvisEksisterer(behandlingId);
         var behandlingsresultatOriginal = finnBehandlingsresultatPåOriginalBehandling(originalBehandling.getId());
 
-        if (revurdering.harBehandlingÅrsak(BehandlingÅrsakType.RE_UTSATT_START)) {
+        if (SpesialBehandling.erOppsagtUttak(revurdering)) {
             return buildBehandlingsresultat(revurdering, behandlingsresultatRevurdering.orElse(null),
                 BehandlingResultatType.FORELDREPENGER_SENERE, RettenTil.HAR_RETT_TIL_FP,
                 Vedtaksbrev.AUTOMATISK, List.of(KonsekvensForYtelsen.ENDRING_I_UTTAK));

--- a/domenetjenester/behandling-revurdering/src/main/java/no/nav/foreldrepenger/behandling/revurdering/felles/SettOpphørOgIkkeRett.java
+++ b/domenetjenester/behandling-revurdering/src/main/java/no/nav/foreldrepenger/behandling/revurdering/felles/SettOpphørOgIkkeRett.java
@@ -1,5 +1,8 @@
 package no.nav.foreldrepenger.behandling.revurdering.felles;
 
+
+import java.util.List;
+
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingResultatType;
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandlingsresultat;
@@ -8,15 +11,10 @@ import no.nav.foreldrepenger.behandlingslager.behandling.RettenTil;
 import no.nav.foreldrepenger.behandlingslager.behandling.vedtak.Vedtaksbrev;
 
 public class SettOpphørOgIkkeRett {
-    private SettOpphørOgIkkeRett() {
-    }
 
     public static Behandlingsresultat fastsett(Behandling revurdering, Behandlingsresultat behandlingsresultat, Vedtaksbrev vedtaksbrev) {
-        var behandlingsresultatBuilder = Behandlingsresultat.builderEndreEksisterende(behandlingsresultat);
-        behandlingsresultatBuilder.medBehandlingResultatType(BehandlingResultatType.OPPHØR);
-        behandlingsresultatBuilder.medRettenTil(RettenTil.HAR_IKKE_RETT_TIL_FP);
-        behandlingsresultatBuilder.leggTilKonsekvensForYtelsen(KonsekvensForYtelsen.FORELDREPENGER_OPPHØRER);
-        behandlingsresultatBuilder.medVedtaksbrev(vedtaksbrev);
-        return behandlingsresultatBuilder.buildFor(revurdering);
+        return RevurderingBehandlingsresultatutlederFelles.buildBehandlingsresultat(revurdering, behandlingsresultat,
+            BehandlingResultatType.OPPHØR, RettenTil.HAR_IKKE_RETT_TIL_FP,
+            vedtaksbrev, List.of(KonsekvensForYtelsen.FORELDREPENGER_OPPHØRER));
     }
 }

--- a/domenetjenester/behandling-revurdering/src/main/java/no/nav/foreldrepenger/behandling/revurdering/flytkontroll/BehandlingFlytkontroll.java
+++ b/domenetjenester/behandling-revurdering/src/main/java/no/nav/foreldrepenger/behandling/revurdering/flytkontroll/BehandlingFlytkontroll.java
@@ -6,7 +6,7 @@ import javax.inject.Inject;
 import no.nav.foreldrepenger.behandlingskontroll.BehandlingskontrollTjeneste;
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingStegType;
-import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingÅrsakType;
+import no.nav.foreldrepenger.behandlingslager.behandling.SpesialBehandling;
 import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.AksjonspunktDefinisjon;
 import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.Venteårsak;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepository;
@@ -51,10 +51,10 @@ public class BehandlingFlytkontroll {
             return false;
         }
         var finnesBerørt = behandlingRepository.hentÅpneYtelseBehandlingerForFagsakId(behandling.getFagsak().getId()).stream()
-                .anyMatch(b -> !b.getId().equals(behandling.getId()) && b.harBehandlingÅrsak(BehandlingÅrsakType.BERØRT_BEHANDLING));
+                .anyMatch(b -> !b.getId().equals(behandling.getId()) && SpesialBehandling.skalIkkeKøes(behandling));
         var annenpartÅpneBehandlinger = behandlingRepository.hentÅpneYtelseBehandlingerForFagsakId(annenpartFagsak.getId());
         var annenPartHarBerørt = annenpartÅpneBehandlinger.stream()
-                .anyMatch(b -> b.harBehandlingÅrsak(BehandlingÅrsakType.BERØRT_BEHANDLING));
+                .anyMatch(SpesialBehandling::skalIkkeKøes);
         var annenPartAktivUttak = annenpartÅpneBehandlinger.stream()
                 .anyMatch(b -> behandlingskontrollTjeneste.erStegPassert(b, SYNK_STEG));
         // TODO avklare om aktivUttak skal ekskludere behandling.isBehandlingPåVent();
@@ -69,7 +69,7 @@ public class BehandlingFlytkontroll {
             return false;
         }
         var finnesBerørt = behandlingRepository.hentÅpneYtelseBehandlingerForFagsakId(fagsak.getId()).stream()
-                .anyMatch(b -> b.harBehandlingÅrsak(BehandlingÅrsakType.BERØRT_BEHANDLING));
+                .anyMatch(SpesialBehandling::skalIkkeKøes);
         var annenPartRevurderingEllerAktivUttak = behandlingRepository.hentÅpneYtelseBehandlingerForFagsakId(annenpartFagsak.getId()).stream()
                 .anyMatch(b -> b.erRevurdering() || behandlingskontrollTjeneste.erStegPassert(b, SYNK_STEG));
         // TODO avklare om aktivUttak skal ekskludere behandling.isBehandlingPåVent();

--- a/domenetjenester/behandling-revurdering/src/main/java/no/nav/foreldrepenger/behandling/revurdering/flytkontroll/BehandlingFlytkontroll.java
+++ b/domenetjenester/behandling-revurdering/src/main/java/no/nav/foreldrepenger/behandling/revurdering/flytkontroll/BehandlingFlytkontroll.java
@@ -51,7 +51,7 @@ public class BehandlingFlytkontroll {
             return false;
         }
         var finnesBerørt = behandlingRepository.hentÅpneYtelseBehandlingerForFagsakId(behandling.getFagsak().getId()).stream()
-                .anyMatch(b -> !b.getId().equals(behandling.getId()) && SpesialBehandling.skalIkkeKøes(behandling));
+                .anyMatch(b -> !b.getId().equals(behandling.getId()) && SpesialBehandling.skalIkkeKøes(b));
         var annenpartÅpneBehandlinger = behandlingRepository.hentÅpneYtelseBehandlingerForFagsakId(annenpartFagsak.getId());
         var annenPartHarBerørt = annenpartÅpneBehandlinger.stream()
                 .anyMatch(SpesialBehandling::skalIkkeKøes);

--- a/domenetjenester/behandling-revurdering/src/main/java/no/nav/foreldrepenger/behandling/revurdering/ytelse/es/RevurderingTjenesteImpl.java
+++ b/domenetjenester/behandling-revurdering/src/main/java/no/nav/foreldrepenger/behandling/revurdering/ytelse/es/RevurderingTjenesteImpl.java
@@ -1,7 +1,5 @@
 package no.nav.foreldrepenger.behandling.revurdering.ytelse.es;
 
-import java.util.List;
-
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
@@ -65,18 +63,18 @@ public class RevurderingTjenesteImpl implements RevurderingTjeneste {
     public Behandling opprettManuellRevurdering(Fagsak fagsak,
                                                 BehandlingÅrsakType revurderingsÅrsak,
                                                 OrganisasjonsEnhet enhet) {
-        return opprettRevurdering(fagsak, List.of(revurderingsÅrsak), true, enhet);
+        return opprettRevurdering(fagsak, revurderingsÅrsak, true, enhet);
     }
 
     @Override
     public Behandling opprettAutomatiskRevurdering(Fagsak fagsak,
                                                    BehandlingÅrsakType revurderingsÅrsak,
                                                    OrganisasjonsEnhet enhet) {
-        return opprettRevurdering(fagsak, List.of(revurderingsÅrsak), false, enhet);
+        return opprettRevurdering(fagsak, revurderingsÅrsak, false, enhet);
     }
 
     private Behandling opprettRevurdering(Fagsak fagsak,
-                                          List<BehandlingÅrsakType> revurderingÅrsakTyper,
+                                          BehandlingÅrsakType revurderingsÅrsak,
                                           boolean manueltOpprettet,
                                           OrganisasjonsEnhet enhet) {
         var opprinneligBehandlingOptional = behandlingRepository.finnSisteAvsluttedeIkkeHenlagteBehandling(
@@ -89,7 +87,7 @@ public class RevurderingTjenesteImpl implements RevurderingTjeneste {
         behandlingskontrollTjeneste.initBehandlingskontroll(opprinneligBehandling);
 
         // deretter opprett kontekst for revurdering og opprett
-        var revurderingBehandling = revurderingTjenesteFelles.opprettRevurderingsbehandling(revurderingÅrsakTyper,
+        var revurderingBehandling = revurderingTjenesteFelles.opprettRevurderingsbehandling(revurderingsÅrsak,
             opprinneligBehandling, manueltOpprettet, enhet);
         var kontekst = behandlingskontrollTjeneste.initBehandlingskontroll(revurderingBehandling);
         behandlingskontrollTjeneste.opprettBehandling(kontekst, revurderingBehandling);

--- a/domenetjenester/behandling-revurdering/src/main/java/no/nav/foreldrepenger/behandling/revurdering/ytelse/es/RevurderingTjenesteImpl.java
+++ b/domenetjenester/behandling-revurdering/src/main/java/no/nav/foreldrepenger/behandling/revurdering/ytelse/es/RevurderingTjenesteImpl.java
@@ -106,7 +106,7 @@ public class RevurderingTjenesteImpl implements RevurderingTjeneste {
         var orginalBehandlingId = original.getId();
         var nyBehandlingId = ny.getId();
         if (BehandlingType.REVURDERING.equals(ny.getType())) {
-            familieHendelseRepository.kopierGrunnlagFraEksisterendeBehandlingForRevurdering(orginalBehandlingId,
+            familieHendelseRepository.kopierGrunnlagFraEksisterendeBehandlingUtenVurderinger(orginalBehandlingId,
                 nyBehandlingId);
             if (ny.harBehandlingÅrsak(
                 BehandlingÅrsakType.RE_HENDELSE_FØDSEL)) { // Unngå manuell re-evaluering i tilfelle "automatisk" revurdering
@@ -114,9 +114,9 @@ public class RevurderingTjenesteImpl implements RevurderingTjeneste {
                 medlemskapRepository.kopierGrunnlagFraEksisterendeBehandling(orginalBehandlingId, nyBehandlingId);
                 vergeRepository.kopierGrunnlagFraEksisterendeBehandling(orginalBehandlingId, nyBehandlingId);
             } else {
-                personopplysningRepository.kopierGrunnlagFraEksisterendeBehandlingForRevurdering(orginalBehandlingId,
+                personopplysningRepository.kopierGrunnlagFraEksisterendeBehandlingUtenVurderinger(orginalBehandlingId,
                     nyBehandlingId);
-                medlemskapRepository.kopierGrunnlagFraEksisterendeBehandlingForRevurdering(orginalBehandlingId,
+                medlemskapRepository.kopierGrunnlagFraEksisterendeBehandlingUtenVurderinger(orginalBehandlingId,
                     nyBehandlingId);
             }
         } else {

--- a/domenetjenester/behandling-revurdering/src/main/java/no/nav/foreldrepenger/behandling/revurdering/ytelse/fp/RevurderingTjenesteImpl.java
+++ b/domenetjenester/behandling-revurdering/src/main/java/no/nav/foreldrepenger/behandling/revurdering/ytelse/fp/RevurderingTjenesteImpl.java
@@ -85,7 +85,7 @@ public class RevurderingTjenesteImpl implements RevurderingTjeneste {
     public Behandling opprettManuellRevurdering(Fagsak fagsak,
                                                 BehandlingÅrsakType revurderingsÅrsak,
                                                 OrganisasjonsEnhet enhet) {
-        var behandling = opprettRevurdering(fagsak, List.of(revurderingsÅrsak), true, enhet);
+        var behandling = opprettRevurdering(fagsak, revurderingsÅrsak, true, enhet);
         var kontekst = behandlingskontrollTjeneste.initBehandlingskontroll(behandling);
         behandlingskontrollTjeneste.lagreAksjonspunkterFunnet(kontekst,
             List.of(AksjonspunktDefinisjon.KONTROLL_AV_MANUELT_OPPRETTET_REVURDERINGSBEHANDLING));
@@ -96,18 +96,11 @@ public class RevurderingTjenesteImpl implements RevurderingTjeneste {
     public Behandling opprettAutomatiskRevurdering(Fagsak fagsak,
                                                    BehandlingÅrsakType revurderingsÅrsak,
                                                    OrganisasjonsEnhet enhet) {
-        return opprettRevurdering(fagsak, List.of(revurderingsÅrsak), false, enhet);
-    }
-
-    @Override
-    public Behandling opprettAutomatiskRevurderingMultiÅrsak(Fagsak fagsak,
-                                                             List<BehandlingÅrsakType> revurderingsÅrsaker,
-                                                             OrganisasjonsEnhet enhet) {
-        return opprettRevurdering(fagsak, revurderingsÅrsaker, false, enhet);
+        return opprettRevurdering(fagsak, revurderingsÅrsak, false, enhet);
     }
 
     private Behandling opprettRevurdering(Fagsak fagsak,
-                                          List<BehandlingÅrsakType> revurderingsÅrsaker,
+                                          BehandlingÅrsakType revurderingsÅrsak,
                                           boolean manueltOpprettet,
                                           OrganisasjonsEnhet enhet) {
         var origBehandling = behandlingRepository.finnSisteAvsluttedeIkkeHenlagteBehandling(fagsak.getId())
@@ -117,7 +110,7 @@ public class RevurderingTjenesteImpl implements RevurderingTjeneste {
         behandlingskontrollTjeneste.initBehandlingskontroll(origBehandling);
 
         // deretter opprett revurdering
-        var revurdering = revurderingTjenesteFelles.opprettRevurderingsbehandling(revurderingsÅrsaker, origBehandling,
+        var revurdering = revurderingTjenesteFelles.opprettRevurderingsbehandling(revurderingsÅrsak, origBehandling,
             manueltOpprettet, enhet);
         var kontekst = behandlingskontrollTjeneste.initBehandlingskontroll(revurdering);
         behandlingskontrollTjeneste.opprettBehandling(kontekst, revurdering);

--- a/domenetjenester/behandling-revurdering/src/main/java/no/nav/foreldrepenger/behandling/revurdering/ytelse/fp/UttakGrunnlagTjeneste.java
+++ b/domenetjenester/behandling-revurdering/src/main/java/no/nav/foreldrepenger/behandling/revurdering/ytelse/fp/UttakGrunnlagTjeneste.java
@@ -11,7 +11,7 @@ import no.nav.foreldrepenger.behandling.RelatertBehandlingTjeneste;
 import no.nav.foreldrepenger.behandling.revurdering.ytelse.YtelsesesspesifiktGrunnlagTjeneste;
 import no.nav.foreldrepenger.behandlingskontroll.FagsakYtelseTypeRef;
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
-import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingÅrsakType;
+import no.nav.foreldrepenger.behandlingslager.behandling.SpesialBehandling;
 import no.nav.foreldrepenger.behandlingslager.behandling.familiehendelse.FamilieHendelseEntitet;
 import no.nav.foreldrepenger.behandlingslager.behandling.familiehendelse.FamilieHendelseGrunnlagEntitet;
 import no.nav.foreldrepenger.behandlingslager.behandling.familiehendelse.FamilieHendelseType;
@@ -77,10 +77,7 @@ public class UttakGrunnlagTjeneste implements YtelsesesspesifiktGrunnlagTjeneste
         }
         var familiehendelser = familieHendelser(fhaOpt.get());
         var behandling = behandlingRepository.hentBehandling(behandlingId);
-        var erBerørtBehandling =
-            behandling.harBehandlingÅrsak(BehandlingÅrsakType.BERØRT_BEHANDLING) &&
-                !behandling.harBehandlingÅrsak(BehandlingÅrsakType.REBEREGN_FERIEPENGER) &&
-                !behandling.harBehandlingÅrsak(BehandlingÅrsakType.RE_UTSATT_START);
+        var erBerørtBehandling = SpesialBehandling.erBerørtBehandling(behandling) && SpesialBehandling.skalUttakVurderes(behandling);
         var originalBehandling = originalBehandling(behandling);
         var grunnlag = new ForeldrepengerGrunnlag()
             .medErBerørtBehandling(erBerørtBehandling)

--- a/domenetjenester/behandling-revurdering/src/main/java/no/nav/foreldrepenger/behandling/revurdering/ytelse/fp/UttakGrunnlagTjeneste.java
+++ b/domenetjenester/behandling-revurdering/src/main/java/no/nav/foreldrepenger/behandling/revurdering/ytelse/fp/UttakGrunnlagTjeneste.java
@@ -78,8 +78,9 @@ public class UttakGrunnlagTjeneste implements YtelsesesspesifiktGrunnlagTjeneste
         var familiehendelser = familieHendelser(fhaOpt.get());
         var behandling = behandlingRepository.hentBehandling(behandlingId);
         var erBerørtBehandling =
-            behandling.harBehandlingÅrsak(BehandlingÅrsakType.BERØRT_BEHANDLING) && !behandling.harBehandlingÅrsak(
-                BehandlingÅrsakType.REBEREGN_FERIEPENGER);
+            behandling.harBehandlingÅrsak(BehandlingÅrsakType.BERØRT_BEHANDLING) &&
+                !behandling.harBehandlingÅrsak(BehandlingÅrsakType.REBEREGN_FERIEPENGER) &&
+                !behandling.harBehandlingÅrsak(BehandlingÅrsakType.RE_UTSATT_START);
         var originalBehandling = originalBehandling(behandling);
         var grunnlag = new ForeldrepengerGrunnlag()
             .medErBerørtBehandling(erBerørtBehandling)

--- a/domenetjenester/behandling-revurdering/src/main/java/no/nav/foreldrepenger/behandling/revurdering/ytelse/svp/RevurderingTjenesteImpl.java
+++ b/domenetjenester/behandling-revurdering/src/main/java/no/nav/foreldrepenger/behandling/revurdering/ytelse/svp/RevurderingTjenesteImpl.java
@@ -1,6 +1,5 @@
 package no.nav.foreldrepenger.behandling.revurdering.ytelse.svp;
 
-import java.util.List;
 import java.util.Set;
 
 import javax.enterprise.context.ApplicationScoped;
@@ -76,18 +75,18 @@ public class RevurderingTjenesteImpl implements RevurderingTjeneste {
     public Behandling opprettManuellRevurdering(Fagsak fagsak,
                                                 BehandlingÅrsakType revurderingsÅrsak,
                                                 OrganisasjonsEnhet enhet) {
-        return opprettRevurdering(fagsak, List.of(revurderingsÅrsak), true, enhet);
+        return opprettRevurdering(fagsak, revurderingsÅrsak, true, enhet);
     }
 
     @Override
     public Behandling opprettAutomatiskRevurdering(Fagsak fagsak,
                                                    BehandlingÅrsakType revurderingsÅrsak,
                                                    OrganisasjonsEnhet enhet) {
-        return opprettRevurdering(fagsak, List.of(revurderingsÅrsak), false, enhet);
+        return opprettRevurdering(fagsak, revurderingsÅrsak, false, enhet);
     }
 
     private Behandling opprettRevurdering(Fagsak fagsak,
-                                          List<BehandlingÅrsakType> revurderingsÅrsaker,
+                                          BehandlingÅrsakType revurderingsÅrsak,
                                           boolean manueltOpprettet,
                                           OrganisasjonsEnhet enhet) {
         var origBehandling = behandlingRepository.finnSisteAvsluttedeIkkeHenlagteBehandling(fagsak.getId())
@@ -97,7 +96,7 @@ public class RevurderingTjenesteImpl implements RevurderingTjeneste {
         behandlingskontrollTjeneste.initBehandlingskontroll(origBehandling);
 
         // deretter opprett revurdering
-        var revurdering = revurderingTjenesteFelles.opprettRevurderingsbehandling(revurderingsÅrsaker, origBehandling,
+        var revurdering = revurderingTjenesteFelles.opprettRevurderingsbehandling(revurderingsÅrsak, origBehandling,
             manueltOpprettet, enhet);
         var kontekst = behandlingskontrollTjeneste.initBehandlingskontroll(revurdering);
         behandlingskontrollTjeneste.opprettBehandling(kontekst, revurdering);

--- a/domenetjenester/behandling-revurdering/src/test/java/no/nav/foreldrepenger/behandling/revurdering/flytkontroll/BehandlingFlytkontrollTest.java
+++ b/domenetjenester/behandling-revurdering/src/test/java/no/nav/foreldrepenger/behandling/revurdering/flytkontroll/BehandlingFlytkontrollTest.java
@@ -50,7 +50,7 @@ public class BehandlingFlytkontrollTest {
         when(fagsakAnnenPart.getId()).thenReturn(FAGSAK_AP_ID);
         when(behandlingRepository.hentBehandling(BEHANDLING_ID)).thenReturn(behandling);
         when(behandlingBerørt.harBehandlingÅrsak(BehandlingÅrsakType.BERØRT_BEHANDLING)).thenReturn(true);
-        when(behandlingBerørt.harNoenBehandlingÅrsaker(anySet())).thenReturn(true);
+        when(behandlingBerørt.harNoenBehandlingÅrsaker(BehandlingÅrsakType.alleTekniskeÅrsaker())).thenReturn(true);
         flytkontroll = new BehandlingFlytkontroll(behandlingRevurderingRepository, behandlingskontrollTjeneste,
                 behandlingRepository);
     }

--- a/domenetjenester/behandling-revurdering/src/test/java/no/nav/foreldrepenger/behandling/revurdering/flytkontroll/BehandlingFlytkontrollTest.java
+++ b/domenetjenester/behandling-revurdering/src/test/java/no/nav/foreldrepenger/behandling/revurdering/flytkontroll/BehandlingFlytkontrollTest.java
@@ -1,6 +1,7 @@
 package no.nav.foreldrepenger.behandling.revurdering.flytkontroll;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anySet;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
@@ -49,6 +50,7 @@ public class BehandlingFlytkontrollTest {
         when(fagsakAnnenPart.getId()).thenReturn(FAGSAK_AP_ID);
         when(behandlingRepository.hentBehandling(BEHANDLING_ID)).thenReturn(behandling);
         when(behandlingBerørt.harBehandlingÅrsak(BehandlingÅrsakType.BERØRT_BEHANDLING)).thenReturn(true);
+        when(behandlingBerørt.harNoenBehandlingÅrsaker(anySet())).thenReturn(true);
         flytkontroll = new BehandlingFlytkontroll(behandlingRevurderingRepository, behandlingskontrollTjeneste,
                 behandlingRepository);
     }

--- a/domenetjenester/behandling-revurdering/src/test/java/no/nav/foreldrepenger/behandling/revurdering/ytelse/UttakInputTjenesteTest.java
+++ b/domenetjenester/behandling-revurdering/src/test/java/no/nav/foreldrepenger/behandling/revurdering/ytelse/UttakInputTjenesteTest.java
@@ -27,7 +27,7 @@ import no.nav.foreldrepenger.domene.abakus.AbakusInMemoryInntektArbeidYtelseTjen
 import no.nav.foreldrepenger.domene.medlem.MedlemTjeneste;
 import no.nav.foreldrepenger.domene.prosess.HentOgLagreBeregningsgrunnlagTjeneste;
 import no.nav.foreldrepenger.domene.uttak.ForeldrepengerUttakTjeneste;
-import no.nav.foreldrepenger.skjæringstidspunkt.UtsettelseCore2021;
+import no.nav.foreldrepenger.skjæringstidspunkt.UtsettelseBehandling2021;
 import no.nav.foreldrepenger.skjæringstidspunkt.fp.SkjæringstidspunktTjenesteImpl;
 import no.nav.foreldrepenger.skjæringstidspunkt.fp.SkjæringstidspunktUtils;
 
@@ -46,7 +46,7 @@ public class UttakInputTjenesteTest {
         tjeneste = new UttakInputTjeneste(repositoryProvider, new HentOgLagreBeregningsgrunnlagTjeneste(entityManager),
                 new AbakusInMemoryInntektArbeidYtelseTjeneste(), new SkjæringstidspunktTjenesteImpl(repositoryProvider,
                         new YtelseMaksdatoTjeneste(repositoryProvider, new RelatertBehandlingTjeneste(repositoryProvider)),
-                        new SkjæringstidspunktUtils(), mock(UtsettelseCore2021.class)),
+                        new SkjæringstidspunktUtils(), mock(UtsettelseBehandling2021.class)),
                 mock(MedlemTjeneste.class), andelGraderingTjeneste);
     }
 

--- a/domenetjenester/behandling/src/main/java/no/nav/foreldrepenger/behandling/fp/UtledVedtakResultatType.java
+++ b/domenetjenester/behandling/src/main/java/no/nav/foreldrepenger/behandling/fp/UtledVedtakResultatType.java
@@ -1,10 +1,17 @@
 package no.nav.foreldrepenger.behandling.fp;
 
+import java.util.Set;
+
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingResultatType;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingType;
 import no.nav.foreldrepenger.behandlingslager.behandling.vedtak.VedtakResultatType;
 
 public class UtledVedtakResultatType {
+
+    private static Set<BehandlingResultatType> INNVILGET_TYPER = Set.of(BehandlingResultatType.INNVILGET,
+        BehandlingResultatType.FORELDREPENGER_ENDRET,
+        BehandlingResultatType.FORELDREPENGER_SENERE);
+
     private UtledVedtakResultatType() {
         // hide public contructor
     }
@@ -19,10 +26,7 @@ public class UtledVedtakResultatType {
         if (BehandlingType.INNSYN.equals(behandlingType)) {
             return VedtakResultatType.VEDTAK_I_INNSYNBEHANDLING;
         }
-        if (BehandlingResultatType.INNVILGET.equals(behandlingResultatType)) {
-            return VedtakResultatType.INNVILGET;
-        }
-        if (BehandlingResultatType.FORELDREPENGER_ENDRET.equals(behandlingResultatType)) {
+        if (INNVILGET_TYPER.contains(behandlingResultatType)) {
             return VedtakResultatType.INNVILGET;
         }
         if (BehandlingResultatType.INGEN_ENDRING.equals(behandlingResultatType)) {

--- a/domenetjenester/beregning-ytelse/src/main/java/no/nav/foreldrepenger/ytelse/beregning/fp/MapUttakResultatFraVLTilRegel.java
+++ b/domenetjenester/beregning-ytelse/src/main/java/no/nav/foreldrepenger/ytelse/beregning/fp/MapUttakResultatFraVLTilRegel.java
@@ -3,6 +3,7 @@ package no.nav.foreldrepenger.ytelse.beregning.fp;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.time.LocalDate;
+import java.util.List;
 import java.util.stream.Collectors;
 
 import javax.enterprise.context.ApplicationScoped;
@@ -10,8 +11,8 @@ import javax.inject.Inject;
 
 import no.nav.foreldrepenger.behandlingslager.uttak.UttakArbeidType;
 import no.nav.foreldrepenger.domene.typer.InternArbeidsforholdRef;
-import no.nav.foreldrepenger.domene.uttak.ForeldrepengerUttak;
 import no.nav.foreldrepenger.domene.uttak.ForeldrepengerUttakAktivitet;
+import no.nav.foreldrepenger.domene.uttak.ForeldrepengerUttakPeriode;
 import no.nav.foreldrepenger.domene.uttak.ForeldrepengerUttakPeriodeAktivitet;
 import no.nav.foreldrepenger.domene.uttak.input.UttakInput;
 import no.nav.foreldrepenger.domene.uttak.input.UttakYrkesaktiviteter;
@@ -30,8 +31,8 @@ public class MapUttakResultatFraVLTilRegel {
     public MapUttakResultatFraVLTilRegel() {
     }
 
-    public UttakResultat mapFra(ForeldrepengerUttak uttakResultat, UttakInput input) {
-        var uttakResultatPerioder = uttakResultat.getGjeldendePerioder().stream()
+    public UttakResultat mapFra(List<ForeldrepengerUttakPeriode> perioder, UttakInput input) {
+        var uttakResultatPerioder = perioder.stream()
             .map(periode -> {
                 var uttakAktiviteter = periode.getAktiviteter().stream()
                     .map(aktivitet -> mapAktivitet(input, aktivitet, periode.getFom(), periode.isGraderingInnvilget()))

--- a/domenetjenester/beregning-ytelse/src/main/java/no/nav/foreldrepenger/ytelse/beregning/fp/UttakResultatMapper.java
+++ b/domenetjenester/beregning-ytelse/src/main/java/no/nav/foreldrepenger/ytelse/beregning/fp/UttakResultatMapper.java
@@ -1,9 +1,13 @@
 package no.nav.foreldrepenger.ytelse.beregning.fp;
 
+import java.util.List;
+
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
 import no.nav.foreldrepenger.behandlingskontroll.FagsakYtelseTypeRef;
+import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingÅrsakType;
+import no.nav.foreldrepenger.domene.uttak.ForeldrepengerUttak;
 import no.nav.foreldrepenger.domene.uttak.ForeldrepengerUttakTjeneste;
 import no.nav.foreldrepenger.domene.uttak.input.UttakInput;
 import no.nav.foreldrepenger.ytelse.beregning.UttakResultatRepoMapper;
@@ -29,7 +33,10 @@ public class UttakResultatMapper implements UttakResultatRepoMapper {
     @Override
     public UttakResultat hentOgMapUttakResultat(UttakInput input) {
         var ref = input.getBehandlingReferanse();
-        var uttakResultat = uttakTjeneste.hentUttak(ref.getBehandlingId());
-        return mapper.mapFra(uttakResultat, input);
+        var uttakResultat = uttakTjeneste.hentUttakHvisEksisterer(ref.getBehandlingId());
+        if (uttakResultat.isEmpty() && !input.harBehandlingÅrsak(BehandlingÅrsakType.RE_UTSATT_START)) {
+            throw new IllegalStateException("Utviklerfeil mangler uttakresultat");
+        }
+        return mapper.mapFra(uttakResultat.map(ForeldrepengerUttak::getGjeldendePerioder).orElse(List.of()), input);
     }
 }

--- a/domenetjenester/beregning-ytelse/src/test/java/no/nav/foreldrepenger/ytelse/beregning/fp/MapUttakResultatFraVLTilRegelTest.java
+++ b/domenetjenester/beregning-ytelse/src/test/java/no/nav/foreldrepenger/ytelse/beregning/fp/MapUttakResultatFraVLTilRegelTest.java
@@ -19,9 +19,9 @@ import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandlingsresultat;
 import no.nav.foreldrepenger.behandlingslager.testutilities.fagsak.FagsakBuilder;
 import no.nav.foreldrepenger.behandlingslager.uttak.PeriodeResultatType;
+import no.nav.foreldrepenger.behandlingslager.uttak.Utbetalingsgrad;
 import no.nav.foreldrepenger.behandlingslager.uttak.UttakArbeidType;
 import no.nav.foreldrepenger.behandlingslager.uttak.fp.PeriodeResultatÅrsak;
-import no.nav.foreldrepenger.behandlingslager.uttak.Utbetalingsgrad;
 import no.nav.foreldrepenger.behandlingslager.virksomhet.ArbeidType;
 import no.nav.foreldrepenger.behandlingslager.virksomhet.Arbeidsgiver;
 import no.nav.foreldrepenger.domene.iay.modell.AktivitetsAvtaleBuilder;
@@ -36,7 +36,6 @@ import no.nav.foreldrepenger.domene.tid.DatoIntervallEntitet;
 import no.nav.foreldrepenger.domene.typer.AktørId;
 import no.nav.foreldrepenger.domene.typer.EksternArbeidsforholdRef;
 import no.nav.foreldrepenger.domene.typer.InternArbeidsforholdRef;
-import no.nav.foreldrepenger.domene.uttak.ForeldrepengerUttak;
 import no.nav.foreldrepenger.domene.uttak.ForeldrepengerUttakAktivitet;
 import no.nav.foreldrepenger.domene.uttak.ForeldrepengerUttakPeriode;
 import no.nav.foreldrepenger.domene.uttak.ForeldrepengerUttakPeriodeAktivitet;
@@ -60,7 +59,7 @@ public class MapUttakResultatFraVLTilRegelTest {
     private static final LocalDate FOM_MØDREKVOTE = TERMIN_DATO;
     private static final LocalDate FOM_FØR_FØDSEL = TERMIN_DATO.minusWeeks(3);
 
-    private ForeldrepengerUttak vlPlan;
+    private List<ForeldrepengerUttakPeriode> vlPlan;
     private Behandling behandling;
     private MapUttakResultatFraVLTilRegel overriddenMapper;
     private MapUttakResultatFraVLTilRegel mapper;
@@ -255,7 +254,7 @@ public class MapUttakResultatFraVLTilRegelTest {
         return uttakResultatPerioder.stream().filter(a -> fom.equals(a.getFom())).findFirst().orElse(null);
     }
 
-    private ForeldrepengerUttak lagUttakResultatPlan() {
+    private List<ForeldrepengerUttakPeriode> lagUttakResultatPlan() {
         var førFødselPeriode = lagUttakResultatPeriode(FOM_FØR_FØDSEL, TOM_FØR_FØDSEL, INNVILGET);
         var mødrekvote = lagUttakResultatPeriode(FOM_MØDREKVOTE, TOM_MØDREKVOTE, INNVILGET);
         var fellesperiode = lagUttakResultatPeriode(FOM_FELLESPERIODE, TOM_FELLESPERIODE, AVSLÅTT);
@@ -266,8 +265,7 @@ public class MapUttakResultatFraVLTilRegelTest {
         perioder.add(mødrekvote);
         perioder.add(fellesperiode);
 
-        var resultat = new ForeldrepengerUttak(perioder);
-        return resultat;
+        return perioder;
     }
 
     private UttakResultatPeriode onlyOne(UttakResultat resultat) {
@@ -275,7 +273,7 @@ public class MapUttakResultatFraVLTilRegelTest {
         return resultat.getUttakResultatPerioder().iterator().next();
     }
 
-    private ForeldrepengerUttak lagUttaksPeriode(BigDecimal prosentArbeid, Utbetalingsgrad prosentUtbetaling) {
+    private List<ForeldrepengerUttakPeriode> lagUttaksPeriode(BigDecimal prosentArbeid, Utbetalingsgrad prosentUtbetaling) {
         var idag = LocalDate.now();
         var uttakAktivtet = new ForeldrepengerUttakAktivitet(UttakArbeidType.ORDINÆRT_ARBEID,
                 Arbeidsgiver.virksomhet(ARBEIDSFORHOLD_ORGNR), ARBEIDSFORHOLD_ID);
@@ -297,10 +295,10 @@ public class MapUttakResultatFraVLTilRegelTest {
 
         List<ForeldrepengerUttakPeriode> perioder = new ArrayList<>();
         perioder.add(periode);
-        return new ForeldrepengerUttak(perioder);
+        return perioder;
     }
 
-    private ForeldrepengerUttak lagUttaksPeriodeMedMultipleAktiviteter(BigDecimal prosentArbeid, Utbetalingsgrad utbetalingsgrad1,
+    private List<ForeldrepengerUttakPeriode> lagUttaksPeriodeMedMultipleAktiviteter(BigDecimal prosentArbeid, Utbetalingsgrad utbetalingsgrad1,
             Utbetalingsgrad utbetalingsgrad2) {
         var idag = LocalDate.now();
         var uttakAktivtet = new ForeldrepengerUttakAktivitet(UttakArbeidType.ORDINÆRT_ARBEID,
@@ -332,7 +330,7 @@ public class MapUttakResultatFraVLTilRegelTest {
 
         List<ForeldrepengerUttakPeriode> perioder = new ArrayList<>();
         perioder.add(periode);
-        return new ForeldrepengerUttak(perioder);
+        return perioder;
     }
 
     private ForeldrepengerUttakPeriode lagUttakResultatPeriode(LocalDate fom, LocalDate tom, PeriodeResultatType periodeResultatType) {

--- a/domenetjenester/inngangsvilkar/tjeneste/src/test/java/no/nav/foreldrepenger/inngangsvilkaar/fødsel/FødselsvilkårFarTest.java
+++ b/domenetjenester/inngangsvilkar/tjeneste/src/test/java/no/nav/foreldrepenger/inngangsvilkaar/fødsel/FødselsvilkårFarTest.java
@@ -32,7 +32,7 @@ import no.nav.foreldrepenger.domene.personopplysning.PersonopplysningTjeneste;
 import no.nav.foreldrepenger.domene.typer.AktørId;
 import no.nav.foreldrepenger.inngangsvilkaar.impl.InngangsvilkårOversetter;
 import no.nav.foreldrepenger.skjæringstidspunkt.SkjæringstidspunktTjeneste;
-import no.nav.foreldrepenger.skjæringstidspunkt.UtsettelseCore2021;
+import no.nav.foreldrepenger.skjæringstidspunkt.UtsettelseBehandling2021;
 import no.nav.foreldrepenger.skjæringstidspunkt.fp.SkjæringstidspunktTjenesteImpl;
 import no.nav.foreldrepenger.skjæringstidspunkt.fp.SkjæringstidspunktUtils;
 
@@ -56,7 +56,7 @@ public class FødselsvilkårFarTest extends EntityManagerAwareTest {
             iayTjeneste, Period.parse("P6M"));
         var ytelseMaksdatoTjeneste = new YtelseMaksdatoTjeneste(repositoryProvider,
             new RelatertBehandlingTjeneste(repositoryProvider));
-        skjæringstidspunktTjeneste = new SkjæringstidspunktTjenesteImpl(repositoryProvider, ytelseMaksdatoTjeneste, stputil, mock(UtsettelseCore2021.class));
+        skjæringstidspunktTjeneste = new SkjæringstidspunktTjenesteImpl(repositoryProvider, ytelseMaksdatoTjeneste, stputil, mock(UtsettelseBehandling2021.class));
     }
 
     @Test // FP_VK 11.2 Vilkårsutfall oppfylt

--- a/domenetjenester/inngangsvilkar/tjeneste/src/test/java/no/nav/foreldrepenger/inngangsvilkaar/opptjening/OpptjeningsperiodeVilkårTest.java
+++ b/domenetjenester/inngangsvilkar/tjeneste/src/test/java/no/nav/foreldrepenger/inngangsvilkaar/opptjening/OpptjeningsperiodeVilkårTest.java
@@ -29,6 +29,7 @@ import no.nav.foreldrepenger.inngangsvilkaar.opptjening.fp.InngangsvilkårOpptje
 import no.nav.foreldrepenger.inngangsvilkaar.opptjening.fp.OpptjeningsperiodeVilkårTjenesteImpl;
 import no.nav.foreldrepenger.inngangsvilkaar.regelmodell.opptjeningsperiode.OpptjeningsPeriode;
 import no.nav.foreldrepenger.skjæringstidspunkt.SkjæringstidspunktTjeneste;
+import no.nav.foreldrepenger.skjæringstidspunkt.UtsettelseBehandling2021;
 import no.nav.foreldrepenger.skjæringstidspunkt.UtsettelseCore2021;
 import no.nav.foreldrepenger.skjæringstidspunkt.fp.SkjæringstidspunktTjenesteImpl;
 import no.nav.foreldrepenger.skjæringstidspunkt.fp.SkjæringstidspunktUtils;
@@ -38,7 +39,7 @@ public class OpptjeningsperiodeVilkårTest extends EntityManagerAwareTest {
     private BehandlingRepositoryProvider repositoryProvider;
     private SkjæringstidspunktTjeneste skjæringstidspunktTjeneste;
     private OpptjeningsperiodeVilkårTjeneste opptjeningsperiodeVilkårTjeneste;
-    private UtsettelseCore2021 utsettelseCore2021;
+    private UtsettelseBehandling2021 utsettelse2021;
 
     @BeforeEach
     void setUp() {
@@ -47,9 +48,9 @@ public class OpptjeningsperiodeVilkårTest extends EntityManagerAwareTest {
             Period.parse("P1Y"), Period.parse("P6M"));
         var ytelseMaksdatoTjeneste = new YtelseMaksdatoTjeneste(repositoryProvider,
             new RelatertBehandlingTjeneste(repositoryProvider));
-        utsettelseCore2021 = new UtsettelseCore2021(null);
+        utsettelse2021 = new UtsettelseBehandling2021(new UtsettelseCore2021(null), repositoryProvider);
         skjæringstidspunktTjeneste = new SkjæringstidspunktTjenesteImpl(repositoryProvider, ytelseMaksdatoTjeneste,
-            stputil, utsettelseCore2021);
+            stputil, utsettelse2021);
         var beregnMorsMaksdatoTjeneste = new YtelseMaksdatoTjeneste(repositoryProvider,
             new RelatertBehandlingTjeneste(repositoryProvider));
         opptjeningsperiodeVilkårTjeneste = new OpptjeningsperiodeVilkårTjenesteImpl(

--- a/domenetjenester/inngangsvilkar/tjeneste/src/test/java/no/nav/foreldrepenger/inngangsvilkaar/opptjening/fp/OpptjeningsperiodeVilkårUttakVarianterTest.java
+++ b/domenetjenester/inngangsvilkar/tjeneste/src/test/java/no/nav/foreldrepenger/inngangsvilkaar/opptjening/fp/OpptjeningsperiodeVilkårUttakVarianterTest.java
@@ -32,6 +32,7 @@ import no.nav.foreldrepenger.domene.typer.AktørId;
 import no.nav.foreldrepenger.inngangsvilkaar.opptjening.OpptjeningsperiodeVilkårTjeneste;
 import no.nav.foreldrepenger.inngangsvilkaar.regelmodell.opptjeningsperiode.OpptjeningsPeriode;
 import no.nav.foreldrepenger.skjæringstidspunkt.SkjæringstidspunktTjeneste;
+import no.nav.foreldrepenger.skjæringstidspunkt.UtsettelseBehandling2021;
 import no.nav.foreldrepenger.skjæringstidspunkt.UtsettelseCore2021;
 import no.nav.foreldrepenger.skjæringstidspunkt.fp.SkjæringstidspunktTjenesteImpl;
 import no.nav.foreldrepenger.skjæringstidspunkt.fp.SkjæringstidspunktUtils;
@@ -42,7 +43,7 @@ public class OpptjeningsperiodeVilkårUttakVarianterTest extends EntityManagerAw
     private BehandlingRepositoryProvider repositoryProvider;
     private SkjæringstidspunktTjeneste skjæringstidspunktTjeneste;
     private OpptjeningsperiodeVilkårTjeneste opptjeningsperiodeVilkårTjeneste;
-    private UtsettelseCore2021 utsettelseCore2021;
+    private UtsettelseBehandling2021 utsettelse2021;
     @Mock
     private YtelseMaksdatoTjeneste ytelseMaksdatoTjeneste;
     private SkjæringstidspunktUtils stputil = new SkjæringstidspunktUtils(
@@ -58,10 +59,10 @@ public class OpptjeningsperiodeVilkårUttakVarianterTest extends EntityManagerAw
         var fødselsdato = LocalDate.now().minusMonths(4);
         var morsmaksdato = fødselsdato.plusWeeks(31);
         var førsteUttaksdato = morsmaksdato.plusWeeks(4);
-        utsettelseCore2021 = new UtsettelseCore2021(fødselsdato.plusMonths(1));
+        utsettelse2021 = new UtsettelseBehandling2021(new UtsettelseCore2021(fødselsdato.plusMonths(1)), repositoryProvider);
 
         skjæringstidspunktTjeneste = new SkjæringstidspunktTjenesteImpl(repositoryProvider, ytelseMaksdatoTjeneste,
-            stputil, utsettelseCore2021);
+            stputil, utsettelse2021);
         opptjeningsperiodeVilkårTjeneste = new OpptjeningsperiodeVilkårTjenesteImpl(
             repositoryProvider.getFamilieHendelseRepository(), ytelseMaksdatoTjeneste);
 
@@ -105,10 +106,10 @@ public class OpptjeningsperiodeVilkårUttakVarianterTest extends EntityManagerAw
         var fødselsdato = LocalDate.now().minusMonths(4);
         var morsmaksdato = fødselsdato.plusWeeks(31);
         var førsteUttaksdato = morsmaksdato.minusWeeks(4);
-        utsettelseCore2021 = new UtsettelseCore2021(fødselsdato.plusMonths(1));
+        utsettelse2021 = new UtsettelseBehandling2021(new UtsettelseCore2021(fødselsdato.plusMonths(1)), repositoryProvider);
 
         skjæringstidspunktTjeneste = new SkjæringstidspunktTjenesteImpl(repositoryProvider, ytelseMaksdatoTjeneste,
-            stputil, utsettelseCore2021);
+            stputil, utsettelse2021);
         opptjeningsperiodeVilkårTjeneste = new OpptjeningsperiodeVilkårTjenesteImpl(
             repositoryProvider.getFamilieHendelseRepository(), ytelseMaksdatoTjeneste);
 
@@ -152,9 +153,9 @@ public class OpptjeningsperiodeVilkårUttakVarianterTest extends EntityManagerAw
         var fødselsdato = LocalDate.now().minusWeeks(4);
         var morsmaksdato = fødselsdato.plusWeeks(31);
         var førsteUttaksdato = morsmaksdato.plusWeeks(4);
-        utsettelseCore2021 = new UtsettelseCore2021(fødselsdato.minusMonths(1));
+        utsettelse2021 = new UtsettelseBehandling2021(new UtsettelseCore2021(fødselsdato.minusMonths(1)), repositoryProvider);
         skjæringstidspunktTjeneste = new SkjæringstidspunktTjenesteImpl(repositoryProvider, ytelseMaksdatoTjeneste,
-            stputil, utsettelseCore2021);
+            stputil, utsettelse2021);
         opptjeningsperiodeVilkårTjeneste = new OpptjeningsperiodeVilkårTjenesteImpl(
             repositoryProvider.getFamilieHendelseRepository(), ytelseMaksdatoTjeneste);
 

--- a/domenetjenester/medlem/src/test/java/no/nav/foreldrepenger/domene/medlem/impl/UtledVurderingsdatoerForMedlemskapTjenesteTest.java
+++ b/domenetjenester/medlem/src/test/java/no/nav/foreldrepenger/domene/medlem/impl/UtledVurderingsdatoerForMedlemskapTjenesteTest.java
@@ -398,7 +398,7 @@ public class UtledVurderingsdatoerForMedlemskapTjenesteTest {
         var revurderingId = revudering.getId();
         medlemskapRepository.kopierGrunnlagFraEksisterendeBehandling(behandlingId, revurderingId);
         iayTjeneste.kopierGrunnlagFraEksisterendeBehandling(behandlingId, revurderingId);
-        personopplysningRepository.kopierGrunnlagFraEksisterendeBehandlingForRevurdering(behandlingId, revurderingId);
+        personopplysningRepository.kopierGrunnlagFraEksisterendeBehandlingUtenVurderinger(behandlingId, revurderingId);
 
         return revudering;
     }

--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/Behandlingsoppretter.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/Behandlingsoppretter.java
@@ -224,6 +224,14 @@ public class Behandlingsoppretter {
             .isPresent();
     }
 
+    public boolean erUtsattBehandling(Behandling behandling) {
+        var forrigeResultatUtsatt = behandlingsresultatRepository.hentHvisEksisterer(behandling.getId())
+            .map(Behandlingsresultat::getBehandlingResultatType)
+            .filter(BehandlingResultatType.FORELDREPENGER_SENERE::equals)
+            .isPresent();
+        return behandlingRepository.hentÅpneYtelseBehandlingerForFagsakId(behandling.getFagsakId()).isEmpty() && forrigeResultatUtsatt;
+    }
+
     private void kopierTidligereGrunnlagFraTil(Fagsak fagsak, Behandling behandlingMedSøknad, Behandling nyBehandling) {
         var søknad = søknadRepository.hentSøknad(behandlingMedSøknad.getId());
         if (søknad != null) {
@@ -231,6 +239,11 @@ public class Behandlingsoppretter {
         }
         var revurderingTjeneste = FagsakYtelseTypeRef.Lookup.find(RevurderingTjeneste.class, fagsak.getYtelseType()).orElseThrow();
         revurderingTjeneste.kopierAlleGrunnlagFraTidligereBehandling(behandlingMedSøknad, nyBehandling);
+    }
+
+    public void kopierAlleGrunnlagFraTidligereBehandlingTilUtsattSøknad(Fagsak fagsak, Behandling forrige, Behandling nyBehandling) {
+        var revurderingTjeneste = FagsakYtelseTypeRef.Lookup.find(RevurderingTjeneste.class, fagsak.getYtelseType()).orElseThrow();
+        revurderingTjeneste.kopierAlleGrunnlagFraTidligereBehandlingTilUtsattSøknad(forrige, nyBehandling);
     }
 
     public Behandling opprettNyFørstegangsbehandlingFraTidligereSøknad(Fagsak fagsak, BehandlingÅrsakType behandlingÅrsakType, Behandling behandlingMedSøknad) {

--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/Behandlingsoppretter.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/Behandlingsoppretter.java
@@ -108,11 +108,6 @@ public class Behandlingsoppretter {
         return revurderingTjeneste.opprettAutomatiskRevurdering(fagsak, revurderingsÅrsak, behandlendeEnhetTjeneste.finnBehandlendeEnhetFor(fagsak));
     }
 
-    public Behandling opprettRevurderingMultiÅrsak(Fagsak fagsak, List<BehandlingÅrsakType> revurderingsÅrsaker) {
-        var revurderingTjeneste = FagsakYtelseTypeRef.Lookup.find(RevurderingTjeneste.class, fagsak.getYtelseType()).orElseThrow();
-        return revurderingTjeneste.opprettAutomatiskRevurderingMultiÅrsak(fagsak, revurderingsÅrsaker, behandlendeEnhetTjeneste.finnBehandlendeEnhetFor(fagsak));
-    }
-
     public Behandling opprettManuellRevurdering(Fagsak fagsak, BehandlingÅrsakType revurderingsÅrsak) {
         var revurderingTjeneste = FagsakYtelseTypeRef.Lookup.find(RevurderingTjeneste.class, fagsak.getYtelseType()).orElseThrow();
         return revurderingTjeneste.opprettManuellRevurdering(fagsak, revurderingsÅrsak, behandlendeEnhetTjeneste.finnBehandlendeEnhetFor(fagsak));

--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/dokumentmottak/MottatteDokumentTjeneste.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/dokumentmottak/MottatteDokumentTjeneste.java
@@ -22,8 +22,9 @@ import no.nav.foreldrepenger.behandlingslager.behandling.repository.MottatteDoku
 import no.nav.foreldrepenger.behandlingslager.behandling.vedtak.BehandlingVedtak;
 import no.nav.foreldrepenger.behandlingslager.behandling.vilkår.Avslagsårsak;
 import no.nav.foreldrepenger.behandlingslager.fagsak.Fagsak;
-import no.nav.foreldrepenger.mottak.dokumentpersiterer.impl.MottattDokumentPersisterer;
 import no.nav.foreldrepenger.konfig.KonfigVerdi;
+import no.nav.foreldrepenger.mottak.dokumentpersiterer.EndringsSøknadUtsettelseUttak;
+import no.nav.foreldrepenger.mottak.dokumentpersiterer.impl.MottattDokumentPersisterer;
 
 @ApplicationScoped
 public class MottatteDokumentTjeneste {
@@ -59,6 +60,15 @@ public class MottatteDokumentTjeneste {
             @SuppressWarnings("rawtypes") var dokumentWrapper = mottattDokumentPersisterer.xmlTilWrapper(dokument);
             mottattDokumentPersisterer.persisterDokumentinnhold(dokumentWrapper, dokument, behandling, gjelderFra);
         }
+    }
+
+    public EndringsSøknadUtsettelseUttak finnUtsettelseUttakForEndringssøknad(MottattDokument dokument) {
+        if (!dokument.getDokumentType().erEndringsSøknadType() || dokument.getPayloadXml() == null) {
+            return null;
+        }
+        @SuppressWarnings("rawtypes") var dokumentWrapper = mottattDokumentPersisterer.xmlTilWrapper(dokument);
+        return mottattDokumentPersisterer.ekstraherUtsettelseUttak(dokumentWrapper, dokument);
+
     }
 
     public Long lagreMottattDokumentPåFagsak(MottattDokument dokument) {

--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/dokumentmottak/MottatteDokumentTjeneste.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/dokumentmottak/MottatteDokumentTjeneste.java
@@ -25,6 +25,7 @@ import no.nav.foreldrepenger.behandlingslager.fagsak.Fagsak;
 import no.nav.foreldrepenger.konfig.KonfigVerdi;
 import no.nav.foreldrepenger.mottak.dokumentpersiterer.EndringsSøknadUtsettelseUttak;
 import no.nav.foreldrepenger.mottak.dokumentpersiterer.impl.MottattDokumentPersisterer;
+import no.nav.foreldrepenger.mottak.dokumentpersiterer.impl.søknad.v3.SøknadWrapper;
 
 @ApplicationScoped
 public class MottatteDokumentTjeneste {
@@ -66,7 +67,7 @@ public class MottatteDokumentTjeneste {
         if (!dokument.getDokumentType().erEndringsSøknadType() || dokument.getPayloadXml() == null) {
             return null;
         }
-        @SuppressWarnings("rawtypes") var dokumentWrapper = mottattDokumentPersisterer.xmlTilWrapper(dokument);
+        var dokumentWrapper = (SøknadWrapper) mottattDokumentPersisterer.xmlTilWrapper(dokument);
         return mottattDokumentPersisterer.ekstraherUtsettelseUttak(dokumentWrapper, dokument);
 
     }

--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/dokumentmottak/MottatteDokumentTjeneste.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/dokumentmottak/MottatteDokumentTjeneste.java
@@ -23,8 +23,9 @@ import no.nav.foreldrepenger.behandlingslager.behandling.vedtak.BehandlingVedtak
 import no.nav.foreldrepenger.behandlingslager.behandling.vilkår.Avslagsårsak;
 import no.nav.foreldrepenger.behandlingslager.fagsak.Fagsak;
 import no.nav.foreldrepenger.konfig.KonfigVerdi;
-import no.nav.foreldrepenger.mottak.dokumentpersiterer.EndringsSøknadUtsettelseUttak;
+import no.nav.foreldrepenger.mottak.dokumentpersiterer.SøknadUtsettelseUttakDato;
 import no.nav.foreldrepenger.mottak.dokumentpersiterer.impl.MottattDokumentPersisterer;
+import no.nav.foreldrepenger.mottak.dokumentpersiterer.impl.søknad.v3.EndringUtsettelseUttak;
 import no.nav.foreldrepenger.mottak.dokumentpersiterer.impl.søknad.v3.SøknadWrapper;
 
 @ApplicationScoped
@@ -63,12 +64,12 @@ public class MottatteDokumentTjeneste {
         }
     }
 
-    public EndringsSøknadUtsettelseUttak finnUtsettelseUttakForEndringssøknad(MottattDokument dokument) {
-        if (!dokument.getDokumentType().erEndringsSøknadType() || dokument.getPayloadXml() == null) {
+    public SøknadUtsettelseUttakDato finnUtsettelseUttakForSøknad(MottattDokument dokument) {
+        if (!dokument.getDokumentType().erForeldrepengeSøknad() || dokument.getPayloadXml() == null) {
             return null;
         }
         var dokumentWrapper = (SøknadWrapper) mottattDokumentPersisterer.xmlTilWrapper(dokument);
-        return mottattDokumentPersisterer.ekstraherUtsettelseUttak(dokumentWrapper, dokument);
+        return EndringUtsettelseUttak.ekstraherUtsettelseUttakFra(dokumentWrapper);
 
     }
 

--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/dokumentmottak/impl/Dokumentmottaker.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/dokumentmottak/impl/Dokumentmottaker.java
@@ -19,12 +19,12 @@ public interface Dokumentmottaker {
 
     void mottaDokumentForKøetBehandling(MottattDokument mottattDokument, Fagsak fagsak, BehandlingÅrsakType behandlingÅrsakType);
 
-    default boolean utsetterStartdato(MottattDokument mottattDokument, Fagsak fagsak) {
+    default boolean endringSomUtsetterStartdato(MottattDokument mottattDokument, Fagsak fagsak) {
         return false;
     }
 
-    default void utsettelseFraStart(MottattDokument mottattDokument, Fagsak fagsak) {
-        throw new IllegalStateException("utsettelseFraStart er ikke implementert");
+    default void mottaUtsettelseAvStartdato(MottattDokument mottattDokument, Fagsak fagsak) {
+        throw new IllegalStateException("Utviklerfeil: Mangler implementasjon");
     }
 
     @SuppressWarnings("unused")

--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/dokumentmottak/impl/Dokumentmottaker.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/dokumentmottak/impl/Dokumentmottaker.java
@@ -19,6 +19,14 @@ public interface Dokumentmottaker {
 
     void mottaDokumentForKøetBehandling(MottattDokument mottattDokument, Fagsak fagsak, BehandlingÅrsakType behandlingÅrsakType);
 
+    default boolean utsetterStartdato(MottattDokument mottattDokument, Fagsak fagsak) {
+        return false;
+    }
+
+    default void utsettelseFraStart(MottattDokument mottattDokument, Fagsak fagsak) {
+        throw new IllegalStateException("utsettelseFraStart er ikke implementert");
+    }
+
     @SuppressWarnings("unused")
     default void opprettFraTidligereAvsluttetBehandling(Fagsak fagsak, Long behandlingId, MottattDokument mottattDokument, BehandlingÅrsakType behandlingÅrsakType, boolean opprettSomKøet) {}
 }

--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/dokumentmottak/impl/Dokumentmottaker.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/dokumentmottak/impl/Dokumentmottaker.java
@@ -24,7 +24,8 @@ public interface Dokumentmottaker {
     }
 
     default void mottaUtsettelseAvStartdato(MottattDokument mottattDokument, Fagsak fagsak) {
-        throw new IllegalStateException("Utviklerfeil: Mangler implementasjon");
+        throw new IllegalStateException(String.format("Utviklerfeil: skal ikke kalles for ytelse %s dokumenttype %s",
+            fagsak.getYtelseType().getKode(), mottattDokument.getDokumentType().getKode()));
     }
 
     @SuppressWarnings("unused")

--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/dokumentmottak/impl/DokumentmottakerEndringssøknad.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/dokumentmottak/impl/DokumentmottakerEndringssøknad.java
@@ -124,7 +124,7 @@ class DokumentmottakerEndringssøknad extends DokumentmottakerYtelsesesrelatertD
     }
 
     @Override
-    public boolean utsetterStartdato(MottattDokument mottattDokument, Fagsak fagsak) {
+    public boolean endringSomUtsetterStartdato(MottattDokument mottattDokument, Fagsak fagsak) {
         var søknadUtsettelseUttak = dokumentmottakerFelles.finnUtsettelseUttak(mottattDokument);
         var eksisterendeStartdatoOpt = tomtUttakTjeneste.startdatoUttakResultatFrittUttak(fagsak);
         if (søknadUtsettelseUttak == null || søknadUtsettelseUttak.utsettelseFom() == null || eksisterendeStartdatoOpt.isEmpty()) {
@@ -139,7 +139,7 @@ class DokumentmottakerEndringssøknad extends DokumentmottakerYtelsesesrelatertD
     }
 
     @Override
-    public void utsettelseFraStart(MottattDokument mottattDokument, Fagsak fagsak) {
+    public void mottaUtsettelseAvStartdato(MottattDokument mottattDokument, Fagsak fagsak) {
         behandlingRepository.hentÅpneYtelseBehandlingerForFagsakId(fagsak.getId())
             .forEach(b -> behandlingsoppretter.henleggBehandling(b));
         dokumentmottakerFelles.opprettAnnulleringsBehandlinger(mottattDokument, fagsak);

--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/dokumentmottak/impl/DokumentmottakerEndringssøknad.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/dokumentmottak/impl/DokumentmottakerEndringssøknad.java
@@ -118,16 +118,6 @@ class DokumentmottakerEndringssøknad extends DokumentmottakerYtelsesesrelatertD
         }
     }
 
-    @Override
-    public boolean endringSomUtsetterStartdato(MottattDokument mottattDokument, Fagsak fagsak) {
-        return dokumentmottakerFelles.endringSomUtsetterStartdato(mottattDokument, fagsak);
-    }
-
-    @Override
-    public void mottaUtsettelseAvStartdato(MottattDokument mottattDokument, Fagsak fagsak) {
-        dokumentmottakerFelles.opprettAnnulleringsBehandlinger(mottattDokument, fagsak);
-    }
-
     private BehandlingÅrsakType getBehandlingÅrsakHvisUdefinert(BehandlingÅrsakType behandlingÅrsakType) {
         return behandlingÅrsakType == null || BehandlingÅrsakType.UDEFINERT.equals(behandlingÅrsakType) ?
             BehandlingÅrsakType.RE_ENDRING_FRA_BRUKER : behandlingÅrsakType;

--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/dokumentmottak/impl/DokumentmottakerFelles.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/dokumentmottak/impl/DokumentmottakerFelles.java
@@ -1,7 +1,6 @@
 package no.nav.foreldrepenger.mottak.dokumentmottak.impl;
 
 import java.time.LocalDateTime;
-import java.util.List;
 import java.util.Optional;
 
 import javax.enterprise.context.Dependent;
@@ -284,7 +283,7 @@ public class DokumentmottakerFelles {
     void opprettAnnulleringsBehandlinger(MottattDokument dokument, Fagsak fagsak) {
         var søknadUtsettelseUttak = finnUtsettelseUttak(dokument);
 
-        var revurdering = behandlingsoppretter.opprettRevurderingMultiÅrsak(fagsak, List.of(BehandlingÅrsakType.RE_UTSATT_START, BehandlingÅrsakType.BERØRT_BEHANDLING));
+        var revurdering = behandlingsoppretter.opprettRevurdering(fagsak, BehandlingÅrsakType.RE_UTSATT_START);
         mottatteDokumentTjeneste.persisterDokumentinnhold(revurdering, dokument, Optional.empty());
         opprettHistorikk(revurdering, dokument);
         opprettTaskForÅStarteBehandling(revurdering);

--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/dokumentmottak/impl/DokumentmottakerInntektsmelding.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/dokumentmottak/impl/DokumentmottakerInntektsmelding.java
@@ -75,6 +75,11 @@ class DokumentmottakerInntektsmelding extends DokumentmottakerYtelsesesrelatertD
     }
 
     @Override
+    public void håndterUtsattStartdato(MottattDokument mottattDokument, Fagsak fagsak, BehandlingÅrsakType behandlingÅrsakType) {
+        dokumentmottakerFelles.opprettTaskForÅVurdereDokument(fagsak, null, mottattDokument);
+    }
+
+    @Override
     public boolean skalOppretteKøetBehandling(Fagsak fagsak) {
         return true;
     }

--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/dokumentmottak/impl/DokumentmottakerSøknad.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/dokumentmottak/impl/DokumentmottakerSøknad.java
@@ -93,6 +93,11 @@ public abstract class DokumentmottakerSøknad extends DokumentmottakerYtelsesesr
     }
 
     @Override
+    public void håndterUtsattStartdato(MottattDokument mottattDokument, Fagsak fagsak, BehandlingÅrsakType behandlingÅrsakType) {
+        dokumentmottakerFelles.opprettFørstegangsbehandlingMedHistorikkinslagOgKopiAvDokumenter(mottattDokument, fagsak, getBehandlingÅrsakHvisUdefinert(behandlingÅrsakType));
+    }
+
+    @Override
     public void håndterAvslåttEllerOpphørtBehandling(MottattDokument mottattDokument, Fagsak fagsak, Behandling avsluttetBehandling, BehandlingÅrsakType behandlingÅrsakType) {
         if (erAvslag(avsluttetBehandling)) { //#S4 #S6
             dokumentmottakerFelles.opprettFørstegangsbehandlingMedHistorikkinslagOgKopiAvDokumenter(mottattDokument, fagsak, getBehandlingÅrsakHvisUdefinert(behandlingÅrsakType));

--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/dokumentmottak/impl/DokumentmottakerYtelsesesrelatertDokument.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/dokumentmottak/impl/DokumentmottakerYtelsesesrelatertDokument.java
@@ -13,6 +13,7 @@ import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRe
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepositoryProvider;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRevurderingRepository;
 import no.nav.foreldrepenger.behandlingslager.fagsak.Fagsak;
+import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakYtelseType;
 import no.nav.foreldrepenger.behandlingslager.uttak.PeriodeResultatType;
 import no.nav.foreldrepenger.domene.uttak.ForeldrepengerUttakTjeneste;
 import no.nav.foreldrepenger.mottak.Behandlingsoppretter;
@@ -113,6 +114,24 @@ public abstract class DokumentmottakerYtelsesesrelatertDokument implements Dokum
         } else {
             var sisteAvsluttetBehandling = behandlingRepository.finnSisteAvsluttedeIkkeHenlagteBehandling(fagsak.getId()).orElse(null);
             opprettKøetBehandling(mottattDokument, fagsak, behandlingÅrsakType, sisteAvsluttetBehandling);
+        }
+    }
+
+    @Override
+    public boolean endringSomUtsetterStartdato(MottattDokument mottattDokument, Fagsak fagsak) {
+        return FagsakYtelseType.FORELDREPENGER.equals(fagsak.getYtelseType()) &&
+            mottattDokument.getDokumentType().erForeldrepengeSøknad() &&
+            dokumentmottakerFelles.endringSomUtsetterStartdato(mottattDokument, fagsak);
+    }
+
+    @Override
+    public void mottaUtsettelseAvStartdato(MottattDokument mottattDokument, Fagsak fagsak) {
+        if (FagsakYtelseType.FORELDREPENGER.equals(fagsak.getYtelseType()) &&
+            mottattDokument.getDokumentType().erForeldrepengeSøknad()) {
+            dokumentmottakerFelles.opprettAnnulleringsBehandlinger(mottattDokument, fagsak);
+        } else {
+            throw new IllegalArgumentException(String.format("Utviklerfeil: skal ikke kalles for ytelse %s dokumenttype %s",
+                fagsak.getYtelseType().getKode(), mottattDokument.getDokumentType().getKode()));
         }
     }
 

--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/dokumentmottak/impl/DokumentmottakerYtelsesesrelatertDokument.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/dokumentmottak/impl/DokumentmottakerYtelsesesrelatertDokument.java
@@ -59,6 +59,8 @@ public abstract class DokumentmottakerYtelsesesrelatertDokument implements Dokum
 
     public abstract void håndterAvslåttEllerOpphørtBehandling(MottattDokument mottattDokument, Fagsak fagsak, Behandling avsluttetBehandling, BehandlingÅrsakType behandlingÅrsakType);
 
+    public abstract void håndterUtsattStartdato(MottattDokument mottattDokument, Fagsak fagsak, BehandlingÅrsakType behandlingÅrsakType);
+
     public abstract boolean skalOppretteKøetBehandling(Fagsak fagsak);
 
     protected abstract void opprettKøetBehandling(MottattDokument mottattDokument, Fagsak fagsak, BehandlingÅrsakType behandlingÅrsakType, Behandling sisteAvsluttetBehandling);
@@ -84,6 +86,8 @@ public abstract class DokumentmottakerYtelsesesrelatertDokument implements Dokum
             if (behandlingsoppretter.erAvslåttBehandling(behandling)
                 || behandlingsoppretter.erOpphørtBehandling(behandling)) {
                 håndterAvslåttEllerOpphørtBehandling(mottattDokument, fagsak, behandling, behandlingÅrsakType);
+            } else if (behandlingsoppretter.erUtsattBehandling(behandling)) {
+                håndterUtsattStartdato(mottattDokument, fagsak, behandlingÅrsakType);
             } else {
                 håndterAvsluttetTidligereBehandling(mottattDokument, fagsak, behandlingÅrsakType);
             }

--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/dokumentmottak/impl/InnhentDokumentTjeneste.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/dokumentmottak/impl/InnhentDokumentTjeneste.java
@@ -70,15 +70,13 @@ public class InnhentDokumentTjeneste {
             DOKUMENTTYPE_TIL_GRUPPE.getOrDefault(dokumentTypeId, DokumentGruppe.VEDLEGG);
 
         var dokumentmottaker = finnMottaker(dokumentGruppe, fagsak.getYtelseType());
-        if (dokumentmottaker.utsetterStartdato(mottattDokument, fagsak)) {
-            dokumentmottaker.utsettelseFraStart(mottattDokument, fagsak);
-            return;
-        }
-        if (skalMottasSomKøet(fagsak)) {
+        if (dokumentmottaker.endringSomUtsetterStartdato(mottattDokument, fagsak)) {
+            dokumentmottaker.mottaUtsettelseAvStartdato(mottattDokument, fagsak);
+        } else if (skalMottasSomKøet(fagsak)) {
             dokumentmottaker.mottaDokumentForKøetBehandling(mottattDokument, fagsak, behandlingÅrsakType);
-            return;
+        } else {
+            dokumentmottaker.mottaDokument(mottattDokument, fagsak, behandlingÅrsakType);
         }
-        dokumentmottaker.mottaDokument(mottattDokument, fagsak, behandlingÅrsakType);
     }
 
     public void opprettFraTidligereBehandling(Long behandlingId, MottattDokument mottattDokument, BehandlingÅrsakType behandlingÅrsakType) { //#SXX og #IXX

--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/dokumentmottak/impl/InnhentDokumentTjeneste.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/dokumentmottak/impl/InnhentDokumentTjeneste.java
@@ -15,7 +15,6 @@ import no.nav.foreldrepenger.behandlingslager.behandling.DokumentKategori;
 import no.nav.foreldrepenger.behandlingslager.behandling.DokumentTypeId;
 import no.nav.foreldrepenger.behandlingslager.behandling.MottattDokument;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepositoryProvider;
-import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRevurderingRepository;
 import no.nav.foreldrepenger.behandlingslager.fagsak.Fagsak;
 import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakRepository;
 import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakYtelseType;
@@ -50,18 +49,15 @@ public class InnhentDokumentTjeneste {
     private Instance<Dokumentmottaker> mottakere;
 
     private FagsakRepository fagsakRepository;
-    private BehandlingRevurderingRepository revurderingRepository;
 
     private KøKontroller køKontroller;
 
     @Inject
     public InnhentDokumentTjeneste(BehandlingRepositoryProvider repositoryProvider,
                                    @Any Instance<Dokumentmottaker> mottakere,
-                                   BehandlingRevurderingRepository revurderingRepository,
                                    KøKontroller køKontroller) {
         this.fagsakRepository = repositoryProvider.getFagsakRepository();
         this.mottakere = mottakere;
-        this.revurderingRepository = revurderingRepository;
         this.køKontroller = køKontroller;
     }
 
@@ -74,6 +70,10 @@ public class InnhentDokumentTjeneste {
             DOKUMENTTYPE_TIL_GRUPPE.getOrDefault(dokumentTypeId, DokumentGruppe.VEDLEGG);
 
         var dokumentmottaker = finnMottaker(dokumentGruppe, fagsak.getYtelseType());
+        if (dokumentmottaker.utsetterStartdato(mottattDokument, fagsak)) {
+            dokumentmottaker.utsettelseFraStart(mottattDokument, fagsak);
+            return;
+        }
         if (skalMottasSomKøet(fagsak)) {
             dokumentmottaker.mottaDokumentForKøetBehandling(mottattDokument, fagsak, behandlingÅrsakType);
             return;

--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/dokumentpersiterer/EndringsSøknadUtsettelseUttak.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/dokumentpersiterer/EndringsSøknadUtsettelseUttak.java
@@ -1,0 +1,5 @@
+package no.nav.foreldrepenger.mottak.dokumentpersiterer;
+
+import java.time.LocalDate;
+
+public record EndringsSøknadUtsettelseUttak(LocalDate utsettelseFom, LocalDate uttakFom) { }

--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/dokumentpersiterer/EndringsSøknadUtsettelseUttak.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/dokumentpersiterer/EndringsSøknadUtsettelseUttak.java
@@ -1,5 +1,0 @@
-package no.nav.foreldrepenger.mottak.dokumentpersiterer;
-
-import java.time.LocalDate;
-
-public record EndringsSøknadUtsettelseUttak(LocalDate utsettelseFom, LocalDate uttakFom) { }

--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/dokumentpersiterer/MottattDokumentOversetter.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/dokumentpersiterer/MottattDokumentOversetter.java
@@ -11,7 +11,4 @@ public interface MottattDokumentOversetter<T extends MottattDokumentWrapper<?>> 
 
     void trekkUtDataOgPersister(T wrapper, MottattDokument mottattDokument, Behandling behandling, Optional<LocalDate> gjelderFra);
 
-    default EndringsSøknadUtsettelseUttak ekstraherUtsettelseUttakFra(T wrapper, MottattDokument mottattDokument) {
-        return null;
-    }
 }

--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/dokumentpersiterer/MottattDokumentOversetter.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/dokumentpersiterer/MottattDokumentOversetter.java
@@ -10,4 +10,8 @@ import no.nav.foreldrepenger.mottak.dokumentpersiterer.impl.MottattDokumentWrapp
 public interface MottattDokumentOversetter<T extends MottattDokumentWrapper<?>> {
 
     void trekkUtDataOgPersister(T wrapper, MottattDokument mottattDokument, Behandling behandling, Optional<LocalDate> gjelderFra);
+
+    default EndringsSøknadUtsettelseUttak ekstraherUtsettelseUttakFra(T wrapper, MottattDokument mottattDokument) {
+        return null;
+    }
 }

--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/dokumentpersiterer/SøknadUtsettelseUttakDato.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/dokumentpersiterer/SøknadUtsettelseUttakDato.java
@@ -1,0 +1,5 @@
+package no.nav.foreldrepenger.mottak.dokumentpersiterer;
+
+import java.time.LocalDate;
+
+public record SøknadUtsettelseUttakDato(LocalDate utsettelseFom, LocalDate uttakFom) { }

--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/dokumentpersiterer/impl/MottattDokumentPersisterer.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/dokumentpersiterer/impl/MottattDokumentPersisterer.java
@@ -15,6 +15,8 @@ import no.nav.foreldrepenger.mottak.dokumentpersiterer.EndringsSøknadUtsettelse
 import no.nav.foreldrepenger.mottak.dokumentpersiterer.MottattDokumentFeil;
 import no.nav.foreldrepenger.mottak.dokumentpersiterer.MottattDokumentOversetter;
 import no.nav.foreldrepenger.mottak.dokumentpersiterer.NamespaceRef;
+import no.nav.foreldrepenger.mottak.dokumentpersiterer.impl.søknad.v3.EndringUtsettelseUttak;
+import no.nav.foreldrepenger.mottak.dokumentpersiterer.impl.søknad.v3.SøknadWrapper;
 import no.nav.foreldrepenger.mottak.dokumentpersiterer.xml.MottattDokumentXmlParser;
 import no.nav.foreldrepenger.mottak.publiserer.publish.MottattDokumentPersistertPubliserer;
 import no.nav.vedtak.exception.TekniskException;
@@ -53,10 +55,9 @@ public class MottattDokumentPersisterer {
     }
 
     @SuppressWarnings("unchecked")
-    public EndringsSøknadUtsettelseUttak ekstraherUtsettelseUttak(MottattDokumentWrapper wrapper,
+    public EndringsSøknadUtsettelseUttak ekstraherUtsettelseUttak(SøknadWrapper wrapper,
                                                                   MottattDokument dokument) {
-        MottattDokumentOversetter dokumentOversetter = getDokumentOversetter(wrapper.getSkjemaType());
-        return dokumentOversetter.ekstraherUtsettelseUttakFra(wrapper, dokument);
+        return EndringUtsettelseUttak.ekstraherUtsettelseUttakFra(wrapper, dokument);
     }
 
     private MottattDokumentOversetter<?> getDokumentOversetter(String namespace) {

--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/dokumentpersiterer/impl/MottattDokumentPersisterer.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/dokumentpersiterer/impl/MottattDokumentPersisterer.java
@@ -11,12 +11,9 @@ import javax.inject.Inject;
 
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
 import no.nav.foreldrepenger.behandlingslager.behandling.MottattDokument;
-import no.nav.foreldrepenger.mottak.dokumentpersiterer.EndringsSøknadUtsettelseUttak;
 import no.nav.foreldrepenger.mottak.dokumentpersiterer.MottattDokumentFeil;
 import no.nav.foreldrepenger.mottak.dokumentpersiterer.MottattDokumentOversetter;
 import no.nav.foreldrepenger.mottak.dokumentpersiterer.NamespaceRef;
-import no.nav.foreldrepenger.mottak.dokumentpersiterer.impl.søknad.v3.EndringUtsettelseUttak;
-import no.nav.foreldrepenger.mottak.dokumentpersiterer.impl.søknad.v3.SøknadWrapper;
 import no.nav.foreldrepenger.mottak.dokumentpersiterer.xml.MottattDokumentXmlParser;
 import no.nav.foreldrepenger.mottak.publiserer.publish.MottattDokumentPersistertPubliserer;
 import no.nav.vedtak.exception.TekniskException;
@@ -52,12 +49,6 @@ public class MottattDokumentPersisterer {
     public void persisterDokumentinnhold(MottattDokument dokument, Behandling behandling) {
         var dokumentWrapper = xmlTilWrapper(dokument);
         persisterDokumentinnhold(dokumentWrapper, dokument, behandling, Optional.empty());
-    }
-
-    @SuppressWarnings("unchecked")
-    public EndringsSøknadUtsettelseUttak ekstraherUtsettelseUttak(SøknadWrapper wrapper,
-                                                                  MottattDokument dokument) {
-        return EndringUtsettelseUttak.ekstraherUtsettelseUttakFra(wrapper, dokument);
     }
 
     private MottattDokumentOversetter<?> getDokumentOversetter(String namespace) {

--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/dokumentpersiterer/impl/MottattDokumentPersisterer.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/dokumentpersiterer/impl/MottattDokumentPersisterer.java
@@ -11,6 +11,7 @@ import javax.inject.Inject;
 
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
 import no.nav.foreldrepenger.behandlingslager.behandling.MottattDokument;
+import no.nav.foreldrepenger.mottak.dokumentpersiterer.EndringsSøknadUtsettelseUttak;
 import no.nav.foreldrepenger.mottak.dokumentpersiterer.MottattDokumentFeil;
 import no.nav.foreldrepenger.mottak.dokumentpersiterer.MottattDokumentOversetter;
 import no.nav.foreldrepenger.mottak.dokumentpersiterer.NamespaceRef;
@@ -49,6 +50,13 @@ public class MottattDokumentPersisterer {
     public void persisterDokumentinnhold(MottattDokument dokument, Behandling behandling) {
         var dokumentWrapper = xmlTilWrapper(dokument);
         persisterDokumentinnhold(dokumentWrapper, dokument, behandling, Optional.empty());
+    }
+
+    @SuppressWarnings("unchecked")
+    public EndringsSøknadUtsettelseUttak ekstraherUtsettelseUttak(MottattDokumentWrapper wrapper,
+                                                                  MottattDokument dokument) {
+        MottattDokumentOversetter dokumentOversetter = getDokumentOversetter(wrapper.getSkjemaType());
+        return dokumentOversetter.ekstraherUtsettelseUttakFra(wrapper, dokument);
     }
 
     private MottattDokumentOversetter<?> getDokumentOversetter(String namespace) {

--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/dokumentpersiterer/impl/MottattDokumentWrapper.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/dokumentpersiterer/impl/MottattDokumentWrapper.java
@@ -18,15 +18,14 @@ public abstract class MottattDokumentWrapper<S> {
 
     @SuppressWarnings("rawtypes")
     public static MottattDokumentWrapper tilXmlWrapper(Object skjema) {
-        if (skjema instanceof Soeknad) {
-            return new SøknadWrapper((Soeknad) skjema);
+        if (skjema instanceof Soeknad soeknad) {
+            return new SøknadWrapper(soeknad);
         }
-        if (skjema instanceof no.seres.xsd.nav.inntektsmelding_m._20180924.InntektsmeldingM) {
-            return new no.nav.foreldrepenger.mottak.dokumentpersiterer.impl.inntektsmelding.v1.InntektsmeldingWrapper(
-                (no.seres.xsd.nav.inntektsmelding_m._20180924.InntektsmeldingM) skjema);
+        if (skjema instanceof no.seres.xsd.nav.inntektsmelding_m._20180924.InntektsmeldingM im) {
+            return new no.nav.foreldrepenger.mottak.dokumentpersiterer.impl.inntektsmelding.v1.InntektsmeldingWrapper(im);
         }
-        if (skjema instanceof InntektsmeldingM) {
-            return new InntektsmeldingWrapper((InntektsmeldingM) skjema);
+        if (skjema instanceof InntektsmeldingM im) {
+            return new InntektsmeldingWrapper(im);
         }
         throw MottattDokumentFeil.ukjentSkjemaType(skjema.getClass().getCanonicalName());
     }

--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/dokumentpersiterer/impl/søknad/v3/EndringUtsettelseUttak.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/dokumentpersiterer/impl/søknad/v3/EndringUtsettelseUttak.java
@@ -1,13 +1,14 @@
 package no.nav.foreldrepenger.mottak.dokumentpersiterer.impl.søknad.v3;
 
+import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.List;
 
-import no.nav.foreldrepenger.behandlingslager.behandling.DokumentTypeId;
-import no.nav.foreldrepenger.behandlingslager.behandling.MottattDokument;
-import no.nav.foreldrepenger.mottak.dokumentpersiterer.EndringsSøknadUtsettelseUttak;
 import no.nav.foreldrepenger.mottak.dokumentpersiterer.NamespaceRef;
+import no.nav.foreldrepenger.mottak.dokumentpersiterer.SøknadUtsettelseUttakDato;
 import no.nav.foreldrepenger.søknad.v3.SøknadConstants;
 import no.nav.vedtak.felles.xml.soeknad.endringssoeknad.v3.Endringssoeknad;
+import no.nav.vedtak.felles.xml.soeknad.foreldrepenger.v3.Foreldrepenger;
 import no.nav.vedtak.felles.xml.soeknad.uttak.v3.LukketPeriodeMedVedlegg;
 import no.nav.vedtak.felles.xml.soeknad.uttak.v3.Oppholdsperiode;
 import no.nav.vedtak.felles.xml.soeknad.uttak.v3.Overfoeringsperiode;
@@ -17,11 +18,15 @@ import no.nav.vedtak.felles.xml.soeknad.uttak.v3.Uttaksperiode;
 @NamespaceRef(SøknadConstants.NAMESPACE)
 public class EndringUtsettelseUttak {
 
-    public static EndringsSøknadUtsettelseUttak ekstraherUtsettelseUttakFra(SøknadWrapper wrapper, MottattDokument mottattDokument) {
-        if (!(wrapper.getOmYtelse() instanceof final Endringssoeknad omYtelse) || !erEndring(mottattDokument)) {
-            throw new IllegalArgumentException("Ikke endringssøknad");
+    public static SøknadUtsettelseUttakDato ekstraherUtsettelseUttakFra(SøknadWrapper wrapper) {
+        List<LukketPeriodeMedVedlegg> perioder = new ArrayList<>();
+        if (wrapper.getOmYtelse() instanceof Foreldrepenger foreldrepenger) {
+            perioder.addAll(foreldrepenger.getFordeling().getPerioder());
+        } else if (wrapper.getOmYtelse() instanceof Endringssoeknad endringssoeknad) {
+            perioder.addAll(endringssoeknad.getFordeling().getPerioder());
+        } else {
+            throw new IllegalArgumentException("Ugyldig søknadstype");
         }
-        var perioder = omYtelse.getFordeling().getPerioder();
 
         var utsettelseFom = perioder.stream()
             .filter(p -> p instanceof Utsettelsesperiode || p instanceof Oppholdsperiode)
@@ -32,11 +37,7 @@ public class EndringUtsettelseUttak {
             .map(LukketPeriodeMedVedlegg::getFom)
             .min(Comparator.naturalOrder()).orElse(null);
 
-        return new EndringsSøknadUtsettelseUttak(utsettelseFom, uttakFom);
-    }
-
-    private static boolean erEndring(MottattDokument mottattDokument) {
-        return mottattDokument.getDokumentType().equals(DokumentTypeId.FORELDREPENGER_ENDRING_SØKNAD);
+        return new SøknadUtsettelseUttakDato(utsettelseFom, uttakFom);
     }
 
 }

--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/dokumentpersiterer/impl/søknad/v3/EndringUtsettelseUttak.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/dokumentpersiterer/impl/søknad/v3/EndringUtsettelseUttak.java
@@ -1,0 +1,42 @@
+package no.nav.foreldrepenger.mottak.dokumentpersiterer.impl.søknad.v3;
+
+import java.util.Comparator;
+
+import no.nav.foreldrepenger.behandlingslager.behandling.DokumentTypeId;
+import no.nav.foreldrepenger.behandlingslager.behandling.MottattDokument;
+import no.nav.foreldrepenger.mottak.dokumentpersiterer.EndringsSøknadUtsettelseUttak;
+import no.nav.foreldrepenger.mottak.dokumentpersiterer.NamespaceRef;
+import no.nav.foreldrepenger.søknad.v3.SøknadConstants;
+import no.nav.vedtak.felles.xml.soeknad.endringssoeknad.v3.Endringssoeknad;
+import no.nav.vedtak.felles.xml.soeknad.uttak.v3.LukketPeriodeMedVedlegg;
+import no.nav.vedtak.felles.xml.soeknad.uttak.v3.Oppholdsperiode;
+import no.nav.vedtak.felles.xml.soeknad.uttak.v3.Overfoeringsperiode;
+import no.nav.vedtak.felles.xml.soeknad.uttak.v3.Utsettelsesperiode;
+import no.nav.vedtak.felles.xml.soeknad.uttak.v3.Uttaksperiode;
+
+@NamespaceRef(SøknadConstants.NAMESPACE)
+public class EndringUtsettelseUttak {
+
+    public static EndringsSøknadUtsettelseUttak ekstraherUtsettelseUttakFra(SøknadWrapper wrapper, MottattDokument mottattDokument) {
+        if (!(wrapper.getOmYtelse() instanceof final Endringssoeknad omYtelse) || !erEndring(mottattDokument)) {
+            throw new IllegalArgumentException("Ikke endringssøknad");
+        }
+        var perioder = omYtelse.getFordeling().getPerioder();
+
+        var utsettelseFom = perioder.stream()
+            .filter(p -> p instanceof Utsettelsesperiode || p instanceof Oppholdsperiode)
+            .map(LukketPeriodeMedVedlegg::getFom)
+            .min(Comparator.naturalOrder()).orElse(null);
+        var uttakFom = perioder.stream()
+            .filter(p -> p instanceof Uttaksperiode || p instanceof Overfoeringsperiode)
+            .map(LukketPeriodeMedVedlegg::getFom)
+            .min(Comparator.naturalOrder()).orElse(null);
+
+        return new EndringsSøknadUtsettelseUttak(utsettelseFom, uttakFom);
+    }
+
+    private static boolean erEndring(MottattDokument mottattDokument) {
+        return mottattDokument.getDokumentType().equals(DokumentTypeId.FORELDREPENGER_ENDRING_SØKNAD);
+    }
+
+}

--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/dokumentpersiterer/impl/søknad/v3/SøknadOversetter.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/dokumentpersiterer/impl/søknad/v3/SøknadOversetter.java
@@ -75,7 +75,6 @@ import no.nav.foreldrepenger.domene.tid.DatoIntervallEntitet;
 import no.nav.foreldrepenger.domene.typer.AktørId;
 import no.nav.foreldrepenger.domene.typer.PersonIdent;
 import no.nav.foreldrepenger.mottak.dokumentmottak.impl.OppgittPeriodeTidligstMottattDatoTjeneste;
-import no.nav.foreldrepenger.mottak.dokumentpersiterer.EndringsSøknadUtsettelseUttak;
 import no.nav.foreldrepenger.mottak.dokumentpersiterer.MottattDokumentOversetter;
 import no.nav.foreldrepenger.mottak.dokumentpersiterer.NamespaceRef;
 import no.nav.foreldrepenger.regler.uttak.felles.Virkedager;
@@ -184,26 +183,6 @@ public class SøknadOversetter implements MottattDokumentOversetter<SøknadWrapp
             // DVH oppdatering skal normalt gå gjennom events - dette er en unntaksløsning for å sikre at DVH oppdateres med annen part (som er lagt på DVH-sak)
             datavarehusTjeneste.lagreNedFagsak(behandling.getFagsakId());
         }
-    }
-
-    @Override
-    public EndringsSøknadUtsettelseUttak ekstraherUtsettelseUttakFra(SøknadWrapper wrapper, MottattDokument mottattDokument) {
-        if (!(wrapper.getOmYtelse() instanceof Endringssoeknad) || !erEndring(mottattDokument)) {
-            throw new IllegalArgumentException("Ikke endringssøknad");
-        }
-        final var omYtelse = (Endringssoeknad) wrapper.getOmYtelse();
-        var perioder = omYtelse.getFordeling().getPerioder();
-
-        var utsettelseFom = perioder.stream()
-            .filter(p -> p instanceof Utsettelsesperiode || p instanceof Oppholdsperiode)
-            .map(LukketPeriodeMedVedlegg::getFom)
-            .min(Comparator.naturalOrder()).orElse(null);
-        var uttakFom = perioder.stream()
-            .filter(p -> p instanceof Uttaksperiode || p instanceof Overfoeringsperiode || p instanceof Gradering)
-            .map(LukketPeriodeMedVedlegg::getFom)
-            .min(Comparator.naturalOrder()).orElse(null);
-
-        return new EndringsSøknadUtsettelseUttak(utsettelseFom, uttakFom);
     }
 
     private SøknadEntitet.Builder kopierSøknad(Behandling behandling) {

--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/dokumentpersiterer/impl/søknad/v3/SøknadOversetter.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/dokumentpersiterer/impl/søknad/v3/SøknadOversetter.java
@@ -75,6 +75,7 @@ import no.nav.foreldrepenger.domene.tid.DatoIntervallEntitet;
 import no.nav.foreldrepenger.domene.typer.AktørId;
 import no.nav.foreldrepenger.domene.typer.PersonIdent;
 import no.nav.foreldrepenger.mottak.dokumentmottak.impl.OppgittPeriodeTidligstMottattDatoTjeneste;
+import no.nav.foreldrepenger.mottak.dokumentpersiterer.EndringsSøknadUtsettelseUttak;
 import no.nav.foreldrepenger.mottak.dokumentpersiterer.MottattDokumentOversetter;
 import no.nav.foreldrepenger.mottak.dokumentpersiterer.NamespaceRef;
 import no.nav.foreldrepenger.regler.uttak.felles.Virkedager;
@@ -183,6 +184,26 @@ public class SøknadOversetter implements MottattDokumentOversetter<SøknadWrapp
             // DVH oppdatering skal normalt gå gjennom events - dette er en unntaksløsning for å sikre at DVH oppdateres med annen part (som er lagt på DVH-sak)
             datavarehusTjeneste.lagreNedFagsak(behandling.getFagsakId());
         }
+    }
+
+    @Override
+    public EndringsSøknadUtsettelseUttak ekstraherUtsettelseUttakFra(SøknadWrapper wrapper, MottattDokument mottattDokument) {
+        if (!(wrapper.getOmYtelse() instanceof Endringssoeknad) || !erEndring(mottattDokument)) {
+            throw new IllegalArgumentException("Ikke endringssøknad");
+        }
+        final var omYtelse = (Endringssoeknad) wrapper.getOmYtelse();
+        var perioder = omYtelse.getFordeling().getPerioder();
+
+        var utsettelseFom = perioder.stream()
+            .filter(p -> p instanceof Utsettelsesperiode || p instanceof Oppholdsperiode)
+            .map(LukketPeriodeMedVedlegg::getFom)
+            .min(Comparator.naturalOrder()).orElse(null);
+        var uttakFom = perioder.stream()
+            .filter(p -> p instanceof Uttaksperiode || p instanceof Overfoeringsperiode || p instanceof Gradering)
+            .map(LukketPeriodeMedVedlegg::getFom)
+            .min(Comparator.naturalOrder()).orElse(null);
+
+        return new EndringsSøknadUtsettelseUttak(utsettelseFom, uttakFom);
     }
 
     private SøknadEntitet.Builder kopierSøknad(Behandling behandling) {

--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/kompletthettjeneste/impl/fp/KompletthetsjekkerRevurderingImpl.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/kompletthettjeneste/impl/fp/KompletthetsjekkerRevurderingImpl.java
@@ -10,8 +10,8 @@ import no.nav.foreldrepenger.behandling.BehandlingReferanse;
 import no.nav.foreldrepenger.behandlingskontroll.BehandlingTypeRef;
 import no.nav.foreldrepenger.behandlingskontroll.FagsakYtelseTypeRef;
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
-import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingÅrsakType;
 import no.nav.foreldrepenger.behandlingslager.behandling.DokumentTypeId;
+import no.nav.foreldrepenger.behandlingslager.behandling.SpesialBehandling;
 import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.Venteårsak;
 import no.nav.foreldrepenger.behandlingslager.behandling.søknad.SøknadRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.vedtak.BehandlingVedtakRepository;
@@ -60,7 +60,7 @@ public class KompletthetsjekkerRevurderingImpl implements Kompletthetsjekker {
     @Override
     public KompletthetResultat vurderForsendelseKomplett(BehandlingReferanse ref) {
         var behandling = fellesUtil.hentBehandling(ref.getBehandlingId());
-        if (behandling.harBehandlingÅrsak(BehandlingÅrsakType.BERØRT_BEHANDLING)) {
+        if (SpesialBehandling.skalGrunnlagBeholdes(behandling)) {
             return KompletthetResultat.oppfylt();
         }
 

--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/sakskompleks/BerørtBehandlingKontroller.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/sakskompleks/BerørtBehandlingKontroller.java
@@ -12,6 +12,7 @@ import org.slf4j.LoggerFactory;
 import no.nav.foreldrepenger.behandling.revurdering.BerørtBehandlingTjeneste;
 import no.nav.foreldrepenger.behandlingskontroll.FagsakYtelseTypeRef;
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
+import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingResultatType;
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandlingsresultat;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingsresultatRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingÅrsakType;
@@ -85,8 +86,8 @@ public class BerørtBehandlingKontroller {
 
         if (sistVedtatteYtelsesbehandlingMedforelder.isPresent()) {
             var avsluttetBehandlingsresultatBruker = behandlingsresultatRepository.hent(behandlingIdBruker);
-            var skalBerørtBehandlingOpprettes = berørtBehandlingTjeneste.skalBerørtBehandlingOpprettes(
-                avsluttetBehandlingsresultatBruker, behandlingIdBruker, sistVedtatteYtelsesbehandlingMedforelder.get().getId());
+            var skalBerørtBehandlingOpprettes = !BehandlingResultatType.FORELDREPENGER_SENERE.equals(avsluttetBehandlingsresultatBruker.getBehandlingResultatType()) &&
+                berørtBehandlingTjeneste.skalBerørtBehandlingOpprettes(avsluttetBehandlingsresultatBruker, behandlingIdBruker, sistVedtatteYtelsesbehandlingMedforelder.get().getId());
             if (skalBerørtBehandlingOpprettes) {
                 opprettBerørtBehandling(fagsakMedforelder, avsluttetBehandlingsresultatBruker);
             } else {

--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/sakskompleks/BerørtBehandlingKontroller.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/sakskompleks/BerørtBehandlingKontroller.java
@@ -1,6 +1,5 @@
 package no.nav.foreldrepenger.mottak.sakskompleks;
 
-import java.util.List;
 import java.util.Optional;
 
 import javax.enterprise.context.ApplicationScoped;
@@ -12,11 +11,11 @@ import org.slf4j.LoggerFactory;
 import no.nav.foreldrepenger.behandling.revurdering.BerørtBehandlingTjeneste;
 import no.nav.foreldrepenger.behandlingskontroll.FagsakYtelseTypeRef;
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
-import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingResultatType;
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandlingsresultat;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingsresultatRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingÅrsakType;
 import no.nav.foreldrepenger.behandlingslager.behandling.KonsekvensForYtelsen;
+import no.nav.foreldrepenger.behandlingslager.behandling.SpesialBehandling;
 import no.nav.foreldrepenger.behandlingslager.behandling.beregning.BeregningsresultatRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.historikk.HistorikkBegrunnelseType;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepository;
@@ -86,8 +85,7 @@ public class BerørtBehandlingKontroller {
 
         if (sistVedtatteYtelsesbehandlingMedforelder.isPresent()) {
             var avsluttetBehandlingsresultatBruker = behandlingsresultatRepository.hent(behandlingIdBruker);
-            var skalBerørtBehandlingOpprettes = !BehandlingResultatType.FORELDREPENGER_SENERE.equals(avsluttetBehandlingsresultatBruker.getBehandlingResultatType()) &&
-                berørtBehandlingTjeneste.skalBerørtBehandlingOpprettes(avsluttetBehandlingsresultatBruker, behandlingIdBruker, sistVedtatteYtelsesbehandlingMedforelder.get().getId());
+            var skalBerørtBehandlingOpprettes = berørtBehandlingTjeneste.skalBerørtBehandlingOpprettes(avsluttetBehandlingsresultatBruker, behandlingIdBruker, sistVedtatteYtelsesbehandlingMedforelder.get().getId());
             if (skalBerørtBehandlingOpprettes) {
                 opprettBerørtBehandling(fagsakMedforelder, avsluttetBehandlingsresultatBruker);
             } else {
@@ -119,9 +117,17 @@ public class BerørtBehandlingKontroller {
 
     private void opprettBerørtBehandling(Fagsak fagsakMedforelder, Behandlingsresultat behandlingsresultatBruker) {
         fagsakLåsRepository.taLås(fagsakMedforelder.getId());
+        var åpenTømUttak = behandlingRepository.hentÅpneYtelseBehandlingerForFagsakId(fagsakMedforelder.getId()).stream()
+            .anyMatch(SpesialBehandling::erOppsagtUttak);
+        if (åpenTømUttak) {
+            // Holder på å tømme uttaket. Ingen vits med berørt behandling
+            LOG.info("OPPRETT BERØRT finnes allerede åpen behandling som tømmer uttak for sak {}", fagsakMedforelder.getSaksnummer());
+            return;
+        }
         // Hvis det nå allerede skulle være en åpen behandling (ikke i kø) så legg den i kø før oppretting av berørt.
-        var åpenBerørtBehandling = behandlingRepository.hentSisteYtelsesBehandlingForFagsakId(fagsakMedforelder.getId())
-            .filter(b -> b.harBehandlingÅrsak(BehandlingÅrsakType.BERØRT_BEHANDLING));
+        var åpenBerørtBehandling = behandlingRepository.hentÅpneYtelseBehandlingerForFagsakId(fagsakMedforelder.getId()).stream()
+            .filter(SpesialBehandling::erBerørtBehandling)
+            .findFirst();
         if (åpenBerørtBehandling.isPresent()) {
             LOG.info("OPPRETT BERØRT finnes allerede åpen berørt for sak {}  behandling {}", fagsakMedforelder.getSaksnummer(), åpenBerørtBehandling.get().getId());
             var origBehandlingId = behandlingRepository.finnSisteAvsluttedeIkkeHenlagteBehandling(fagsakMedforelder.getId()).orElseThrow().getId();
@@ -131,6 +137,11 @@ public class BerørtBehandlingKontroller {
                 return;
             }
         }
+        // Stans eventuelle åpne feriepengereberegninger - de håndteres av ny berørt behandling
+        behandlingRepository.hentÅpneYtelseBehandlingerForFagsakId(fagsakMedforelder.getId()).stream()
+            .filter(SpesialBehandling::erJusterFeriepenger)
+            .forEach(behandlingsoppretter::henleggBehandling);
+
         var åpenBehandling = behandlingRevurderingRepository.finnÅpenYtelsesbehandling(fagsakMedforelder.getId());
         var berørtBehandling = behandlingsoppretter.opprettRevurdering(fagsakMedforelder, BehandlingÅrsakType.BERØRT_BEHANDLING);
         opprettHistorikkinnslag(berørtBehandling, behandlingsresultatBruker);
@@ -139,8 +150,7 @@ public class BerørtBehandlingKontroller {
 
     private void opprettFerieBerørtBehandling(Fagsak fagsakMedforelder, Behandlingsresultat behandlingsresultatBruker) {
         fagsakLåsRepository.taLås(fagsakMedforelder.getId());
-        var berørtBehandling = behandlingsoppretter.opprettRevurderingMultiÅrsak(fagsakMedforelder,
-            List.of(BehandlingÅrsakType.BERØRT_BEHANDLING, BehandlingÅrsakType.REBEREGN_FERIEPENGER));
+        var berørtBehandling = behandlingsoppretter.opprettRevurdering(fagsakMedforelder, BehandlingÅrsakType.REBEREGN_FERIEPENGER);
         opprettHistorikkinnslag(berørtBehandling, behandlingsresultatBruker);
         køKontroller.submitBerørtBehandling(berørtBehandling, Optional.empty());
     }

--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/sakskompleks/KøKontroller.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/sakskompleks/KøKontroller.java
@@ -10,6 +10,7 @@ import no.nav.foreldrepenger.behandlingskontroll.BehandlingskontrollTjeneste;
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingType;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingÅrsakType;
+import no.nav.foreldrepenger.behandlingslager.behandling.SpesialBehandling;
 import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.AksjonspunktDefinisjon;
 import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.Venteårsak;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepository;
@@ -89,7 +90,7 @@ public class KøKontroller {
     }
 
     public void submitBerørtBehandling(Behandling behandling, Optional<Behandling> åpenBehandling) {
-        if (!behandling.harBehandlingÅrsak(BehandlingÅrsakType.BERØRT_BEHANDLING)) throw new IllegalArgumentException("Behandling er ikke berørt");
+        if (!behandling.harNoenBehandlingÅrsaker(BehandlingÅrsakType.alleTekniskeÅrsaker())) throw new IllegalArgumentException("Behandling er ikke berørt");
         åpenBehandling.ifPresent(b -> behandlingskontrollTjeneste.settBehandlingPåVent(b, AksjonspunktDefinisjon.AUTO_KØET_BEHANDLING,
             null, null, Venteårsak.VENT_ÅPEN_BEHANDLING));
         behandlingProsesseringTjeneste.opprettTasksForStartBehandling(behandling);
@@ -184,7 +185,7 @@ public class KøKontroller {
         var åpenBehandling = behandlingRevurderingRepository.finnÅpenYtelsesbehandling(fagsak.getId());
         if (åpenBehandling.isPresent()) {
             // Køes hvis finnes berørt, ellers legg dokument på åpen behandling
-            return åpenBehandling.filter(b -> b.harBehandlingÅrsak(BehandlingÅrsakType.BERØRT_BEHANDLING)).isPresent();
+            return åpenBehandling.filter(SpesialBehandling::erSpesialBehandling).isPresent();
         }
         return behandlingRevurderingRepository.finnKøetYtelsesbehandling(fagsak.getId()).isPresent() || flytkontroll.nyRevurderingSkalVente(fagsak);
     }

--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/vedtak/overlapp/HåndterOpphørAvYtelser.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/vedtak/overlapp/HåndterOpphørAvYtelser.java
@@ -15,6 +15,7 @@ import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingStatus;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingÅrsak;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingÅrsakType;
+import no.nav.foreldrepenger.behandlingslager.behandling.SpesialBehandling;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepositoryProvider;
 import no.nav.foreldrepenger.behandlingslager.fagsak.Fagsak;
@@ -95,7 +96,7 @@ public class HåndterOpphørAvYtelser {
         return behandlingRepository.hentSisteYtelsesBehandlingForFagsakId(fagsak.getId())
             .filter(b -> !BehandlingStatus.getFerdigbehandletStatuser().contains(b.getStatus()))
             .filter(b -> !b.harBehandlingÅrsak(årsakType))
-            .filter(b -> !b.harBehandlingÅrsak(BehandlingÅrsakType.BERØRT_BEHANDLING))
+            .filter(SpesialBehandling::erIkkeSpesialBehandling)
             .orElse(null);
     }
 

--- a/domenetjenester/mottak/src/test/java/no/nav/foreldrepenger/mottak/dokumentmottak/es/DokumentmottakerSøknadEngangsstønadHåndteringVedAvslåttBehandlingTest.java
+++ b/domenetjenester/mottak/src/test/java/no/nav/foreldrepenger/mottak/dokumentmottak/es/DokumentmottakerSøknadEngangsstønadHåndteringVedAvslåttBehandlingTest.java
@@ -24,6 +24,7 @@ import no.nav.foreldrepenger.mottak.dokumentmottak.impl.DokumentmottakerSøknadE
 import no.nav.foreldrepenger.mottak.dokumentmottak.impl.DokumentmottakerTestsupport;
 import no.nav.foreldrepenger.mottak.sakskompleks.KøKontroller;
 import no.nav.foreldrepenger.produksjonsstyring.behandlingenhet.BehandlendeEnhetTjeneste;
+import no.nav.foreldrepenger.skjæringstidspunkt.TomtUttakTjeneste;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTaskTjeneste;
 
 public class DokumentmottakerSøknadEngangsstønadHåndteringVedAvslåttBehandlingTest extends DokumentmottakerTestsupport {
@@ -56,7 +57,8 @@ public class DokumentmottakerSøknadEngangsstønadHåndteringVedAvslåttBehandli
             enhetsTjeneste,
             mockHist,
             mockMD,
-            behandlingsoppretterSpied);
+            behandlingsoppretterSpied,
+            mock(TomtUttakTjeneste.class));
         dokumentmottakerSøknad = new DokumentmottakerSøknadEngangsstønad(
             repositoryProvider,
             felles,
@@ -95,7 +97,8 @@ public class DokumentmottakerSøknadEngangsstønadHåndteringVedAvslåttBehandli
             enhetsTjeneste,
             mockHist,
             mockMD,
-            behandlingsoppretterSpied);
+            behandlingsoppretterSpied,
+            mock(TomtUttakTjeneste.class));
         dokumentmottakerSøknad = new DokumentmottakerSøknadEngangsstønad(
             repositoryProvider,
             felles,

--- a/domenetjenester/mottak/src/test/java/no/nav/foreldrepenger/mottak/dokumentmottak/fp/DokmentmottakerSøknadHåndterÅpenFørstegang.java
+++ b/domenetjenester/mottak/src/test/java/no/nav/foreldrepenger/mottak/dokumentmottak/fp/DokmentmottakerSøknadHåndterÅpenFørstegang.java
@@ -25,6 +25,7 @@ import no.nav.foreldrepenger.mottak.dokumentmottak.impl.DokumentmottakerSøknadD
 import no.nav.foreldrepenger.mottak.dokumentmottak.impl.DokumentmottakerTestsupport;
 import no.nav.foreldrepenger.mottak.sakskompleks.KøKontroller;
 import no.nav.foreldrepenger.produksjonsstyring.behandlingenhet.BehandlendeEnhetTjeneste;
+import no.nav.foreldrepenger.skjæringstidspunkt.TomtUttakTjeneste;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTaskTjeneste;
 
 public class DokmentmottakerSøknadHåndterÅpenFørstegang extends DokumentmottakerTestsupport {
@@ -57,7 +58,8 @@ public class DokmentmottakerSøknadHåndterÅpenFørstegang extends Dokumentmott
             enhetsTjeneste,
             mockHist,
             mockMD,
-            behandlingsoppretterSpied);
+            behandlingsoppretterSpied,
+            mock(TomtUttakTjeneste.class));
         dokumentmottakerSøknad = new DokumentmottakerSøknadDefault(
             repositoryProvider,
             felles,

--- a/domenetjenester/mottak/src/test/java/no/nav/foreldrepenger/mottak/dokumentmottak/fp/DokumentmottakerSøknadHåndteringVedAvslåttBehandlingTest.java
+++ b/domenetjenester/mottak/src/test/java/no/nav/foreldrepenger/mottak/dokumentmottak/fp/DokumentmottakerSøknadHåndteringVedAvslåttBehandlingTest.java
@@ -24,6 +24,7 @@ import no.nav.foreldrepenger.mottak.dokumentmottak.impl.DokumentmottakerSøknadD
 import no.nav.foreldrepenger.mottak.dokumentmottak.impl.DokumentmottakerTestsupport;
 import no.nav.foreldrepenger.mottak.sakskompleks.KøKontroller;
 import no.nav.foreldrepenger.produksjonsstyring.behandlingenhet.BehandlendeEnhetTjeneste;
+import no.nav.foreldrepenger.skjæringstidspunkt.TomtUttakTjeneste;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTaskTjeneste;
 
 public class DokumentmottakerSøknadHåndteringVedAvslåttBehandlingTest extends DokumentmottakerTestsupport {
@@ -56,7 +57,8 @@ public class DokumentmottakerSøknadHåndteringVedAvslåttBehandlingTest extends
             enhetsTjeneste,
             mockHist,
             mockMD,
-            behandlingsoppretterSpied);
+            behandlingsoppretterSpied,
+            mock(TomtUttakTjeneste.class));
         dokumentmottakerSøknad = new DokumentmottakerSøknadDefault(
             repositoryProvider,
             felles,

--- a/domenetjenester/mottak/src/test/java/no/nav/foreldrepenger/mottak/dokumentmottak/impl/DokumentmottakerEndringssøknadTest.java
+++ b/domenetjenester/mottak/src/test/java/no/nav/foreldrepenger/mottak/dokumentmottak/impl/DokumentmottakerEndringssøknadTest.java
@@ -53,6 +53,7 @@ import no.nav.foreldrepenger.mottak.dokumentmottak.HistorikkinnslagTjeneste;
 import no.nav.foreldrepenger.mottak.dokumentmottak.MottatteDokumentTjeneste;
 import no.nav.foreldrepenger.mottak.sakskompleks.KøKontroller;
 import no.nav.foreldrepenger.produksjonsstyring.behandlingenhet.BehandlendeEnhetTjeneste;
+import no.nav.foreldrepenger.skjæringstidspunkt.TomtUttakTjeneste;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTaskTjeneste;
 
 @ExtendWith(MockitoExtension.class)
@@ -103,7 +104,7 @@ public class DokumentmottakerEndringssøknadTest extends EntityManagerAwareTest 
         dokumentmottakerFelles = Mockito.spy(dokumentmottakerFelles);
 
         dokumentmottaker = new DokumentmottakerEndringssøknad(repositoryProvider, dokumentmottakerFelles,
-                behandlingsoppretter, kompletthetskontroller, køKontroller, fpUttakTjeneste);
+                behandlingsoppretter, kompletthetskontroller, køKontroller, fpUttakTjeneste, mock(TomtUttakTjeneste.class));
         dokumentmottaker = Mockito.spy(dokumentmottaker);
     }
 

--- a/domenetjenester/mottak/src/test/java/no/nav/foreldrepenger/mottak/dokumentmottak/impl/DokumentmottakerEndringssøknadTest.java
+++ b/domenetjenester/mottak/src/test/java/no/nav/foreldrepenger/mottak/dokumentmottak/impl/DokumentmottakerEndringssøknadTest.java
@@ -100,11 +100,12 @@ public class DokumentmottakerEndringssøknadTest extends EntityManagerAwareTest 
         lenient().when(enhetsTjeneste.finnBehandlendeEnhetFor(any(Fagsak.class))).thenReturn(enhet);
 
         dokumentmottakerFelles = new DokumentmottakerFelles(repositoryProvider, taskTjeneste,
-            enhetsTjeneste, historikkinnslagTjeneste, mottatteDokumentTjeneste, behandlingsoppretter);
+            enhetsTjeneste, historikkinnslagTjeneste, mottatteDokumentTjeneste, behandlingsoppretter,
+            mock(TomtUttakTjeneste.class));
         dokumentmottakerFelles = Mockito.spy(dokumentmottakerFelles);
 
         dokumentmottaker = new DokumentmottakerEndringssøknad(repositoryProvider, dokumentmottakerFelles,
-                behandlingsoppretter, kompletthetskontroller, køKontroller, fpUttakTjeneste, mock(TomtUttakTjeneste.class));
+                behandlingsoppretter, kompletthetskontroller, køKontroller, fpUttakTjeneste);
         dokumentmottaker = Mockito.spy(dokumentmottaker);
     }
 

--- a/domenetjenester/mottak/src/test/java/no/nav/foreldrepenger/mottak/dokumentmottak/impl/DokumentmottakerInntektsmeldingTest.java
+++ b/domenetjenester/mottak/src/test/java/no/nav/foreldrepenger/mottak/dokumentmottak/impl/DokumentmottakerInntektsmeldingTest.java
@@ -47,6 +47,7 @@ import no.nav.foreldrepenger.mottak.Behandlingsoppretter;
 import no.nav.foreldrepenger.mottak.dokumentmottak.HistorikkinnslagTjeneste;
 import no.nav.foreldrepenger.mottak.dokumentmottak.MottatteDokumentTjeneste;
 import no.nav.foreldrepenger.produksjonsstyring.behandlingenhet.BehandlendeEnhetTjeneste;
+import no.nav.foreldrepenger.skjæringstidspunkt.TomtUttakTjeneste;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTaskTjeneste;
 
 @CdiDbAwareTest
@@ -83,7 +84,7 @@ public class DokumentmottakerInntektsmeldingTest {
     public void oppsett() {
 
         dokumentmottakerFelles = new DokumentmottakerFelles(repositoryProvider, taskTjeneste, behandlendeEnhetTjeneste,
-                historikkinnslagTjeneste, mottatteDokumentTjeneste, behandlingsoppretter);
+                historikkinnslagTjeneste, mottatteDokumentTjeneste, behandlingsoppretter, mock(TomtUttakTjeneste.class));
 
         dokumentmottakerFelles = Mockito.spy(dokumentmottakerFelles);
 

--- a/domenetjenester/mottak/src/test/java/no/nav/foreldrepenger/mottak/dokumentmottak/impl/DokumentmottakerKlageTest.java
+++ b/domenetjenester/mottak/src/test/java/no/nav/foreldrepenger/mottak/dokumentmottak/impl/DokumentmottakerKlageTest.java
@@ -47,6 +47,7 @@ import no.nav.foreldrepenger.mottak.Behandlingsoppretter;
 import no.nav.foreldrepenger.mottak.dokumentmottak.HistorikkinnslagTjeneste;
 import no.nav.foreldrepenger.mottak.dokumentmottak.MottatteDokumentTjeneste;
 import no.nav.foreldrepenger.produksjonsstyring.behandlingenhet.BehandlendeEnhetTjeneste;
+import no.nav.foreldrepenger.skjæringstidspunkt.TomtUttakTjeneste;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTaskTjeneste;
 
 @CdiDbAwareTest
@@ -93,8 +94,8 @@ public class DokumentmottakerKlageTest {
 
         var behandlingskontrollTjeneste = DokumentmottakTestUtil.lagBehandlingskontrollTjenesteMock(serviceProvider);
 
-        dokumentmottakerFelles = new DokumentmottakerFelles(repositoryProvider, taskTjeneste,
-                behandlendeEnhetTjeneste, historikkinnslagTjeneste, mottatteDokumentTjeneste, behandlingsoppretter);
+        dokumentmottakerFelles = new DokumentmottakerFelles(repositoryProvider, taskTjeneste, behandlendeEnhetTjeneste,
+            historikkinnslagTjeneste, mottatteDokumentTjeneste, behandlingsoppretter, mock(TomtUttakTjeneste.class));
         dokumentmottakerFelles = Mockito.spy(dokumentmottakerFelles);
         var behOpprettTjeneste = new BehandlingOpprettingTjeneste(behandlingskontrollTjeneste, behandlendeEnhetTjeneste,
                 mock(HistorikkRepository.class), taskTjeneste);

--- a/domenetjenester/mottak/src/test/java/no/nav/foreldrepenger/mottak/dokumentmottak/impl/DokumentmottakerSøknadDefaultTest.java
+++ b/domenetjenester/mottak/src/test/java/no/nav/foreldrepenger/mottak/dokumentmottak/impl/DokumentmottakerSøknadDefaultTest.java
@@ -60,6 +60,7 @@ import no.nav.foreldrepenger.mottak.dokumentmottak.MottatteDokumentTjeneste;
 import no.nav.foreldrepenger.mottak.sakskompleks.KøKontroller;
 import no.nav.foreldrepenger.produksjonsstyring.behandlingenhet.BehandlendeEnhetTjeneste;
 import no.nav.foreldrepenger.produksjonsstyring.oppgavebehandling.task.OpprettOppgaveVurderDokumentTask;
+import no.nav.foreldrepenger.skjæringstidspunkt.TomtUttakTjeneste;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTaskData;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTaskTjeneste;
 import no.nav.vedtak.felles.prosesstask.api.TaskType;
@@ -105,7 +106,7 @@ public class DokumentmottakerSøknadDefaultTest extends EntityManagerAwareTest {
         lenient().when(enhetsTjeneste.gyldigEnhetNfpNk(any())).thenReturn(true);
 
         dokumentmottakerFelles = new DokumentmottakerFelles(repositoryProvider, taskTjeneste, enhetsTjeneste,
-                historikkinnslagTjeneste, mottatteDokumentTjeneste, behandlingsoppretter);
+                historikkinnslagTjeneste, mottatteDokumentTjeneste, behandlingsoppretter, mock(TomtUttakTjeneste.class));
         dokumentmottakerFelles = Mockito.spy(dokumentmottakerFelles);
 
         dokumentmottaker = new DokumentmottakerSøknadDefault(repositoryProvider, dokumentmottakerFelles,

--- a/domenetjenester/mottak/src/test/java/no/nav/foreldrepenger/mottak/dokumentmottak/impl/DokumentmottakerVedleggTest.java
+++ b/domenetjenester/mottak/src/test/java/no/nav/foreldrepenger/mottak/dokumentmottak/impl/DokumentmottakerVedleggTest.java
@@ -38,6 +38,7 @@ import no.nav.foreldrepenger.mottak.dokumentmottak.HistorikkinnslagTjeneste;
 import no.nav.foreldrepenger.mottak.dokumentmottak.MottatteDokumentTjeneste;
 import no.nav.foreldrepenger.produksjonsstyring.behandlingenhet.BehandlendeEnhetTjeneste;
 import no.nav.foreldrepenger.produksjonsstyring.oppgavebehandling.task.OpprettOppgaveVurderDokumentTask;
+import no.nav.foreldrepenger.skjæringstidspunkt.TomtUttakTjeneste;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTaskData;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTaskTjeneste;
 import no.nav.vedtak.felles.prosesstask.api.TaskType;
@@ -75,7 +76,7 @@ public class DokumentmottakerVedleggTest {
         lenient().when(behandlendeEnhetTjeneste.gyldigEnhetNfpNk(any())).thenReturn(true);
 
         dokumentmottakerFelles = new DokumentmottakerFelles(repositoryProvider, taskTjeneste, behandlendeEnhetTjeneste,
-                historikkinnslagTjeneste, mottatteDokumentTjeneste, behandlingsoppretter);
+                historikkinnslagTjeneste, mottatteDokumentTjeneste, behandlingsoppretter, mock(TomtUttakTjeneste.class));
         dokumentmottakerFelles = Mockito.spy(dokumentmottakerFelles);
 
         kompletthetskontroller = mock(Kompletthetskontroller.class);

--- a/domenetjenester/mottak/src/test/java/no/nav/foreldrepenger/mottak/dokumentmottak/impl/DokumentmottakerYtelsesesrelatertDokumentTest.java
+++ b/domenetjenester/mottak/src/test/java/no/nav/foreldrepenger/mottak/dokumentmottak/impl/DokumentmottakerYtelsesesrelatertDokumentTest.java
@@ -4,6 +4,7 @@ import static java.time.LocalDate.now;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -33,6 +34,7 @@ import no.nav.foreldrepenger.mottak.Behandlingsoppretter;
 import no.nav.foreldrepenger.mottak.dokumentmottak.HistorikkinnslagTjeneste;
 import no.nav.foreldrepenger.mottak.dokumentmottak.MottatteDokumentTjeneste;
 import no.nav.foreldrepenger.produksjonsstyring.behandlingenhet.BehandlendeEnhetTjeneste;
+import no.nav.foreldrepenger.skjæringstidspunkt.TomtUttakTjeneste;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTaskTjeneste;
 
 @CdiDbAwareTest
@@ -66,7 +68,7 @@ public class DokumentmottakerYtelsesesrelatertDokumentTest {
     public void oppsett() {
         lenient().when(behandlendeEnhetTjeneste.gyldigEnhetNfpNk(any())).thenReturn(true);
         dokumentmottakerFelles = new DokumentmottakerFelles(repositoryProvider, taskTjeneste, behandlendeEnhetTjeneste,
-                historikkinnslagTjeneste, mottatteDokumentTjeneste, behandlingsoppretter);
+                historikkinnslagTjeneste, mottatteDokumentTjeneste, behandlingsoppretter, mock(TomtUttakTjeneste.class));
 
         dokumentmottakerFelles = Mockito.spy(dokumentmottakerFelles);
 

--- a/domenetjenester/mottak/src/test/java/no/nav/foreldrepenger/mottak/dokumentpersisterer/SøknadUtsettelseUttakDatoTest.java
+++ b/domenetjenester/mottak/src/test/java/no/nav/foreldrepenger/mottak/dokumentpersisterer/SøknadUtsettelseUttakDatoTest.java
@@ -1,0 +1,75 @@
+package no.nav.foreldrepenger.mottak.dokumentpersisterer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDate;
+
+import org.junit.jupiter.api.Test;
+
+import no.nav.foreldrepenger.mottak.dokumentpersiterer.impl.søknad.v3.EndringUtsettelseUttak;
+import no.nav.foreldrepenger.mottak.dokumentpersiterer.impl.søknad.v3.SøknadWrapper;
+import no.nav.vedtak.felles.xml.soeknad.endringssoeknad.v3.Endringssoeknad;
+import no.nav.vedtak.felles.xml.soeknad.felles.v3.Bruker;
+import no.nav.vedtak.felles.xml.soeknad.foreldrepenger.v3.Foreldrepenger;
+import no.nav.vedtak.felles.xml.soeknad.uttak.v3.Fordeling;
+import no.nav.vedtak.felles.xml.soeknad.uttak.v3.Utsettelsesperiode;
+import no.nav.vedtak.felles.xml.soeknad.uttak.v3.Uttaksperiode;
+import no.nav.vedtak.felles.xml.soeknad.v3.OmYtelse;
+import no.nav.vedtak.felles.xml.soeknad.v3.Soeknad;
+
+public class SøknadUtsettelseUttakDatoTest {
+
+    @Test
+    public void finnUttakUtsettelseFraEndringssøknad() {
+        var baseDato = LocalDate.now();
+        var uttaksPeriode = new Uttaksperiode();
+        uttaksPeriode.setFom(baseDato);
+        uttaksPeriode.setTom(baseDato.plusWeeks(2));
+        var utsettelsePeriode = new Utsettelsesperiode();
+        utsettelsePeriode.setFom(baseDato.plusWeeks(8));
+        utsettelsePeriode.setTom(baseDato.plusWeeks(12));
+        var fordeling = new Fordeling();
+        fordeling.getPerioder().add(utsettelsePeriode);
+        fordeling.getPerioder().add(uttaksPeriode);
+        var endring = new Endringssoeknad();
+        endring.setFordeling(fordeling);
+        var omYtelse = new OmYtelse();
+        omYtelse.getAny().add(new no.nav.vedtak.felles.xml.soeknad.endringssoeknad.v3.ObjectFactory().createEndringssoeknad(endring));
+        var søknad = new Soeknad();
+        søknad.setMottattDato(LocalDate.now());
+        søknad.setSoeker(new Bruker());
+        søknad.setOmYtelse(omYtelse);
+
+        var wrapper = new SøknadWrapper(søknad);
+        var uu = EndringUtsettelseUttak.ekstraherUtsettelseUttakFra(wrapper);
+        assertThat(uu.uttakFom()).isEqualTo(baseDato);
+        assertThat(uu.utsettelseFom()).isEqualTo(baseDato.plusWeeks(8));
+    }
+
+    @Test
+    public void finnUttakUtsettelseFraFørstegangssøknad() {
+        var baseDato = LocalDate.now();
+        var utsettelsePeriode = new Utsettelsesperiode();
+        var uttaksPeriode = new Uttaksperiode();
+        utsettelsePeriode.setFom(baseDato);
+        utsettelsePeriode.setTom(baseDato.plusWeeks(2));
+        uttaksPeriode.setFom(baseDato.plusWeeks(8));
+        uttaksPeriode.setTom(baseDato.plusWeeks(12));
+        var fordeling = new Fordeling();
+        fordeling.getPerioder().add(utsettelsePeriode);
+        fordeling.getPerioder().add(uttaksPeriode);
+        var fp = new Foreldrepenger();
+        fp.setFordeling(fordeling);
+        var omYtelse = new OmYtelse();
+        omYtelse.getAny().add(new no.nav.vedtak.felles.xml.soeknad.foreldrepenger.v3.ObjectFactory().createForeldrepenger(fp));
+        var søknad = new Soeknad();
+        søknad.setMottattDato(LocalDate.now());
+        søknad.setSoeker(new Bruker());
+        søknad.setOmYtelse(omYtelse);
+
+        var wrapper = new SøknadWrapper(søknad);
+        var uu = EndringUtsettelseUttak.ekstraherUtsettelseUttakFra(wrapper);
+        assertThat(uu.utsettelseFom()).isEqualTo(baseDato);
+        assertThat(uu.uttakFom()).isEqualTo(baseDato.plusWeeks(8));
+    }
+}

--- a/domenetjenester/mottak/src/test/java/no/nav/foreldrepenger/mottak/sakskompleks/BerørtBehandlingKontrollerTest.java
+++ b/domenetjenester/mottak/src/test/java/no/nav/foreldrepenger/mottak/sakskompleks/BerørtBehandlingKontrollerTest.java
@@ -385,12 +385,11 @@ public class BerørtBehandlingKontrollerTest {
         when(beregnFeriepenger.avvikBeregnetFeriepengerBeregningsresultat(any(), any())).thenReturn(true);
         when(beregningsresultatRepository.hentUtbetBeregningsresultat(any())).thenReturn(Optional.of(new BeregningsresultatEntitet()));
         when(behandlingRepository.hentÅpneYtelseBehandlingerForFagsakId(any())).thenReturn(List.of());
-        when(behandlingsoppretter.opprettRevurderingMultiÅrsak(any(), any())).thenReturn(berørtFeriepenger);
+        when(behandlingsoppretter.opprettRevurdering(any(), eq(BehandlingÅrsakType.REBEREGN_FERIEPENGER))).thenReturn(berørtFeriepenger);
         // Act
         berørtBehandlingKontroller.vurderNesteOppgaveIBehandlingskø(fBehandling.getId());
         // Assert opprett berørt (for medforelder)
-        verify(behandlingsoppretter).opprettRevurderingMultiÅrsak(fagsakMedforelder,
-            List.of(BehandlingÅrsakType.BERØRT_BEHANDLING, BehandlingÅrsakType.REBEREGN_FERIEPENGER));
+        verify(behandlingsoppretter).opprettRevurdering(fagsakMedforelder, BehandlingÅrsakType.REBEREGN_FERIEPENGER);
         verify(behandlingProsesseringTjeneste).opprettTasksForStartBehandling(any());
     }
 

--- a/domenetjenester/mottak/src/test/java/no/nav/foreldrepenger/mottak/sakskompleks/BerørtBehandlingKontrollerTest.java
+++ b/domenetjenester/mottak/src/test/java/no/nav/foreldrepenger/mottak/sakskompleks/BerørtBehandlingKontrollerTest.java
@@ -228,15 +228,17 @@ public class BerørtBehandlingKontrollerTest {
     private void settOppAvsluttetBehandlingBruker() {
         when(behandlingRepository.finnSisteAvsluttedeIkkeHenlagteBehandling(fagsak.getId())).thenReturn(
             Optional.of(fBehandling));
-        when(behandlingsresultatRepository.hentHvisEksisterer(fBehandling.getId())).thenReturn(
-            lagBehandlingsresultatInnvilget(fBehandling));
+        var br = lagBehandlingsresultatInnvilget(fBehandling);
+        when(behandlingsresultatRepository.hentHvisEksisterer(fBehandling.getId())).thenReturn(Optional.of(br));
+        when(behandlingsresultatRepository.hent(fBehandling.getId())).thenReturn(br);
     }
 
     private void settOppAvsluttetBehandlingAnnenpart() {
         when(behandlingRepository.finnSisteAvsluttedeIkkeHenlagteBehandling(fagsakMedforelder.getId())).thenReturn(
             Optional.of(fBehandlingMedforelder));
-        when(behandlingsresultatRepository.hentHvisEksisterer(fBehandling.getId())).thenReturn(
-            lagBehandlingsresultatInnvilget(fBehandlingMedforelder));
+        var br = lagBehandlingsresultatInnvilget(fBehandlingMedforelder);
+        when(behandlingsresultatRepository.hentHvisEksisterer(fBehandlingMedforelder.getId())).thenReturn(Optional.of(br));
+        when(behandlingsresultatRepository.hent(fBehandlingMedforelder.getId())).thenReturn(br);
     }
 
     private void settOppKøBruker() {
@@ -285,10 +287,10 @@ public class BerørtBehandlingKontrollerTest {
             .buildFor(behandling));
     }
 
-    private Optional<Behandlingsresultat> lagBehandlingsresultatInnvilget(Behandling behandling) {
-        return Optional.of(Behandlingsresultat.builder()
+    private Behandlingsresultat lagBehandlingsresultatInnvilget(Behandling behandling) {
+        return Behandlingsresultat.builder()
             .medBehandlingResultatType(BehandlingResultatType.INNVILGET)
-            .buildFor(behandling));
+            .buildFor(behandling);
     }
 
 

--- a/domenetjenester/mottak/src/test/java/no/nav/foreldrepenger/mottak/sakskompleks/BerørtBehandlingKontrollerTest.java
+++ b/domenetjenester/mottak/src/test/java/no/nav/foreldrepenger/mottak/sakskompleks/BerørtBehandlingKontrollerTest.java
@@ -367,7 +367,7 @@ public class BerørtBehandlingKontrollerTest {
         settOppAvsluttetBehandlingBruker();
         settOppAvsluttetBehandlingAnnenpart();
         when(berørtBehandlingTjeneste.skalBerørtBehandlingOpprettes(any(), any(Long.class), any(Long.class))).thenReturn(true);
-        when(behandlingRepository.hentSisteYtelsesBehandlingForFagsakId(any())).thenReturn(Optional.of(berørt));
+        when(behandlingRepository.hentÅpneYtelseBehandlingerForFagsakId(any())).thenReturn(List.of(berørt));
         // Act
         berørtBehandlingKontroller.vurderNesteOppgaveIBehandlingskø(fBehandlingMedforelder.getId());
         // Assert opprett berørt (for medforelder)

--- a/domenetjenester/registerinnhenting/src/main/java/no/nav/foreldrepenger/domene/registerinnhenting/RegisterdataEndringshåndterer.java
+++ b/domenetjenester/registerinnhenting/src/main/java/no/nav/foreldrepenger/domene/registerinnhenting/RegisterdataEndringshåndterer.java
@@ -16,9 +16,9 @@ import org.slf4j.LoggerFactory;
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandlingsresultat;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingsresultatRepository;
-import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingÅrsakType;
 import no.nav.foreldrepenger.behandlingslager.behandling.EndringsresultatDiff;
 import no.nav.foreldrepenger.behandlingslager.behandling.EndringsresultatSnapshot;
+import no.nav.foreldrepenger.behandlingslager.behandling.SpesialBehandling;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepositoryProvider;
 import no.nav.foreldrepenger.behandlingslager.behandling.vilkår.Vilkår;
@@ -72,7 +72,7 @@ public class RegisterdataEndringshåndterer {
 
     public boolean skalInnhenteRegisteropplysningerPåNytt(Behandling behandling) {
         if (!endringskontroller.erRegisterinnhentingPassert(behandling) || erAvslag(behandling)
-            || behandling.erSaksbehandlingAvsluttet() || behandling.harBehandlingÅrsak(BehandlingÅrsakType.BERØRT_BEHANDLING)) {
+            || behandling.erSaksbehandlingAvsluttet() || SpesialBehandling.skalGrunnlagBeholdes(behandling)) {
             return false;
         }
         var midnatt = LocalDate.now().atStartOfDay();

--- a/domenetjenester/skjaeringstidspunkt/src/main/java/no/nav/foreldrepenger/skjæringstidspunkt/TomtUttakTjeneste.java
+++ b/domenetjenester/skjaeringstidspunkt/src/main/java/no/nav/foreldrepenger/skjæringstidspunkt/TomtUttakTjeneste.java
@@ -1,0 +1,73 @@
+package no.nav.foreldrepenger.skjæringstidspunkt;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
+import no.nav.foreldrepenger.behandlingslager.behandling.familiehendelse.FamilieHendelseGrunnlagEntitet;
+import no.nav.foreldrepenger.behandlingslager.behandling.familiehendelse.FamilieHendelseRepository;
+import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepository;
+import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepositoryProvider;
+import no.nav.foreldrepenger.behandlingslager.fagsak.Fagsak;
+import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakRelasjonRepository;
+import no.nav.foreldrepenger.behandlingslager.uttak.fp.FpUttakRepository;
+import no.nav.foreldrepenger.konfig.Environment;
+
+@ApplicationScoped
+public class TomtUttakTjeneste {
+
+    private static final Logger LOG = LoggerFactory.getLogger(TomtUttakTjeneste.class);
+    private static final boolean ER_PROD = Environment.current().isProd();
+
+    private FamilieHendelseRepository familieGrunnlagRepository;
+    private FpUttakRepository fpUttakRepository;
+    private BehandlingRepository behandlingRepository;
+    private FagsakRelasjonRepository fagsakRelasjonRepository;
+    private UtsettelseCore2021 utsettelse2021;
+
+    TomtUttakTjeneste() {
+        // CDI
+    }
+
+    @Inject
+    public TomtUttakTjeneste(BehandlingRepositoryProvider repositoryProvider,
+                             UtsettelseCore2021 utsettelse2021) {
+        this.behandlingRepository = repositoryProvider.getBehandlingRepository();
+        this.fagsakRelasjonRepository = repositoryProvider.getFagsakRelasjonRepository();
+        this.fpUttakRepository = repositoryProvider.getFpUttakRepository();
+        this.familieGrunnlagRepository = repositoryProvider.getFamilieHendelseRepository();
+        this.utsettelse2021 = utsettelse2021;
+    }
+
+    public Optional<LocalDate> startdatoUttakResultatFrittUttak(Fagsak fagsak) {
+        return behandlingRepository.finnSisteAvsluttedeIkkeHenlagteBehandling(fagsak.getId())
+            .filter(b -> !kreverSammenhengendeUttak(b))
+            .map(b -> fpUttakRepository.hentUttakResultat(b.getId()).getGjeldendePerioder())
+            .flatMap(ur -> UtsettelseCore2021.finnFørsteDatoFraUttakResultat(ur.getPerioder(), false));
+    }
+
+    private boolean kreverSammenhengendeUttak(Behandling behandling) {
+        var sammenhengendeUttak = familieGrunnlagRepository.hentAggregatHvisEksisterer(behandling.getId())
+            .or(() -> finnFHSistVedtatteBehandlingKobletFagsak(behandling))
+            .map(utsettelse2021::kreverSammenhengendeUttak).orElse(UtsettelseCore2021.DEFAULT_KREVER_SAMMENHENGENDE_UTTAK);
+        if (!sammenhengendeUttak && ER_PROD) {
+            LOG.info("Prod uten krav om sammenhengende periode - sjekk om korrekt, saksnummer {}", behandling.getFagsak().getSaksnummer());
+        } else if (!sammenhengendeUttak) {
+            LOG.info("Non-prod uten krav om sammenhengende periode, saksnummer {} behandling {}", behandling.getFagsak().getSaksnummer(), behandling.getId());
+        }
+        return sammenhengendeUttak;
+    }
+
+    private Optional<FamilieHendelseGrunnlagEntitet> finnFHSistVedtatteBehandlingKobletFagsak(Behandling behandling) {
+        return fagsakRelasjonRepository.finnRelasjonForHvisEksisterer(behandling.getFagsak())
+            .flatMap(fr -> fr.getRelatertFagsak(behandling.getFagsak()))
+            .flatMap(f -> behandlingRepository.finnSisteAvsluttedeIkkeHenlagteBehandling(f.getId()))
+            .flatMap(b -> familieGrunnlagRepository.hentAggregatHvisEksisterer(b.getId()));
+    }
+}

--- a/domenetjenester/skjaeringstidspunkt/src/main/java/no/nav/foreldrepenger/skjæringstidspunkt/TomtUttakTjeneste.java
+++ b/domenetjenester/skjaeringstidspunkt/src/main/java/no/nav/foreldrepenger/skjæringstidspunkt/TomtUttakTjeneste.java
@@ -9,6 +9,7 @@ import javax.inject.Inject;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepositoryProvider;
 import no.nav.foreldrepenger.behandlingslager.fagsak.Fagsak;
+import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakYtelseType;
 import no.nav.foreldrepenger.behandlingslager.uttak.fp.FpUttakRepository;
 
 @ApplicationScoped
@@ -33,6 +34,7 @@ public class TomtUttakTjeneste {
 
     public Optional<LocalDate> startdatoUttakResultatFrittUttak(Fagsak fagsak) {
         return behandlingRepository.finnSisteAvsluttedeIkkeHenlagteBehandling(fagsak.getId())
+            .filter(b -> FagsakYtelseType.FORELDREPENGER.equals(b.getFagsakYtelseType()))
             .filter(b -> !utsettelseBehandling2021.kreverSammenhengendeUttak(b))
             .map(b -> fpUttakRepository.hentUttakResultat(b.getId()).getGjeldendePerioder())
             .flatMap(ur -> UtsettelseCore2021.finnFørsteDatoFraUttakResultat(ur.getPerioder(), false));

--- a/domenetjenester/skjaeringstidspunkt/src/main/java/no/nav/foreldrepenger/skjæringstidspunkt/TomtUttakTjeneste.java
+++ b/domenetjenester/skjaeringstidspunkt/src/main/java/no/nav/foreldrepenger/skjæringstidspunkt/TomtUttakTjeneste.java
@@ -6,30 +6,18 @@ import java.util.Optional;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
-import no.nav.foreldrepenger.behandlingslager.behandling.familiehendelse.FamilieHendelseGrunnlagEntitet;
-import no.nav.foreldrepenger.behandlingslager.behandling.familiehendelse.FamilieHendelseRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepositoryProvider;
 import no.nav.foreldrepenger.behandlingslager.fagsak.Fagsak;
-import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakRelasjonRepository;
 import no.nav.foreldrepenger.behandlingslager.uttak.fp.FpUttakRepository;
-import no.nav.foreldrepenger.konfig.Environment;
 
 @ApplicationScoped
 public class TomtUttakTjeneste {
 
-    private static final Logger LOG = LoggerFactory.getLogger(TomtUttakTjeneste.class);
-    private static final boolean ER_PROD = Environment.current().isProd();
 
-    private FamilieHendelseRepository familieGrunnlagRepository;
     private FpUttakRepository fpUttakRepository;
     private BehandlingRepository behandlingRepository;
-    private FagsakRelasjonRepository fagsakRelasjonRepository;
-    private UtsettelseCore2021 utsettelse2021;
+    private UtsettelseBehandling2021 utsettelseBehandling2021;
 
     TomtUttakTjeneste() {
         // CDI
@@ -37,37 +25,16 @@ public class TomtUttakTjeneste {
 
     @Inject
     public TomtUttakTjeneste(BehandlingRepositoryProvider repositoryProvider,
-                             UtsettelseCore2021 utsettelse2021) {
+                             UtsettelseBehandling2021 utsettelseBehandling2021) {
         this.behandlingRepository = repositoryProvider.getBehandlingRepository();
-        this.fagsakRelasjonRepository = repositoryProvider.getFagsakRelasjonRepository();
         this.fpUttakRepository = repositoryProvider.getFpUttakRepository();
-        this.familieGrunnlagRepository = repositoryProvider.getFamilieHendelseRepository();
-        this.utsettelse2021 = utsettelse2021;
+        this.utsettelseBehandling2021 = utsettelseBehandling2021;
     }
 
     public Optional<LocalDate> startdatoUttakResultatFrittUttak(Fagsak fagsak) {
         return behandlingRepository.finnSisteAvsluttedeIkkeHenlagteBehandling(fagsak.getId())
-            .filter(b -> !kreverSammenhengendeUttak(b))
+            .filter(b -> !utsettelseBehandling2021.kreverSammenhengendeUttak(b))
             .map(b -> fpUttakRepository.hentUttakResultat(b.getId()).getGjeldendePerioder())
             .flatMap(ur -> UtsettelseCore2021.finnFørsteDatoFraUttakResultat(ur.getPerioder(), false));
-    }
-
-    private boolean kreverSammenhengendeUttak(Behandling behandling) {
-        var sammenhengendeUttak = familieGrunnlagRepository.hentAggregatHvisEksisterer(behandling.getId())
-            .or(() -> finnFHSistVedtatteBehandlingKobletFagsak(behandling))
-            .map(utsettelse2021::kreverSammenhengendeUttak).orElse(UtsettelseCore2021.DEFAULT_KREVER_SAMMENHENGENDE_UTTAK);
-        if (!sammenhengendeUttak && ER_PROD) {
-            LOG.info("Prod uten krav om sammenhengende periode - sjekk om korrekt, saksnummer {}", behandling.getFagsak().getSaksnummer());
-        } else if (!sammenhengendeUttak) {
-            LOG.info("Non-prod uten krav om sammenhengende periode, saksnummer {} behandling {}", behandling.getFagsak().getSaksnummer(), behandling.getId());
-        }
-        return sammenhengendeUttak;
-    }
-
-    private Optional<FamilieHendelseGrunnlagEntitet> finnFHSistVedtatteBehandlingKobletFagsak(Behandling behandling) {
-        return fagsakRelasjonRepository.finnRelasjonForHvisEksisterer(behandling.getFagsak())
-            .flatMap(fr -> fr.getRelatertFagsak(behandling.getFagsak()))
-            .flatMap(f -> behandlingRepository.finnSisteAvsluttedeIkkeHenlagteBehandling(f.getId()))
-            .flatMap(b -> familieGrunnlagRepository.hentAggregatHvisEksisterer(b.getId()));
     }
 }

--- a/domenetjenester/skjaeringstidspunkt/src/main/java/no/nav/foreldrepenger/skjæringstidspunkt/UtsettelseBehandling2021.java
+++ b/domenetjenester/skjaeringstidspunkt/src/main/java/no/nav/foreldrepenger/skjæringstidspunkt/UtsettelseBehandling2021.java
@@ -39,13 +39,20 @@ public class UtsettelseBehandling2021 {
 
     public boolean kreverSammenhengendeUttak(Long behandlingId) {
         return familieHendelseRepository.hentAggregatHvisEksisterer(behandlingId)
-            .or(() -> vedtattFamilieHendelseRelatertFagsak(behandlingId))
+            .or(() -> vedtattFamilieHendelseRelatertFagsak(behandlingRepository.hentBehandling(behandlingId)))
             .map(utsettelseCore::kreverSammenhengendeUttak)
             .orElse(UtsettelseCore2021.DEFAULT_KREVER_SAMMENHENGENDE_UTTAK);
     }
 
-    private Optional<FamilieHendelseGrunnlagEntitet> vedtattFamilieHendelseRelatertFagsak(Long behandlingId) {
-        var fagsak = behandlingRepository.hentBehandling(behandlingId).getFagsak();
+    public boolean kreverSammenhengendeUttak(Behandling behandling) {
+        return familieHendelseRepository.hentAggregatHvisEksisterer(behandling.getId())
+            .or(() -> vedtattFamilieHendelseRelatertFagsak(behandling))
+            .map(utsettelseCore::kreverSammenhengendeUttak)
+            .orElse(UtsettelseCore2021.DEFAULT_KREVER_SAMMENHENGENDE_UTTAK);
+    }
+
+    private Optional<FamilieHendelseGrunnlagEntitet> vedtattFamilieHendelseRelatertFagsak(Behandling behandling) {
+        var fagsak = behandling.getFagsak();
         return fagsakRelasjonRepository.finnRelasjonForHvisEksisterer(fagsak)
             .flatMap(r -> r.getRelatertFagsak(fagsak)).map(Fagsak::getId)
             .flatMap(behandlingRepository::finnSisteAvsluttedeIkkeHenlagteBehandling).map(Behandling::getId)

--- a/domenetjenester/skjaeringstidspunkt/src/main/java/no/nav/foreldrepenger/skjæringstidspunkt/fp/SkjæringstidspunktTjenesteImpl.java
+++ b/domenetjenester/skjaeringstidspunkt/src/main/java/no/nav/foreldrepenger/skjæringstidspunkt/fp/SkjæringstidspunktTjenesteImpl.java
@@ -24,11 +24,9 @@ import no.nav.foreldrepenger.behandlingslager.behandling.søknad.SøknadReposito
 import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.AvklarteUttakDatoerEntitet;
 import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.YtelseFordelingAggregat;
 import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.YtelsesFordelingRepository;
-import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakRelasjonRepository;
 import no.nav.foreldrepenger.behandlingslager.uttak.fp.FpUttakRepository;
 import no.nav.foreldrepenger.behandlingslager.uttak.fp.UttakResultatEntitet;
 import no.nav.foreldrepenger.behandlingslager.uttak.fp.UttakResultatPerioderEntitet;
-import no.nav.foreldrepenger.konfig.Environment;
 import no.nav.foreldrepenger.skjæringstidspunkt.SkjæringstidspunktRegisterinnhentingTjeneste;
 import no.nav.foreldrepenger.skjæringstidspunkt.SkjæringstidspunktTjeneste;
 import no.nav.foreldrepenger.skjæringstidspunkt.UtsettelseBehandling2021;
@@ -42,7 +40,6 @@ import no.nav.vedtak.konfig.Tid;
 public class SkjæringstidspunktTjenesteImpl implements SkjæringstidspunktTjeneste , SkjæringstidspunktRegisterinnhentingTjeneste {
 
     private static final Logger LOG = LoggerFactory.getLogger(SkjæringstidspunktTjenesteImpl.class);
-    private static final boolean ER_PROD = Environment.current().isProd();
 
     private FamilieHendelseRepository familieGrunnlagRepository;
     private SkjæringstidspunktUtils utlederUtils;
@@ -51,7 +48,6 @@ public class SkjæringstidspunktTjenesteImpl implements SkjæringstidspunktTjene
     private OpptjeningRepository opptjeningRepository;
     private SøknadRepository søknadRepository;
     private BehandlingRepository behandlingRepository;
-    private FagsakRelasjonRepository fagsakRelasjonRepository;
     private YtelseMaksdatoTjeneste ytelseMaksdatoTjeneste;
     private UtsettelseBehandling2021 utsettelse2021;
 
@@ -65,7 +61,6 @@ public class SkjæringstidspunktTjenesteImpl implements SkjæringstidspunktTjene
                                           SkjæringstidspunktUtils utlederUtils,
                                           UtsettelseBehandling2021 utsettelse2021) {
         this.behandlingRepository = repositoryProvider.getBehandlingRepository();
-        this.fagsakRelasjonRepository = repositoryProvider.getFagsakRelasjonRepository();
         this.ytelsesFordelingRepository = repositoryProvider.getYtelsesFordelingRepository();
         this.fpUttakRepository = repositoryProvider.getFpUttakRepository();
         this.opptjeningRepository = repositoryProvider.getOpptjeningRepository();

--- a/domenetjenester/skjaeringstidspunkt/src/test/java/no/nav/foreldrepenger/skjæringstidspunkt/fp/SkjæringstidspunktTjenesteImplTest.java
+++ b/domenetjenester/skjaeringstidspunkt/src/test/java/no/nav/foreldrepenger/skjæringstidspunkt/fp/SkjæringstidspunktTjenesteImplTest.java
@@ -20,6 +20,7 @@ import no.nav.foreldrepenger.behandlingslager.testutilities.behandling.ScenarioM
 import no.nav.foreldrepenger.dbstoette.EntityManagerAwareTest;
 import no.nav.foreldrepenger.domene.tid.VirkedagUtil;
 import no.nav.foreldrepenger.skjæringstidspunkt.SkjæringstidspunktTjeneste;
+import no.nav.foreldrepenger.skjæringstidspunkt.UtsettelseBehandling2021;
 import no.nav.foreldrepenger.skjæringstidspunkt.UtsettelseCore2021;
 
 public class SkjæringstidspunktTjenesteImplTest extends EntityManagerAwareTest {
@@ -27,12 +28,13 @@ public class SkjæringstidspunktTjenesteImplTest extends EntityManagerAwareTest 
     private BehandlingRepositoryProvider repositoryProvider;
     private SkjæringstidspunktTjeneste skjæringstidspunktTjeneste;
     private SkjæringstidspunktUtils stputil = new SkjæringstidspunktUtils(Period.parse("P4M"), Period.parse("P1Y"));
-    private UtsettelseCore2021 utsettelseCore2021 = new UtsettelseCore2021(LocalDate.now().minusMonths(1));
+    private UtsettelseBehandling2021 utsettelse2021;
 
     @BeforeEach
     void setUp() {
         repositoryProvider = new BehandlingRepositoryProvider(getEntityManager());
-        skjæringstidspunktTjeneste = new SkjæringstidspunktTjenesteImpl(repositoryProvider, null, stputil, utsettelseCore2021);
+        utsettelse2021 = new UtsettelseBehandling2021(new UtsettelseCore2021(LocalDate.now().minusMonths(1)), repositoryProvider);
+        skjæringstidspunktTjeneste = new SkjæringstidspunktTjenesteImpl(repositoryProvider, null, stputil, utsettelse2021);
     }
 
     @Test

--- a/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/KopierForeldrepengerUttaktjeneste.java
+++ b/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/KopierForeldrepengerUttaktjeneste.java
@@ -6,10 +6,10 @@ import javax.inject.Inject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import no.nav.foreldrepenger.behandling.BehandlingReferanse;
 import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.YtelsesFordelingRepository;
 import no.nav.foreldrepenger.behandlingslager.uttak.fp.FpUttakRepository;
 import no.nav.foreldrepenger.behandlingslager.uttak.fp.UttakResultatEntitet;
+import no.nav.foreldrepenger.behandlingslager.uttak.fp.UttakResultatPerioderEntitet;
 import no.nav.foreldrepenger.domene.uttak.fastsetteperioder.FastsettePerioderRevurderingUtil;
 
 @ApplicationScoped
@@ -31,19 +31,24 @@ public class KopierForeldrepengerUttaktjeneste {
         //CDI
     }
 
-    public void kopierUttakFraOriginalBehandling(BehandlingReferanse referanse) {
-        kopierUttaksgrunnlagSøknadsfristResultatFraOriginalBehandling(referanse);
-        kopierUttaksresultatFraOriginalBehandling(referanse);
+    public void kopierUttakFraOriginalBehandling(Long originalBehandlingId, Long behandlingId) {
+        kopierUttaksgrunnlagSøknadsfristResultatFraOriginalBehandling(originalBehandlingId, behandlingId);
+        kopierUttaksresultatFraOriginalBehandling(originalBehandlingId, behandlingId);
     }
 
-    public void kopierUttaksgrunnlagSøknadsfristResultatFraOriginalBehandling(BehandlingReferanse ref) {
-        LOG.info("Kopierer yfgrunnlag fra behandling {}, til behandling {}", ref.getOriginalBehandlingId(), ref.getBehandlingId());
-        ytelsesFordelingRepository.kopierGrunnlagFraEksisterendeBehandlingForOverhoppUttak(ref.getOriginalBehandlingId().orElseThrow(), ref.getBehandlingId());
+    public void lagreTomtUttakResultat(Long behandlingId) {
+        var tomtUttak = new UttakResultatPerioderEntitet();
+        fpUttakRepository.lagreOpprinneligUttakResultatPerioder(behandlingId, tomtUttak);
     }
 
-    public void kopierUttaksresultatFraOriginalBehandling(BehandlingReferanse referanse) {
-        fpUttakRepository.hentUttakResultatHvisEksisterer(referanse.getOriginalBehandlingId().orElseThrow())
-            .ifPresent(uttak -> kopierUttaksresultat(referanse.getBehandlingId(), uttak));
+    public void kopierUttaksgrunnlagSøknadsfristResultatFraOriginalBehandling(Long originalBehandlingId, Long behandlingId) {
+        LOG.info("Kopierer yfgrunnlag fra behandling {}, til behandling {}", originalBehandlingId, behandlingId);
+        ytelsesFordelingRepository.kopierGrunnlagFraEksisterendeBehandlingForOverhoppUttak(originalBehandlingId, behandlingId);
+    }
+
+    public void kopierUttaksresultatFraOriginalBehandling(Long originalBehandlingId, Long behandlingId) {
+        fpUttakRepository.hentUttakResultatHvisEksisterer(originalBehandlingId)
+            .ifPresent(uttak -> kopierUttaksresultat(behandlingId, uttak));
     }
 
     private void kopierUttaksresultat(Long behandlingId, UttakResultatEntitet uttak) {

--- a/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/KopierForeldrepengerUttaktjeneste.java
+++ b/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/KopierForeldrepengerUttaktjeneste.java
@@ -9,7 +9,6 @@ import org.slf4j.LoggerFactory;
 import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.YtelsesFordelingRepository;
 import no.nav.foreldrepenger.behandlingslager.uttak.fp.FpUttakRepository;
 import no.nav.foreldrepenger.behandlingslager.uttak.fp.UttakResultatEntitet;
-import no.nav.foreldrepenger.behandlingslager.uttak.fp.UttakResultatPerioderEntitet;
 import no.nav.foreldrepenger.domene.uttak.fastsetteperioder.FastsettePerioderRevurderingUtil;
 
 @ApplicationScoped
@@ -37,8 +36,11 @@ public class KopierForeldrepengerUttaktjeneste {
     }
 
     public void lagreTomtUttakResultat(Long behandlingId) {
-        var tomtUttak = new UttakResultatPerioderEntitet();
-        fpUttakRepository.lagreOpprinneligUttakResultatPerioder(behandlingId, tomtUttak);
+        /* TODO: evaluer testresultat og vurdere dette alternativet
+            var tomtUttak = new UttakResultatPerioderEntitet();
+            fpUttakRepository.lagreOpprinneligUttakResultatPerioder(behandlingId, tomtUttak);
+         */
+        fpUttakRepository.deaktivterAktivtResultat(behandlingId);
     }
 
     public void kopierUttaksgrunnlagSøknadsfristResultatFraOriginalBehandling(Long originalBehandlingId, Long behandlingId) {

--- a/domenetjenester/vedtak/src/main/java/no/nav/foreldrepenger/domene/vedtak/intern/SendVedtaksbrev.java
+++ b/domenetjenester/vedtak/src/main/java/no/nav/foreldrepenger/domene/vedtak/intern/SendVedtaksbrev.java
@@ -11,6 +11,7 @@ import org.slf4j.LoggerFactory;
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingType;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingÅrsakType;
+import no.nav.foreldrepenger.behandlingslager.behandling.SpesialBehandling;
 import no.nav.foreldrepenger.behandlingslager.behandling.anke.AnkeRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.anke.AnkeVurdering;
 import no.nav.foreldrepenger.behandlingslager.behandling.klage.KlageRepository;
@@ -86,7 +87,7 @@ public class SendVedtaksbrev {
             return;
         }
 
-        if (behandling.harBehandlingÅrsak(BehandlingÅrsakType.REBEREGN_FERIEPENGER)) {
+        if (SpesialBehandling.erJusterFeriepenger(behandling)) {
             LOG.info("Sender ikke vedtaksbrev for reberegning av feriepenger: {}", behandlingId); //$NON-NLS-1$
             return;
         }

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/BehandlingRestTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/BehandlingRestTjeneste.java
@@ -46,6 +46,7 @@ import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingResultatType;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingStatus;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingType;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingÅrsakType;
+import no.nav.foreldrepenger.behandlingslager.behandling.SpesialBehandling;
 import no.nav.foreldrepenger.behandlingslager.behandling.historikk.HistorikkAktør;
 import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakYtelseType;
 import no.nav.foreldrepenger.behandlingsprosess.prosessering.BehandlingOpprettingTjeneste;
@@ -410,7 +411,7 @@ public class BehandlingRestTjeneste {
             throw new FunksjonellException("FP-722320", "Behandling må tas av vent før den kan åpnes",
                 "Ta behandling av vent");
         }
-        if (behandling.harBehandlingÅrsak(BehandlingÅrsakType.BERØRT_BEHANDLING)) {
+        if (SpesialBehandling.erSpesialBehandling(behandling)) {
             throw new FunksjonellException("FP-722321", "Behandling er berørt må gjennomføres. BehandlingId=" + behandlingId,
                 "Behandle ferdig berørt og opprett revurdering");
         }
@@ -473,7 +474,7 @@ public class BehandlingRestTjeneste {
             return BehandlingOperasjonerDto.builder(b.getUuid()).medTilGodkjenning(tilgokjenning).build();
         }
         var kanÅpnesForEndring = b.erRevurdering() && !b.isBehandlingPåVent() &&
-            !b.harBehandlingÅrsak(BehandlingÅrsakType.BERØRT_BEHANDLING) && !b.erKøet() &&
+            SpesialBehandling.erIkkeSpesialBehandling(b) && !b.erKøet() &&
             !FagsakYtelseType.ENGANGSTØNAD.equals(b.getFagsakYtelseType());
         var totrinnRetur = totrinnTjeneste.hentTotrinnaksjonspunktvurderinger(b).stream()
             .anyMatch(tt -> !tt.isGodkjent());
@@ -481,7 +482,7 @@ public class BehandlingRestTjeneste {
             .medTilGodkjenning(false)
             .medFraBeslutter(!b.isBehandlingPåVent() && totrinnRetur)
             .medKanBytteEnhet(!b.erKøet())
-            .medKanHenlegges(true)
+            .medKanHenlegges(SpesialBehandling.kanHenlegges(b))
             .medKanSettesPaVent(!b.isBehandlingPåVent())
             .medKanGjenopptas(b.isBehandlingPåVent() && !b.erKøet())
             .medKanOpnesForEndringer(kanÅpnesForEndring)

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/aksjonspunkt/AksjonspunktRestTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/aksjonspunkt/AksjonspunktRestTjeneste.java
@@ -214,9 +214,7 @@ public class AksjonspunktRestTjeneste {
     }
 
     private static void validerBetingelserForAksjonspunkt(Behandling behandling, Collection<? extends AksjonspunktKode> aksjonspunktDtoer) {
-        // TODO (FC): skal ikke ha spesfikke pre-conditions inne i denne tjenesten
-        // (sjekk på status FATTER_VEDTAK). Se
-        // om kan håndteres annerledes.
+        // TODO (FC): skal ikke ha spesfikke pre-conditions inne i denne tjenesten (sjekk på status FATTER_VEDTAK). Se om kan håndteres annerledes.
         if (behandling.getStatus().equals(BehandlingStatus.FATTER_VEDTAK) && !erFatteVedtakAkpt(aksjonspunktDtoer)) {
             throw new FunksjonellException("FP-760743",
                 String.format("Det kan ikke akseptere endringer siden totrinnsbehandling er startet og behandlingen med behandlingId: %s er hos beslutter", behandling.getId()),

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/aksjonspunkt/AksjonspunktTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/aksjonspunkt/AksjonspunktTjeneste.java
@@ -38,6 +38,7 @@ import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingResultatType;
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandlingsresultat;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingsresultatRepository;
+import no.nav.foreldrepenger.behandlingslager.behandling.SpesialBehandling;
 import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.Aksjonspunkt;
 import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.AksjonspunktDefinisjon;
 import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.AksjonspunktStatus;
@@ -50,6 +51,7 @@ import no.nav.foreldrepenger.behandlingslager.behandling.vilkår.VilkårResultat
 import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakYtelseType;
 import no.nav.foreldrepenger.historikk.HistorikkTjenesteAdapter;
 import no.nav.foreldrepenger.skjæringstidspunkt.SkjæringstidspunktTjeneste;
+import no.nav.vedtak.exception.FunksjonellException;
 import no.nav.vedtak.exception.TekniskException;
 import no.nav.vedtak.sikkerhet.context.SubjectHandler;
 
@@ -166,6 +168,10 @@ public class AksjonspunktTjeneste {
 
     public void overstyrAksjonspunkter(Collection<OverstyringAksjonspunktDto> overstyrteAksjonspunkter, Long behandlingId) {
         var behandling = behandlingRepository.hentBehandling(behandlingId);
+        if (SpesialBehandling.kanIkkeOverstyres(behandling)) {
+            throw new FunksjonellException("FP-760744", "Behandlingen kan ikke overstyres og må gjennomføres",
+                "Vurder behov for ordinær revurdering etter at denne behnadlingen er avsluttet");
+        }
         var kontekst = behandlingskontrollTjeneste.initBehandlingskontroll(behandlingId);
 
         // Tilbakestill gjeldende steg før fremføring

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/dto/behandling/BehandlingFormidlingDtoTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/dto/behandling/BehandlingFormidlingDtoTjeneste.java
@@ -1,5 +1,12 @@
 package no.nav.foreldrepenger.web.app.tjenester.behandling.dto.behandling;
 
+import static no.nav.foreldrepenger.web.app.tjenester.behandling.dto.behandling.BehandlingDtoUtil.get;
+
+import java.util.Optional;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
 import no.nav.foreldrepenger.behandling.RelatertBehandlingTjeneste;
 import no.nav.foreldrepenger.behandling.revurdering.RevurderingTjeneste;
 import no.nav.foreldrepenger.behandlingskontroll.FagsakYtelseTypeRef;
@@ -48,12 +55,6 @@ import no.nav.foreldrepenger.web.app.tjenester.fagsak.dto.SaksnummerDto;
 import no.nav.foreldrepenger.web.app.tjenester.familiehendelse.FamiliehendelseRestTjeneste;
 import no.nav.foreldrepenger.web.app.tjenester.formidling.FormidlingRestTjeneste;
 import no.nav.foreldrepenger.web.app.tjenester.formidling.beregningsgrunnlag.BeregningsgrunnlagFormidlingRestTjeneste;
-
-import javax.enterprise.context.ApplicationScoped;
-import javax.inject.Inject;
-import java.util.Optional;
-
-import static no.nav.foreldrepenger.web.app.tjenester.behandling.dto.behandling.BehandlingDtoUtil.get;
 
 /**
  * Bygger en BehandlingBrevDto som skal brukes til å populere brev for behandlinger behandlet i fpsak.
@@ -231,6 +232,7 @@ public class BehandlingFormidlingDtoTjeneste {
                 }
 
                 dto.leggTil(get(FormidlingRestTjeneste.DOKMAL_INNVFP_PATH, "dokmal-innvfp", uuidDto));
+                dto.leggTil(get(FormidlingRestTjeneste.UTSATT_START_PATH, "utsatt-oppstart", uuidDto));
                 dto.leggTil(get(UttakRestTjeneste.SAMMENHENGENDE_UTTAK_PATH, "krever-sammenhengende-uttak", uuidDto));
             }
         }

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/verge/VergeTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/verge/VergeTjeneste.java
@@ -8,6 +8,7 @@ import javax.inject.Inject;
 import no.nav.foreldrepenger.behandlingskontroll.BehandlingskontrollTjeneste;
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingStegType;
+import no.nav.foreldrepenger.behandlingslager.behandling.SpesialBehandling;
 import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.AksjonspunktDefinisjon;
 import no.nav.foreldrepenger.behandlingslager.behandling.historikk.HistorikkAktør;
 import no.nav.foreldrepenger.behandlingslager.behandling.historikk.HistorikkRepository;
@@ -54,7 +55,7 @@ public class VergeTjeneste {
         var harVergeAksjonspunkt = behandling.harÅpentAksjonspunktMedType(AksjonspunktDefinisjon.AVKLAR_VERGE);
         var stårIKofakEllerSenereSteg = behandling.harSattStartpunkt();
 
-        if (!stårIKofakEllerSenereSteg || !behandling.erYtelseBehandling()) {
+        if (!stårIKofakEllerSenereSteg || !behandling.erYtelseBehandling() || SpesialBehandling.erSpesialBehandling(behandling)) {
             return new VergeBehandlingsmenyDto(behandlingId, VergeBehandlingsmenyEnum.SKJUL);
         }
         if (!harRegistrertVerge && !harVergeAksjonspunkt) {

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/formidling/FormidlingRestTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/formidling/FormidlingRestTjeneste.java
@@ -44,7 +44,7 @@ public class FormidlingRestTjeneste {
     public static final String DOKMAL_INNVFP_PART_PATH = "/dokumentmal/innvfp";
     public static final String DOKMAL_INNVFP_PATH = BASE_PATH + DOKMAL_INNVFP_PART_PATH;
     public static final String UTSATT_START_PART_PATH = "/utsattstart";
-    public static final String UTSATT_START_PATH = BASE_PATH + DOKMAL_INNVFP_PART_PATH;
+    public static final String UTSATT_START_PATH = BASE_PATH + UTSATT_START_PART_PATH;
 
     private BehandlingRepository behandlingRepository;
     private BehandlingFormidlingDtoTjeneste behandlingFormidlingDtoTjeneste;

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/formidling/FormidlingRestTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/formidling/FormidlingRestTjeneste.java
@@ -80,8 +80,8 @@ public class FormidlingRestTjeneste {
     @Produces(MediaType.APPLICATION_JSON + ";charset=utf-8")
     @Operation(description = "Hent informasjon om sak er utsatt fra start og evt ny dato", tags = "formidling")
     @BeskyttetRessurs(action = READ, resource = FPSakBeskyttetRessursAttributt.FAGSAK)
-    public Response uts(@TilpassetAbacAttributt(supplierClass = BehandlingAbacSuppliers.BehandlingIdAbacDataSupplier.class)
-                            @NotNull @Parameter(description = "UUID for behandlingen") @QueryParam("behandlingId") @Valid BehandlingIdDto behandlingIdDto) {
+    public Response utsattStartdato(@TilpassetAbacAttributt(supplierClass = BehandlingAbacSuppliers.BehandlingIdAbacDataSupplier.class)
+                                        @NotNull @Parameter(description = "UUID for behandlingen") @QueryParam("behandlingId") @Valid BehandlingIdDto behandlingIdDto) {
         var behandling = behandlingRepository.hentBehandlingHvisFinnes(behandlingIdDto.getBehandlingUuid());
         var dto = behandling.map(value -> startdatoUtsattDtoTjeneste.getInformasjonOmUtsettelseFraStart(value))
             .orElse(new StartdatoUtsattDto(false, null));

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/formidling/FormidlingRestTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/formidling/FormidlingRestTjeneste.java
@@ -1,16 +1,6 @@
 package no.nav.foreldrepenger.web.app.tjenester.formidling;
 
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
-import no.nav.foreldrepenger.abac.FPSakBeskyttetRessursAttributt;
-import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepository;
-import no.nav.foreldrepenger.web.app.tjenester.behandling.dto.BehandlingAbacSuppliers;
-import no.nav.foreldrepenger.web.app.tjenester.behandling.dto.BehandlingIdDto;
-import no.nav.foreldrepenger.web.app.tjenester.behandling.dto.behandling.BehandlingFormidlingDtoTjeneste;
-import no.nav.vedtak.sikkerhet.abac.BeskyttetRessurs;
-import no.nav.vedtak.sikkerhet.abac.TilpassetAbacAttributt;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import static no.nav.vedtak.sikkerhet.abac.BeskyttetRessursActionAttributt.READ;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
@@ -24,7 +14,20 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
-import static no.nav.vedtak.sikkerhet.abac.BeskyttetRessursActionAttributt.READ;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import no.nav.foreldrepenger.abac.FPSakBeskyttetRessursAttributt;
+import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepository;
+import no.nav.foreldrepenger.web.app.tjenester.behandling.dto.BehandlingAbacSuppliers;
+import no.nav.foreldrepenger.web.app.tjenester.behandling.dto.BehandlingIdDto;
+import no.nav.foreldrepenger.web.app.tjenester.behandling.dto.behandling.BehandlingFormidlingDtoTjeneste;
+import no.nav.foreldrepenger.web.app.tjenester.formidling.utsattoppstart.StartdatoUtsattDto;
+import no.nav.foreldrepenger.web.app.tjenester.formidling.utsattoppstart.StartdatoUtsattDtoTjeneste;
+import no.nav.vedtak.sikkerhet.abac.BeskyttetRessurs;
+import no.nav.vedtak.sikkerhet.abac.TilpassetAbacAttributt;
 
 
 @Path(FormidlingRestTjeneste.BASE_PATH)
@@ -40,15 +43,20 @@ public class FormidlingRestTjeneste {
     public static final String RESSURSER_PATH = BASE_PATH + RESSURSER_PART_PATH;
     public static final String DOKMAL_INNVFP_PART_PATH = "/dokumentmal/innvfp";
     public static final String DOKMAL_INNVFP_PATH = BASE_PATH + DOKMAL_INNVFP_PART_PATH;
+    public static final String UTSATT_START_PART_PATH = "/utsattstart";
+    public static final String UTSATT_START_PATH = BASE_PATH + DOKMAL_INNVFP_PART_PATH;
 
     private BehandlingRepository behandlingRepository;
     private BehandlingFormidlingDtoTjeneste behandlingFormidlingDtoTjeneste;
+    private StartdatoUtsattDtoTjeneste startdatoUtsattDtoTjeneste;
 
     @Inject
     public FormidlingRestTjeneste(BehandlingRepository behandlingRepository,
-                                  BehandlingFormidlingDtoTjeneste behandlingFormidlingDtoTjeneste) {
+                                  BehandlingFormidlingDtoTjeneste behandlingFormidlingDtoTjeneste,
+                                  StartdatoUtsattDtoTjeneste startdatoUtsattDtoTjeneste) {
         this.behandlingRepository = behandlingRepository;
         this.behandlingFormidlingDtoTjeneste = behandlingFormidlingDtoTjeneste;
+        this.startdatoUtsattDtoTjeneste = startdatoUtsattDtoTjeneste;
     }
 
     public FormidlingRestTjeneste() {
@@ -63,6 +71,20 @@ public class FormidlingRestTjeneste {
         @NotNull @Parameter(description = "UUID for behandlingen") @QueryParam("behandlingId") @Valid BehandlingIdDto behandlingIdDto) {
         var behandling = behandlingRepository.hentBehandlingHvisFinnes(behandlingIdDto.getBehandlingUuid());
         var dto = behandling.map(value -> behandlingFormidlingDtoTjeneste.lagDtoForFormidling(value)).orElse(null);
+        var responseBuilder = Response.ok().entity(dto);
+        return responseBuilder.build();
+    }
+
+    @GET
+    @Path(UTSATT_START_PART_PATH)
+    @Produces(MediaType.APPLICATION_JSON + ";charset=utf-8")
+    @Operation(description = "Hent informasjon om sak er utsatt fra start og evt ny dato", tags = "formidling")
+    @BeskyttetRessurs(action = READ, resource = FPSakBeskyttetRessursAttributt.FAGSAK)
+    public Response uts(@TilpassetAbacAttributt(supplierClass = BehandlingAbacSuppliers.BehandlingIdAbacDataSupplier.class)
+                            @NotNull @Parameter(description = "UUID for behandlingen") @QueryParam("behandlingId") @Valid BehandlingIdDto behandlingIdDto) {
+        var behandling = behandlingRepository.hentBehandlingHvisFinnes(behandlingIdDto.getBehandlingUuid());
+        var dto = behandling.map(value -> startdatoUtsattDtoTjeneste.getInformasjonOmUtsettelseFraStart(value))
+            .orElse(new StartdatoUtsattDto(false, null));
         var responseBuilder = Response.ok().entity(dto);
         return responseBuilder.build();
     }

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/formidling/utsattoppstart/StartdatoUtsattDto.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/formidling/utsattoppstart/StartdatoUtsattDto.java
@@ -1,0 +1,45 @@
+package no.nav.foreldrepenger.web.app.tjenester.formidling.utsattoppstart;
+
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+import javax.validation.Valid;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(value = JsonInclude.Include.NON_ABSENT, content = JsonInclude.Include.NON_EMPTY)
+@JsonAutoDetect(fieldVisibility = NONE, getterVisibility = NONE, setterVisibility = NONE, isGetterVisibility = NONE, creatorVisibility = NONE)
+public class StartdatoUtsattDto {
+
+    @JsonProperty("utsettelseFraStart")
+    @Valid
+    private Boolean utsettelseFraStart;
+
+    @JsonProperty(value = "nyStartDato")
+    @Valid
+    private LocalDate nyStartDato;
+
+    public StartdatoUtsattDto(@Valid Boolean utsettelseFraStart,
+                              @Valid LocalDate nyStartDato) {
+        this.utsettelseFraStart = utsettelseFraStart;
+        this.nyStartDato = nyStartDato;
+    }
+
+    public Boolean getUtsettelseFraStart() {
+        return utsettelseFraStart;
+    }
+
+    public LocalDate getNyStartDato() {
+        return nyStartDato;
+    }
+
+    public Optional<LocalDate> getNyStartDatoOptional() {
+        return Optional.ofNullable(nyStartDato);
+    }
+}

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/formidling/utsattoppstart/StartdatoUtsattDto.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/formidling/utsattoppstart/StartdatoUtsattDto.java
@@ -1,45 +1,6 @@
 package no.nav.foreldrepenger.web.app.tjenester.formidling.utsattoppstart;
 
-import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
-
 import java.time.LocalDate;
-import java.util.Optional;
 
-import javax.validation.Valid;
-
-import com.fasterxml.jackson.annotation.JsonAutoDetect;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonProperty;
-
-@JsonIgnoreProperties(ignoreUnknown = true)
-@JsonInclude(value = JsonInclude.Include.NON_ABSENT, content = JsonInclude.Include.NON_EMPTY)
-@JsonAutoDetect(fieldVisibility = NONE, getterVisibility = NONE, setterVisibility = NONE, isGetterVisibility = NONE, creatorVisibility = NONE)
-public class StartdatoUtsattDto {
-
-    @JsonProperty("utsettelseFraStart")
-    @Valid
-    private Boolean utsettelseFraStart;
-
-    @JsonProperty(value = "nyStartDato")
-    @Valid
-    private LocalDate nyStartDato;
-
-    public StartdatoUtsattDto(@Valid Boolean utsettelseFraStart,
-                              @Valid LocalDate nyStartDato) {
-        this.utsettelseFraStart = utsettelseFraStart;
-        this.nyStartDato = nyStartDato;
-    }
-
-    public Boolean getUtsettelseFraStart() {
-        return utsettelseFraStart;
-    }
-
-    public LocalDate getNyStartDato() {
-        return nyStartDato;
-    }
-
-    public Optional<LocalDate> getNyStartDatoOptional() {
-        return Optional.ofNullable(nyStartDato);
-    }
+public record StartdatoUtsattDto(Boolean utsettelseFraStart, LocalDate nyStartDato) {
 }

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/formidling/utsattoppstart/StartdatoUtsattDtoTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/formidling/utsattoppstart/StartdatoUtsattDtoTjeneste.java
@@ -1,0 +1,42 @@
+package no.nav.foreldrepenger.web.app.tjenester.formidling.utsattoppstart;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
+import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingResultatType;
+import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingsresultatRepository;
+import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepositoryProvider;
+import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.YtelseFordelingAggregat;
+import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.YtelsesFordelingRepository;
+import no.nav.foreldrepenger.skjæringstidspunkt.UtsettelseCore2021;
+
+@ApplicationScoped
+public class StartdatoUtsattDtoTjeneste {
+
+    private BehandlingsresultatRepository behandlingsresultatRepository;
+    private YtelsesFordelingRepository ytelsesFordelingRepository;
+
+    @Inject
+    public StartdatoUtsattDtoTjeneste(BehandlingRepositoryProvider repositoryProvider) {
+        this.ytelsesFordelingRepository = repositoryProvider.getYtelsesFordelingRepository();
+        this.behandlingsresultatRepository = repositoryProvider.getBehandlingsresultatRepository();
+    }
+
+    public StartdatoUtsattDtoTjeneste() {
+    }
+
+    public StartdatoUtsattDto getInformasjonOmUtsettelseFraStart(Behandling behandling) {
+        var resultat = behandlingsresultatRepository.hentHvisEksisterer(behandling.getId())
+            .filter(r -> BehandlingResultatType.FORELDREPENGER_SENERE.equals(r.getBehandlingResultatType()));
+        if (resultat.isEmpty()) {
+            return new StartdatoUtsattDto(false, null);
+        }
+        var oppgitt = ytelsesFordelingRepository.hentAggregatHvisEksisterer(behandling.getId())
+            .map(YtelseFordelingAggregat::getOppgittFordeling);
+        var tidligsteUttaksperiode = UtsettelseCore2021.finnFørsteDatoFraSøknad(oppgitt, false);
+        return new StartdatoUtsattDto(true, tidligsteUttaksperiode.orElse(null));
+    }
+
+
+}

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/forvaltning/ForvaltningBeregningRestTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/forvaltning/ForvaltningBeregningRestTjeneste.java
@@ -36,7 +36,7 @@ import no.nav.foreldrepenger.abac.FPSakBeskyttetRessursAttributt;
 import no.nav.foreldrepenger.behandling.revurdering.satsregulering.AutomatiskGrunnbelopReguleringTask;
 import no.nav.foreldrepenger.behandling.steg.beregningsgrunnlag.BeregningsgrunnlagInputProvider;
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
-import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingÅrsakType;
+import no.nav.foreldrepenger.behandlingslager.behandling.SpesialBehandling;
 import no.nav.foreldrepenger.behandlingslager.behandling.beregning.BeregningSats;
 import no.nav.foreldrepenger.behandlingslager.behandling.beregning.BeregningSatsType;
 import no.nav.foreldrepenger.behandlingslager.behandling.beregning.BeregningsresultatRepository;
@@ -149,7 +149,7 @@ public class ForvaltningBeregningRestTjeneste {
         var saksnummer = new Saksnummer(saksnummerDto.getVerdi());
         var fagsak = fagsakRepository.hentSakGittSaksnummer(saksnummer).orElseThrow();
         var åpneBehandlinger = behandlingRepository.hentÅpneYtelseBehandlingerForFagsakId(fagsak.getId())
-            .stream().anyMatch(b -> !b.harBehandlingÅrsak(BehandlingÅrsakType.BERØRT_BEHANDLING));
+            .stream().anyMatch(SpesialBehandling::erIkkeSpesialBehandling);
         if (no.nav.foreldrepenger.behandlingslager.fagsak.FagsakYtelseType.ENGANGSTØNAD.equals(fagsak.getYtelseType()) || åpneBehandlinger) {
             return Response.status(Response.Status.BAD_REQUEST).build();
         }

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/forvaltning/ForvaltningSøknadRestTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/forvaltning/ForvaltningSøknadRestTjeneste.java
@@ -16,7 +16,7 @@ import javax.ws.rs.core.Response;
 
 import io.swagger.v3.oas.annotations.Operation;
 import no.nav.foreldrepenger.abac.FPSakBeskyttetRessursAttributt;
-import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingÅrsakType;
+import no.nav.foreldrepenger.behandlingslager.behandling.SpesialBehandling;
 import no.nav.foreldrepenger.behandlingslager.behandling.familiehendelse.FamilieHendelseGrunnlagEntitet;
 import no.nav.foreldrepenger.behandlingslager.behandling.familiehendelse.FamilieHendelseRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.personopplysning.PersonopplysningRepository;
@@ -65,7 +65,7 @@ public class ForvaltningSøknadRestTjeneste {
     public Response endreTermindato(@BeanParam @Valid SaksnummerTermindatoDto dto) {
         var fagsakId = fagsakRepository.hentSakGittSaksnummer(new Saksnummer(dto.getSaksnummer())).map(Fagsak::getId).orElseThrow();
         var behandling = behandlingRepository.hentÅpneYtelseBehandlingerForFagsakId(fagsakId).stream()
-                .filter(b -> !b.harBehandlingÅrsak(BehandlingÅrsakType.BERØRT_BEHANDLING))
+                .filter(SpesialBehandling::erIkkeSpesialBehandling)
                 .findFirst().orElseGet(() -> behandlingRepository.hentSisteYtelsesBehandlingForFagsakId(fagsakId).orElseThrow());
         var antall = familieHendelseRepository.oppdaterGjeldendeTermindatoForBehandling(behandling.getId(), dto.getTermindato(),
                 dto.getBegrunnelse());
@@ -81,7 +81,7 @@ public class ForvaltningSøknadRestTjeneste {
     public Response manglendeTermindato(@BeanParam @Valid SaksnummerTermindatoDto dto) {
         var fagsakId = fagsakRepository.hentSakGittSaksnummer(new Saksnummer(dto.getSaksnummer())).map(Fagsak::getId).orElseThrow();
         var behandling = behandlingRepository.hentÅpneYtelseBehandlingerForFagsakId(fagsakId).stream()
-            .filter(b -> !b.harBehandlingÅrsak(BehandlingÅrsakType.BERØRT_BEHANDLING))
+            .filter(SpesialBehandling::erIkkeSpesialBehandling)
             .findFirst().orElseGet(() -> behandlingRepository.hentSisteYtelsesBehandlingForFagsakId(fagsakId).orElseThrow());
         var gjeldende = familieHendelseRepository.hentAggregatHvisEksisterer(behandling.getId());
         if (gjeldende.isEmpty() || gjeldende.flatMap(FamilieHendelseGrunnlagEntitet::getGjeldendeTerminbekreftelse).isPresent())
@@ -103,7 +103,7 @@ public class ForvaltningSøknadRestTjeneste {
     public Response settNorskIdentAnnenpart(@BeanParam @Valid SaksnummerAnnenpartIdentDto dto) {
         var fagsakId = fagsakRepository.hentSakGittSaksnummer(new Saksnummer(dto.getSaksnummer())).map(Fagsak::getId).orElseThrow();
         var behandling = behandlingRepository.hentÅpneYtelseBehandlingerForFagsakId(fagsakId).stream()
-                .filter(b -> !b.harBehandlingÅrsak(BehandlingÅrsakType.BERØRT_BEHANDLING))
+            .filter(SpesialBehandling::erIkkeSpesialBehandling)
                 .findFirst().orElseGet(() -> behandlingRepository.hentSisteYtelsesBehandlingForFagsakId(fagsakId).orElseThrow());
         var oap = personopplysningRepository.hentPersonopplysninger(behandling.getId()).getOppgittAnnenPart().orElseThrow();
 
@@ -130,8 +130,8 @@ public class ForvaltningSøknadRestTjeneste {
     public Response settUtlandskIdentAnnenpart(@BeanParam @Valid SaksnummerAnnenpartIdentDto dto) {
         var fagsakId = fagsakRepository.hentSakGittSaksnummer(new Saksnummer(dto.getSaksnummer())).map(Fagsak::getId).orElseThrow();
         var behandling = behandlingRepository.hentÅpneYtelseBehandlingerForFagsakId(fagsakId).stream()
-                .filter(b -> !b.harBehandlingÅrsak(BehandlingÅrsakType.BERØRT_BEHANDLING))
-                .findFirst().orElseGet(() -> behandlingRepository.hentSisteYtelsesBehandlingForFagsakId(fagsakId).orElseThrow());
+            .filter(SpesialBehandling::erIkkeSpesialBehandling)
+            .findFirst().orElseGet(() -> behandlingRepository.hentSisteYtelsesBehandlingForFagsakId(fagsakId).orElseThrow());
         var oap = personopplysningRepository.hentPersonopplysninger(behandling.getId()).getOppgittAnnenPart().orElseThrow();
 
         var eksisterendeAnnenPart = oap.getAktørId();

--- a/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/BehandlingRestTjenesteTest.java
+++ b/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/BehandlingRestTjenesteTest.java
@@ -31,7 +31,7 @@ import no.nav.foreldrepenger.domene.opptjening.aksjonspunkt.OpptjeningIUtlandDok
 import no.nav.foreldrepenger.domene.prosess.HentOgLagreBeregningsgrunnlagTjeneste;
 import no.nav.foreldrepenger.domene.uttak.ForeldrepengerUttakTjeneste;
 import no.nav.foreldrepenger.produksjonsstyring.totrinn.TotrinnTjeneste;
-import no.nav.foreldrepenger.skjæringstidspunkt.UtsettelseCore2021;
+import no.nav.foreldrepenger.skjæringstidspunkt.UtsettelseBehandling2021;
 import no.nav.foreldrepenger.skjæringstidspunkt.fp.SkjæringstidspunktTjenesteImpl;
 import no.nav.foreldrepenger.skjæringstidspunkt.fp.SkjæringstidspunktUtils;
 import no.nav.foreldrepenger.web.app.tjenester.behandling.aksjonspunkt.BehandlingsoppretterTjeneste;
@@ -77,7 +77,7 @@ public class BehandlingRestTjenesteTest {
         var ytelseMaksdatoTjeneste = new YtelseMaksdatoTjeneste(repositoryProvider,
             new RelatertBehandlingTjeneste(repositoryProvider));
         var skjæringstidspunktTjeneste = new SkjæringstidspunktTjenesteImpl(repositoryProvider, ytelseMaksdatoTjeneste,
-            stputil, mock(UtsettelseCore2021.class));
+            stputil, mock(UtsettelseBehandling2021.class));
         var behandlingDtoTjeneste = new BehandlingDtoTjeneste(repositoryProvider, beregningsgrunnlagTjeneste,
             tilbakekrevingRepository, skjæringstidspunktTjeneste, opptjeningIUtlandDokStatusTjeneste,
             behandlingDokumentRepository, relatertBehandlingTjeneste,

--- a/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/BehandlingÅrsakDtoTest.java
+++ b/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/BehandlingÅrsakDtoTest.java
@@ -28,7 +28,7 @@ import no.nav.foreldrepenger.domene.opptjening.aksjonspunkt.OpptjeningIUtlandDok
 import no.nav.foreldrepenger.domene.prosess.HentOgLagreBeregningsgrunnlagTjeneste;
 import no.nav.foreldrepenger.domene.uttak.ForeldrepengerUttakTjeneste;
 import no.nav.foreldrepenger.domene.ytelsefordeling.YtelseFordelingTjeneste;
-import no.nav.foreldrepenger.skjæringstidspunkt.UtsettelseCore2021;
+import no.nav.foreldrepenger.skjæringstidspunkt.UtsettelseBehandling2021;
 import no.nav.foreldrepenger.skjæringstidspunkt.fp.SkjæringstidspunktTjenesteImpl;
 import no.nav.foreldrepenger.skjæringstidspunkt.fp.SkjæringstidspunktUtils;
 import no.nav.foreldrepenger.web.app.tjenester.behandling.dto.behandling.BehandlingDtoTjeneste;
@@ -47,7 +47,7 @@ public class BehandlingÅrsakDtoTest extends EntityManagerAwareTest {
         var ytelseMaksdatoTjeneste = new YtelseMaksdatoTjeneste(repositoryProvider,
             new RelatertBehandlingTjeneste(repositoryProvider));
         var skjæringstidspunktTjeneste = new SkjæringstidspunktTjenesteImpl(repositoryProvider, ytelseMaksdatoTjeneste,
-            stputil, mock(UtsettelseCore2021.class));
+            stputil, mock(UtsettelseBehandling2021.class));
         var beregningsgrunnlagTjeneste = new HentOgLagreBeregningsgrunnlagTjeneste(entityManager);
         var opptjeningIUtlandDokStatusTjeneste = new OpptjeningIUtlandDokStatusTjeneste(
             new OpptjeningIUtlandDokStatusRepository(entityManager));

--- a/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/uttak/app/KontrollerAktivitetskravDtoTjenesteTest.java
+++ b/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/uttak/app/KontrollerAktivitetskravDtoTjenesteTest.java
@@ -37,7 +37,7 @@ import no.nav.foreldrepenger.domene.medlem.MedlemTjeneste;
 import no.nav.foreldrepenger.domene.prosess.HentOgLagreBeregningsgrunnlagTjeneste;
 import no.nav.foreldrepenger.domene.uttak.ForeldrepengerUttakTjeneste;
 import no.nav.foreldrepenger.domene.ytelsefordeling.YtelseFordelingTjeneste;
-import no.nav.foreldrepenger.skjæringstidspunkt.UtsettelseCore2021;
+import no.nav.foreldrepenger.skjæringstidspunkt.UtsettelseBehandling2021;
 import no.nav.foreldrepenger.skjæringstidspunkt.fp.SkjæringstidspunktTjenesteImpl;
 import no.nav.foreldrepenger.skjæringstidspunkt.fp.SkjæringstidspunktUtils;
 import no.nav.foreldrepenger.web.app.tjenester.behandling.dto.UuidDto;
@@ -61,7 +61,7 @@ class KontrollerAktivitetskravDtoTjenesteTest {
         var uttakInputTjeneste = new UttakInputTjeneste(repositoryProvider, new HentOgLagreBeregningsgrunnlagTjeneste(entityManager),
             new AbakusInMemoryInntektArbeidYtelseTjeneste(), new SkjæringstidspunktTjenesteImpl(repositoryProvider,
             new YtelseMaksdatoTjeneste(repositoryProvider, new RelatertBehandlingTjeneste(repositoryProvider)),
-            new SkjæringstidspunktUtils(), mock(UtsettelseCore2021.class)),
+            new SkjæringstidspunktUtils(), mock(UtsettelseBehandling2021.class)),
             mock(MedlemTjeneste.class), andelGraderingTjeneste);
         tjeneste = new KontrollerAktivitetskravDtoTjeneste(repositoryProvider.getBehandlingRepository(),
             ytelseFordelingTjeneste, uttakInputTjeneste, foreldrepengerUttakTjeneste);


### PR DESCRIPTION
Mottak og håndtering av endringssøknad som har fri utsettelse fra start av innvilget uttak - med mindre startdato flyttes innen samme måned eller <14 dager (ref TFP-4716 under diskusjon).
Oppretter og kjører spesialbehandling (årsak RE_UTSATT_START) som setter tomt uttakresultat og BehResType FORELDREPENGER_SENERE
Dersom endringssøknad inneholder uttaksperioder: lager køet 1gang med kopi av oppgitte data som kjøres når spesbehandling er ferdig

RestTjeneste for fpformidling for å sjekke om et tomt uttak er utsettelse fra start og om det finnes en ny startdato.

Se også PR i autotest.