### PR TITLE
Rett STP for revurdering med kort utsettelse

### DIFF
--- a/domenetjenester/registerinnhenting/src/main/java/no/nav/foreldrepenger/domene/registerinnhenting/impl/startpunkt/StartpunktUtlederYtelseFordeling.java
+++ b/domenetjenester/registerinnhenting/src/main/java/no/nav/foreldrepenger/domene/registerinnhenting/impl/startpunkt/StartpunktUtlederYtelseFordeling.java
@@ -51,22 +51,22 @@ class StartpunktUtlederYtelseFordeling implements StartpunktUtleder {
             FellesStartpunktUtlederLogger.loggEndringSomFørteTilStartpunkt(this.getClass().getSimpleName(), StartpunktType.UTTAKSVILKÅR, "ikke revurdering el passert kofak", grunnlagId1, grunnlagId2);
             return StartpunktType.UTTAKSVILKÅR;
         }
+        if (erSkjæringsdatoEndret(ref, originalBehandling)) {
+            FellesStartpunktUtlederLogger.loggEndringSomFørteTilStartpunkt(this.getClass().getSimpleName(), StartpunktType.INNGANGSVILKÅR_OPPLYSNINGSPLIKT, "endring i skjæringsdato", grunnlagId1, grunnlagId2);
+            return StartpunktType.INNGANGSVILKÅR_OPPLYSNINGSPLIKT;
+        }
         if (erStartpunktBeregning(ref)) {
             FellesStartpunktUtlederLogger.loggEndringSomFørteTilStartpunkt(this.getClass().getSimpleName(), StartpunktType.BEREGNING, "Søkt om gradert periode", grunnlagId1, grunnlagId2);
             return StartpunktType.BEREGNING;
         }
-        if (erSkjæringsdatoUendret(ref, originalBehandling)) {
-            FellesStartpunktUtlederLogger.loggEndringSomFørteTilStartpunkt(this.getClass().getSimpleName(), StartpunktType.UTTAKSVILKÅR, "ingen endring i skjæringsdato", grunnlagId1, grunnlagId2);
-            return StartpunktType.UTTAKSVILKÅR;
-        }
-        FellesStartpunktUtlederLogger.loggEndringSomFørteTilStartpunkt(this.getClass().getSimpleName(), StartpunktType.INNGANGSVILKÅR_OPPLYSNINGSPLIKT, "endring i skjæringsdato", grunnlagId1, grunnlagId2);
-        return StartpunktType.INNGANGSVILKÅR_OPPLYSNINGSPLIKT;
+        FellesStartpunktUtlederLogger.loggEndringSomFørteTilStartpunkt(this.getClass().getSimpleName(), StartpunktType.UTTAKSVILKÅR, "ingen endring i skjæringsdato", grunnlagId1, grunnlagId2);
+        return StartpunktType.UTTAKSVILKÅR;
     }
 
-    private boolean erSkjæringsdatoUendret(BehandlingReferanse ref, Long originalBehandlingId) {
+    private boolean erSkjæringsdatoEndret(BehandlingReferanse ref, Long originalBehandlingId) {
         var nySkjæringsdato = ref.getSkjæringstidspunkt().getSkjæringstidspunktHvisUtledet().orElse(null);
         var originalSkjæringsdato = skjæringstidspunktTjeneste.getSkjæringstidspunkter(originalBehandlingId).getSkjæringstidspunktHvisUtledet().orElse(null);
-        return Objects.equals(originalSkjæringsdato, nySkjæringsdato);
+        return !Objects.equals(originalSkjæringsdato, nySkjæringsdato);
     }
 
 

--- a/domenetjenester/registerinnhenting/src/test/java/no/nav/foreldrepenger/domene/registerinnhenting/impl/startpunkt/StartpunktUtlederYtelseFordelingTest.java
+++ b/domenetjenester/registerinnhenting/src/test/java/no/nav/foreldrepenger/domene/registerinnhenting/impl/startpunkt/StartpunktUtlederYtelseFordelingTest.java
@@ -77,6 +77,26 @@ public class StartpunktUtlederYtelseFordelingTest extends EntityManagerAwareTest
     }
 
     @Test
+    public void skal_returnere_opplysningplikt_ved_endret_stp_tross_gradering() {
+        // Arrange
+        var originalBehandling = lagFørstegangsBehandling();
+
+        var revurdering = lagRevurdering(originalBehandling, BehandlingÅrsakType.RE_ENDRING_FRA_BRUKER);
+
+        lagreEndringssøknad(revurdering);
+        opprettYtelsesFordelingMedGradering(revurdering, AG2, ARBEIDSPROSENT_30);
+
+        var førsteuttaksdato = LocalDate.now();
+        var endretUttaksdato = førsteuttaksdato.plusDays(1);
+        var skjæringstidspunkt = Skjæringstidspunkt.builder().medFørsteUttaksdato(førsteuttaksdato).medUtledetSkjæringstidspunkt(førsteuttaksdato).build();
+        var revSkjæringstidspunkt = Skjæringstidspunkt.builder().medFørsteUttaksdato(endretUttaksdato).medUtledetSkjæringstidspunkt(endretUttaksdato).build();
+        when(skjæringstidspunktTjeneste.getSkjæringstidspunkter(originalBehandling.getId())).thenReturn(skjæringstidspunkt);
+
+        // Act/Assert
+        assertThat(utleder.utledStartpunkt(BehandlingReferanse.fra(revurdering, revSkjæringstidspunkt), 1L, 2L)).isEqualTo(INNGANGSVILKÅR_OPPLYSNINGSPLIKT);
+    }
+
+    @Test
     public void skal_returnere_beregning_dersom_søker_gradering_på_andel_uten_dagsats() {
         // Arrange
         var originalBehandling = lagFørstegangsBehandling();

--- a/domenetjenester/registerinnhenting/src/test/java/no/nav/foreldrepenger/domene/registerinnhenting/impl/startpunkt/StartpunktUtlederYtelseFordelingTest.java
+++ b/domenetjenester/registerinnhenting/src/test/java/no/nav/foreldrepenger/domene/registerinnhenting/impl/startpunkt/StartpunktUtlederYtelseFordelingTest.java
@@ -86,8 +86,12 @@ public class StartpunktUtlederYtelseFordelingTest extends EntityManagerAwareTest
         lagreEndringssøknad(revurdering);
         opprettYtelsesFordelingMedGradering(revurdering, AG2, ARBEIDSPROSENT_30);
 
+        var førsteuttaksdato = LocalDate.now();
+        var skjæringstidspunkt = Skjæringstidspunkt.builder().medFørsteUttaksdato(førsteuttaksdato).medUtledetSkjæringstidspunkt(førsteuttaksdato).build();
+        when(skjæringstidspunktTjeneste.getSkjæringstidspunkter(originalBehandling.getId())).thenReturn(skjæringstidspunkt);
+
         // Act/Assert
-        assertThat(utleder.utledStartpunkt(BehandlingReferanse.fra(revurdering), 1L, 2L)).isEqualTo(BEREGNING);
+        assertThat(utleder.utledStartpunkt(BehandlingReferanse.fra(revurdering, skjæringstidspunkt), 1L, 2L)).isEqualTo(BEREGNING);
     }
 
     @Test
@@ -117,8 +121,12 @@ public class StartpunktUtlederYtelseFordelingTest extends EntityManagerAwareTest
         lagreEndringssøknad(revurdering);
         opprettYtelsesFordelingMedGradering(revurdering, AG2, ARBEIDSPROSENT_30);
 
+        var førsteuttaksdato = LocalDate.now();
+        var skjæringstidspunkt = Skjæringstidspunkt.builder().medFørsteUttaksdato(førsteuttaksdato).medUtledetSkjæringstidspunkt(førsteuttaksdato).build();
+        when(skjæringstidspunktTjeneste.getSkjæringstidspunkter(originalBehandling.getId())).thenReturn(skjæringstidspunkt);
+
         // Act/Assert
-        assertThat(utleder.utledStartpunkt(BehandlingReferanse.fra(revurdering), 1L, 2L)).isEqualTo(BEREGNING);
+        assertThat(utleder.utledStartpunkt(BehandlingReferanse.fra(revurdering, skjæringstidspunkt), 1L, 2L)).isEqualTo(BEREGNING);
     }
 
     @Test
@@ -130,6 +138,7 @@ public class StartpunktUtlederYtelseFordelingTest extends EntityManagerAwareTest
 
         var førsteuttaksdato = LocalDate.now();
         var skjæringstidspunkt = Skjæringstidspunkt.builder().medUtledetSkjæringstidspunkt(førsteuttaksdato).build();
+        when(skjæringstidspunktTjeneste.getSkjæringstidspunkter(originalBehandling.getId())).thenReturn(skjæringstidspunkt);
 
         lagreEndringssøknad(revurdering);
         opprettYtelsesFordelingMedGradering(revurdering, AG1, ARBEIDSPROSENT_30);
@@ -148,8 +157,12 @@ public class StartpunktUtlederYtelseFordelingTest extends EntityManagerAwareTest
         lagreEndringssøknad(revurdering);
         opprettYtelsesFordelingMedGradering(revurdering, AG1, BigDecimal.valueOf(50));
 
+        var førsteuttaksdato = LocalDate.now();
+        var skjæringstidspunkt = Skjæringstidspunkt.builder().medFørsteUttaksdato(førsteuttaksdato).medUtledetSkjæringstidspunkt(førsteuttaksdato).build();
+        when(skjæringstidspunktTjeneste.getSkjæringstidspunkter(originalBehandling.getId())).thenReturn(skjæringstidspunkt);
+
         // Act
-        var startpunkt = utleder.utledStartpunkt(BehandlingReferanse.fra(revurdering), 1L, 2L);
+        var startpunkt = utleder.utledStartpunkt(BehandlingReferanse.fra(revurdering, skjæringstidspunkt), 1L, 2L);
 
         // Assert
         assertThat(startpunkt).isEqualTo(BEREGNING);

--- a/domenetjenester/skjaeringstidspunkt/src/main/java/no/nav/foreldrepenger/skjæringstidspunkt/UtsettelseCore2021.java
+++ b/domenetjenester/skjaeringstidspunkt/src/main/java/no/nav/foreldrepenger/skjæringstidspunkt/UtsettelseCore2021.java
@@ -124,6 +124,13 @@ public class UtsettelseCore2021 {
             .min(Comparator.naturalOrder());
     }
 
+    public static Optional<LocalDate> finnFørsteUtsettelseDatoFraSøknad(Optional<OppgittFordelingEntitet> oppgittFordeling, boolean kreverSammenhengendeUttak) {
+        return oppgittFordeling.map(OppgittFordelingEntitet::getOppgittePerioder).orElse(Collections.emptyList()).stream()
+            .filter(p -> !kreverSammenhengendeUttak && !frittUttakErPeriodeMedUttak(p))
+            .map(OppgittPeriodeEntitet::getFom)
+            .min(Comparator.naturalOrder());
+    }
+
     public static Optional<LocalDate> finnSisteDatoFraSøknad(Optional<OppgittFordelingEntitet> oppgittFordeling, boolean kreverSammenhengendeUttak) {
         return oppgittFordeling.map(OppgittFordelingEntitet::getOppgittePerioder).orElse(Collections.emptyList()).stream()
             .filter(p -> kreverSammenhengendeUttak || frittUttakErPeriodeMedUttak(p))


### PR DESCRIPTION
Utlede rett STP når det er fritt uttak - revurdering med utsatt start og utsettelse innen samme måned (el <2uker)

Startpunkt litt strengere dersom både endret STP og gradering - før kunne disse endt i BEREGNING