### PR TITLE
TFP-4772 Formidling henter alle IM hvis mangler STP

### DIFF
--- a/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/arbeidsforhold/dto/InntektArbeidYtelseDtoMapper.java
+++ b/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/arbeidsforhold/dto/InntektArbeidYtelseDtoMapper.java
@@ -64,6 +64,15 @@ public class InntektArbeidYtelseDtoMapper {
         return dto;
     }
 
+    public InntektsmeldingerDto mapInntektsmeldinger(BehandlingReferanse ref, InntektArbeidYtelseGrunnlag iayGrunnlag) {
+        if (!FagsakYtelseType.ENGANGSTØNAD.equals(ref.getFagsakYtelseType())) {
+
+            return new InntektsmeldingerDto(lagInntektsmeldingDto(ref, iayGrunnlag));
+        } else {
+            return new InntektsmeldingerDto(List.of());
+        }
+    }
+
     private void mapArbeidsforhold(InntektArbeidYtelseDto dto, BehandlingReferanse ref, UtledArbeidsforholdParametere param,
             InntektArbeidYtelseGrunnlag iayGrunnlag, SakInntektsmeldinger sakInntektsmeldinger) {
         var arbeidsforholdSet = arbeidsforholdAdministrasjonTjeneste.hentArbeidsforholdFerdigUtledet(ref, iayGrunnlag,
@@ -132,7 +141,8 @@ public class InntektArbeidYtelseDtoMapper {
 
     private List<InntektsmeldingDto> lagInntektsmeldingDto(BehandlingReferanse ref, InntektArbeidYtelseGrunnlag iayGrunnlag) {
         var dato = ref.getUtledetSkjæringstidspunkt();
-        var inntektsmeldinger = inntektsmeldingTjeneste.hentInntektsmeldinger(ref.getAktørId(), dato, iayGrunnlag);
+        var inntektsmeldinger = inntektsmeldingTjeneste.hentInntektsmeldinger(ref.getAktørId(), dato, iayGrunnlag,
+            ref.getSkjæringstidspunkt().getFørsteUttaksdatoSøknad().isPresent());
         return inntektsmeldinger.stream()
                 .map(inntektsmelding -> {
                     var virksomhet = virksomhetTjeneste.finnOrganisasjon(inntektsmelding.getArbeidsgiver().getOrgnr());

--- a/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/arbeidsforhold/dto/InntektsmeldingerDto.java
+++ b/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/arbeidsforhold/dto/InntektsmeldingerDto.java
@@ -1,0 +1,6 @@
+package no.nav.foreldrepenger.domene.arbeidsforhold.dto;
+
+import java.util.List;
+
+public record InntektsmeldingerDto(List<InntektsmeldingDto> inntektsmeldinger) {
+}

--- a/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/arbeidsforhold/impl/ArbeidsforholdAdministrasjonTjeneste.java
+++ b/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/arbeidsforhold/impl/ArbeidsforholdAdministrasjonTjeneste.java
@@ -103,7 +103,7 @@ public class ArbeidsforholdAdministrasjonTjeneste {
         var arbeidsgiverSetMap = vurderArbeidsforholdTjeneste.endringerIInntektsmelding(ref, iayGrunnlag,
                 sakInntektsmeldinger, ytelseType);
 
-        var inntektsmeldinger = inntektsmeldingTjeneste.hentInntektsmeldinger(ref.getAktørId(), skjæringstidspunkt, iayGrunnlag);
+        var inntektsmeldinger = inntektsmeldingTjeneste.hentInntektsmeldinger(ref.getAktørId(), skjæringstidspunkt, iayGrunnlag, true);
 
         var filter = new YrkesaktivitetFilter(iayGrunnlag.getArbeidsforholdInformasjon(), iayGrunnlag.getAktørArbeidFraRegister(aktørId));
         var filterFør = filter.før(skjæringstidspunkt);

--- a/domenetjenester/behandling/src/main/java/no/nav/foreldrepenger/behandling/Skjæringstidspunkt.java
+++ b/domenetjenester/behandling/src/main/java/no/nav/foreldrepenger/behandling/Skjæringstidspunkt.java
@@ -15,6 +15,7 @@ public class Skjæringstidspunkt {
     private LocalDate skjæringstidspunktBeregning;
     private LocalDate førsteUttaksdato;
     private LocalDate førsteUttaksdatoGrunnbeløp;
+    private LocalDate førsteUttaksdatoSøknad;
     private LocalDateInterval utledetMedlemsintervall;
     private boolean kreverSammenhengendeUttak = true; // Beholdes inntil lovendring avklart
 
@@ -28,6 +29,7 @@ public class Skjæringstidspunkt {
         this.skjæringstidspunktBeregning = other.skjæringstidspunktBeregning;
         this.førsteUttaksdato = other.førsteUttaksdato;
         this.førsteUttaksdatoGrunnbeløp = other.førsteUttaksdatoGrunnbeløp;
+        this.førsteUttaksdatoSøknad = other.førsteUttaksdatoSøknad;
         this.kreverSammenhengendeUttak = other.kreverSammenhengendeUttak;
     }
 
@@ -83,6 +85,11 @@ public class Skjæringstidspunkt {
     public LocalDate getFørsteUttaksdatoGrunnbeløp() {
         Objects.requireNonNull(førsteUttaksdatoGrunnbeløp, "Utvikler-feil: grunnbeløpdato er ikke satt. Sørg for at det er satt ifht. anvendelse");
         return førsteUttaksdatoGrunnbeløp;
+    }
+
+    /** Grunnbeløpdato er første dag med innvilget uttak/utsettelse/overføring. */
+    public Optional<LocalDate> getFørsteUttaksdatoSøknad() {
+        return Optional.ofNullable(førsteUttaksdatoSøknad);
     }
 
     /** Skal behandles etter nytt regelverk for uttak anno 2021. */
@@ -161,6 +168,11 @@ public class Skjæringstidspunkt {
 
         public Builder medFørsteUttaksdatoGrunnbeløp(LocalDate dato) {
             kladd.førsteUttaksdatoGrunnbeløp = dato;
+            return this;
+        }
+
+        public Builder medFørsteUttaksdatoSøknad(LocalDate dato) {
+            kladd.førsteUttaksdatoSøknad = dato;
             return this;
         }
 

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/arbeidInntektsmelding/ArbeidOgInntektsmeldingDtoTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/arbeidInntektsmelding/ArbeidOgInntektsmeldingDtoTjeneste.java
@@ -1,5 +1,14 @@
 package no.nav.foreldrepenger.web.app.tjenester.behandling.arbeidInntektsmelding;
 
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
 import no.nav.foreldrepenger.behandling.BehandlingReferanse;
 import no.nav.foreldrepenger.behandlingslager.behandling.MottattDokument;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.MottatteDokumentRepository;
@@ -14,19 +23,10 @@ import no.nav.foreldrepenger.domene.iay.modell.ArbeidsforholdInformasjon;
 import no.nav.foreldrepenger.domene.iay.modell.InntektArbeidYtelseGrunnlag;
 import no.nav.foreldrepenger.domene.iay.modell.InntektFilter;
 import no.nav.foreldrepenger.domene.iay.modell.Inntektsmelding;
-import no.nav.foreldrepenger.domene.iay.modell.InntektsmeldingAggregat;
 import no.nav.foreldrepenger.domene.iay.modell.YrkesaktivitetFilter;
 import no.nav.foreldrepenger.mottak.dokumentpersiterer.impl.inntektsmelding.InntektsmeldingKontaktinformasjon;
 import no.nav.foreldrepenger.mottak.dokumentpersiterer.impl.inntektsmelding.KontaktinformasjonIM;
 import no.nav.foreldrepenger.mottak.dokumentpersiterer.xml.MottattDokumentXmlParser;
-
-import javax.enterprise.context.ApplicationScoped;
-import javax.inject.Inject;
-import java.util.Collections;
-import java.util.List;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.stream.Collectors;
 
 @ApplicationScoped
 public class ArbeidOgInntektsmeldingDtoTjeneste {
@@ -73,7 +73,7 @@ public class ArbeidOgInntektsmeldingDtoTjeneste {
     }
 
     private List<InntektsmeldingDto> mapInntektsmeldinger(InntektArbeidYtelseGrunnlag iayGrunnlag, BehandlingReferanse referanse) {
-        var inntektsmeldinger = inntektsmeldingTjeneste.hentInntektsmeldinger(referanse.getAktørId(), referanse.getUtledetSkjæringstidspunkt(), iayGrunnlag);
+        var inntektsmeldinger = inntektsmeldingTjeneste.hentInntektsmeldinger(referanse.getAktørId(), referanse.getUtledetSkjæringstidspunkt(), iayGrunnlag, true);
         var referanser = iayGrunnlag.getArbeidsforholdInformasjon()
             .map(ArbeidsforholdInformasjon::getArbeidsforholdReferanser)
             .orElse(Collections.emptyList());

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/dto/behandling/BehandlingFormidlingDtoTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/dto/behandling/BehandlingFormidlingDtoTjeneste.java
@@ -187,7 +187,7 @@ public class BehandlingFormidlingDtoTjeneste {
             dto.leggTil(get(BrevRestTjeneste.VARSEL_REVURDERING_PATH, "sendt-varsel-om-revurdering", uuidDto));
         }
 
-        dto.leggTil(get(InntektArbeidYtelseRestTjeneste.INNTEKT_ARBEID_YTELSE_PATH, "inntekt-arbeid-ytelse", uuidDto));
+        dto.leggTil(get(InntektArbeidYtelseRestTjeneste.ALLE_INNTEKTSMELDINGER_PATH, "inntekt-arbeid-ytelse", uuidDto));
 
         if (FagsakYtelseType.ENGANGSTØNAD.equals(behandling.getFagsakYtelseType())) {
             dto.leggTil(get(BeregningsresultatRestTjeneste.ENGANGSTONAD_PATH, "beregningsresultat-engangsstonad", uuidDto));


### PR DESCRIPTION
FPformidling bruker kun feltet inntektsmeldinger i sin InntektArbeidYtelseDto - skiller derfor dette ut fra IAYDto i en Dto som matcher formidling sitt behov.

Unngår startdato-filtrering dersom det mangler søknad

@tor-nav og @pekern  ser ut som frontend kun bruker inntektsmeldinger fra inntektArbeidYtelseTsType.ts i StartdatoForForeldrepengerperiodenForm og stories. Nå har vi pensjonert 5045 - så Formen kan vel fjernes + at vi kan slanke inntektArbeidYtelseTsType dersom ingen annen bruk av inntektsmeldinger?