### PR TITLE
Mottak legger konsekvent til beh.årsak for revurderinger (#3422)

### DIFF
--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/Behandlingsoppretter.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/Behandlingsoppretter.java
@@ -167,6 +167,18 @@ public class Behandlingsoppretter {
 
     }
 
+    public void leggTilBehandlingsårsak(Behandling behandling, BehandlingÅrsakType behandlingÅrsakType) {
+        if (behandlingÅrsakType == null || BehandlingÅrsakType.UDEFINERT.equals(behandlingÅrsakType)) return;
+        if (!behandling.harBehandlingÅrsak(behandlingÅrsakType)) {
+            var builder = BehandlingÅrsak.builder(behandlingÅrsakType);
+            behandling.getOriginalBehandlingId().ifPresent(builder::medOriginalBehandlingId);
+            builder.buildFor(behandling);
+
+            var behandlingLås = behandlingRepository.taSkriveLås(behandling);
+            behandlingRepository.lagre(behandling, behandlingLås);
+        }
+    }
+
     private void kopierPapirsøknadVedBehov(Behandling opprinneligBehandling, Behandling nyBehandling) {
         var søknad = mottatteDokumentTjeneste.hentMottatteDokumentFagsak(opprinneligBehandling.getFagsakId()).stream()
             .filter(MottattDokument::erSøknadsDokument)

--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/dokumentmottak/impl/DokumentmottakerFelles.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/dokumentmottak/impl/DokumentmottakerFelles.java
@@ -10,7 +10,6 @@ import javax.inject.Inject;
 import no.nav.foreldrepenger.behandlingslager.aktør.OrganisasjonsEnhet;
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingType;
-import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingÅrsak;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingÅrsakType;
 import no.nav.foreldrepenger.behandlingslager.behandling.DokumentKategori;
 import no.nav.foreldrepenger.behandlingslager.behandling.DokumentTypeId;
@@ -69,12 +68,7 @@ public class DokumentmottakerFelles {
     }
 
     void leggTilBehandlingsårsak(Behandling behandling, BehandlingÅrsakType behandlingÅrsak) {
-        var builder = BehandlingÅrsak.builder(behandlingÅrsak);
-        behandling.getOriginalBehandlingId().ifPresent(builder::medOriginalBehandlingId);
-        builder.buildFor(behandling);
-
-        var behandlingLås = behandlingRepository.taSkriveLås(behandling);
-        behandlingRepository.lagre(behandling, behandlingLås);
+        behandlingsoppretter.leggTilBehandlingsårsak(behandling, behandlingÅrsak);
     }
 
     void opprettTaskForÅStarteBehandling(Behandling behandling) {

--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/dokumentmottak/impl/DokumentmottakerSøknad.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/dokumentmottak/impl/DokumentmottakerSøknad.java
@@ -47,6 +47,9 @@ public abstract class DokumentmottakerSøknad extends DokumentmottakerYtelsesesr
             var nyBehandling = dokumentmottakerFelles.oppdatereViaHenleggelse(behandling, mottattDokument, getBehandlingÅrsakHvisUdefinert(behandlingÅrsakType));
             køKontroller.dekøFørsteBehandlingISakskompleks(nyBehandling);
         } else {
+            if (behandling.erRevurdering()) {
+                dokumentmottakerFelles.leggTilBehandlingsårsak(behandling, getBehandlingÅrsakHvisUdefinert(behandlingÅrsakType));
+            }
             if (!mottattDokument.getElektroniskRegistrert()) { //#S3a
                 if (kompletthetskontroller.støtterBehandlingstypePapirsøknad(behandling)) {
                     dokumentmottakerFelles.oppdaterMottattDokumentMedBehandling(mottattDokument, behandling.getId());
@@ -71,6 +74,9 @@ public abstract class DokumentmottakerSøknad extends DokumentmottakerYtelsesesr
             }
         } else { //#S10, #S11, #S12 og #S14
             // Oppdater køet behandling med søknad
+            if (køetBehandling.erRevurdering()) {
+                dokumentmottakerFelles.leggTilBehandlingsårsak(køetBehandling, getBehandlingÅrsakHvisUdefinert(behandlingÅrsakType));
+            }
             Optional<LocalDate> søknadsdato = Optional.empty();
             kompletthetskontroller.persisterKøetDokumentOgVurderKompletthet(køetBehandling, mottattDokument, søknadsdato);
         }

--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/dokumentmottak/impl/Kompletthetskontroller.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/dokumentmottak/impl/Kompletthetskontroller.java
@@ -100,10 +100,6 @@ public class Kompletthetskontroller {
         vurderKompletthetForKøetBehandling(behandling);
     }
 
-    public void oppdaterKompletthetForKøetBehandling(Behandling behandling) {
-        vurderKompletthetForKøetBehandling(behandling);
-    }
-
     private void vurderKompletthetForKøetBehandling(Behandling behandling) {
         var autoPunkter = kompletthetModell.rangerKompletthetsfunksjonerKnyttetTilAutopunkt(behandling.getFagsakYtelseType(), behandling.getType());
         var ref = BehandlingReferanse.fra(behandling, skjæringstidspunktTjeneste.getSkjæringstidspunkter(behandling.getId()));

--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/hendelser/håndterer/ForretningshendelseHåndtererFelles.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/hendelser/håndterer/ForretningshendelseHåndtererFelles.java
@@ -50,6 +50,7 @@ public class ForretningshendelseHåndtererFelles {
     }
 
     public void håndterÅpenBehandling(Behandling åpenBehandling, BehandlingÅrsakType behandlingÅrsakType) {
+        behandlingsoppretter.leggTilBehandlingsårsak(åpenBehandling, behandlingÅrsakType);
         historikkinnslagTjeneste.opprettHistorikkinnslagForBehandlingOppdatertMedNyeOpplysninger(åpenBehandling, behandlingÅrsakType);
         kompletthetskontroller.vurderNyForretningshendelse(åpenBehandling);
     }

--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/vedtak/overlapp/HåndterOpphørAvYtelser.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/vedtak/overlapp/HåndterOpphørAvYtelser.java
@@ -136,12 +136,15 @@ public class HåndterOpphørAvYtelser {
     }
 
     private void oppdatereBehMedÅrsak(Long behandlingId, BehandlingÅrsakType behandlingÅrsakType) {
+        if (behandlingÅrsakType == null || BehandlingÅrsakType.UDEFINERT.equals(behandlingÅrsakType)) return;
         var lås = behandlingRepository.taSkriveLås(behandlingId);
         var behandling = behandlingRepository.hentBehandling(behandlingId);
-        var årsakBuilder = BehandlingÅrsak.builder(behandlingÅrsakType);
-        behandling.getOriginalBehandlingId().ifPresent(årsakBuilder::medOriginalBehandlingId);
-        årsakBuilder.buildFor(behandling);
-        behandlingRepository.lagre(behandling, lås);
+        if (!behandling.harBehandlingÅrsak(behandlingÅrsakType)) {
+            var årsakBuilder = BehandlingÅrsak.builder(behandlingÅrsakType);
+            behandling.getOriginalBehandlingId().ifPresent(årsakBuilder::medOriginalBehandlingId);
+            årsakBuilder.buildFor(behandling);
+            behandlingRepository.lagre(behandling, lås);
+        }
     }
 
     private OrganisasjonsEnhet utledEnhetFraBehandling(Behandling behandling) {


### PR DESCRIPTION
Nytt forsøk etter det var avklart at feilene test var relatert til Inntektsmeling-dato i tet