### PR TITLE
Repopulere abakus vedtak med andeler der utbetaling i 2021

### DIFF
--- a/domenetjenester/vedtak/src/main/java/no/nav/foreldrepenger/domene/vedtak/observer/VedtattYtelseTjeneste.java
+++ b/domenetjenester/vedtak/src/main/java/no/nav/foreldrepenger/domene/vedtak/observer/VedtattYtelseTjeneste.java
@@ -1,11 +1,8 @@
 package no.nav.foreldrepenger.domene.vedtak.observer;
 
 
-import java.math.BigDecimal;
-import java.math.RoundingMode;
 import java.util.Comparator;
 import java.util.List;
-import java.util.Objects;
 import java.util.stream.Collectors;
 
 import javax.enterprise.context.ApplicationScoped;
@@ -15,7 +12,6 @@ import no.nav.abakus.iaygrunnlag.kodeverk.Fagsystem;
 import no.nav.abakus.iaygrunnlag.kodeverk.YtelseStatus;
 import no.nav.abakus.iaygrunnlag.kodeverk.YtelseType;
 import no.nav.abakus.vedtak.ytelse.Aktør;
-import no.nav.abakus.vedtak.ytelse.Desimaltall;
 import no.nav.abakus.vedtak.ytelse.Periode;
 import no.nav.abakus.vedtak.ytelse.Ytelse;
 import no.nav.abakus.vedtak.ytelse.v1.YtelseV1;
@@ -32,11 +28,7 @@ import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakYtelseType;
 import no.nav.foreldrepenger.domene.arbeidsforhold.InntektArbeidYtelseTjeneste;
 import no.nav.foreldrepenger.domene.iay.modell.ArbeidsforholdReferanse;
 import no.nav.foreldrepenger.domene.iay.modell.InntektArbeidYtelseGrunnlag;
-import no.nav.foreldrepenger.domene.modell.BeregningsgrunnlagPeriode;
 import no.nav.foreldrepenger.domene.modell.BeregningsgrunnlagRepository;
-import no.nav.fpsak.tidsserie.LocalDateSegment;
-import no.nav.fpsak.tidsserie.LocalDateTimeline;
-import no.nav.fpsak.tidsserie.StandardCombinators;
 import no.nav.vedtak.konfig.Tid;
 
 @ApplicationScoped
@@ -88,73 +80,27 @@ public class VedtattYtelseTjeneste {
         if (tilkjentYtelse == null) {
             return List.of();
         }
+        List<ArbeidsforholdReferanse> arbeidsforholdReferanser = !mapArbeidsforhold ? List.of() :
+            inntektArbeidYtelseTjeneste.finnGrunnlag(behandling.getId())
+                .flatMap(InntektArbeidYtelseGrunnlag::getArbeidsforholdInformasjon)
+                .stream()
+                .flatMap(a -> a.getArbeidsforholdReferanser().stream()).collect(Collectors.toList());
         if (FagsakYtelseType.FORELDREPENGER.equals(behandling.getFagsakYtelseType())) {
-            if (mapArbeidsforhold) {
-                List<ArbeidsforholdReferanse> arbeidsforholdReferanser = inntektArbeidYtelseTjeneste.finnGrunnlag(behandling.getId())
-                    .flatMap(InntektArbeidYtelseGrunnlag::getArbeidsforholdInformasjon)
-                    .stream()
-                    .flatMap(a -> a.getArbeidsforholdReferanser().stream()).collect(Collectors.toList());
-                return VedtattYtelseForeldrepengerMapper.medArbeidsforhold(arbeidsforholdReferanser)
-                    .mapForeldrepenger(tilkjentYtelse);
-            } else {
-                return VedtattYtelseForeldrepengerMapper.utenArbeidsforhold()
-                    .mapForeldrepenger(tilkjentYtelse);
-            }
+            return !mapArbeidsforhold ? VedtattYtelseMapper.utenArbeidsforhold().mapForeldrepenger(tilkjentYtelse) :
+                VedtattYtelseMapper.medArbeidsforhold(arbeidsforholdReferanser).mapForeldrepenger(tilkjentYtelse);
         }
         if (FagsakYtelseType.SVANGERSKAPSPENGER.equals(behandling.getFagsakYtelseType())) {
-            return mapSvangerskapspenger(behandling, tilkjentYtelse); // TODO - følg med på TFP-2667 må finne ny metode når Beregning/SVP er skrevet om.
+            var beregningsgrunnlag = beregningsgrunnlagRepository.hentBeregningsgrunnlagForBehandling(behandling.getId()).orElse(null);
+            if (beregningsgrunnlag == null) {
+                return List.of();
+            }
+            // TODO - følg med på TFP-2667 må finne ny metode når Beregning/SVP er skrevet om.
+            return !mapArbeidsforhold ? VedtattYtelseMapper.utenArbeidsforhold().mapSvangerskapspenger(tilkjentYtelse, beregningsgrunnlag) :
+                VedtattYtelseMapper.medArbeidsforhold(arbeidsforholdReferanser).mapSvangerskapspenger(tilkjentYtelse,beregningsgrunnlag);
         }
         return List.of();
     }
 
-    private List<Anvisning> mapSvangerskapspenger(Behandling behandling, BeregningsresultatEntitet tilkjent) {
-        var beregningsgrunnlag = beregningsgrunnlagRepository.hentBeregningsgrunnlagForBehandling(behandling.getId()).orElse(null);
-        if (beregningsgrunnlag == null) {
-            return List.of();
-        }
-        var grunnlagSatsUtbetGrad = beregningsgrunnlag.getBeregningsgrunnlagPerioder().stream()
-            .filter(p -> p.getDagsats() > 0)
-            .map(p -> new LocalDateSegment<>(p.getBeregningsgrunnlagPeriodeFom(), p.getBeregningsgrunnlagPeriodeTom(), beregnGrunnlagSatsUtbetGradSvp(p, beregningsgrunnlag.getGrunnbeløp().getVerdi())))
-            .collect(Collectors.toList());
-        var resultatTidslinje = new LocalDateTimeline<DagsatsUtbgradSVP>(tilkjent.getBeregningsresultatPerioder().stream()
-            .filter(p -> p.getDagsats() > 0)
-            .map(p -> finnKombinertDagsatsUtbetaling(p, grunnlagSatsUtbetGrad))
-            .filter(Objects::nonNull)
-            .collect(Collectors.toList()), StandardCombinators::coalesceLeftHandSide);
-
-        return resultatTidslinje.compress(Objects::equals, StandardCombinators::leftOnly).toSegments().stream()
-            .map(this::mapSvangerskapspengerPeriode)
-            .collect(Collectors.toList());
-    }
-
-    private LocalDateSegment<DagsatsUtbgradSVP> finnKombinertDagsatsUtbetaling(BeregningsresultatPeriode periode, List<LocalDateSegment<DagsatsUtbgradSVP>> dagsatsGrader) {
-        return dagsatsGrader.stream()
-            .filter(d -> d.getLocalDateInterval().encloses(periode.getBeregningsresultatPeriodeFom())) // Antar at BR-perioder ikke krysser BG-perioder
-            .findFirst()
-            .map(v -> new LocalDateSegment<>(periode.getBeregningsresultatPeriodeFom(), periode.getBeregningsresultatPeriodeTom(), v.getValue()))
-            .orElse(null);
-    }
-
-    private Anvisning mapSvangerskapspengerPeriode(LocalDateSegment<DagsatsUtbgradSVP> periode) {
-        final var anvisning = new Anvisning();
-        final var p = new Periode();
-        p.setFom(periode.getFom());
-        p.setTom(periode.getTom());
-        anvisning.setPeriode(p);
-        anvisning.setDagsats(new Desimaltall(new BigDecimal(periode.getValue().dagsats())));
-        anvisning.setUtbetalingsgrad(new Desimaltall(new BigDecimal(periode.getValue().utbetalingsgrad())));
-        return anvisning;
-    }
-
-    private DagsatsUtbgradSVP beregnGrunnlagSatsUtbetGradSvp(BeregningsgrunnlagPeriode bgPeriode, BigDecimal grunnbeløp) {
-        var seksG = new BigDecimal(6).multiply(grunnbeløp);
-        var avkortet = bgPeriode.getBruttoPrÅr().compareTo(seksG) > 0 ? seksG : bgPeriode.getBruttoPrÅr();
-        var grad = BigDecimal.ZERO.compareTo(avkortet) == 0 ? 0 :
-            BigDecimal.TEN.multiply(BigDecimal.TEN).multiply(bgPeriode.getRedusertPrÅr()).divide(avkortet, RoundingMode.HALF_EVEN).longValue();
-        var dagsats = BigDecimal.ZERO.compareTo(bgPeriode.getRedusertPrÅr()) == 0 ? 0 :
-            new BigDecimal(bgPeriode.getDagsats()).multiply(avkortet).divide(bgPeriode.getRedusertPrÅr(), RoundingMode.HALF_EVEN).longValue();
-        return new DagsatsUtbgradSVP(dagsats, grad);
-    }
 
     private Periode utledPeriode(Behandling behandling, BehandlingVedtak vedtak, BeregningsresultatEntitet beregningsresultat) {
         final var periode = new Periode();
@@ -196,35 +142,22 @@ public class VedtattYtelseTjeneste {
 
 
     private YtelseType map(FagsakYtelseType type) {
-        if (FagsakYtelseType.ENGANGSTØNAD.equals(type)) {
-            return YtelseType.ENGANGSTØNAD;
-        }
-        if (FagsakYtelseType.FORELDREPENGER.equals(type)) {
-            return YtelseType.FORELDREPENGER;
-        }
-        if (FagsakYtelseType.SVANGERSKAPSPENGER.equals(type)) {
-            return YtelseType.SVANGERSKAPSPENGER;
-        }
-        throw new IllegalStateException("Ukjent ytelsestype " + type);
+        return switch (type) {
+            case ENGANGSTØNAD -> YtelseType.ENGANGSTØNAD;
+            case FORELDREPENGER -> YtelseType.FORELDREPENGER;
+            case SVANGERSKAPSPENGER -> YtelseType.SVANGERSKAPSPENGER;
+            default -> throw new IllegalStateException("Ukjent ytelsestype " + type);
+        };
     }
 
     private YtelseStatus map(FagsakStatus kode) {
-        YtelseStatus typeKode;
-        if (FagsakStatus.OPPRETTET.equals(kode)) {
-            typeKode = YtelseStatus.OPPRETTET;
-        } else if (FagsakStatus.UNDER_BEHANDLING.equals(kode)) {
-            typeKode = YtelseStatus.UNDER_BEHANDLING;
-        } else if (FagsakStatus.LØPENDE.equals(kode)) {
-            typeKode = YtelseStatus.LØPENDE;
-        } else if (FagsakStatus.AVSLUTTET.equals(kode)) {
-            typeKode = YtelseStatus.AVSLUTTET;
-        } else {
-            typeKode = YtelseStatus.OPPRETTET;
-        }
-        return typeKode;
+        return switch (kode) {
+            case OPPRETTET -> YtelseStatus.OPPRETTET;
+            case UNDER_BEHANDLING -> YtelseStatus.UNDER_BEHANDLING;
+            case LØPENDE -> YtelseStatus.LØPENDE;
+            case AVSLUTTET -> YtelseStatus.AVSLUTTET;
+        };
     }
 
-    static record DagsatsUtbgradSVP(long dagsats, long utbetalingsgrad) {
-    }
 
 }

--- a/domenetjenester/vedtak/src/test/java/no/nav/foreldrepenger/domene/vedtak/observer/VedtattYtelseForeldrepengerMapperTest.java
+++ b/domenetjenester/vedtak/src/test/java/no/nav/foreldrepenger/domene/vedtak/observer/VedtattYtelseForeldrepengerMapperTest.java
@@ -53,7 +53,7 @@ class VedtattYtelseForeldrepengerMapperTest {
             .build(periode);
 
         List<ArbeidsforholdReferanse> arbeidsforholdReferanser = List.of(arbeidsforholdReferanse);
-        List<Anvisning> anvisninger = VedtattYtelseForeldrepengerMapper.medArbeidsforhold(arbeidsforholdReferanser)
+        List<Anvisning> anvisninger = VedtattYtelseMapper.medArbeidsforhold(arbeidsforholdReferanser)
             .mapForeldrepenger(resultat);
 
         assertThat(anvisninger.size()).isEqualTo(1);
@@ -93,7 +93,7 @@ class VedtattYtelseForeldrepengerMapperTest {
         fullRefusjon(arbeidsgiver2, periode, arbeidsforholdRef2, dagsats2);
 
         List<ArbeidsforholdReferanse> arbeidsforholdReferanser = List.of(arbeidsforholdReferanse1, arbeidsforholdReferanse2);
-        List<Anvisning> anvisninger = VedtattYtelseForeldrepengerMapper.medArbeidsforhold(arbeidsforholdReferanser)
+        List<Anvisning> anvisninger = VedtattYtelseMapper.medArbeidsforhold(arbeidsforholdReferanser)
             .mapForeldrepenger(resultat);
 
         assertThat(anvisninger.size()).isEqualTo(1);
@@ -138,7 +138,7 @@ class VedtattYtelseForeldrepengerMapperTest {
         fullRefusjon(arbeidsgiver, periode, arbeidsforholdRef, dagsats);
 
         List<ArbeidsforholdReferanse> arbeidsforholdReferanser = List.of(arbeidsforholdReferanse);
-        List<Anvisning> anvisninger = VedtattYtelseForeldrepengerMapper.medArbeidsforhold(arbeidsforholdReferanser)
+        List<Anvisning> anvisninger = VedtattYtelseMapper.medArbeidsforhold(arbeidsforholdReferanser)
             .mapForeldrepenger(resultat);
 
         assertThat(anvisninger.size()).isEqualTo(1);
@@ -170,7 +170,7 @@ class VedtattYtelseForeldrepengerMapperTest {
         fullRefusjon(arbeidsgiver, periode, arbeidsforholdRef, dagsats);
 
         var arbeidsforholdReferanser = new ArrayList<ArbeidsforholdReferanse>();
-        List<Anvisning> anvisninger = VedtattYtelseForeldrepengerMapper.medArbeidsforhold(arbeidsforholdReferanser)
+        List<Anvisning> anvisninger = VedtattYtelseMapper.medArbeidsforhold(arbeidsforholdReferanser)
             .mapForeldrepenger(resultat);
 
         assertThat(anvisninger.size()).isEqualTo(1);
@@ -209,7 +209,7 @@ class VedtattYtelseForeldrepengerMapperTest {
             .build(periode);
 
         var arbeidsforholdReferanser = new ArrayList<ArbeidsforholdReferanse>();
-        List<Anvisning> anvisninger = VedtattYtelseForeldrepengerMapper.medArbeidsforhold(arbeidsforholdReferanser)
+        List<Anvisning> anvisninger = VedtattYtelseMapper.medArbeidsforhold(arbeidsforholdReferanser)
             .mapForeldrepenger(resultat);
 
         assertThat(anvisninger.size()).isEqualTo(1);

--- a/domenetjenester/vedtak/src/test/java/no/nav/foreldrepenger/domene/vedtak/observer/VedtattYtelseTjenesteTest.java
+++ b/domenetjenester/vedtak/src/test/java/no/nav/foreldrepenger/domene/vedtak/observer/VedtattYtelseTjenesteTest.java
@@ -5,7 +5,6 @@ import static org.mockito.Mockito.when;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
@@ -22,7 +21,6 @@ import no.nav.foreldrepenger.behandlingslager.behandling.beregning.Inntektskateg
 import no.nav.foreldrepenger.behandlingslager.behandling.familiehendelse.FamilieHendelseRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.vedtak.BehandlingVedtak;
 import no.nav.foreldrepenger.behandlingslager.behandling.vedtak.BehandlingVedtakRepository;
-import no.nav.foreldrepenger.behandlingslager.behandling.vedtak.VedtakResultatType;
 import no.nav.foreldrepenger.behandlingslager.testutilities.behandling.ScenarioMorSøkerEngangsstønad;
 import no.nav.foreldrepenger.behandlingslager.testutilities.behandling.ScenarioMorSøkerSvangerskapspenger;
 import no.nav.foreldrepenger.behandlingslager.virksomhet.Arbeidsgiver;
@@ -71,9 +69,11 @@ public class VedtattYtelseTjenesteTest {
 
         var ytelse= (YtelseV1)tjeneste.genererYtelse(behandling, false);
         // Assert
-        assertThat(ytelse.getAnvist()).hasSize(3);
+        assertThat(ytelse.getAnvist()).hasSize(4);
         assertThat(ytelse.getAnvist().get(0).getUtbetalingsgrad().getVerdi().longValue()).isEqualTo(20);
-        assertThat(ytelse.getAnvist().get(2).getUtbetalingsgrad().getVerdi().longValue()).isEqualTo(60);
+        assertThat(ytelse.getAnvist().get(1).getUtbetalingsgrad().getVerdi().longValue()).isEqualTo(20);
+        assertThat(ytelse.getAnvist().get(2).getUtbetalingsgrad().getVerdi().longValue()).isEqualTo(40);
+        assertThat(ytelse.getAnvist().get(3).getUtbetalingsgrad().getVerdi().longValue()).isEqualTo(60);
     }
 
     @Test

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/forvaltning/ReLagreVedtakDagTask.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/forvaltning/ReLagreVedtakDagTask.java
@@ -1,0 +1,67 @@
+package no.nav.foreldrepenger.web.app.tjenester.forvaltning;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakProsesstaskRekkefølge;
+import no.nav.foreldrepenger.behandlingslager.task.GenerellProsessTask;
+import no.nav.foreldrepenger.behandlingsprosess.dagligejobber.infobrev.InformasjonssakRepository;
+import no.nav.foreldrepenger.domene.vedtak.observer.RestRePubliserVedtattYtelseHendelseTask;
+import no.nav.vedtak.felles.prosesstask.api.ProsessTask;
+import no.nav.vedtak.felles.prosesstask.api.ProsessTaskData;
+import no.nav.vedtak.felles.prosesstask.api.ProsessTaskTjeneste;
+import no.nav.vedtak.log.mdc.MDCOperations;
+
+@ApplicationScoped
+@ProsessTask(value = "vedtak.republiser.dag", maxFailedRuns = 1)
+@FagsakProsesstaskRekkefølge(gruppeSekvens = false)
+public class ReLagreVedtakDagTask extends GenerellProsessTask {
+
+    public static final String LOG_FOM_KEY = "logfom";
+    public static final String LOG_TOM_KEY = "logtom";
+
+
+    private InformasjonssakRepository informasjonssakRepository;
+    private ProsessTaskTjeneste taskTjeneste;
+
+    ReLagreVedtakDagTask() {
+        // for CDI proxy
+    }
+
+    @Inject
+    public ReLagreVedtakDagTask(InformasjonssakRepository informasjonssakRepository,
+                                ProsessTaskTjeneste taskTjeneste) {
+        super();
+        this.informasjonssakRepository = informasjonssakRepository;
+        this.taskTjeneste = taskTjeneste;
+    }
+
+    @Override
+    public void prosesser(ProsessTaskData prosessTaskData, Long fagsakId, Long behandlingId) {
+        var fom = LocalDate.parse(prosessTaskData.getPropertyValue(LOG_FOM_KEY), DateTimeFormatter.ISO_LOCAL_DATE);
+        var tom = LocalDate.parse(prosessTaskData.getPropertyValue(LOG_TOM_KEY), DateTimeFormatter.ISO_LOCAL_DATE);
+
+
+        // Finner alle behandlinger med vedtaksdato innen intervall (evt med gitt saksnummer) - tidligste dato = tidligeste dato med utbetaling
+        var saker = informasjonssakRepository.finnSakerSisteVedtakInnenIntervallMedKunUtbetalte(fom, tom, null);
+        var spread = 3599;
+        var baseline = LocalDateTime.now();
+        if (MDCOperations.getCallId() == null) MDCOperations.putCallId();
+        var callId = MDCOperations.getCallId();
+        int suffix = 1;
+        for (var o : saker) {
+            var taskData = ProsessTaskData.forProsessTask(RestRePubliserVedtattYtelseHendelseTask.class);
+            taskData.setProperty(RestRePubliserVedtattYtelseHendelseTask.KEY, o.getBehandlingId().toString());
+            taskData.setNesteKjøringEtter(baseline.plusSeconds(LocalDateTime.now().getNano() % spread));
+            taskData.setCallId(callId + "_" + suffix);
+            taskData.setPrioritet(50);
+            taskTjeneste.lagre(taskData);
+            suffix++;
+        }
+    }
+
+}


### PR DESCRIPTION
Så enkelt det er uten task-konfig i tabell ...
Denne vil bare republisere siste vedtak saker med utbetaling i 2021

Strategi -> lag en task for hver dag siden oppstart i 2018 - spre kjøring utover 1 time. 
Denne tasken finner siste behandling for hver sak opprettet aktuell dag og lager en annen task for hver behandling - spredt utover en time. Har hadde vi allerede en passende spørring ifm avstemming av overlapp med andre ytelser...
Task for behandling vil lagre Ytelse dersom utbetaling i 2021