### PR TITLE
Sikre at forretningshendelser blir håndtert

### DIFF
--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/dokumentmottak/impl/Kompletthetskontroller.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/dokumentmottak/impl/Kompletthetskontroller.java
@@ -118,6 +118,8 @@ public class Kompletthetskontroller {
 
     public void vurderNyForretningshendelse(Behandling behandling) {
         if (kompletthetModell.erKompletthetssjekkPassert(behandling.getId())) {
+            // Sikre oppdatering dersom behandling står i FatteVedtak eller registerdata er innhentet samme dag.
+            behandlingProsesseringTjeneste.tvingInnhentingRegisteropplysninger(behandling);
             behandlingProsesseringTjeneste.opprettTasksForGjenopptaOppdaterFortsett(behandling, LocalDateTime.now());
         }
     }

--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/vedtak/kafka/VedtaksHendelseHåndterer.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/vedtak/kafka/VedtaksHendelseHåndterer.java
@@ -163,6 +163,8 @@ public class VedtaksHendelseHåndterer {
     private void opprettHåndterOverlappTaskPleiepenger(Fagsak f, UUID callID) {
         var prosessTaskData = ProsessTaskData.forProsessTask(HåndterOverlappPleiepengerTask.class);
         prosessTaskData.setFagsak(f.getId(), f.getAktørId().getId());
+        // Gi abakus tid til å konsumere samme hendelse så det finnes et grunnlag å hente opp.
+        prosessTaskData.setNesteKjøringEtter(LocalDateTime.now().plusMinutes(10));
         prosessTaskData.setCallId(callID.toString());
         taskTjeneste.lagre(prosessTaskData);
     }

--- a/domenetjenester/mottak/src/test/java/no/nav/foreldrepenger/mottak/vedtak/overlapp/HåndterOpphørAvYtelserTest.java
+++ b/domenetjenester/mottak/src/test/java/no/nav/foreldrepenger/mottak/vedtak/overlapp/HåndterOpphørAvYtelserTest.java
@@ -43,6 +43,7 @@ import no.nav.foreldrepenger.behandlingsprosess.prosessering.BehandlingProsesser
 import no.nav.foreldrepenger.dbstoette.EntityManagerAwareTest;
 import no.nav.foreldrepenger.domene.tid.VirkedagUtil;
 import no.nav.foreldrepenger.domene.typer.AktørId;
+import no.nav.foreldrepenger.mottak.dokumentmottak.impl.Kompletthetskontroller;
 import no.nav.foreldrepenger.mottak.sakskompleks.KøKontroller;
 import no.nav.foreldrepenger.produksjonsstyring.behandlingenhet.BehandlendeEnhetTjeneste;
 import no.nav.foreldrepenger.produksjonsstyring.oppgavebehandling.task.OpprettOppgaveVurderKonsekvensTask;
@@ -89,7 +90,7 @@ public class HåndterOpphørAvYtelserTest extends EntityManagerAwareTest {
         fagsakRepository = new FagsakRepository(entityManager);
         håndterOpphørAvYtelser = new HåndterOpphørAvYtelser(repositoryProvider, revurderingTjenesteMockFP,
             revurderingTjenesteMockSVP, taskTjeneste, behandlendeEnhetTjeneste, behandlingProsesseringTjenesteMock,
-            mock(KøKontroller.class));
+            mock(KøKontroller.class), mock(Kompletthetskontroller.class));
     }
 
     @Test

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/dto/behandling/BehandlingDtoTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/dto/behandling/BehandlingDtoTjeneste.java
@@ -350,6 +350,7 @@ public class BehandlingDtoTjeneste {
 
         dto.leggTil(get(InntektArbeidYtelseRestTjeneste.INNTEKT_ARBEID_YTELSE_PATH, "inntekt-arbeid-ytelse", uuidDto));
         dto.leggTil(get(InntektArbeidYtelseRestTjeneste.ARBEIDSGIVERE_OPPLYSNINGER_PATH, "arbeidsgivere-oversikt", uuidDto));
+        dto.leggTil(get(InntektArbeidYtelseRestTjeneste.ALLE_INNTEKTSMELDINGER_PATH, "inntektsmeldinger", uuidDto));
 
         if (opptjeningIUtlandDokStatusTjeneste.hentStatus(behandling.getId()).isPresent()) {
             dto.leggTil(get(OpptjeningRestTjeneste.UTLAND_DOK_STATUS_PATH, "utland-dok-status", uuidDto));

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/dto/behandling/BehandlingFormidlingDtoTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/dto/behandling/BehandlingFormidlingDtoTjeneste.java
@@ -187,7 +187,8 @@ public class BehandlingFormidlingDtoTjeneste {
             dto.leggTil(get(BrevRestTjeneste.VARSEL_REVURDERING_PATH, "sendt-varsel-om-revurdering", uuidDto));
         }
 
-        dto.leggTil(get(InntektArbeidYtelseRestTjeneste.ALLE_INNTEKTSMELDINGER_PATH, "inntekt-arbeid-ytelse", uuidDto));
+        dto.leggTil(get(InntektArbeidYtelseRestTjeneste.ALLE_INNTEKTSMELDINGER_PATH, "inntekt-arbeid-ytelse", uuidDto)); // TODO(jol) fjern etter update formidling
+        dto.leggTil(get(InntektArbeidYtelseRestTjeneste.ALLE_INNTEKTSMELDINGER_PATH, "inntektsmeldinger", uuidDto));
 
         if (FagsakYtelseType.ENGANGSTØNAD.equals(behandling.getFagsakYtelseType())) {
             dto.leggTil(get(BeregningsresultatRestTjeneste.ENGANGSTONAD_PATH, "beregningsresultat-engangsstonad", uuidDto));


### PR DESCRIPTION
Oppdaget etter studier av innkommende PSB-vedtaks-hendelser
* Sikre oppdatering dersom behandling opprettet samme dag som hendelsen kommer
* Sikre oppdatering dersom behandling står hos beslutter (alternativet er å legge i kø)

Bør antagelig sjekke hvor mange fødsels/dødfødsel/død/utflytting-hendelser som ikke er håndtert av samme grunn + sjekke manglende opphør pga ny stønadsperiode.