### PR TITLE
TFP-4803: Mapper ikke inn tilkjent ytelse perioder der dagsats er 0, …

### DIFF
--- a/domenetjenester/beregningsgrunnlag/src/main/java/no/nav/foreldrepenger/domene/fp/BesteberegningYtelsegrunnlagMapper.java
+++ b/domenetjenester/beregningsgrunnlag/src/main/java/no/nav/foreldrepenger/domene/fp/BesteberegningYtelsegrunnlagMapper.java
@@ -58,6 +58,7 @@ public class BesteberegningYtelsegrunnlagMapper {
     public static Optional<Ytelsegrunnlag> mapFpsakYtelseTilYtelsegrunnlag(BeregningsresultatEntitet resultat,
                                                                            no.nav.foreldrepenger.behandlingslager.fagsak.FagsakYtelseType ytelseType) {
         List<Ytelseperiode> ytelseperioder = resultat.getBeregningsresultatPerioder().stream()
+            .filter(periode -> periode.getDagsats() > 0)
             .map(BesteberegningYtelsegrunnlagMapper::mapPeriode)
             .collect(Collectors.toList());
         return ytelseperioder.isEmpty()


### PR DESCRIPTION
…da disse ikke kan brukes til å vurdere fordeling av besteberegning