### PR TITLE
TFP-4676 infrastruktur for å lagre uføretrygd

### DIFF
--- a/.deploy/dev-fss-teamforeldrepenger.json
+++ b/.deploy/dev-fss-teamforeldrepenger.json
@@ -28,7 +28,6 @@
     "SCHEMA_REGISTRY_URL": "https://kafka-schema-registry.nais.preprod.local",
     "SECURITYTOKENSERVICE_URL": "https://sts-q1.preprod.local/SecurityTokenServiceProvider/",
     "BOOTSTRAP_SERVERS": "b27apvl00045.preprod.local:8443,b27apvl00046.preprod.local:8443,b27apvl00047.preprod.local:8443",
-    "BUCKET_URL": "http://s3.nais-rook",
     "LOADBALANCER_FPSAK_POOLNAME": "nais",
     "LOADBALANCER_FPSAK_CONTEXTROOTS": "fpsak",
     "OIDC_STS_ISSUER_URL": "https://security-token-service.nais.preprod.local",
@@ -48,7 +47,6 @@
     "FPRISK_URL": "http://fprisk/fprisk",
     "FPABAKUS_URL": "http://fpabakus/fpabakus",
     "ABAKUS_CALLBACK_URL": "http://fpsak.teamforeldrepenger/fpsak/api/registerdata/iay/callback",
-    "FPFORDEL_BASE_URL": "http://fpfordel/fpfordel",
     "FPOPPDRAG_OVERRIDE_DIREKTE_URL": "http://fpoppdrag/fpoppdrag/api",
     "FPTILBAKE_OVERRIDE_DIREKTE_URL": "http://fptilbake/fptilbake/api",
     "ORGANISASJON_RS_URL": "https://modapp-q1.adeo.no/ereg/api/v1/organisasjon",
@@ -59,6 +57,7 @@
     "PDL_BASE_URL" : "http://pdl-api.pdl/graphql",
     "SAF_BASE_URL" : "http://saf-q1.teamdokumenthandtering",
     "KODEVERK_BASE_URL": "http://kodeverk.org",
-    "SKJERMET_PERSON_RS_URL": "http://skjermede-personer-pip.nom/skjermet"
+    "SKJERMET_PERSON_RS_URL": "http://skjermede-personer-pip.nom/skjermet",
+    "UFORE_RS_URL": "http://pensjon-pen-q1.teampensjon/pen/api/sak/uforehistorikk"
   }
 }

--- a/.deploy/naiserator.yaml
+++ b/.deploy/naiserator.yaml
@@ -36,8 +36,8 @@ spec:
       cpu: "4000m"
       memory: "3072Mi"
     requests:
-      cpu: "100m"
-      memory: "2816Mi"
+      cpu: "128m"
+      memory: "2688Mi"
   azure:
     application:
       enabled: true

--- a/.deploy/prod-fss-teamforeldrepenger.json
+++ b/.deploy/prod-fss-teamforeldrepenger.json
@@ -25,7 +25,6 @@
     "SCHEMA_REGISTRY_URL": "https://kafka-schema-registry.nais.adeo.no",
     "SECURITYTOKENSERVICE_URL": "https://sts.adeo.no/SecurityTokenServiceProvider/",
     "BOOTSTRAP_SERVERS": "a01apvl00145.adeo.no:8443,a01apvl00146.adeo.no:8443,a01apvl00147.adeo.no:8443,a01apvl00148.adeo.no:8443,a01apvl00149.adeo.no:8443,a01apvl00150.adeo.no:8443",
-    "BUCKET_URL": "http://s3.nais-rook",
     "LOADBALANCER_FPSAK_POOLNAME": "nais",
     "LOADBALANCER_FPSAK_CONTEXTROOTS": "fpsak",
     "OIDC_STS_ISSUER_URL": "https://security-token-service.nais.adeo.no",
@@ -45,7 +44,6 @@
     "FPRISK_URL": "http://fprisk/fprisk",
     "FPABAKUS_URL": "http://fpabakus/fpabakus",
     "ABAKUS_CALLBACK_URL": "http://fpsak.teamforeldrepenger/fpsak/api/registerdata/iay/callback",
-    "FPFORDEL_BASE_URL": "http://fpfordel/fpfordel",
     "FPOPPDRAG_OVERRIDE_DIREKTE_URL": "http://fpoppdrag/fpoppdrag/api",
     "FPTILBAKE_OVERRIDE_DIREKTE_URL": "http://fptilbake/fptilbake/api",
     "ORGANISASJON_RS_URL": "https://modapp.adeo.no/ereg/api/v1/organisasjon",
@@ -59,6 +57,7 @@
     "AZURE_HTTP_PROXY": "http://webproxy.nais:8088",
     "SPOKELSE_GRUNNLAG_SCOPES": "api://prod-fss.tbd.spokelse/.default",
     "SPOKELSE_GRUNNLAG_URL": "http://spokelse.tbd/grunnlag",
-    "SKJERMET_PERSON_RS_URL": "http://skjermede-personer-pip.nom/skjermet"
+    "SKJERMET_PERSON_RS_URL": "http://skjermede-personer-pip.nom/skjermet",
+    "UFORE_RS_URL": "http://pensjon-pen.pensjondeployer/pen/api/sak/uforehistorikk"
   }
 }

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/pleiepenger/PleiepengerGrunnlagEntitet.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/pleiepenger/PleiepengerGrunnlagEntitet.java
@@ -64,10 +64,6 @@ public class PleiepengerGrunnlagEntitet extends BaseEntitet {
         this.aktiv = false;
     }
 
-    public void reaktiver() {
-        this.aktiv = true;
-    }
-
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/pleiepenger/PleiepengerRepository.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/pleiepenger/PleiepengerRepository.java
@@ -1,12 +1,8 @@
 package no.nav.foreldrepenger.behandlingslager.behandling.pleiepenger;
 
-import java.util.Comparator;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
@@ -64,26 +60,6 @@ public class PleiepengerRepository {
 
         return HibernateVerktøy.hentUniktResultat(query);
     }
-
-    public void reaktiverDerSisteGrunnlagErPassiv() {
-        final var query = entityManager.createQuery(
-                "FROM PleiepengerGrunnlag p ",
-                PleiepengerGrunnlagEntitet.class);
-
-        query.getResultList().stream()
-            .collect(Collectors.groupingBy(PleiepengerGrunnlagEntitet::getBehandlingId))
-            .forEach((key, value) -> {
-                if (value.stream().noneMatch(PleiepengerGrunnlagEntitet::isAktiv)) {
-                    var last = value.stream().max(Comparator.comparing(PleiepengerGrunnlagEntitet::getOpprettetTidspunkt));
-                    last.ifPresent(gpe -> {
-                        gpe.reaktiver();
-                        entityManager.persist(gpe);
-                    });
-            }
-        });
-    }
-
-
 
     public void kopierGrunnlagFraEksisterendeBehandling(Long orginalBehandlingId, Long nyBehandlingId) {
         var eksisterendeGrunnlag = hentGrunnlag(orginalBehandlingId);

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/repository/BehandlingRepositoryProvider.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/repository/BehandlingRepositoryProvider.java
@@ -18,6 +18,7 @@ import no.nav.foreldrepenger.behandlingslager.behandling.personopplysning.Person
 import no.nav.foreldrepenger.behandlingslager.behandling.pleiepenger.PleiepengerRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.søknad.SøknadRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.tilrettelegging.SvangerskapspengerRepository;
+import no.nav.foreldrepenger.behandlingslager.behandling.ufore.UføretrygdRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.vedtak.BehandlingVedtakRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.YtelsesFordelingRepository;
 import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakLåsRepository;
@@ -47,6 +48,7 @@ public class BehandlingRepositoryProvider {
     private MedlemskapVilkårPeriodeRepository medlemskapVilkårPeriodeRepository;
     private FamilieHendelseRepository familieHendelseRepository;
     private PleiepengerRepository pleiepengerRepository;
+    private UføretrygdRepository uføretrygdRepository;
     private HistorikkRepository historikkRepository;
     private SøknadRepository søknadRepository;
     private FagsakRelasjonRepository fagsakRelasjonRepository;
@@ -95,6 +97,7 @@ public class BehandlingRepositoryProvider {
         this.opptjeningRepository = new OpptjeningRepository(entityManager, this.behandlingRepository);
         this.personopplysningRepository = new PersonopplysningRepository(entityManager);
         this.pleiepengerRepository = new PleiepengerRepository(entityManager);
+        this.uføretrygdRepository = new UføretrygdRepository(entityManager);
         this.søknadRepository = new SøknadRepository(entityManager, this.behandlingRepository);
         this.fpUttakRepository = new FpUttakRepository(entityManager);
         this.uttaksperiodegrenseRepository = new UttaksperiodegrenseRepository(entityManager);
@@ -155,6 +158,10 @@ public class BehandlingRepositoryProvider {
 
     public PleiepengerRepository getPleiepengerRepository() {
         return pleiepengerRepository;
+    }
+
+    public UføretrygdRepository getUføretrygdRepository() {
+        return uføretrygdRepository;
     }
 
     public HistorikkRepository getHistorikkRepository() {

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/ufore/UføretrygdGrunnlagEntitet.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/ufore/UføretrygdGrunnlagEntitet.java
@@ -1,0 +1,189 @@
+package no.nav.foreldrepenger.behandlingslager.behandling.ufore;
+
+import java.time.LocalDate;
+import java.util.Objects;
+import java.util.Optional;
+
+import javax.persistence.AttributeOverride;
+import javax.persistence.AttributeOverrides;
+import javax.persistence.Column;
+import javax.persistence.Convert;
+import javax.persistence.Embedded;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+import no.nav.foreldrepenger.behandlingslager.BaseEntitet;
+import no.nav.foreldrepenger.behandlingslager.diff.ChangeTracked;
+import no.nav.foreldrepenger.domene.typer.AktørId;
+import no.nav.vedtak.felles.jpa.converters.BooleanToStringConverter;
+
+/*
+ * Grunnlag med livssyklus gitt av søknad - vil bare bli innhentet dersom søknad tilsier at annenpart (mor) er uføretrygdet
+ * Dette er litt spesielt sammensatt ettersom eldre tilfelle er gitt av oppgitt søknadsperiode, ikke oppgitt rettighet
+ * Dersom register (Pesys) ikke har informasjon om Uføretrygd, legges det opp til manuell avklaring
+ */
+@Entity(name = "UforetrygdGrunnlag")
+@Table(name = "GR_UFORETRYGD")
+public class UføretrygdGrunnlagEntitet extends BaseEntitet {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "SEQ_GR_UFORETRYGD")
+    private Long id;
+
+    @Convert(converter = BooleanToStringConverter.class)
+    @Column(name = "aktiv", nullable = false)
+    private boolean aktiv = true;
+
+    @Column(name = "behandling_id", nullable = false, updatable = false)
+    private Long behandlingId;
+
+    @Embedded
+    @AttributeOverrides(@AttributeOverride(name = "aktørId", column = @Column(name = "aktoer_id", updatable = false, nullable=false)))
+    private AktørId aktørId;
+
+    @Convert(converter = BooleanToStringConverter.class)
+    @Column(name = "register_ufore")
+    private Boolean uføretrygdRegister;
+
+    @Convert(converter = BooleanToStringConverter.class)
+    @Column(name = "overstyrt_ufore")
+    private Boolean uføretrygdOverstyrt;
+
+    @Column(name = "uforedato")
+    @ChangeTracked
+    private LocalDate uføredato;
+
+    @Column(name = "virkningsdato")
+    @ChangeTracked
+    private LocalDate virkningsdato;
+
+
+
+    UføretrygdGrunnlagEntitet() {
+    }
+
+    UføretrygdGrunnlagEntitet(UføretrygdGrunnlagEntitet grunnlag) {
+        this.aktørId = grunnlag.aktørId;
+        this.uføretrygdRegister = grunnlag.uføretrygdRegister;
+        this.uføretrygdOverstyrt = grunnlag.uføretrygdOverstyrt;
+        this.uføredato = grunnlag.uføredato;
+        this.virkningsdato = grunnlag.virkningsdato;
+    }
+
+    public boolean annenForelderMottarUføretrygd() {
+        return Objects.equals(Boolean.TRUE, uføretrygdRegister) || Objects.equals(Boolean.TRUE, uføretrygdOverstyrt);
+    }
+
+    public boolean uavklartAnnenForelderMottarUføretrygd() {
+        Objects.requireNonNull(uføretrygdRegister, "Utviklerfeil: Skal ikke kalles uten at registerdata er innhentet");
+        return !Objects.equals(Boolean.TRUE, uføretrygdRegister) && uføretrygdOverstyrt == null;
+    }
+
+    Long getId() {
+        return id;
+    }
+
+    public long getBehandlingId() {
+        return behandlingId;
+    }
+
+    public boolean isAktiv() {
+        return aktiv;
+    }
+
+    public void deaktiver() {
+        this.aktiv = false;
+    }
+
+    public AktørId getAktørIdAnnenPart() {
+        return aktørId;
+    }
+
+    public Boolean getUføretrygdRegister() {
+        return uføretrygdRegister;
+    }
+
+    public Boolean getUføretrygdOverstyrt() {
+        return uføretrygdOverstyrt;
+    }
+
+    public LocalDate getUføredato() {
+        return uføredato;
+    }
+
+    public LocalDate getVirkningsdato() {
+        return virkningsdato;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof UføretrygdGrunnlagEntitet)) return false;
+        UføretrygdGrunnlagEntitet that = (UføretrygdGrunnlagEntitet) o;
+        return Objects.equals(behandlingId, that.behandlingId) &&
+            Objects.equals(aktørId, that.aktørId) &&
+            Objects.equals(uføretrygdRegister, that.uføretrygdRegister) &&
+            Objects.equals(uføretrygdOverstyrt, that.uføretrygdOverstyrt) &&
+            Objects.equals(uføredato, that.uføredato) &&
+            Objects.equals(virkningsdato, that.virkningsdato);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(behandlingId, aktørId, uføretrygdRegister, uføretrygdOverstyrt, uføredato, virkningsdato);
+    }
+
+    public static class Builder {
+
+        private UføretrygdGrunnlagEntitet kladd;
+
+        private Builder(UføretrygdGrunnlagEntitet kladd) {
+            this.kladd = kladd;
+        }
+
+        private static Builder nytt() {
+            return new Builder(new UføretrygdGrunnlagEntitet());
+        }
+
+        private static Builder oppdatere(UføretrygdGrunnlagEntitet kladd) {
+            return new Builder(new UføretrygdGrunnlagEntitet(kladd));
+        }
+
+        public static Builder oppdatere(Optional<UføretrygdGrunnlagEntitet> kladd) {
+            return kladd.map(Builder::oppdatere).orElseGet(Builder::nytt);
+        }
+
+        public Builder medBehandlingId(Long behandlingId) {
+            this.kladd.behandlingId = behandlingId;
+            return this;
+        }
+
+        public Builder medAktørIdUføretrygdet(AktørId aktørId) {
+            this.kladd.aktørId = aktørId;
+            return this;
+        }
+
+        public Builder medRegisterUføretrygd(boolean erUføretrygdet, LocalDate uføredato, LocalDate virkningsdato) {
+            if (erUføretrygdet && uføredato == null) {
+                throw new IllegalArgumentException("Utviklerfeil: Skal ikke kalles uten uføredato");
+            }
+            this.kladd.uføretrygdRegister = erUføretrygdet;
+            this.kladd.uføredato = erUføretrygdet ? uføredato : null;
+            this.kladd.virkningsdato = erUføretrygdet ? virkningsdato : null;
+            return this;
+        }
+
+        public Builder medOverstyrtUføretrygd(boolean erUføretrygdet) {
+            this.kladd.uføretrygdRegister = erUføretrygdet;
+            return this;
+        }
+
+        public UføretrygdGrunnlagEntitet build() {
+            Objects.requireNonNull(this.kladd.uføretrygdRegister, "Utviklerfeil: register skal være satt");
+            return this.kladd;
+        }
+    }
+}

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/ufore/UføretrygdRepository.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/ufore/UføretrygdRepository.java
@@ -1,0 +1,78 @@
+package no.nav.foreldrepenger.behandlingslager.behandling.ufore;
+
+import java.time.LocalDate;
+import java.util.Objects;
+import java.util.Optional;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import javax.persistence.EntityManager;
+
+import no.nav.foreldrepenger.domene.typer.AktørId;
+import no.nav.vedtak.felles.jpa.HibernateVerktøy;
+
+@ApplicationScoped
+public class UføretrygdRepository {
+
+    private EntityManager entityManager;
+
+    @Inject
+    public UføretrygdRepository(EntityManager entityManager) {
+        Objects.requireNonNull(entityManager, "entityManager"); //$NON-NLS-1$
+        this.entityManager = entityManager;
+    }
+
+    UføretrygdRepository() {
+        // CDI proxy
+    }
+
+    public void lagreUføreGrunnlagRegisterVersjon(Long behandlingId, AktørId aktørId, boolean erUføretrygdet, LocalDate uføredato, LocalDate virkningsdato) {
+        var aktivtGrunnlag = hentGrunnlag(behandlingId);
+        var nyttGrunnlag = UføretrygdGrunnlagEntitet.Builder.oppdatere(aktivtGrunnlag)
+            .medBehandlingId(behandlingId)
+            .medAktørIdUføretrygdet(aktørId)
+            .medRegisterUføretrygd(erUføretrygdet, uføredato, virkningsdato);
+        lagreGrunnlag(aktivtGrunnlag, nyttGrunnlag);
+    }
+
+    public void lagreUføreGrunnlagOverstyrtVersjon(Long behandlingId, boolean erUføretrygdet) {
+        var aktivtGrunnlag = hentGrunnlag(behandlingId);
+        if (aktivtGrunnlag.isEmpty()) throw new IllegalStateException("Utviklerfeil - finnes ikke UFO-grunnlag");
+        var nyttGrunnlag = UføretrygdGrunnlagEntitet.Builder.oppdatere(aktivtGrunnlag)
+            .medBehandlingId(behandlingId)
+            .medOverstyrtUføretrygd(erUføretrygdet);
+        lagreGrunnlag(aktivtGrunnlag, nyttGrunnlag);
+    }
+
+    private void lagreGrunnlag(Optional<UføretrygdGrunnlagEntitet> aktivtGrunnlag, UføretrygdGrunnlagEntitet.Builder builder) {
+        var nyttGrunnlag = builder.build();
+
+        if (!Objects.equals(aktivtGrunnlag.orElse(null), nyttGrunnlag)) {
+            aktivtGrunnlag.ifPresent(eksisterendeGrunnlag -> {
+                eksisterendeGrunnlag.deaktiver();
+                entityManager.persist(eksisterendeGrunnlag);
+            });
+            entityManager.persist(nyttGrunnlag);
+            entityManager.flush();
+        }
+    }
+
+    public Optional<UføretrygdGrunnlagEntitet> hentGrunnlag(Long behandlingId) {
+        final var query = entityManager.createQuery(
+            "FROM UforetrygdGrunnlag u WHERE u.behandlingId = :behandlingId AND u.aktiv = true",
+                    UføretrygdGrunnlagEntitet.class)
+            .setParameter("behandlingId", behandlingId);
+
+        return HibernateVerktøy.hentUniktResultat(query);
+    }
+
+    public void kopierGrunnlagFraEksisterendeBehandling(Long orginalBehandlingId, Long nyBehandlingId) {
+        var eksisterendeGrunnlag = hentGrunnlag(orginalBehandlingId);
+        eksisterendeGrunnlag.ifPresent(g -> {
+            var nyttgrunnlag = UføretrygdGrunnlagEntitet.Builder.oppdatere(eksisterendeGrunnlag)
+                .medBehandlingId(nyBehandlingId);
+            lagreGrunnlag(Optional.empty(), nyttgrunnlag);
+        });
+    }
+
+}

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/ytelsefordeling/OppgittRettighetEntitet.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/ytelsefordeling/OppgittRettighetEntitet.java
@@ -42,6 +42,11 @@ public class OppgittRettighetEntitet extends BaseEntitet {
     @ChangeTracked
     private Boolean harAleneomsorgForBarnet;
 
+    @Convert(converter = BooleanToStringConverter.class)
+    @Column(name = "mor_uforetrygd")
+    @ChangeTracked
+    private Boolean morMottarUføretrygd;
+
     OppgittRettighetEntitet() {
     }
 
@@ -49,6 +54,14 @@ public class OppgittRettighetEntitet extends BaseEntitet {
         this.harAnnenForeldreRett = harAnnenForeldreRett;
         this.harOmsorgForBarnetIHelePerioden = harOmsorgForBarnetIHelePerioden;
         this.harAleneomsorgForBarnet = harAleneomsorgForBarnet;
+        this.morMottarUføretrygd = Boolean.FALSE;
+    }
+
+    public OppgittRettighetEntitet(Boolean harAnnenForeldreRett, Boolean harOmsorgForBarnetIHelePerioden, Boolean harAleneomsorgForBarnet, Boolean morMottarUføretrygd) {
+        this.harAnnenForeldreRett = harAnnenForeldreRett;
+        this.harOmsorgForBarnetIHelePerioden = harOmsorgForBarnetIHelePerioden;
+        this.harAleneomsorgForBarnet = harAleneomsorgForBarnet;
+        this.morMottarUføretrygd = morMottarUføretrygd;
     }
 
     public Boolean getHarAleneomsorgForBarnet() {
@@ -63,6 +76,10 @@ public class OppgittRettighetEntitet extends BaseEntitet {
         return harOmsorgForBarnetIHelePerioden;
     }
 
+    public boolean getMorMottarUføretrygd() {
+        return morMottarUføretrygd != null && morMottarUføretrygd;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -70,12 +87,13 @@ public class OppgittRettighetEntitet extends BaseEntitet {
         var that = (OppgittRettighetEntitet) o;
         return Objects.equals(harAnnenForeldreRett, that.harAnnenForeldreRett) &&
             Objects.equals(harOmsorgForBarnetIHelePerioden, that.harOmsorgForBarnetIHelePerioden) &&
-            Objects.equals(harAleneomsorgForBarnet, that.harAleneomsorgForBarnet);
+            Objects.equals(harAleneomsorgForBarnet, that.harAleneomsorgForBarnet) &&
+            Objects.equals(morMottarUføretrygd, that.morMottarUføretrygd);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(harAnnenForeldreRett, harOmsorgForBarnetIHelePerioden, harAleneomsorgForBarnet);
+        return Objects.hash(harAnnenForeldreRett, harOmsorgForBarnetIHelePerioden, harAleneomsorgForBarnet, morMottarUføretrygd);
     }
 
     @Override
@@ -85,6 +103,7 @@ public class OppgittRettighetEntitet extends BaseEntitet {
             ", harAnnenForeldreRett=" + harAnnenForeldreRett +
             ", harOmsorgForBarnetIHelePerioden=" + harOmsorgForBarnetIHelePerioden +
             ", harAleneomsorgForBarnet=" + harAleneomsorgForBarnet +
+            ", morUføretrygd=" + morMottarUføretrygd +
             '}';
     }
 }

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/hendelser/MottattVedtak.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/hendelser/MottattVedtak.java
@@ -1,0 +1,118 @@
+package no.nav.foreldrepenger.behandlingslager.hendelser;
+
+import java.util.Objects;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+import no.nav.foreldrepenger.behandlingslager.BaseCreateableEntitet;
+
+@Entity(name = "MottattVedtak")
+@Table(name = "MOTTATT_VEDTAK")
+public class MottattVedtak extends BaseCreateableEntitet {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "SEQ_MOTTATT_VEDTAK")
+    private Long id;
+
+    // Må kunne håndtere saksnummer fra eksterne system
+    @Column(name = "SAKSNUMMER", nullable = false)
+    private String saksnummer;
+
+    @Column(name = "FAGSYSTEM", nullable = false)
+    private String fagsystem;
+
+    @Column(name = "YTELSE", nullable = false)
+    private String ytelse;
+
+    @Column(name = "REFERANSE", nullable = false)
+    private String referanse;
+
+    MottattVedtak() {
+        //for hibernate
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getSaksnummer() {
+        return saksnummer;
+    }
+
+    public String getFagsystem() {
+        return fagsystem;
+    }
+
+    public String getYtelse() {
+        return ytelse;
+    }
+
+    public String getReferanse() {
+        return referanse;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        var that = (MottattVedtak) o;
+        return Objects.equals(saksnummer, that.saksnummer) &&
+            Objects.equals(fagsystem, that.fagsystem) &&
+            Objects.equals(ytelse, that.ytelse) &&
+            Objects.equals(referanse, that.referanse);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(saksnummer, fagsystem, ytelse, referanse);
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private MottattVedtak kladd;
+
+        private Builder() {
+            kladd = new MottattVedtak();
+        }
+
+        public Builder medSaksnummer(String saksnummer) {
+            this.kladd.saksnummer = saksnummer;
+            return this;
+        }
+
+        public Builder medFagsystem(String fagsystem) {
+            this.kladd.fagsystem = fagsystem;
+            return this;
+        }
+
+        public Builder medYtelse(String ytelse) {
+            this.kladd.ytelse = ytelse;
+            return this;
+        }
+
+        public Builder medReferanse(String referanse) {
+            this.kladd.referanse = referanse;
+            return this;
+        }
+
+        public MottattVedtak build() {
+            verifyStateForBuild();
+            return kladd;
+        }
+
+        private void verifyStateForBuild() {
+            Objects.requireNonNull(kladd.saksnummer);
+            Objects.requireNonNull(kladd.fagsystem);
+            Objects.requireNonNull(kladd.ytelse);
+            Objects.requireNonNull(kladd.referanse);
+        }
+    }
+}

--- a/behandlingslager/domene/src/main/resources/META-INF/pu-default.behandling.orm.xml
+++ b/behandlingslager/domene/src/main/resources/META-INF/pu-default.behandling.orm.xml
@@ -14,6 +14,7 @@
 	<sequence-generator name="SEQ_VILKAR" allocation-size="50" sequence-name="SEQ_VILKAR" />
 
 	<sequence-generator name="SEQ_MOTTATT_DOKUMENT" allocation-size="50" sequence-name="SEQ_MOTTATT_DOKUMENT" />
+	<sequence-generator name="SEQ_MOTTATT_VEDTAK" allocation-size="50" sequence-name="SEQ_MOTTATT_VEDTAK" />
 	
 	<entity class="no.nav.foreldrepenger.behandlingslager.behandling.Behandling" />
 	<entity class="no.nav.foreldrepenger.behandlingslager.behandling.BehandlingStegTilstand" />
@@ -23,6 +24,7 @@
 
 	<!-- Hendelser -->
 	<entity class="no.nav.foreldrepenger.behandlingslager.hendelser.MottattHendelse" />
+	<entity class="no.nav.foreldrepenger.behandlingslager.hendelser.MottattVedtak" />
 	<entity class="no.nav.foreldrepenger.behandlingslager.behandling.MottattDokument" />
 
 	<entity class="no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.Aksjonspunkt" />

--- a/behandlingslager/domene/src/main/resources/META-INF/pu-default.grunnlag.orm.xml
+++ b/behandlingslager/domene/src/main/resources/META-INF/pu-default.grunnlag.orm.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entity-mappings xmlns="http://xmlns.jcp.org/xml/ns/persistence/orm" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence/orm
+      http://xmlns.jcp.org/xml/ns/persistence/orm_2_1.xsd" version="2.1">
+
+    <sequence-generator name="SEQ_GR_PLEIEPENGER" allocation-size="50" sequence-name="SEQ_GR_PLEIEPENGER" />
+    <sequence-generator name="SEQ_PSB_PERIODER" allocation-size="50" sequence-name="SEQ_PSB_PERIODER" />
+    <sequence-generator name="SEQ_PSB_INNLAGT_PERIODE" allocation-size="50" sequence-name="SEQ_PSB_INNLAGT_PERIODE" />
+
+    <sequence-generator name="SEQ_GR_UFORETRYGD" allocation-size="50" sequence-name="SEQ_GR_UFORETRYGD" />
+
+    <!-- Andre grunnlag -->
+    <entity class="no.nav.foreldrepenger.behandlingslager.behandling.pleiepenger.PleiepengerGrunnlagEntitet"/>
+    <entity class="no.nav.foreldrepenger.behandlingslager.behandling.pleiepenger.PleiepengerPerioderEntitet"/>
+    <entity class="no.nav.foreldrepenger.behandlingslager.behandling.pleiepenger.PleiepengerInnleggelseEntitet"/>
+
+    <entity class="no.nav.foreldrepenger.behandlingslager.behandling.ufore.UføretrygdGrunnlagEntitet"/>
+
+
+</entity-mappings>

--- a/behandlingslager/domene/src/main/resources/META-INF/pu-default.opptjening.orm.xml
+++ b/behandlingslager/domene/src/main/resources/META-INF/pu-default.opptjening.orm.xml
@@ -5,10 +5,12 @@
 
     <sequence-generator name="SEQ_OPPTJENING" allocation-size="50" sequence-name="SEQ_OPPTJENING" />
     <sequence-generator name="SEQ_OPPTJENING_AKTIVITET" allocation-size="50" sequence-name="SEQ_OPPTJENING_AKTIVITET" />
+    <sequence-generator name="SEQ_GR_OPPTJ_UTLAND_DOK_VALG" allocation-size="50" sequence-name="SEQ_GR_OPPTJ_UTLAND_DOK_VALG" />
 
     <!-- Opptjening -->
     <entity class="no.nav.foreldrepenger.behandlingslager.behandling.opptjening.Opptjening"/>
     <entity class="no.nav.foreldrepenger.behandlingslager.behandling.opptjening.OpptjeningAktivitet"/>
+    <entity class="no.nav.foreldrepenger.behandlingslager.behandling.opptjening.utlanddok.OpptjeningIUtlandDokStatusEntitet"/>
 
 
 </entity-mappings>

--- a/behandlingslager/domene/src/main/resources/META-INF/pu-default.svangerskapspenger.orm.xml
+++ b/behandlingslager/domene/src/main/resources/META-INF/pu-default.svangerskapspenger.orm.xml
@@ -3,6 +3,11 @@
 	xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence/orm
       http://xmlns.jcp.org/xml/ns/persistence/orm_2_1.xsd" version="2.1">
 
+	<sequence-generator name="SEQ_SVP_GRUNNLAG" allocation-size="50" sequence-name="SEQ_SVP_GRUNNLAG" />
+	<sequence-generator name="SEQ_SVP_TILRETTELEGGING" allocation-size="50" sequence-name="SEQ_SVP_TILRETTELEGGING" />
+	<sequence-generator name="SEQ_SVP_TILRETTELEGGINGER" allocation-size="50" sequence-name="SEQ_SVP_TILRETTELEGGINGER" />
+	<sequence-generator name="SEQ_TILRETTELEGGING_FOM" allocation-size="50" sequence-name="SEQ_TILRETTELEGGING_FOM" />
+
 	<!-- SvpTilrettelegging -->
 	<entity class="no.nav.foreldrepenger.behandlingslager.behandling.tilrettelegging.SvpTilretteleggingEntitet" />
 	<entity class="no.nav.foreldrepenger.behandlingslager.behandling.tilrettelegging.SvpTilretteleggingerEntitet" />

--- a/behandlingslager/domene/src/main/resources/META-INF/pu-default.uttak.orm.xml
+++ b/behandlingslager/domene/src/main/resources/META-INF/pu-default.uttak.orm.xml
@@ -16,8 +16,8 @@
     <sequence-generator name="SEQ_UTTAK_RES_PER_SOKNAD" allocation-size="50" sequence-name="SEQ_UTTAK_RES_PER_SOKNAD" />
 
     <sequence-generator name="SEQ_SVP_UTTAK_RESULTAT" allocation-size="50" sequence-name="SEQ_SVP_UTTAK_RESULTAT" />
-    <sequence-generator name="SEQ_SVP_UTTAK_RESULTAT_ARBEIDSFORHOLD" allocation-size="50" sequence-name="SEQ_SVP_UTTAK_RESULTAT_ARBEIDSFORHOLD" />
-    <sequence-generator name="SEQ_SVP_UTTAK_RESULTAT_PERIODE" allocation-size="50" sequence-name="SEQ_SVP_UTTAK_RESULTAT_PERIODE" />
+    <sequence-generator name="SEQ_SVP_UTTAK_ARBEIDSFORHOLD" allocation-size="50" sequence-name="SEQ_SVP_UTTAK_ARBEIDSFORHOLD" />
+    <sequence-generator name="SEQ_SVP_UTTAK_PERIODE" allocation-size="50" sequence-name="SEQ_SVP_UTTAK_PERIODE" />
 
     <sequence-generator name="SEQ_GR_YTELSES_FORDELING" allocation-size="50" sequence-name="SEQ_GR_YTELSES_FORDELING"/>
     <sequence-generator name="SEQ_YF_FORDELING" allocation-size="50" sequence-name="SEQ_YF_FORDELING"/>
@@ -27,6 +27,8 @@
     <sequence-generator name="SEQ_SO_DEKNINGSGRAD" allocation-size="50" sequence-name="SEQ_SO_DEKNINGSGRAD"/>
     <sequence-generator name="SEQ_YF_DOKUMENTASJON_PERIODE" allocation-size="50" sequence-name="SEQ_YF_DOKUMENTASJON_PERIODE"/>
     <sequence-generator name="SEQ_YF_DOKUMENTASJON_PERIODER" allocation-size="50" sequence-name="SEQ_YF_DOKUMENTASJON_PERIODER"/>
+    <sequence-generator name="SEQ_YF_AKTIVITETSKRAV_PERIODE" allocation-size="50" sequence-name="SEQ_YF_AKTIVITETSKRAV_PERIODE"/>
+    <sequence-generator name="SEQ_YF_AKTIVITETSKRAV_PERIODER" allocation-size="50" sequence-name="SEQ_YF_AKTIVITETSKRAV_PERIODER"/>
 
     <!-- Uttak av FP -->
     <entity class="no.nav.foreldrepenger.behandlingslager.uttak.fp.UttakResultatPerioderEntitet"/>

--- a/behandlingslager/testutil/src/main/java/no/nav/foreldrepenger/behandlingslager/testutilities/behandling/AbstractTestScenario.java
+++ b/behandlingslager/testutil/src/main/java/no/nav/foreldrepenger/behandlingslager/testutilities/behandling/AbstractTestScenario.java
@@ -75,6 +75,7 @@ import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRe
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepositoryProvider;
 import no.nav.foreldrepenger.behandlingslager.behandling.søknad.SøknadEntitet;
 import no.nav.foreldrepenger.behandlingslager.behandling.søknad.SøknadRepository;
+import no.nav.foreldrepenger.behandlingslager.behandling.ufore.UføretrygdRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.vedtak.BehandlingVedtak;
 import no.nav.foreldrepenger.behandlingslager.behandling.vedtak.BehandlingVedtakRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.vedtak.VedtakResultatType;
@@ -237,6 +238,7 @@ public abstract class AbstractTestScenario<S extends AbstractTestScenario<S>> {
         lenient().when(repositoryProvider.getFamilieHendelseRepository()).thenReturn(familieHendelseRepository);
         lenient().when(repositoryProvider.getMedlemskapRepository()).thenReturn(mockMedlemskapRepository);
         lenient().when(repositoryProvider.getPleiepengerRepository()).thenReturn(mock(PleiepengerRepository.class));
+        lenient().when(repositoryProvider.getUføretrygdRepository()).thenReturn(mock(UføretrygdRepository.class));
         lenient().when(repositoryProvider.getSøknadRepository()).thenReturn(søknadRepository);
         lenient().when(repositoryProvider.getBehandlingVedtakRepository()).thenReturn(behandlingVedtakRepository);
         lenient().when(repositoryProvider.getFagsakLåsRepository()).thenReturn(fagsakLåsRepository);

--- a/domenetjenester/behandling-revurdering/src/main/java/no/nav/foreldrepenger/behandling/revurdering/ytelse/fp/RevurderingTjenesteImpl.java
+++ b/domenetjenester/behandling-revurdering/src/main/java/no/nav/foreldrepenger/behandling/revurdering/ytelse/fp/RevurderingTjenesteImpl.java
@@ -29,6 +29,7 @@ import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRe
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepositoryProvider;
 import no.nav.foreldrepenger.behandlingslager.behandling.søknad.SøknadEntitet;
 import no.nav.foreldrepenger.behandlingslager.behandling.søknad.SøknadRepository;
+import no.nav.foreldrepenger.behandlingslager.behandling.ufore.UføretrygdRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.verge.VergeRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.YtelseFordelingAggregat;
 import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.YtelsesFordelingRepository;
@@ -46,6 +47,7 @@ public class RevurderingTjenesteImpl implements RevurderingTjeneste {
     private PersonopplysningRepository personopplysningRepository;
     private MedlemskapRepository medlemskapRepository;
     private PleiepengerRepository pleiepengerRepository;
+    private UføretrygdRepository uføretrygdRepository;
     private YtelsesFordelingRepository ytelsesFordelingRepository;
     private OpptjeningIUtlandDokStatusRepository opptjeningIUtlandDokStatusRepository;
     private RevurderingTjenesteFelles revurderingTjenesteFelles;
@@ -74,6 +76,7 @@ public class RevurderingTjenesteImpl implements RevurderingTjeneste {
         this.personopplysningRepository = repositoryProvider.getPersonopplysningRepository();
         this.medlemskapRepository = repositoryProvider.getMedlemskapRepository();
         this.pleiepengerRepository = repositoryProvider.getPleiepengerRepository();
+        this.uføretrygdRepository = repositoryProvider.getUføretrygdRepository();
         this.opptjeningIUtlandDokStatusRepository = repositoryProvider.getOpptjeningIUtlandDokStatusRepository();
         this.revurderingEndring = revurderingEndring;
         this.revurderingTjenesteFelles = revurderingTjenesteFelles;
@@ -132,6 +135,7 @@ public class RevurderingTjenesteImpl implements RevurderingTjeneste {
         personopplysningRepository.kopierGrunnlagFraEksisterendeBehandling(originalBehandlingId, nyBehandlingId);
         medlemskapRepository.kopierGrunnlagFraEksisterendeBehandling(originalBehandlingId, nyBehandlingId);
         pleiepengerRepository.kopierGrunnlagFraEksisterendeBehandling(originalBehandlingId, nyBehandlingId);
+        uføretrygdRepository.kopierGrunnlagFraEksisterendeBehandling(originalBehandlingId, nyBehandlingId);
 
         if (BehandlingType.REVURDERING.equals(ny.getType())) {
             ytelsesFordelingRepository.kopierGrunnlagFraEksisterendeBehandling(originalBehandlingId, nyBehandlingId);
@@ -163,6 +167,7 @@ public class RevurderingTjenesteImpl implements RevurderingTjeneste {
         familieHendelseRepository.kopierGrunnlagFraEksisterendeBehandlingUtenVurderinger(originalBehandlingId, nyBehandlingId);
         personopplysningRepository.kopierGrunnlagFraEksisterendeBehandlingUtenVurderinger(originalBehandlingId, nyBehandlingId);
         medlemskapRepository.kopierGrunnlagFraEksisterendeBehandlingUtenVurderinger(originalBehandlingId, nyBehandlingId);
+        uføretrygdRepository.kopierGrunnlagFraEksisterendeBehandling(originalBehandlingId, nyBehandlingId);
 
         // Nytt til post-annullering
         var ytelseFordelingAggregat = ytelsesFordelingRepository.hentAggregat(originalBehandlingId);

--- a/domenetjenester/behandling-revurdering/src/main/java/no/nav/foreldrepenger/behandling/revurdering/ytelse/fp/UttakGrunnlagTjeneste.java
+++ b/domenetjenester/behandling-revurdering/src/main/java/no/nav/foreldrepenger/behandling/revurdering/ytelse/fp/UttakGrunnlagTjeneste.java
@@ -22,6 +22,8 @@ import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRe
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepositoryProvider;
 import no.nav.foreldrepenger.behandlingslager.behandling.søknad.SøknadEntitet;
 import no.nav.foreldrepenger.behandlingslager.behandling.søknad.SøknadRepository;
+import no.nav.foreldrepenger.behandlingslager.behandling.ufore.UføretrygdGrunnlagEntitet;
+import no.nav.foreldrepenger.behandlingslager.behandling.ufore.UføretrygdRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.vedtak.BehandlingVedtakRepository;
 import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakRelasjon;
 import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakRelasjonRepository;
@@ -46,6 +48,7 @@ public class UttakGrunnlagTjeneste implements YtelsesesspesifiktGrunnlagTjeneste
     private BehandlingVedtakRepository behandlingVedtakRepository;
     private SøknadRepository søknadRepository;
     private PleiepengerRepository pleiepengerRepository;
+    private UføretrygdRepository uføretrygdRepository;
 
     @Inject
     public UttakGrunnlagTjeneste(BehandlingRepositoryProvider behandlingRepositoryProvider,
@@ -58,6 +61,7 @@ public class UttakGrunnlagTjeneste implements YtelsesesspesifiktGrunnlagTjeneste
         this.familieHendelseTjeneste = familieHendelseTjeneste;
         this.søknadRepository = behandlingRepositoryProvider.getSøknadRepository();
         this.pleiepengerRepository = behandlingRepositoryProvider.getPleiepengerRepository();
+        this.uføretrygdRepository = behandlingRepositoryProvider.getUføretrygdRepository();
     }
 
     UttakGrunnlagTjeneste() {
@@ -83,7 +87,8 @@ public class UttakGrunnlagTjeneste implements YtelsesesspesifiktGrunnlagTjeneste
             .medErBerørtBehandling(erBerørtBehandling)
             .medFamilieHendelser(familiehendelser)
             .medOriginalBehandling(originalBehandling.orElse(null))
-            .medPleiepengerGrunnlag(pleiepengerGrunnlag(ref).orElse(null));
+            .medPleiepengerGrunnlag(pleiepengerGrunnlag(ref).orElse(null))
+            .medUføretrygdGrunnlag(uføretrygdGrunnlag(ref).orElse(null));
         if (fagsakRelasjon.isPresent()) {
             var annenpart = annenpart(fagsakRelasjon.get(), familiehendelser, behandling);
             grunnlag = grunnlag.medAnnenpart(annenpart.orElse(null));
@@ -93,6 +98,10 @@ public class UttakGrunnlagTjeneste implements YtelsesesspesifiktGrunnlagTjeneste
 
     private Optional<PleiepengerGrunnlagEntitet> pleiepengerGrunnlag(BehandlingReferanse ref) {
         return pleiepengerRepository.hentGrunnlag(ref.getBehandlingId());
+    }
+
+    private Optional<UføretrygdGrunnlagEntitet> uføretrygdGrunnlag(BehandlingReferanse ref) {
+        return uføretrygdRepository.hentGrunnlag(ref.getBehandlingId());
     }
 
     private Optional<Annenpart> annenpart(FagsakRelasjon fagsakRelasjon,

--- a/domenetjenester/behandling-revurdering/src/main/resources/META-INF/pu-default.revurdering.orm.xml
+++ b/domenetjenester/behandling-revurdering/src/main/resources/META-INF/pu-default.revurdering.orm.xml
@@ -3,7 +3,7 @@
 	xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence/orm
       http://xmlns.jcp.org/xml/ns/persistence/orm_2_1.xsd" version="2.1">
 
-	<sequence-generator name="SEQ_ETTERKONTROLL_LOGG" allocation-size="50" sequence-name="SEQ_ETTERKONTROLL_LOGG" />
+	<sequence-generator name="SEQ_ETTERKONTROLL" allocation-size="50" sequence-name="SEQ_ETTERKONTROLL" />
 
 	<!-- Etterkontroll -->	
     <entity class="no.nav.foreldrepenger.behandling.revurdering.etterkontroll.Etterkontroll"/>

--- a/domenetjenester/beregningsgrunnlag/src/main/resources/META-INF/pu-default.beregningsgrunnlag.orm.xml
+++ b/domenetjenester/beregningsgrunnlag/src/main/resources/META-INF/pu-default.beregningsgrunnlag.orm.xml
@@ -26,6 +26,7 @@
     <sequence-generator name="SEQ_BG_BESTEBEREGNINGGRUNNLAG" allocation-size="50" sequence-name="SEQ_BG_BESTEBEREGNINGGRUNNLAG"/>
     <sequence-generator name="SEQ_BESTEBEREGNING_MAANED" allocation-size="50" sequence-name="SEQ_BESTEBEREGNING_MAANED"/>
     <sequence-generator name="SEQ_BESTEBEREGNING_INNTEKT" allocation-size="50" sequence-name="SEQ_BESTEBEREGNING_INNTEKT"/>
+    <sequence-generator name="SEQ_BG_AKTIVITET_STATUS" allocation-size="50" sequence-name="SEQ_BG_AKTIVITET_STATUS"/>
 
 
     <entity class="no.nav.foreldrepenger.domene.modell.BeregningsgrunnlagEntitet" />

--- a/domenetjenester/registerinnhenting/src/main/java/no/nav/foreldrepenger/domene/registerinnhenting/ufo/UforeTypeCtiDto.java
+++ b/domenetjenester/registerinnhenting/src/main/java/no/nav/foreldrepenger/domene/registerinnhenting/ufo/UforeTypeCtiDto.java
@@ -1,5 +1,4 @@
 package no.nav.foreldrepenger.domene.registerinnhenting.ufo;
 
-public record UforeTypeCtiDto(UforeTypeCode code,
-                              String decode) {
+public record UforeTypeCtiDto(UforeTypeCode code) {
 }

--- a/domenetjenester/registerinnhenting/src/main/java/no/nav/foreldrepenger/domene/registerinnhenting/ufo/UforehistorikkDto.java
+++ b/domenetjenester/registerinnhenting/src/main/java/no/nav/foreldrepenger/domene/registerinnhenting/ufo/UforehistorikkDto.java
@@ -1,9 +1,8 @@
 package no.nav.foreldrepenger.domene.registerinnhenting.ufo;
 
-import java.util.Date;
 import java.util.List;
 
-public record UforehistorikkDto(Date reaktiviseringFomDato, Date reaktiviseringTomDato, List<UforeperiodeDto> uforeperiodeListe) {
+public record UforehistorikkDto(List<UforeperiodeDto> uforeperiodeListe) {
     public List<UforeperiodeDto> uforeperioder() {
         return uforeperiodeListe == null ? List.of() : uforeperiodeListe;
     }

--- a/domenetjenester/registerinnhenting/src/main/java/no/nav/foreldrepenger/domene/registerinnhenting/ufo/UforeperiodeDto.java
+++ b/domenetjenester/registerinnhenting/src/main/java/no/nav/foreldrepenger/domene/registerinnhenting/ufo/UforeperiodeDto.java
@@ -6,7 +6,6 @@ public record UforeperiodeDto(Integer uforegrad,
                               Date uforetidspunkt,
                               Date virk,
                               UforeTypeCtiDto uforetype,
-                              Date uforetidspunktTom,
                               Date ufgFom,
                               Date ufgTom) {
 }

--- a/domenetjenester/registerinnhenting/src/main/java/no/nav/foreldrepenger/domene/registerinnhenting/ufo/UføreInnhenter.java
+++ b/domenetjenester/registerinnhenting/src/main/java/no/nav/foreldrepenger/domene/registerinnhenting/ufo/UføreInnhenter.java
@@ -1,27 +1,43 @@
 package no.nav.foreldrepenger.domene.registerinnhenting.ufo;
 
+import java.time.LocalDate;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
+import java.util.Optional;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
+import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingType;
 import no.nav.foreldrepenger.behandlingslager.behandling.personopplysning.OppgittAnnenPartEntitet;
 import no.nav.foreldrepenger.behandlingslager.behandling.personopplysning.PersonopplysningRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.personopplysning.RelasjonsRolleType;
+import no.nav.foreldrepenger.behandlingslager.behandling.ufore.UføretrygdRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.MorsAktivitet;
+import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.OppgittRettighetEntitet;
 import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.YtelseFordelingAggregat;
 import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.YtelsesFordelingRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.periode.OppgittFordelingEntitet;
+import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.periode.OppgittPeriodeEntitet;
 import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.periode.UttakPeriodeType;
 import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakYtelseType;
+import no.nav.foreldrepenger.behandlingslager.uttak.fp.FpUttakRepository;
+import no.nav.foreldrepenger.behandlingslager.uttak.fp.UttakResultatEntitet;
+import no.nav.foreldrepenger.behandlingslager.uttak.fp.UttakResultatPeriodeEntitet;
+import no.nav.foreldrepenger.behandlingslager.uttak.fp.UttakResultatPerioderEntitet;
 import no.nav.foreldrepenger.domene.person.PersoninfoAdapter;
+import no.nav.foreldrepenger.domene.typer.AktørId;
+import no.nav.vedtak.konfig.Tid;
 
 @ApplicationScoped
 public class UføreInnhenter {
 
+    private UføretrygdRepository uføretrygdRepository;
     private YtelsesFordelingRepository yfRepository;
     private PersonopplysningRepository poRepository;
+    private FpUttakRepository uttakRepository;
     private PersoninfoAdapter personinfoAdapter;
     private PesysUføreKlient pesysUføreKlient;
 
@@ -30,33 +46,93 @@ public class UføreInnhenter {
     }
 
     @Inject
-    public UføreInnhenter(YtelsesFordelingRepository yfRepository,
+    public UføreInnhenter(UføretrygdRepository uføretrygdRepository,
+                          YtelsesFordelingRepository yfRepository,
                           PersonopplysningRepository poRepository,
+                          FpUttakRepository uttakRepository,
                           PersoninfoAdapter personinfoAdapter,
                           PesysUføreKlient pesysUføreKlient) {
+        this.uføretrygdRepository = uføretrygdRepository;
         this.yfRepository = yfRepository;
         this.poRepository = poRepository;
+        this.uttakRepository = uttakRepository;
         this.personinfoAdapter = personinfoAdapter;
         this.pesysUføreKlient = pesysUføreKlient;
     }
 
     public void innhentUføretrygd(Behandling behandling) {
-
+        // 14-14 Bare Far/Medmor har rett
         if (!FagsakYtelseType.FORELDREPENGER.equals(behandling.getFagsakYtelseType()) ||
             RelasjonsRolleType.erMor(behandling.getFagsak().getRelasjonsRolleType())) {
             return;
         }
-        var finnesPerioderMedMorAktivitetUfør = yfRepository.hentAggregatHvisEksisterer(behandling.getId())
-            .map(YtelseFordelingAggregat::getGjeldendeSøknadsperioder)
+        var annenpartAktørId = poRepository.hentOppgittAnnenPartHvisEksisterer(behandling.getId())
+            .map(OppgittAnnenPartEntitet::getAktørId).orElse(null);
+        var harGrunnlagForAnnenPart = uføretrygdRepository.hentGrunnlag(behandling.getId())
+            .filter(g -> annenpartAktørId != null && annenpartAktørId.equals(g.getAktørIdAnnenPart())).isPresent();
+        // Mangler annenpart eller har allerede innhentet Venter ikke oppdatering av uførestatus
+        if (annenpartAktørId == null || harGrunnlagForAnnenPart) {
+            return;
+        }
+
+        var yfAggregat = yfRepository.hentAggregatHvisEksisterer(behandling.getId());
+        var finnesPerioderMedMorAktivitetUfør = yfAggregat.map(YtelseFordelingAggregat::getGjeldendeSøknadsperioder)
             .map(OppgittFordelingEntitet::getOppgittePerioder).orElse(List.of()).stream()
             .filter(p -> UttakPeriodeType.FORELDREPENGER.equals(p.getPeriodeType()))
             .anyMatch(p -> MorsAktivitet.UFØRE.equals(p.getMorsAktivitet()));
-        if (finnesPerioderMedMorAktivitetUfør) {
-            poRepository.hentOppgittAnnenPartHvisEksisterer(behandling.getId())
-                .map(OppgittAnnenPartEntitet::getAktørId)
-                .flatMap(ap -> personinfoAdapter.hentFnr(ap))
-                .ifPresent(fnr -> pesysUføreKlient.hentUføreHistorikk(fnr.getIdent(), behandling.getFagsak().getSaksnummer().getVerdi()));
+        var oppgittRettighetMorUfør = yfAggregat.map(YtelseFordelingAggregat::getOppgittRettighet)
+            .filter(OppgittRettighetEntitet::getMorMottarUføretrygd)
+            .isPresent();
+        // Midlertidig: Sjekker også om det finnes innvilgete perioder for å opprette grunnlag for eksisterende
+        var harInnvilgetUttakMedUføre = uttakResultatMedInnvilgetUføre(behandling);
+        if (finnesPerioderMedMorAktivitetUfør || oppgittRettighetMorUfør || harInnvilgetUttakMedUføre) {
+            var førsteUttakDato = førsteUttaksdag(behandling, yfAggregat);
+            innhentOgLagre(behandling, annenpartAktørId, førsteUttakDato);
         }
+    }
+
+    private void innhentOgLagre(Behandling behandling, AktørId annenpart, LocalDate startDato) {
+        var uføreperiode = poRepository.hentOppgittAnnenPartHvisEksisterer(behandling.getId())
+            .map(OppgittAnnenPartEntitet::getAktørId)
+            .flatMap(ap -> personinfoAdapter.hentFnr(ap))
+            .flatMap(fnr -> pesysUføreKlient.hentUføreHistorikk(fnr.getIdent(), startDato, behandling.getFagsak().getSaksnummer().getVerdi()));
+        // TODO (JOL): Slå på lagring av tilfellse der vi ikke finner
+        uføreperiode.ifPresent(uføre -> uføretrygdRepository.lagreUføreGrunnlagRegisterVersjon(behandling.getId(), annenpart, true, uføre.uforetidspunkt(), uføre.virkningsdato()));
+    }
+
+    private LocalDate førsteUttaksdag(Behandling behandling, Optional<YtelseFordelingAggregat> ytelseFordeling) {
+
+        final var førsteUttaksdagSøknad = ytelseFordeling.map(YtelseFordelingAggregat::getGjeldendeSøknadsperioder)
+            .map(OppgittFordelingEntitet::getOppgittePerioder).orElse(Collections.emptyList()).stream()
+            .map(OppgittPeriodeEntitet::getFom)
+            .min(Comparator.naturalOrder()).orElse(Tid.TIDENES_ENDE);
+
+        final var førsteUttaksdagForrigeVedtak = finnFørsteDatoIUttakResultat(behandling).orElse(Tid.TIDENES_ENDE);
+        final var førsteUttaksdag = førsteUttaksdagSøknad.isBefore(førsteUttaksdagForrigeVedtak) ? førsteUttaksdagSøknad : førsteUttaksdagForrigeVedtak;
+        return førsteUttaksdag.equals(Tid.TIDENES_ENDE) ? LocalDate.now() : førsteUttaksdag;
+    }
+
+    private Optional<LocalDate> finnFørsteDatoIUttakResultat(Behandling behandling) {
+        if (!BehandlingType.REVURDERING.equals(behandling.getType())) return Optional.empty();
+        return uttakRepository.hentUttakResultatHvisEksisterer(originalBehandling(behandling))
+            .map(UttakResultatEntitet::getGjeldendePerioder)
+            .map(UttakResultatPerioderEntitet::getPerioder).orElse(List.of()).stream()
+            .map(UttakResultatPeriodeEntitet::getFom)
+            .min(Comparator.naturalOrder());
+    }
+
+    private boolean uttakResultatMedInnvilgetUføre(Behandling behandling) {
+        return BehandlingType.REVURDERING.equals(behandling.getType()) &&
+            uttakRepository.hentUttakResultatHvisEksisterer(originalBehandling(behandling))
+            .map(UttakResultatEntitet::getGjeldendePerioder)
+            .map(UttakResultatPerioderEntitet::getPerioder).orElse(List.of()).stream()
+            .filter(UttakResultatPeriodeEntitet::isInnvilget)
+            .anyMatch(p -> p.getPeriodeSøknad().filter(s -> MorsAktivitet.UFØRE.equals(s.getMorsAktivitet())).isPresent());
+    }
+
+    private Long originalBehandling(Behandling behandling) {
+        return behandling.getOriginalBehandlingId()
+            .orElseThrow(() -> new IllegalArgumentException("Revurdering må ha original behandling"));
     }
 
 }

--- a/domenetjenester/registerinnhenting/src/main/java/no/nav/foreldrepenger/domene/registerinnhenting/ufo/UføreType.java
+++ b/domenetjenester/registerinnhenting/src/main/java/no/nav/foreldrepenger/domene/registerinnhenting/ufo/UføreType.java
@@ -1,9 +1,0 @@
-package no.nav.foreldrepenger.domene.registerinnhenting.ufo;
-
-public enum UføreType {
-    UFØRE,
-    UFØRE_MED_YRKESSKADE,
-    VIRKNINGSDATO_IKKE_UFØR,
-    YRKESSKADE,
-    UDFEFINERT
-}

--- a/domenetjenester/registerinnhenting/src/main/java/no/nav/foreldrepenger/domene/registerinnhenting/ufo/Uføreperiode.java
+++ b/domenetjenester/registerinnhenting/src/main/java/no/nav/foreldrepenger/domene/registerinnhenting/ufo/Uføreperiode.java
@@ -5,34 +5,16 @@ import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.Date;
 
-public record Uføreperiode(Integer uforegrad,
-                           LocalDate uforetidspunkt,
+public record Uføreperiode(LocalDate uforetidspunkt,
                            LocalDate virkningsdato,
-                           UføreType uføretype,
-                           LocalDate uforetidspunktTom,
                            LocalDate ufgFom,
                            LocalDate ufgTom) {
     public Uføreperiode(UforeperiodeDto dto) {
-        this(dto.uforegrad(),
-            tilLocalDate(dto.uforetidspunkt()),
-            tilLocalDate(dto.virk()),
-            tilUføreType(dto.uforetype()),
-            tilLocalDate(dto.uforetidspunktTom()),
-            tilLocalDate(dto.ufgFom()),
-            tilLocalDate(dto.ufgTom()));
+        this(tilLocalDate(dto.uforetidspunkt()), tilLocalDate(dto.virk()),
+            tilLocalDate(dto.ufgFom()), tilLocalDate(dto.ufgTom()));
     }
 
     private static LocalDate tilLocalDate(Date dato) {
         return dato == null ? null : LocalDateTime.ofInstant(dato.toInstant(), ZoneId.systemDefault()).toLocalDate();
-    }
-    private static UføreType tilUføreType(UforeTypeCtiDto dto) {
-        if (dto == null || dto.code() == null) return UføreType.UDFEFINERT;
-        return switch (dto.code()) {
-            case UFORE -> UføreType.UFØRE;
-            case UKJENT -> UføreType.UDFEFINERT;
-            case UF_M_YRKE -> UføreType.UFØRE_MED_YRKESSKADE;
-            case YRKE -> UføreType.YRKESSKADE;
-            case VIRK_IKKE_UFOR -> UføreType.VIRKNINGSDATO_IKKE_UFØR;
-        };
     }
 }

--- a/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/ForeldrepengerUttakPeriode.java
+++ b/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/ForeldrepengerUttakPeriode.java
@@ -4,6 +4,7 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.Objects;
 
+import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.MorsAktivitet;
 import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.periode.UttakPeriodeType;
 import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.årsak.OppholdÅrsak;
 import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.årsak.OverføringÅrsak;
@@ -36,6 +37,7 @@ public class ForeldrepengerUttakPeriode {
     private boolean manueltBehandlet;
     private LocalDate mottattDato;
     private LocalDate tidligstMottattDato;
+    private MorsAktivitet morsAktivitet;
 
     private ForeldrepengerUttakPeriode() {
 
@@ -71,7 +73,8 @@ public class ForeldrepengerUttakPeriode {
             && Objects.equals(periode.isFlerbarnsdager(), isFlerbarnsdager())
             && Objects.equals(periode.getUtsettelseType(), getUtsettelseType())
             && Objects.equals(periode.getOverføringÅrsak(), getOverføringÅrsak())
-            && Objects.equals(periode.getOppholdÅrsak(), getOppholdÅrsak());
+            && Objects.equals(periode.getOppholdÅrsak(), getOppholdÅrsak())
+            && Objects.equals(periode.getMorsAktivitet(), getMorsAktivitet());
     }
 
     public LocalDateInterval getTidsperiode() {
@@ -201,6 +204,10 @@ public class ForeldrepengerUttakPeriode {
         return !OppholdÅrsak.UDEFINERT.equals(getOppholdÅrsak());
     }
 
+    public MorsAktivitet getMorsAktivitet() {
+        return morsAktivitet;
+    }
+
     @Override
     public String toString() {
         return "ForeldrepengerUttakPeriode{" +
@@ -221,6 +228,7 @@ public class ForeldrepengerUttakPeriode {
             ", manueltBehandlet=" + manueltBehandlet +
             ", mottattDato=" + mottattDato +
             ", tidligstMottattDato=" + tidligstMottattDato +
+            ", morsAktivitet=" + morsAktivitet +
             '}';
     }
 
@@ -328,6 +336,11 @@ public class ForeldrepengerUttakPeriode {
 
         public Builder medTidligstMottattDato(LocalDate tidligstMottattDato) {
             kladd.tidligstMottattDato = tidligstMottattDato;
+            return this;
+        }
+
+        public Builder medMorsAktivitet(MorsAktivitet morsAktivitet) {
+            kladd.morsAktivitet = morsAktivitet;
             return this;
         }
 

--- a/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/ForeldrepengerUttakTjeneste.java
+++ b/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/ForeldrepengerUttakTjeneste.java
@@ -6,10 +6,12 @@ import java.util.stream.Collectors;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
+import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.MorsAktivitet;
 import no.nav.foreldrepenger.behandlingslager.uttak.fp.FpUttakRepository;
 import no.nav.foreldrepenger.behandlingslager.uttak.fp.UttakResultatEntitet;
 import no.nav.foreldrepenger.behandlingslager.uttak.fp.UttakResultatPeriodeAktivitetEntitet;
 import no.nav.foreldrepenger.behandlingslager.uttak.fp.UttakResultatPeriodeEntitet;
+import no.nav.foreldrepenger.behandlingslager.uttak.fp.UttakResultatPeriodeSøknadEntitet;
 import no.nav.fpsak.tidsserie.LocalDateInterval;
 
 @ApplicationScoped
@@ -65,9 +67,10 @@ public class ForeldrepengerUttakTjeneste {
             .medGraderingAvslagÅrsak(entitet.getGraderingAvslagÅrsak())
             .medSamtidigUttaksprosent(entitet.getSamtidigUttaksprosent())
             .medManuellBehandlingÅrsak(entitet.getManuellBehandlingÅrsak())
-            .medSøktKonto(entitet.getPeriodeSøknad().map(se -> se.getUttakPeriodeType()).orElse(null))
+            .medSøktKonto(entitet.getPeriodeSøknad().map(UttakResultatPeriodeSøknadEntitet::getUttakPeriodeType).orElse(null))
             .medMottattDato(mottattDato)
             .medTidligstMottattDato(entitet.getPeriodeSøknad().map(se -> se.getTidligstMottattDato().orElse(mottattDato)).orElse(null))
+            .medMorsAktivitet(entitet.getPeriodeSøknad().map(UttakResultatPeriodeSøknadEntitet::getMorsAktivitet).orElse(MorsAktivitet.UDEFINERT))
             .medOpprinneligSendtTilManuellBehandling(entitet.opprinneligSendtTilManuellBehandling())
             .medManueltBehandlet(entitet.isManueltBehandlet());
         return periodeBuilder.build();

--- a/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/fakta/omsorg/AnnenForelderHarRettAksjonspunktUtleder.java
+++ b/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/fakta/omsorg/AnnenForelderHarRettAksjonspunktUtleder.java
@@ -21,6 +21,7 @@ import no.nav.foreldrepenger.domene.uttak.ForeldrepengerUttakTjeneste;
 import no.nav.foreldrepenger.domene.uttak.PersonopplysningerForUttak;
 import no.nav.foreldrepenger.domene.uttak.UttakRepositoryProvider;
 import no.nav.foreldrepenger.domene.uttak.fakta.FaktaUttakAksjonspunktUtleder;
+import no.nav.foreldrepenger.domene.uttak.input.Annenpart;
 import no.nav.foreldrepenger.domene.uttak.input.ForeldrepengerGrunnlag;
 import no.nav.foreldrepenger.domene.uttak.input.UttakInput;
 
@@ -64,11 +65,9 @@ public class AnnenForelderHarRettAksjonspunktUtleder implements FaktaUttakAksjon
             !oppgittAleneomsorg(ytelseFordelingAggregat) &&
             !annenForelderHarUttakMedUtbetaling(annenpartsGjeldendeUttaksplan)) {
             ForeldrepengerGrunnlag fpGrunnlag = input.getYtelsespesifiktGrunnlag();
-            if (fpGrunnlag.getAnnenpart().isPresent()) {
-                var harAnnennartInnvilgetES = fpGrunnlag.getAnnenpart().get().innvilgetES();
-                return harAnnennartInnvilgetES ? List.of() : aksjonspunkt();
-            }
-            return aksjonspunkt();
+            var harAnnennartInnvilgetES = fpGrunnlag.getAnnenpart().filter(Annenpart::innvilgetES).isPresent();
+            var erUavklartAnnenpartUførhet = false; // TODO: koble inn når klar fpGrunnlag.getUføretrygdGrunnlag().filter(UføretrygdGrunnlagEntitet::uavklartAnnenForelderMottarUføretrygd).isPresent();
+            return harAnnennartInnvilgetES && !erUavklartAnnenpartUførhet ? List.of() : aksjonspunkt();
         }
 
         if (oppgittHarAnnenForeldreRett(ytelseFordelingAggregat) &&

--- a/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/input/ForeldrepengerGrunnlag.java
+++ b/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/input/ForeldrepengerGrunnlag.java
@@ -3,6 +3,7 @@ package no.nav.foreldrepenger.domene.uttak.input;
 import java.util.Optional;
 
 import no.nav.foreldrepenger.behandlingslager.behandling.pleiepenger.PleiepengerGrunnlagEntitet;
+import no.nav.foreldrepenger.behandlingslager.behandling.ufore.UføretrygdGrunnlagEntitet;
 
 public class ForeldrepengerGrunnlag implements YtelsespesifiktGrunnlag {
 
@@ -11,6 +12,7 @@ public class ForeldrepengerGrunnlag implements YtelsespesifiktGrunnlag {
     private OriginalBehandling originalBehandling;
     private Annenpart annenpart;
     private PleiepengerGrunnlagEntitet pleiepengerGrunnlag;
+    private UføretrygdGrunnlagEntitet uføretrygdGrunnlag;
 
     public ForeldrepengerGrunnlag() {
 
@@ -22,6 +24,7 @@ public class ForeldrepengerGrunnlag implements YtelsespesifiktGrunnlag {
         originalBehandling = foreldrepengerGrunnlag.originalBehandling;
         annenpart = foreldrepengerGrunnlag.annenpart;
         pleiepengerGrunnlag = foreldrepengerGrunnlag.pleiepengerGrunnlag;
+        uføretrygdGrunnlag = foreldrepengerGrunnlag.uføretrygdGrunnlag;
     }
 
     public boolean isBerørtBehandling() {
@@ -42,6 +45,10 @@ public class ForeldrepengerGrunnlag implements YtelsespesifiktGrunnlag {
 
     public Optional<PleiepengerGrunnlagEntitet> getPleiepengerGrunnlag() {
         return Optional.ofNullable(pleiepengerGrunnlag);
+    }
+
+    public Optional<UføretrygdGrunnlagEntitet> getUføretrygdGrunnlag() {
+        return Optional.ofNullable(uføretrygdGrunnlag);
     }
 
     public ForeldrepengerGrunnlag medErBerørtBehandling(boolean berørtBehandling) {
@@ -71,6 +78,12 @@ public class ForeldrepengerGrunnlag implements YtelsespesifiktGrunnlag {
     public ForeldrepengerGrunnlag medPleiepengerGrunnlag(PleiepengerGrunnlagEntitet pleiepengerGrunnlag) {
         var nyttGrunnlag = new ForeldrepengerGrunnlag(this);
         nyttGrunnlag.pleiepengerGrunnlag = pleiepengerGrunnlag;
+        return nyttGrunnlag;
+    }
+
+    public ForeldrepengerGrunnlag medUføretrygdGrunnlag(UføretrygdGrunnlagEntitet uføretrygdGrunnlag) {
+        var nyttGrunnlag = new ForeldrepengerGrunnlag(this);
+        nyttGrunnlag.uføretrygdGrunnlag = uføretrygdGrunnlag;
         return nyttGrunnlag;
     }
 }

--- a/migreringer/src/main/resources/db/migration/defaultDS/4.0.0/V4.0.0_074__TFP-4676_gr_uforetrygd.sql
+++ b/migreringer/src/main/resources/db/migration/defaultDS/4.0.0/V4.0.0_074__TFP-4676_gr_uforetrygd.sql
@@ -1,0 +1,66 @@
+-- Utvide rettighet med oppgitt verdi
+ALTER TABLE SO_RETTIGHET ADD MOR_UFORETRYGD VARCHAR2(1 CHAR) DEFAULT 'N' ;
+COMMENT ON COLUMN SO_RETTIGHET.MOR_UFORETRYGD IS 'Oppgitt at mor mottar uføretrygd';
+
+-- Tabell for å lagre bekreftet uføretrygd - fra Pesys eller aksjonspunkt
+CREATE SEQUENCE SEQ_GR_UFORETRYGD MINVALUE 1 INCREMENT BY 50 START WITH 1 NOCACHE  NOCYCLE ;
+
+CREATE TABLE GR_UFORETRYGD (
+    id NUMBER(19,0) NOT NULL
+        constraint PK_GR_UFORETRYGD
+            primary key,
+    behandling_id NUMBER(19,0) NOT NULL,
+    aktoer_id VARCHAR2(50 char),
+    register_ufore VARCHAR2(1 CHAR),
+    uforedato DATE,
+    virkningsdato DATE,
+    overstyrt_ufore VARCHAR2(1 CHAR),
+    opprettet_av VARCHAR2(20 CHAR) DEFAULT 'VL' NOT NULL,
+    opprettet_tid TIMESTAMP (3) DEFAULT systimestamp NOT NULL,
+    endret_av VARCHAR2(20 CHAR),
+    endret_tid TIMESTAMP (3),
+    aktiv VARCHAR2(1 CHAR) DEFAULT 'J' NOT NULL
+);
+
+ALTER TABLE GR_UFORETRYGD ADD CONSTRAINT FK_GR_UFORETRYGD_1 FOREIGN KEY (behandling_id) REFERENCES BEHANDLING(id);
+ALTER TABLE GR_UFORETRYGD ADD CONSTRAINT GR_UFORETRYGD_AKTIV CHECK (aktiv IN ('J', 'N'));
+
+COMMENT ON TABLE GR_UFORETRYGD IS 'Bekreftet grunnlag for 14-14 mor mottar uføretrygd';
+
+COMMENT ON COLUMN GR_UFORETRYGD.id IS 'PK';
+COMMENT ON COLUMN GR_UFORETRYGD.behandling_id IS 'Foreign key til behandling';
+comment on column GR_UFORETRYGD.AKTOER_ID is 'Aktørid fra PDL';
+COMMENT ON COLUMN GR_UFORETRYGD.register_ufore IS 'Registrert uføretrygd i fagsystem';
+COMMENT ON COLUMN GR_UFORETRYGD.uforedato IS 'Uføredato';
+COMMENT ON COLUMN GR_UFORETRYGD.virkningsdato IS 'Virkningsdato for uføretrygd';
+COMMENT ON COLUMN GR_UFORETRYGD.overstyrt_ufore IS 'Saksbehandlervurdering uføretrygd';
+COMMENT ON COLUMN GR_UFORETRYGD.aktiv IS 'Om valg er aktivt';
+
+CREATE INDEX IDX_GR_UFORETRYGD_1 ON GR_UFORETRYGD (BEHANDLING_ID);
+
+-- Sikre idempotens ved gjentatt mottak av vedtakshendelse
+create sequence SEQ_MOTTATT_VEDTAK increment by 50 START WITH 1 NOCACHE  NOCYCLE ;
+
+create table MOTTATT_VEDTAK (
+    ID NUMBER(19) not null
+        constraint PK_MOTTATT_VEDTAK
+            primary key,
+    SAKSNUMMER VARCHAR2(19 char) not null,
+    FAGSYSTEM VARCHAR2(19 char) not null,
+    YTELSE VARCHAR2(19 char) not null,
+    REFERANSE VARCHAR2(100 char),
+    OPPRETTET_AV VARCHAR2(20 char) default 'VL' not null,
+    OPPRETTET_TID TIMESTAMP(3) default systimestamp not null
+);
+
+comment on table MOTTATT_VEDTAK is 'Vedtak som er mottatt og håndert - idempotens ved rekonsumering';
+
+comment on column MOTTATT_VEDTAK.SAKSNUMMER is 'FK: Fagsak.SAKSNUMMER';
+comment on column MOTTATT_VEDTAK.FAGSYSTEM is 'Eksternt fagsystem som har fattet mottatt vedtak';
+comment on column MOTTATT_VEDTAK.YTELSE is 'Ytelse for mottatt vedtak';
+comment on column MOTTATT_VEDTAK.REFERANSE is 'Referanse UUID el til mottatt vedtak';
+
+create index IDX_OVERLAPP_VEDTAK_01 on MOTTATT_VEDTAK (REFERANSE);
+
+-- div rydding
+DROP SEQUENCE SEQ_ADOPSJON_BARN;

--- a/migreringer/src/main/resources/db/migration/defaultDS/4.0.0/V4.0.0_074__TFP-4676_gr_uforetrygd.sql
+++ b/migreringer/src/main/resources/db/migration/defaultDS/4.0.0/V4.0.0_074__TFP-4676_gr_uforetrygd.sql
@@ -60,7 +60,7 @@ comment on column MOTTATT_VEDTAK.FAGSYSTEM is 'Eksternt fagsystem som har fattet
 comment on column MOTTATT_VEDTAK.YTELSE is 'Ytelse for mottatt vedtak';
 comment on column MOTTATT_VEDTAK.REFERANSE is 'Referanse UUID el til mottatt vedtak';
 
-create index IDX_OVERLAPP_VEDTAK_01 on MOTTATT_VEDTAK (REFERANSE);
+create index IDX_MOTTATT_VEDTAK_01 on MOTTATT_VEDTAK (REFERANSE);
 
 -- div rydding
 DROP SEQUENCE SEQ_ADOPSJON_BARN;

--- a/pom.xml
+++ b/pom.xml
@@ -46,11 +46,11 @@
         <prosesstask.version>3.0.6</prosesstask.version>
         <ukelonn.felles.version>2.0.22</ukelonn.felles.version>
 
-        <fp-kontrakter.version>6.1.2</fp-kontrakter.version>
+        <fp-kontrakter.version>6.1.3</fp-kontrakter.version>
         <fp-tidsserie.version>2.5.7</fp-tidsserie.version>
         <fp-nare.version>2.1.5</fp-nare.version>
         <kalkulus.version>1.4.1</kalkulus.version>
-        <abakus-kontrakt.version>1.3.25</abakus-kontrakt.version>
+        <abakus-kontrakt.version>1.3.26</abakus-kontrakt.version>
 
         <swaggercore.version>2.1.12</swaggercore.version>
         <flyway.version>4.2.0</flyway.version>

--- a/pom.xml
+++ b/pom.xml
@@ -757,7 +757,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-jar-plugin</artifactId>
-                    <version>3.2.0</version>
+                    <version>3.2.1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -367,7 +367,7 @@
             <dependency>
                 <groupId>com.zaxxer</groupId>
                 <artifactId>HikariCP</artifactId>
-                <version>5.0.0</version>
+                <version>5.0.1</version>
             </dependency>
 
             <dependency>

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/soap/sak/v1/OpprettSakService.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/soap/sak/v1/OpprettSakService.java
@@ -120,7 +120,7 @@ public class OpprettSakService implements BehandleForeldrepengesakV1 {
                 journalpostYtelseType = FagsakYtelseType.SVANGERSKAPSPENGER;
             }
         }
-        LOG.info("FPSAK vurdering FPFORDEL ytelsedok {} vs ytelseoppgitt {}", journalpostYtelseType, behandlingTema.getFagsakYtelseType());
+        LOG.info("FPSAK vurdering ytelsedok {} vs ytelseoppgitt {}", journalpostYtelseType, behandlingTema.getFagsakYtelseType());
         if (!behandlingTema.getFagsakYtelseType().equals(journalpostYtelseType)) {
             throw new FunksjonellException("FP-785356", "Dokument og valgt ytelsetype i uoverenstemmelse",
                 "Velg ytelsetype som samstemmer med dokument");

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/uttak/app/FaktaUttakToTrinnsTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/uttak/app/FaktaUttakToTrinnsTjeneste.java
@@ -12,7 +12,6 @@ import java.util.stream.Collectors;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
-import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
 import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.årsak.UtsettelseÅrsak;
 import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.årsak.Årsak;
 import no.nav.foreldrepenger.domene.ytelsefordeling.YtelseFordelingTjeneste;
@@ -98,23 +97,19 @@ public class FaktaUttakToTrinnsTjeneste {
     /**
      * sett totrinns ved avklar annen forelder har ikke rett endring
      */
-    public boolean oppdaterToTrinnskontrollVedEndringerAnnenforelderHarRett(AvklarAnnenforelderHarRettDto dto, Behandling behandling){
+    public boolean oppdaterToTrinnskontrollVedEndringerAnnenforelderHarRett(AvklarAnnenforelderHarRettDto dto, Long behandlingId){
 
-        var ytelseFordelingAggregat = ytelseFordelingTjeneste.hentAggregat(behandling.getId());
-        var rettAvkaring = ytelseFordelingAggregat.getAnnenForelderRettAvklaring();
-        var harAnnenForeldreRettSokVersjon = ytelseFordelingAggregat
-            .getOppgittRettighet().getHarAnnenForeldreRett();
+        var ytelseFordelingAggregat = ytelseFordelingTjeneste.hentAggregat(behandlingId);
+        var rettAvklaring = ytelseFordelingAggregat.getAnnenForelderRettAvklaring();
+        var harAnnenForeldreRettSokVersjon = ytelseFordelingAggregat.getOppgittRettighet().getHarAnnenForeldreRett();
 
-        Boolean harAnnenForeldreRettBekreftetVersjon = null;
-        if (rettAvkaring.isPresent()) {
-            harAnnenForeldreRettBekreftetVersjon = rettAvkaring.get();
-        }
+        Boolean harAnnenForeldreRettBekreftetVersjon = rettAvklaring.orElse(null);
 
         var avkreftetBrukersOpplysinger = erEndretBekreftetVersjonEllerAvkreftetBrukersOpplysinger(harAnnenForeldreRettSokVersjon, dto.getAnnenforelderHarRett());
         var erEndretBekreftetVersjon = erEndretBekreftetVersjonEllerAvkreftetBrukersOpplysinger(harAnnenForeldreRettBekreftetVersjon, dto.getAnnenforelderHarRett());
 
 
-        return setToTrinns(rettAvkaring, erEndretBekreftetVersjon, avkreftetBrukersOpplysinger);
+        return setToTrinns(rettAvklaring, erEndretBekreftetVersjon, avkreftetBrukersOpplysinger);
     }
 
     private boolean erEndretBekreftetVersjonEllerAvkreftetBrukersOpplysinger(Object original, Object bekreftet) {

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/uttak/app/KontrollerOppgittFordelingTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/uttak/app/KontrollerOppgittFordelingTjeneste.java
@@ -63,8 +63,8 @@ public class KontrollerOppgittFordelingTjeneste {
     /**
      * Brukes i bekreft aksjonspunkt avklar annen forelder har rett
      */
-    public void avklarAnnenforelderHarIkkeRett(AvklarAnnenforelderHarRettDto dto, Behandling behandling) {
-        ytelseFordelingTjeneste.bekreftAnnenforelderHarRett(behandling.getId(), dto.getAnnenforelderHarRett());
+    public void avklarAnnenforelderHarIkkeRett(AvklarAnnenforelderHarRettDto dto, Long behandlingId) {
+        ytelseFordelingTjeneste.bekreftAnnenforelderHarRett(behandlingId, dto.getAnnenforelderHarRett());
     }
 
     public void bekreftOppgittePerioder(List<BekreftetOppgittPeriodeDto> bekreftedePerioder, Behandling behandling) {

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/uttak/dto/AvklarAnnenforelderHarRettDto.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/uttak/dto/AvklarAnnenforelderHarRettDto.java
@@ -13,6 +13,8 @@ public class AvklarAnnenforelderHarRettDto extends BekreftetAksjonspunktDto {
     @NotNull
     private Boolean annenforelderHarRett;
 
+    private Boolean annenforelderMottarUføretrygd;
+
     AvklarAnnenforelderHarRettDto() {
         // For Jackson
     }
@@ -30,4 +32,11 @@ public class AvklarAnnenforelderHarRettDto extends BekreftetAksjonspunktDto {
         return annenforelderHarRett;
     }
 
+    public Boolean getAnnenforelderMottarUføretrygd() {
+        return annenforelderMottarUføretrygd;
+    }
+
+    public void setAnnenforelderMottarUføretrygd(Boolean annenforelderMottarUføretrygd) {
+        this.annenforelderMottarUføretrygd = annenforelderMottarUføretrygd;
+    }
 }

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/ytelsefordeling/AnnenforelderHarRettDto.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/ytelsefordeling/AnnenforelderHarRettDto.java
@@ -4,36 +4,8 @@ import java.util.List;
 
 import no.nav.foreldrepenger.familiehendelse.rest.PeriodeDto;
 
-public class AnnenforelderHarRettDto {
-
-    private Boolean annenforelderHarRett;
-    private String begrunnelse;
-    private List<PeriodeDto> annenforelderHarRettPerioder;
-
-    public AnnenforelderHarRettDto() {
-    }
-
-    public Boolean getAnnenforelderHarRett() {
-        return annenforelderHarRett;
-    }
-
-    public void setAnnenforelderHarRett(Boolean annenforelderHarRett) {
-        this.annenforelderHarRett = annenforelderHarRett;
-    }
-
-    public String getBegrunnelse() {
-        return begrunnelse;
-    }
-
-    public void setBegrunnelse(String begrunnelse) {
-        this.begrunnelse = begrunnelse;
-    }
-
-    public List<PeriodeDto> getAnnenforelderHarRettPerioder() {
-        return annenforelderHarRettPerioder;
-    }
-
-    public void setAnnenforelderHarRettPerioder(List<PeriodeDto> annenforelderHarRettPerioder) {
-        this.annenforelderHarRettPerioder = annenforelderHarRettPerioder;
-    }
+public record AnnenforelderHarRettDto(String begrunnelse,
+                                      Boolean annenforelderHarRett,
+                                      List<PeriodeDto> annenforelderHarRettPerioder,
+                                      boolean avklarAnnenforelderMottarUføretrygd) {
 }

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/ytelsefordeling/YtelseFordelingDtoTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/ytelsefordeling/YtelseFordelingDtoTjeneste.java
@@ -75,8 +75,7 @@ public class YtelseFordelingDtoTjeneste {
     private void lagAnnenforelderHarRettDto(Behandling behandling, Optional<PerioderAnnenforelderHarRettEntitet> perioderAnnenforelderHarRett, YtelseFordelingDto.Builder dtoBuilder) {
         var begrunnelse = behandling.getAksjonspunkter().stream()
             .filter(ap -> ap.getAksjonspunktDefinisjon().equals(AksjonspunktDefinisjon.AVKLAR_FAKTA_ANNEN_FORELDER_HAR_RETT))
-            .map(Aksjonspunkt::getBegrunnelse)
-            .findFirst().orElse(null);
+            .findFirst().map(Aksjonspunkt::getBegrunnelse).orElse(null);
         var avklareUføretrygd = uføretrygdRepository.hentGrunnlag(behandling.getId())
             .filter(UføretrygdGrunnlagEntitet::uavklartAnnenForelderMottarUføretrygd)
             .isPresent();

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/forvaltning/ForvaltningTekniskRestTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/forvaltning/ForvaltningTekniskRestTjeneste.java
@@ -29,13 +29,11 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import no.nav.foreldrepenger.abac.FPSakBeskyttetRessursAttributt;
-import no.nav.foreldrepenger.behandling.anke.AnkeVurderingTjeneste;
 import no.nav.foreldrepenger.behandlingskontroll.BehandlingskontrollTjeneste;
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingStegType;
 import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.Aksjonspunkt;
 import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.AksjonspunktDefinisjon;
-import no.nav.foreldrepenger.behandlingslager.behandling.pleiepenger.PleiepengerRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepositoryProvider;
 import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakProsessTaskRepository;
@@ -62,7 +60,6 @@ public class ForvaltningTekniskRestTjeneste {
     private BehandlingRepository behandlingRepository;
     private BehandlingskontrollTjeneste behandlingskontrollTjeneste;
     private OppgaveTjeneste oppgaveTjeneste;
-    private PleiepengerRepository pleiepengerRepository;
     private PostnummerSynkroniseringTjeneste postnummerTjeneste;
     private ProsessTaskTjeneste taskTjeneste;
     private FagsakProsessTaskRepository fagsakProsessTaskRepository;
@@ -77,12 +74,10 @@ public class ForvaltningTekniskRestTjeneste {
             OppgaveTjeneste oppgaveTjeneste,
             PostnummerSynkroniseringTjeneste postnummerTjeneste,
             ProsessTaskTjeneste taskTjeneste,
-            AnkeVurderingTjeneste ankeVurderingTjeneste,
             BehandlingskontrollTjeneste behandlingskontrollTjeneste) {
         this.behandlingRepository = repositoryProvider.getBehandlingRepository();
         this.behandlingskontrollTjeneste = behandlingskontrollTjeneste;
         this.oppgaveTjeneste = oppgaveTjeneste;
-        this.pleiepengerRepository = repositoryProvider.getPleiepengerRepository();
         this.postnummerTjeneste = postnummerTjeneste;
         this.taskTjeneste = taskTjeneste;
         this.fagsakProsessTaskRepository = fagsakProsessTaskRepository;
@@ -314,37 +309,6 @@ public class ForvaltningTekniskRestTjeneste {
     @SuppressWarnings("findsecbugs:JAXRS_ENDPOINT")
     public Response fjernFagsakProsesstaskAvsluttetBehandling() {
         fagsakProsessTaskRepository.fjernForAvsluttedeBehandlinger();
-        return Response.ok().build();
-    }
-
-    @POST
-    @Path("/oppdater-psb-grunnlag")
-    @Consumes(APPLICATION_JSON)
-    @Produces(APPLICATION_JSON)
-    @Operation(description = "Oppdater PSB grunnlag", tags = "FORVALTNING-teknisk")
-    @BeskyttetRessurs(action = CREATE, resource = FPSakBeskyttetRessursAttributt.DRIFT)
-    @SuppressWarnings("findsecbugs:JAXRS_ENDPOINT")
-    public Response oppdatertPSBGrunnlag() {
-        pleiepengerRepository.reaktiverDerSisteGrunnlagErPassiv();
-        return Response.ok().build();
-    }
-
-    @POST
-    @Path("/kopier-psb-grunnlag")
-    @Consumes(APPLICATION_JSON)
-    @Produces(APPLICATION_JSON)
-    @Operation(description = "Kopier PSB-grunnlag", tags = "FORVALTNING-teknisk", responses = {
-        @ApiResponse(responseCode = "200", description = "Oppgave satt til ferdig."),
-        @ApiResponse(responseCode = "400", description = "Fant ikke aktuell oppgave."),
-        @ApiResponse(responseCode = "500", description = "Feilet pga ukjent feil.")
-    })
-    @BeskyttetRessurs(action = CREATE, resource = FPSakBeskyttetRessursAttributt.DRIFT)
-    public Response kopierPSB(@BeanParam @Valid ForvaltningBehandlingIdDto behandlingIdDto) {
-        var behandling = behandlingRepository.hentBehandling(behandlingIdDto.getBehandlingUuid());
-        behandling.getBehandlingÅrsaker().stream().filter(ba -> ba.getOriginalBehandlingId() != null)
-            .findFirst().ifPresent(ba -> {
-                pleiepengerRepository.kopierGrunnlagFraEksisterendeBehandling(ba.getOriginalBehandlingId(), behandling.getId());
-            });
         return Response.ok().build();
     }
 

--- a/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/uttak/app/AvklarAnnenforelderHarRettOppdatererTest.java
+++ b/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/uttak/app/AvklarAnnenforelderHarRettOppdatererTest.java
@@ -18,6 +18,7 @@ import no.nav.foreldrepenger.behandlingslager.behandling.historikk.Historikkinns
 import no.nav.foreldrepenger.behandlingslager.behandling.historikk.HistorikkinnslagType;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepositoryProvider;
 import no.nav.foreldrepenger.behandlingslager.behandling.skjermlenke.SkjermlenkeType;
+import no.nav.foreldrepenger.behandlingslager.behandling.ufore.UføretrygdRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.YtelsesFordelingRepository;
 import no.nav.foreldrepenger.dbstoette.EntityManagerAwareTest;
 import no.nav.foreldrepenger.domene.arbeidsforhold.InntektArbeidYtelseTjeneste;
@@ -114,7 +115,7 @@ public class AvklarAnnenforelderHarRettOppdatererTest extends EntityManagerAware
 
     private AvklarAnnenforelderHarRettOppdaterer oppdaterer() {
         return new AvklarAnnenforelderHarRettOppdaterer(kontrollerOppgittFordelingTjeneste, faktaUttakHistorikkTjeneste,
-            faktaUttakToTrinnsTjeneste);
+            faktaUttakToTrinnsTjeneste, mock(UføretrygdRepository.class));
     }
 
     private HistorikkTjenesteAdapter lagMockHistory() {

--- a/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/ytelsefordeling/YtelseFordelingDtoTjenesteTest.java
+++ b/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/ytelsefordeling/YtelseFordelingDtoTjenesteTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.when;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -46,8 +47,7 @@ public class YtelseFordelingDtoTjenesteTest extends EntityManagerAwareTest {
 
     private final HistorikkInnslagTekstBuilder tekstBuilder = new HistorikkInnslagTekstBuilder();
     private final InntektArbeidYtelseTjeneste inntektArbeidYtelseTjeneste = mock(InntektArbeidYtelseTjeneste.class);
-    private final ArbeidsgiverHistorikkinnslag arbeidsgiverHistorikkinnslagTjeneste = mock(
-        ArbeidsgiverHistorikkinnslag.class);
+    private final ArbeidsgiverHistorikkinnslag arbeidsgiverHistorikkinnslagTjeneste = mock(ArbeidsgiverHistorikkinnslag.class);
     private BehandlingRepositoryProvider repositoryProvider;
     private YtelseFordelingTjeneste ytelseFordelingTjeneste;
     private FaktaUttakToTrinnsTjeneste faktaUttakToTrinnsTjeneste;
@@ -67,8 +67,7 @@ public class YtelseFordelingDtoTjenesteTest extends EntityManagerAwareTest {
         kontrollerOppgittFordelingTjeneste = new KontrollerOppgittFordelingTjeneste(ytelseFordelingTjeneste,
             repositoryProvider, førsteUttaksdatoTjeneste);
         fordelingRepository = new YtelsesFordelingRepository(entityManager);
-        when(inntektArbeidYtelseTjeneste.hentGrunnlag(anyLong())).thenReturn(
-            InntektArbeidYtelseGrunnlagBuilder.nytt().build());
+        when(inntektArbeidYtelseTjeneste.hentGrunnlag(anyLong())).thenReturn(InntektArbeidYtelseGrunnlagBuilder.nytt().build());
         faktaUttakHistorikkTjeneste = new FaktaUttakHistorikkTjeneste(lagMockHistory(),
             arbeidsgiverHistorikkinnslagTjeneste, ytelseFordelingTjeneste, inntektArbeidYtelseTjeneste);
     }
@@ -95,18 +94,18 @@ public class YtelseFordelingDtoTjenesteTest extends EntityManagerAwareTest {
     public void teste_lag_ytelsefordeling_dto_med_annenforelder_har_rett_perioder() {
         var behandling = opprettBehandling(AksjonspunktDefinisjon.AVKLAR_FAKTA_ANNEN_FORELDER_HAR_RETT);
         var dto = AvklarFaktaTestUtil.opprettDtoAvklarAnnenforelderharIkkeRett();
+        var uforeRepoMock = mock(UføretrygdRepository.class);
+        when(uforeRepoMock.hentGrunnlag(anyLong())).thenReturn(Optional.empty());
         // Act
         var aksjonspunkt = behandling.getAksjonspunktMedDefinisjonOptional(dto.getAksjonspunktDefinisjon());
         new AvklarAnnenforelderHarRettOppdaterer(kontrollerOppgittFordelingTjeneste, faktaUttakHistorikkTjeneste,
-            faktaUttakToTrinnsTjeneste, mock(UføretrygdRepository.class)).oppdater(dto, new AksjonspunktOppdaterParameter(behandling, aksjonspunkt, dto));
+            faktaUttakToTrinnsTjeneste, uforeRepoMock).oppdater(dto, new AksjonspunktOppdaterParameter(behandling, aksjonspunkt, dto));
         var ytelseFordelingDtoOpt = tjeneste().mapFra(behandling);
         assertThat(ytelseFordelingDtoOpt).isNotNull();
         assertThat(ytelseFordelingDtoOpt.get().getAnnenforelderHarRettDto().annenforelderHarRett()).isNotNull();
         assertThat(ytelseFordelingDtoOpt.get().getAnnenforelderHarRettDto().annenforelderHarRett()).isTrue();
-        assertThat(
-            ytelseFordelingDtoOpt.get().getAnnenforelderHarRettDto().annenforelderHarRettPerioder()).isNotNull();
-        assertThat(ytelseFordelingDtoOpt.get().getAnnenforelderHarRettDto().annenforelderHarRettPerioder()).hasSize(
-            1);
+        assertThat(ytelseFordelingDtoOpt.get().getAnnenforelderHarRettDto().annenforelderHarRettPerioder()).isNotNull();
+        assertThat(ytelseFordelingDtoOpt.get().getAnnenforelderHarRettDto().annenforelderHarRettPerioder()).hasSize(1);
         assertThat(ytelseFordelingDtoOpt.get().getEndringsdato()).isEqualTo(LocalDate.now().minusDays(20));
         assertThat(ytelseFordelingDtoOpt.get().getGjeldendeDekningsgrad()).isEqualTo(100);
     }

--- a/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/ytelsefordeling/YtelseFordelingDtoTjenesteTest.java
+++ b/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/ytelsefordeling/YtelseFordelingDtoTjenesteTest.java
@@ -17,6 +17,7 @@ import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingStegType;
 import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.AksjonspunktDefinisjon;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepositoryProvider;
+import no.nav.foreldrepenger.behandlingslager.behandling.ufore.UføretrygdRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.AvklarteUttakDatoerEntitet;
 import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.OppgittDekningsgradEntitet;
 import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.OppgittRettighetEntitet;
@@ -97,14 +98,14 @@ public class YtelseFordelingDtoTjenesteTest extends EntityManagerAwareTest {
         // Act
         var aksjonspunkt = behandling.getAksjonspunktMedDefinisjonOptional(dto.getAksjonspunktDefinisjon());
         new AvklarAnnenforelderHarRettOppdaterer(kontrollerOppgittFordelingTjeneste, faktaUttakHistorikkTjeneste,
-            faktaUttakToTrinnsTjeneste).oppdater(dto, new AksjonspunktOppdaterParameter(behandling, aksjonspunkt, dto));
+            faktaUttakToTrinnsTjeneste, mock(UføretrygdRepository.class)).oppdater(dto, new AksjonspunktOppdaterParameter(behandling, aksjonspunkt, dto));
         var ytelseFordelingDtoOpt = tjeneste().mapFra(behandling);
         assertThat(ytelseFordelingDtoOpt).isNotNull();
-        assertThat(ytelseFordelingDtoOpt.get().getAnnenforelderHarRettDto().getAnnenforelderHarRett()).isNotNull();
-        assertThat(ytelseFordelingDtoOpt.get().getAnnenforelderHarRettDto().getAnnenforelderHarRett()).isTrue();
+        assertThat(ytelseFordelingDtoOpt.get().getAnnenforelderHarRettDto().annenforelderHarRett()).isNotNull();
+        assertThat(ytelseFordelingDtoOpt.get().getAnnenforelderHarRettDto().annenforelderHarRett()).isTrue();
         assertThat(
-            ytelseFordelingDtoOpt.get().getAnnenforelderHarRettDto().getAnnenforelderHarRettPerioder()).isNotNull();
-        assertThat(ytelseFordelingDtoOpt.get().getAnnenforelderHarRettDto().getAnnenforelderHarRettPerioder()).hasSize(
+            ytelseFordelingDtoOpt.get().getAnnenforelderHarRettDto().annenforelderHarRettPerioder()).isNotNull();
+        assertThat(ytelseFordelingDtoOpt.get().getAnnenforelderHarRettDto().annenforelderHarRettPerioder()).hasSize(
             1);
         assertThat(ytelseFordelingDtoOpt.get().getEndringsdato()).isEqualTo(LocalDate.now().minusDays(20));
         assertThat(ytelseFordelingDtoOpt.get().getGjeldendeDekningsgrad()).isEqualTo(100);
@@ -112,7 +113,7 @@ public class YtelseFordelingDtoTjenesteTest extends EntityManagerAwareTest {
 
     private YtelseFordelingDtoTjeneste tjeneste() {
         return new YtelseFordelingDtoTjeneste(ytelseFordelingTjeneste, repositoryProvider.getFagsakRelasjonRepository(),
-            førsteUttaksdatoTjeneste);
+            repositoryProvider.getUføretrygdRepository(), førsteUttaksdatoTjeneste);
     }
 
     private Behandling opprettBehandling(AksjonspunktDefinisjon aksjonspunktDefinisjon) {


### PR DESCRIPTION
Litt div rydding i ORM'er - manglende og feil mappinger. Utvider SO_RETTIGHET og ny tabell for UFO-grunnlag

* Setter oppgittrettighet dersom satt i søknad eller det finnes uttak/utsettelse med aktivitet=Uføre. Kan diskuteres
* Innhenter og lagrer relevant resultat fra Pesys. Foreløpig kun warn-logg dersom Pesys ikke har noe.
* Tatt in UFO-grunnlag i div Uttak-input-strukturer
* Utvidet 5086/AnnenPartIkkeRett-Dto'er med avklaringsbehov og evt avklaring dersom APIkkeRett - ikke helt wired ennå

Espen: Snart på tide å lage en UFO-mock i VTP og utvide scenariomodell med registeruføre der BFHR og søker med oppgitt mor uføretrygdet. 