### PR TITLE
TFP-4678 første generasjon regler for bfhr / mor ufør

### DIFF
--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/historikk/HistorikkEndretFeltType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/historikk/HistorikkEndretFeltType.java
@@ -125,6 +125,7 @@ public enum HistorikkEndretFeltType implements Kodeverdi {
     ER_SÆRLIGE_GRUNNER_TIL_REDUKSJON("ER_SÆRLIGE_GRUNNER_TIL_REDUKSJON", "Er det særlige grunner til reduksjon"),
     FASTSETT_VIDERE_BEHANDLING("FASTSETT_VIDERE_BEHANDLING", "Fastsett videre behandling"),
     RETT_TIL_FORELDREPENGER("RETT_TIL_FORELDREPENGER", "Rett til foreldrepenger"),
+    MOR_MOTTAR_UFØRETRYGD("MOR_MOTTAR_UFØRETRYGD", "Mor mottar uføretrygd"),
     VURDER_GRADERING_PÅ_ANDEL_UTEN_BG("VURDER_GRADERING_PÅ_ANDEL_UTEN_BG", "Vurder om søker har gradering på en andel uten beregningsgrunnlag"),
     DEKNINGSGRAD("DEKNINGSGRAD", "Dekningsgrad"),
     TILBAKETREKK("TILBAKETREKK", "Tilbaketrekk"),

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/ufore/UføretrygdGrunnlagEntitet.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/ufore/UføretrygdGrunnlagEntitet.java
@@ -177,7 +177,7 @@ public class UføretrygdGrunnlagEntitet extends BaseEntitet {
         }
 
         public Builder medOverstyrtUføretrygd(boolean erUføretrygdet) {
-            this.kladd.uføretrygdRegister = erUføretrygdet;
+            this.kladd.uføretrygdOverstyrt = erUføretrygdet;
             return this;
         }
 

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/uttak/svp/ArbeidsforholdIkkeOppfyltÅrsak.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/uttak/svp/ArbeidsforholdIkkeOppfyltÅrsak.java
@@ -21,6 +21,7 @@ import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
 @JsonAutoDetect(getterVisibility = Visibility.NONE, setterVisibility = Visibility.NONE, fieldVisibility = Visibility.ANY)
 public enum ArbeidsforholdIkkeOppfyltÅrsak implements Kodeverdi {
 
+    // Se også Periode ikke oppfylt - der brukes 8304-83011 + 8313+8314
     INGEN("-", "Ikke definert"),
     HELE_UTTAKET_ER_ETTER_3_UKER_FØR_TERMINDATO("8301", "Hele uttaket er etter 3 uker før termindato"),
     UTTAK_KUN_PÅ_HELG("8302", "Uttak kun på helg"),

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/uttak/svp/PeriodeIkkeOppfyltÅrsak.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/uttak/svp/PeriodeIkkeOppfyltÅrsak.java
@@ -27,6 +27,7 @@ public enum PeriodeIkkeOppfyltÅrsak implements Kodeverdi, ÅrsakskodeMedLovrefe
 
     INGEN("-", "Ikke definert", null),
 
+    // Se også Arbeidsforhold ikke oppfylt - der brukes 8301-8303 + 8312
     _8304("8304", "Bruker er død", null),
     _8305("8305", "Barnet er dødt", null),
     _8306("8306", "Bruker er ikke medlem", null),
@@ -34,8 +35,8 @@ public enum PeriodeIkkeOppfyltÅrsak implements Kodeverdi, ÅrsakskodeMedLovrefe
     _8309("8309", "Perioden er ikke før fødsel", null),
     _8310("8310", "Perioden må slutte senest tre uker før termin", null),
     _8311("8311", "Perioden er samtidig som en ferie", null),
-    _8312("8312", "Perioden er etter startdato foreldrepenger", null),
     _8313("8313", "Perioden er etter et opphold i ytelsen", null),
+    _8314("8314", "Perioden er etter startdato foreldrepenger", null),
 
     ;
 

--- a/domenetjenester/registerinnhenting/src/main/java/no/nav/foreldrepenger/domene/registerinnhenting/ufo/PesysUføreKlient.java
+++ b/domenetjenester/registerinnhenting/src/main/java/no/nav/foreldrepenger/domene/registerinnhenting/ufo/PesysUføreKlient.java
@@ -65,10 +65,6 @@ public class PesysUføreKlient {
             .filter(u -> u.ufgTom() == null || u.ufgTom().isAfter(startDato))
             .max(Comparator.comparing(Uføreperiode::virkningsdato));
 
-        if (uføreperiode.isEmpty()) {
-            LOG.warn("Kjære loggleser: gjer produkteigar merksam på sak {} - finn ikkje uføretrygd. Pesys svarar {}", saksnummerTilLogging, response);
-        }
-
         return uføreperiode;
     }
 

--- a/domenetjenester/registerinnhenting/src/main/java/no/nav/foreldrepenger/domene/registerinnhenting/ufo/PesysUføreKlient.java
+++ b/domenetjenester/registerinnhenting/src/main/java/no/nav/foreldrepenger/domene/registerinnhenting/ufo/PesysUføreKlient.java
@@ -52,7 +52,7 @@ public class PesysUføreKlient {
         this.endpoint = endpoint;
     }
 
-    public Optional<Uføreperiode> hentUføreHistorikk(String fnr, LocalDate startDato, String saksnummerTilLogging) {
+    public Optional<Uføreperiode> hentUføreHistorikk(String fnr, LocalDate startDato) {
         if (!SKAL_KALLE) return Optional.empty();
 
         var response = this.oidcRestClient.get(endpoint, this.lagHeader(fnr), HentUforehistorikkResponseDto.class);

--- a/domenetjenester/registerinnhenting/src/main/java/no/nav/foreldrepenger/domene/registerinnhenting/ufo/UføreInnhenter.java
+++ b/domenetjenester/registerinnhenting/src/main/java/no/nav/foreldrepenger/domene/registerinnhenting/ufo/UføreInnhenter.java
@@ -93,8 +93,8 @@ public class UføreInnhenter {
     private void innhentOgLagre(Behandling behandling, AktørId annenpartAktørId, LocalDate startDato) {
         var uføreperiode = personinfoAdapter.hentFnr(annenpartAktørId)
             .flatMap(fnr -> pesysUføreKlient.hentUføreHistorikk(fnr.getIdent(), startDato, behandling.getFagsak().getSaksnummer().getVerdi()));
-        // TODO (JOL): Slå på lagring av tilfellse der vi ikke finner data i Pesys + trigge avklaring i aksjonspunkt
-        uføreperiode.ifPresent(uføre -> uføretrygdRepository.lagreUføreGrunnlagRegisterVersjon(behandling.getId(), annenpartAktørId, true, uføre.uforetidspunkt(), uføre.virkningsdato()));
+        uføretrygdRepository.lagreUføreGrunnlagRegisterVersjon(behandling.getId(), annenpartAktørId, uføreperiode.isPresent(),
+            uføreperiode.map(Uføreperiode::uforetidspunkt).orElse(null), uføreperiode.map(Uføreperiode::virkningsdato).orElse(null));
     }
 
     private LocalDate førsteUttaksdag(Behandling behandling, Optional<YtelseFordelingAggregat> ytelseFordeling) {

--- a/domenetjenester/registerinnhenting/src/main/java/no/nav/foreldrepenger/domene/registerinnhenting/ufo/UføreInnhenter.java
+++ b/domenetjenester/registerinnhenting/src/main/java/no/nav/foreldrepenger/domene/registerinnhenting/ufo/UføreInnhenter.java
@@ -92,7 +92,7 @@ public class UføreInnhenter {
 
     private void innhentOgLagre(Behandling behandling, AktørId annenpartAktørId, LocalDate startDato) {
         var uføreperiode = personinfoAdapter.hentFnr(annenpartAktørId)
-            .flatMap(fnr -> pesysUføreKlient.hentUføreHistorikk(fnr.getIdent(), startDato, behandling.getFagsak().getSaksnummer().getVerdi()));
+            .flatMap(fnr -> pesysUføreKlient.hentUføreHistorikk(fnr.getIdent(), startDato));
         uføretrygdRepository.lagreUføreGrunnlagRegisterVersjon(behandling.getId(), annenpartAktørId, uføreperiode.isPresent(),
             uføreperiode.map(Uføreperiode::uforetidspunkt).orElse(null), uføreperiode.map(Uføreperiode::virkningsdato).orElse(null));
     }

--- a/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/fakta/omsorg/AnnenForelderHarRettAksjonspunktUtleder.java
+++ b/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/fakta/omsorg/AnnenForelderHarRettAksjonspunktUtleder.java
@@ -14,6 +14,7 @@ import no.nav.foreldrepenger.behandlingskontroll.FagsakYtelseTypeRef;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingType;
 import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.AksjonspunktDefinisjon;
 import no.nav.foreldrepenger.behandlingslager.behandling.personopplysning.RelasjonsRolleType;
+import no.nav.foreldrepenger.behandlingslager.behandling.ufore.UføretrygdGrunnlagEntitet;
 import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.YtelseFordelingAggregat;
 import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.YtelsesFordelingRepository;
 import no.nav.foreldrepenger.domene.uttak.ForeldrepengerUttak;
@@ -66,7 +67,7 @@ public class AnnenForelderHarRettAksjonspunktUtleder implements FaktaUttakAksjon
             !annenForelderHarUttakMedUtbetaling(annenpartsGjeldendeUttaksplan)) {
             ForeldrepengerGrunnlag fpGrunnlag = input.getYtelsespesifiktGrunnlag();
             var harAnnennartInnvilgetES = fpGrunnlag.getAnnenpart().filter(Annenpart::innvilgetES).isPresent();
-            var erUavklartAnnenpartUførhet = false; // TODO: koble inn når klar fpGrunnlag.getUføretrygdGrunnlag().filter(UføretrygdGrunnlagEntitet::uavklartAnnenForelderMottarUføretrygd).isPresent();
+            var erUavklartAnnenpartUførhet = fpGrunnlag.getUføretrygdGrunnlag().filter(UføretrygdGrunnlagEntitet::uavklartAnnenForelderMottarUføretrygd).isPresent();
             return harAnnennartInnvilgetES && !erUavklartAnnenpartUførhet ? List.of() : aksjonspunkt();
         }
 

--- a/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/fakta/omsorg/AnnenForelderHarRettAksjonspunktUtleder.java
+++ b/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/fakta/omsorg/AnnenForelderHarRettAksjonspunktUtleder.java
@@ -67,8 +67,10 @@ public class AnnenForelderHarRettAksjonspunktUtleder implements FaktaUttakAksjon
             !annenForelderHarUttakMedUtbetaling(annenpartsGjeldendeUttaksplan)) {
             ForeldrepengerGrunnlag fpGrunnlag = input.getYtelsespesifiktGrunnlag();
             var harAnnennartInnvilgetES = fpGrunnlag.getAnnenpart().filter(Annenpart::innvilgetES).isPresent();
-            var erUavklartAnnenpartUførhet = fpGrunnlag.getUføretrygdGrunnlag().filter(UføretrygdGrunnlagEntitet::uavklartAnnenForelderMottarUføretrygd).isPresent();
-            return harAnnennartInnvilgetES && !erUavklartAnnenpartUførhet ? List.of() : aksjonspunkt();
+            var måAvklareMorUfør = fpGrunnlag.getUføretrygdGrunnlag()
+                .filter(UføretrygdGrunnlagEntitet::uavklartAnnenForelderMottarUføretrygd)
+                .isPresent();
+            return !harAnnennartInnvilgetES || måAvklareMorUfør ? aksjonspunkt() : List.of();
         }
 
         if (oppgittHarAnnenForeldreRett(ytelseFordelingAggregat) &&

--- a/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/fastsetteperioder/FastsettePerioderRegelGrunnlagBygger.java
+++ b/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/fastsetteperioder/FastsettePerioderRegelGrunnlagBygger.java
@@ -84,7 +84,7 @@ public class FastsettePerioderRegelGrunnlagBygger {
             .inngangsvilkår(inngangsvilkårGrunnlagBygger.byggGrunnlag(input))
             .opptjening(opptjeningGrunnlagBygger.byggGrunnlag(input))
             .adopsjon(adopsjonGrunnlagBygger.byggGrunnlag(foreldrepengerGrunnlag).orElse(null))
-            .kontoer(kontoerGrunnlagBygger.byggGrunnlag(input.getBehandlingReferanse()))
+            .kontoer(kontoerGrunnlagBygger.byggGrunnlag(input.getBehandlingReferanse(), foreldrepengerGrunnlag))
             .ytelser(ytelserGrunnlagBygger.byggGrunnlag(input))
             .build();
     }

--- a/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/fastsetteperioder/grunnlagbyggere/KontoerGrunnlagBygger.java
+++ b/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/fastsetteperioder/grunnlagbyggere/KontoerGrunnlagBygger.java
@@ -35,10 +35,25 @@ public class KontoerGrunnlagBygger {
         //CDI
     }
 
+    /*
+     * Ved siden av kontoer kan grunnlaget inneholde enten utenAktivitetskravDager eller minsterettDager, men ikke begge
+     *
+     * utenAktivitetskravDager
+     * - gir mulighet til å innvilge perioder selv om aktivitetskravet ikke er oppfylt
+     * - vil ikke påvirke stønadsperioden dvs må tas ut fortløpende. Ingen utsettelse uten at aktivitetskrav oppfylt
+     * - Skal alltid brukes på tilfelle som krever sammenhengende uttak
+     * - TFP-4842 tillat at avslått aktivitetskrav kan innvilges fra utenAktivitetskravDager
+     *
+     * minsterettDager
+     * - gir mulighet til å innvilge perioder selv om aktivitetskravet ikke er oppfylt
+     * - automatiske trekk pga manglende søkt, avslag mv vil ikke påvirke minsterett
+     * - kan utsettes og  utvide stønadsperioden
+     * - TBD når kan denne brukes framfor utenAktivitetskravDager
+     */
     public Kontoer.Builder byggGrunnlag(BehandlingReferanse ref, ForeldrepengerGrunnlag foreldrepengerGrunnlag) {
         var stønadskontoer = hentStønadskontoer(ref);
         return new Kontoer.Builder()
-            .minsterettDager(minsterettDager(ref, foreldrepengerGrunnlag, stønadskontoer))
+            .utenAktivitetskravDager(minsterettDager(ref, foreldrepengerGrunnlag, stønadskontoer))
             .kontoList(stønadskontoer.stream().map(this::map).collect(Collectors.toList()));
     }
 

--- a/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/fastsetteperioder/grunnlagbyggere/KontoerGrunnlagBygger.java
+++ b/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/fastsetteperioder/grunnlagbyggere/KontoerGrunnlagBygger.java
@@ -61,9 +61,9 @@ public class KontoerGrunnlagBygger {
         var morHarUføretrygd = foreldrepengerGrunnlag.getUføretrygdGrunnlag()
             .filter(UføretrygdGrunnlagEntitet::annenForelderMottarUføretrygd)
             .isPresent();
-        var erIkkeMor = !RelasjonsRolleType.MORA.equals(ref.getRelasjonsRolleType());
+        var erMor = RelasjonsRolleType.MORA.equals(ref.getRelasjonsRolleType());
         var erForeldrepenger = stønadskontoer.stream().map(Stønadskonto::getStønadskontoType).anyMatch(StønadskontoType.FORELDREPENGER::equals);
-        if (morHarUføretrygd && erIkkeMor && erForeldrepenger) {
+        if (morHarUføretrygd && !erMor && erForeldrepenger) {
             var dekningsgrad = fagsakRelasjonRepository.finnRelasjonFor(ref.getSaksnummer()).getGjeldendeDekningsgrad();
             return Dekningsgrad._80.equals(dekningsgrad) ? MINSTEDAGER_80_PROSENT : MINSTEDAGER_100_PROSENT;
         }

--- a/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/fastsetteperioder/grunnlagbyggere/RettOgOmsorgGrunnlagBygger.java
+++ b/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/fastsetteperioder/grunnlagbyggere/RettOgOmsorgGrunnlagBygger.java
@@ -8,6 +8,7 @@ import javax.inject.Inject;
 import no.nav.foreldrepenger.behandling.BehandlingReferanse;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingsresultatRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.personopplysning.RelasjonsRolleType;
+import no.nav.foreldrepenger.behandlingslager.behandling.ufore.UføretrygdGrunnlagEntitet;
 import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.YtelseFordelingAggregat;
 import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.YtelsesFordelingRepository;
 import no.nav.foreldrepenger.domene.uttak.ForeldrepengerUttak;
@@ -44,6 +45,7 @@ public class RettOgOmsorgGrunnlagBygger {
                 .aleneomsorg(aleneomsorg(ytelseFordelingAggregat))
                 .farHarRett(farHarRett(ref, ytelseFordelingAggregat, annenpartsUttaksplan))
                 .morHarRett(morHarRett(ref, ytelseFordelingAggregat, annenpartsUttaksplan))
+                .morUføretrygd(morUføretrygd(uttakInput))
                 .samtykke(samtykke(ytelseFordelingAggregat));
     }
 
@@ -80,6 +82,13 @@ public class RettOgOmsorgGrunnlagBygger {
             return UttakOmsorgUtil.harAnnenForelderRett(ytelseFordelingAggregat, annenpartsUttaksplan);
         }
         throw new IllegalStateException("Uventet foreldrerolletype " + relasjonsRolleType);
+    }
+
+    private boolean morUføretrygd(UttakInput uttakInput) {
+        ForeldrepengerGrunnlag fpGrunnlag = uttakInput.getYtelsespesifiktGrunnlag();
+        return fpGrunnlag.getUføretrygdGrunnlag()
+            .filter(UføretrygdGrunnlagEntitet::annenForelderMottarUføretrygd)
+            .isPresent();
     }
 
     private boolean samtykke(YtelseFordelingAggregat ytelseFordelingAggregat) {

--- a/domenetjenester/uttak/src/test/java/no/nav/foreldrepenger/domene/uttak/fakta/omsorg/AnnenForelderHarRettAksjonspunktUtlederTest.java
+++ b/domenetjenester/uttak/src/test/java/no/nav/foreldrepenger/domene/uttak/fakta/omsorg/AnnenForelderHarRettAksjonspunktUtlederTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
 
@@ -12,6 +13,7 @@ import no.nav.foreldrepenger.behandling.BehandlingReferanse;
 import no.nav.foreldrepenger.behandling.Skjæringstidspunkt;
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingÅrsakType;
+import no.nav.foreldrepenger.behandlingslager.behandling.ufore.UføretrygdGrunnlagEntitet;
 import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.AvklarteUttakDatoerEntitet;
 import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.OppgittRettighetEntitet;
 import no.nav.foreldrepenger.domene.typer.AktørId;
@@ -139,6 +141,71 @@ public class AnnenForelderHarRettAksjonspunktUtlederTest {
 
         // Assert
         assertThat(aksjonspunktResultater).containsExactly(AVKLAR_FAKTA_ANNEN_FORELDER_HAR_RETT);
+    }
+
+    @Test
+    public void ikke_aksjonspunkt_dersom_far_søker_førstegangssøknad_og_annenforelder_har_ikke_rett_men_har_ES_og_har_bekreftet_Uføretrygd() {
+        var fødselsdato = LocalDate.now().minusMonths(1);
+        var mores = ScenarioMorSøkerEngangsstønad.forFødsel(AKTØR_ID_MOR);
+
+        var morEngang = mores.lagre(repositoryProvider);
+        var scenario = ScenarioFarSøkerForeldrepenger.forFødselMedGittAktørId(AKTØR_ID_FAR);
+        scenario.medAvklarteUttakDatoer(
+            new AvklarteUttakDatoerEntitet.Builder().medFørsteUttaksdato(LocalDate.now().minusWeeks(3)).build());
+        var rettighet = new OppgittRettighetEntitet(false, true, false);
+        scenario.medOppgittRettighet(rettighet);
+
+        var behandling = scenario.lagre(repositoryProvider);
+
+        var familieHendelse = FamilieHendelse.forFødsel(null, fødselsdato, List.of(new Barn()), 1);
+        var familieHendelser = new FamilieHendelser().medSøknadHendelse(familieHendelse)
+            .medBekreftetHendelse(familieHendelse);
+        var uføreBuilder = UføretrygdGrunnlagEntitet.Builder.oppdatere(Optional.empty())
+            .medBehandlingId(behandling.getId()).medAktørIdUføretrygdet(AKTØR_ID_MOR)
+            .medRegisterUføretrygd(false, null, null).medOverstyrtUføretrygd(true);
+
+        var aksjonspunktResultater = aksjonspunktUtleder.utledAksjonspunkterFor(
+            lagInputUføre(behandling, familieHendelser, new Annenpart(true, morEngang.getId(), fødselsdato.atStartOfDay()), uføreBuilder));
+
+        // Assert
+        assertThat(aksjonspunktResultater).isEmpty();
+    }
+
+    @Test
+    public void aksjonspunkt_dersom_far_søker_førstegangssøknad_og_annenforelder_har_ikke_rett_men_har_ES_og_har_uavklart_Uføretrygd() {
+        var fødselsdato = LocalDate.now().minusMonths(1);
+        var mores = ScenarioMorSøkerEngangsstønad.forFødsel(AKTØR_ID_MOR);
+
+        var morEngang = mores.lagre(repositoryProvider);
+        var scenario = ScenarioFarSøkerForeldrepenger.forFødselMedGittAktørId(AKTØR_ID_FAR);
+        scenario.medAvklarteUttakDatoer(
+            new AvklarteUttakDatoerEntitet.Builder().medFørsteUttaksdato(LocalDate.now().minusWeeks(3)).build());
+        var rettighet = new OppgittRettighetEntitet(false, true, false);
+        scenario.medOppgittRettighet(rettighet);
+
+        var behandling = scenario.lagre(repositoryProvider);
+
+        var familieHendelse = FamilieHendelse.forFødsel(null, fødselsdato, List.of(new Barn()), 1);
+        var familieHendelser = new FamilieHendelser().medSøknadHendelse(familieHendelse)
+            .medBekreftetHendelse(familieHendelse);
+        var uføreBuilder = UføretrygdGrunnlagEntitet.Builder.oppdatere(Optional.empty())
+            .medBehandlingId(behandling.getId()).medAktørIdUføretrygdet(AKTØR_ID_MOR)
+            .medRegisterUføretrygd(false, null, null);
+
+        var aksjonspunktResultater = aksjonspunktUtleder.utledAksjonspunkterFor(
+            lagInputUføre(behandling, familieHendelser, new Annenpart(true, morEngang.getId(), fødselsdato.atStartOfDay()), uføreBuilder));
+
+        // Assert
+        assertThat(aksjonspunktResultater).containsExactly(AVKLAR_FAKTA_ANNEN_FORELDER_HAR_RETT);
+    }
+
+
+    private UttakInput lagInputUføre(Behandling behandling, FamilieHendelser familieHendelser, Annenpart annenpart,
+                                     UføretrygdGrunnlagEntitet.Builder uføreBuilder) {
+        var ytelsespesifiktGrunnlag = new ForeldrepengerGrunnlag().medFamilieHendelser(familieHendelser)
+            .medAnnenpart(null).medUføretrygdGrunnlag(uføreBuilder.build()).medAnnenpart(annenpart);
+        return new UttakInput(BehandlingReferanse.fra(behandling, lagSkjæringstidspunkt(LocalDate.now())), null,
+            ytelsespesifiktGrunnlag);
     }
 
     @Test

--- a/domenetjenester/uttak/src/test/java/no/nav/foreldrepenger/domene/uttak/fastsetteperioder/FastsettePerioderRegelResultatKonvertererTest.java
+++ b/domenetjenester/uttak/src/test/java/no/nav/foreldrepenger/domene/uttak/fastsetteperioder/FastsettePerioderRegelResultatKonvertererTest.java
@@ -33,12 +33,15 @@ import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.FastsettePeriodeResul
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.Trekkdager;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.AktivitetIdentifikator;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.Orgnummer;
+import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.PeriodeVurderingType;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.Perioderesultattype;
+import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.SamtidigUttaksprosent;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.Utbetalingsgrad;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.UtsettelseÅrsak;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.UttakPeriode;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.UttakPeriodeAktivitet;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.utfall.InnvilgetÅrsak;
+import no.nav.foreldrepenger.regler.uttak.felles.grunnlag.Stønadskontotype;
 
 public class FastsettePerioderRegelResultatKonvertererTest {
 
@@ -79,9 +82,10 @@ public class FastsettePerioderRegelResultatKonvertererTest {
         var aktivitet = new UttakPeriodeAktivitet(
             AktivitetIdentifikator.forArbeid(new Orgnummer(arbeidsgiver.getIdentifikator()), null), Utbetalingsgrad.TEN,
             Trekkdager.ZERO, false);
-        var uttakPeriode = new UttakPeriode(periodeFom, periodeTom, Perioderesultattype.INNVILGET, null,
-            InnvilgetÅrsak.UTSETTELSE_GYLDIG_PGA_100_PROSENT_ARBEID, null, Set.of(aktivitet), false, null, null, null,
-            null, UtsettelseÅrsak.ARBEID, null);
+        var uttakOppgittPeriode = no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.OppgittPeriode.forUtsettelse(periodeFom, periodeTom, PeriodeVurderingType.IKKE_VURDERT,
+            UtsettelseÅrsak.ARBEID, periodeFom, periodeFom, null);
+        var uttakPeriode = new UttakPeriode(uttakOppgittPeriode, Perioderesultattype.INNVILGET, null,
+            InnvilgetÅrsak.UTSETTELSE_GYLDIG_PGA_100_PROSENT_ARBEID, null, Set.of(aktivitet), SamtidigUttaksprosent.ZERO, Stønadskontotype.MØDREKVOTE);
         var fastsetteResultat = List.of(new FastsettePeriodeResultat(uttakPeriode, null, null, null));
         var input = lagInput(behandling, periodeFom);
         var konvertert = konverterer.konverter(input, fastsetteResultat);

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
         <sha1 />
         <changelist>-SNAPSHOT</changelist>
         <jupiter.version>5.7.2</jupiter.version>
-        <fp-uttak.version>11.0.11</fp-uttak.version>
+        <fp-uttak.version>11.1.1</fp-uttak.version>
         <svp-uttak.version>2.2.0</svp-uttak.version>
         <felles.version>4.1.14</felles.version>
         <prosesstask.version>3.1.6</prosesstask.version>

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
         <sha1 />
         <changelist>-SNAPSHOT</changelist>
         <jupiter.version>5.7.2</jupiter.version>
-        <fp-uttak.version>11.1.1</fp-uttak.version>
+        <fp-uttak.version>11.1.2</fp-uttak.version>
         <svp-uttak.version>2.2.0</svp-uttak.version>
         <felles.version>4.1.14</felles.version>
         <prosesstask.version>3.1.6</prosesstask.version>

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/uttak/app/FaktaUttakHistorikkTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/uttak/app/FaktaUttakHistorikkTjeneste.java
@@ -469,7 +469,8 @@ public class FaktaUttakHistorikkTjeneste {
     /**
      * Historikkinnslag for avklar annen forelder har ikke rett
      */
-    public void byggHistorikkinnslagForAvklarAnnenforelderHarIkkeRett(AvklarAnnenforelderHarRettDto annenforelderHarIkkeRettDto, AksjonspunktOppdaterParameter param) {
+    public void byggHistorikkinnslagForAvklarAnnenforelderHarIkkeRett(AvklarAnnenforelderHarRettDto annenforelderHarIkkeRettDto, AksjonspunktOppdaterParameter param,
+                                                                      boolean endretVurderingAvMorsUføretrygd, Boolean tidligereVurderingAvUføretrygd) {
         var ytelseFordelingAggregat = ytelseFordelingTjeneste.hentAggregat(param.getBehandlingId());
         var rettAvklaring = ytelseFordelingAggregat.getAnnenForelderRettAvklaring();
         Boolean harAnnenForeldreRettBekreftetVersjon = null;
@@ -480,6 +481,10 @@ public class FaktaUttakHistorikkTjeneste {
         historikkApplikasjonTjeneste.tekstBuilder().medEndretFelt(HistorikkEndretFeltType.RETT_TIL_FORELDREPENGER,
             konvertBooleanTilVerdiForAnnenforelderHarRett(harAnnenForeldreRettBekreftetVersjon),
             konvertBooleanTilVerdiForAnnenforelderHarRett(annenforelderHarIkkeRettDto.getAnnenforelderHarRett()));
+        if (endretVurderingAvMorsUføretrygd) {
+            historikkApplikasjonTjeneste.tekstBuilder().medEndretFelt(HistorikkEndretFeltType.MOR_MOTTAR_UFØRETRYGD,
+                tidligereVurderingAvUføretrygd, annenforelderHarIkkeRettDto.getAnnenforelderMottarUføretrygd());
+        }
 
         historikkApplikasjonTjeneste.tekstBuilder()
             .medBegrunnelse(annenforelderHarIkkeRettDto.getBegrunnelse(), param.erBegrunnelseEndret())

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/ytelsefordeling/AnnenforelderHarRettDto.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/ytelsefordeling/AnnenforelderHarRettDto.java
@@ -7,6 +7,6 @@ import no.nav.foreldrepenger.familiehendelse.rest.PeriodeDto;
 public record AnnenforelderHarRettDto(String begrunnelse,
                                       Boolean annenforelderHarRett,
                                       List<PeriodeDto> annenforelderHarRettPerioder,
-                                      Boolean annenforelderMottarUføretrygd,
+                                      Boolean annenforelderMottarUføretrygd, // Kun satt dersom tidligere avklart
                                       boolean avklarAnnenforelderMottarUføretrygd) {
 }


### PR DESCRIPTION
Nye uttaksregler integrert og koblet inn logikk rundt uføre
* Lagrer register = nei dersom Pesys ikke har data
* Aksjonspunktutledning i 5086 avklar rett
* Sender med uføre-rett og misterettsdager til uttak-reglene

Alt annet var på plass fra før.