### PR TITLE
Fjerne SamAutoReg

### DIFF
--- a/web/src/main/java/no/nav/foreldrepenger/web/app/util/RestUtils.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/util/RestUtils.java
@@ -17,7 +17,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import no.nav.foreldrepenger.web.app.ApplicationConfig;
 import no.nav.foreldrepenger.web.app.rest.ResourceLink;
 import no.nav.foreldrepenger.web.app.tjenester.RestImplementationClasses;
-import no.nav.foreldrepenger.web.server.jetty.JettyWebKonfigurasjon;
+import no.nav.vedtak.sikkerhet.ContextPathHolder;
 
 public class RestUtils {
 
@@ -46,7 +46,7 @@ public class RestUtils {
     }
 
     public static String getApiPath() {
-        var contextPath = JettyWebKonfigurasjon.CONTEXT_PATH;
+        var contextPath = ContextPathHolder.instance().getContextPath();
         var apiUri = ApplicationConfig.API_URI;
         return contextPath + apiUri;
     }

--- a/web/src/main/java/no/nav/foreldrepenger/web/server/jetty/JettyWebKonfigurasjon.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/server/jetty/JettyWebKonfigurasjon.java
@@ -1,12 +1,22 @@
 package no.nav.foreldrepenger.web.server.jetty;
 
+import no.nav.vedtak.sikkerhet.ContextPathHolder;
+
 public class JettyWebKonfigurasjon {
 
     public static final String CONTEXT_PATH = "/fpsak";
 
-    private final Integer serverPort;
+    private Integer serverPort;
+
+    // Hvis du føler for å omstrukturere Jetty-klassene så sørg for at CPHolder
+    // blir kalt så tidlig som mulig i oppstarten av Jetty og helst kun en gang ....
+    // Cookies: bruker "/" når
+    public JettyWebKonfigurasjon() {
+        ContextPathHolder.instance(CONTEXT_PATH);
+    }
 
     public JettyWebKonfigurasjon(int serverPort) {
+        this();
         this.serverPort = serverPort;
     }
 

--- a/web/src/main/java/no/nav/foreldrepenger/web/server/jetty/JettyWebKonfigurasjon.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/server/jetty/JettyWebKonfigurasjon.java
@@ -10,7 +10,7 @@ public class JettyWebKonfigurasjon {
 
     // Hvis du føler for å omstrukturere Jetty-klassene så sørg for at CPHolder
     // blir kalt så tidlig som mulig i oppstarten av Jetty og helst kun en gang ....
-    // Cookies: bruker "/" når
+    // Cookies: bruker path "/" når man instansierer CPH uten å angi cookiepath
     public JettyWebKonfigurasjon() {
         ContextPathHolder.instance(CONTEXT_PATH);
     }

--- a/web/src/main/resources/WEB-INF/web.xml
+++ b/web/src/main/resources/WEB-INF/web.xml
@@ -17,9 +17,6 @@
         <listener-class>org.jboss.weld.environment.servlet.Listener</listener-class>
     </listener>
     <listener>
-        <listener-class>no.nav.vedtak.sikkerhet.jaspic.SamAutoRegistration</listener-class>
-    </listener>
-    <listener>
         <listener-class>no.nav.foreldrepenger.web.app.startupinfo.AppStartupServletContextListener</listener-class>
     </listener>
     <listener>


### PR DESCRIPTION
SamAuto gjorde to ting: Registrere OidcAuthModule i jaspi og sette ContextPath ut fra ServletContextEvent.
Nå konfigureres Jaspi programmatisk i JettyServer -> sett ContextPathHolder i Jetty og fjerne SamAuto.

Gjør vi dette overalt - så kan vi slette noen filer i felles. Kanskje lage et felles jetty-oppsett i en felles-modul?

WebListeners og WebFilter er inn eller ut/gammeldags avhengig av hvem man snakker med ...