### PR TITLE
TFP-4866 lagre innhentet neste stønadsperiode

### DIFF
--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/historikk/HistorikkinnslagFelt.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/historikk/HistorikkinnslagFelt.java
@@ -1,7 +1,6 @@
 package no.nav.foreldrepenger.behandlingslager.behandling.historikk;
 
 import java.util.Objects;
-import java.util.Set;
 
 import javax.persistence.Column;
 import javax.persistence.Convert;
@@ -20,7 +19,6 @@ import no.nav.foreldrepenger.behandlingslager.BaseEntitet;
 import no.nav.foreldrepenger.behandlingslager.diff.IndexKey;
 import no.nav.foreldrepenger.behandlingslager.kodeverk.BasisKodeverdi;
 import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
-import no.nav.foreldrepenger.behandlingslager.uttak.fp.PeriodeResultatÅrsak;
 
 @Entity(name = "HistorikkinnslagFelt")
 @Table(name = "HISTORIKKINNSLAG_FELT")
@@ -111,7 +109,7 @@ public class HistorikkinnslagFelt extends BaseEntitet implements IndexKey {
     }
 
     public String getKlNavn() {
-        return tempMapKodeverkNavn(klNavn);
+        return klNavn;
     }
 
     public String getFraVerdi() {
@@ -123,25 +121,15 @@ public class HistorikkinnslagFelt extends BaseEntitet implements IndexKey {
     }
 
     public String getKlFraVerdi() {
-        return tempMapKodeverkNavn(klFraVerdi);
+        return klFraVerdi;
     }
 
     public String getKlTilVerdi() {
-        return tempMapKodeverkNavn(klTilVerdi);
+        return klTilVerdi;
     }
 
     public Integer getSekvensNr() {
         return sekvensNr;
-    }
-
-    private static final Set<String> LEGACY_UTTAK_KODEVERK = Set.of("INNVILGET_AARSAK", "IKKE_OPPFYLT_AARSAK", "PERIODE_UTFALL_AARSAK");
-
-    private static String tempMapKodeverkNavn(String k) {
-        if (k == null) return null;
-        if (LEGACY_UTTAK_KODEVERK.contains(k)) {
-            return PeriodeResultatÅrsak.KODEVERK;
-        }
-        return k;
     }
 
     @Override

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/nestesak/NesteSakGrunnlagEntitet.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/nestesak/NesteSakGrunnlagEntitet.java
@@ -1,0 +1,139 @@
+package no.nav.foreldrepenger.behandlingslager.behandling.nestesak;
+
+import java.time.LocalDate;
+import java.util.Objects;
+import java.util.Optional;
+
+import javax.persistence.AttributeOverride;
+import javax.persistence.AttributeOverrides;
+import javax.persistence.Column;
+import javax.persistence.Convert;
+import javax.persistence.Embedded;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+import no.nav.foreldrepenger.behandlingslager.BaseEntitet;
+import no.nav.foreldrepenger.behandlingslager.diff.ChangeTracked;
+import no.nav.foreldrepenger.domene.typer.Saksnummer;
+import no.nav.vedtak.felles.jpa.converters.BooleanToStringConverter;
+
+/*
+ * Grunnlag med livssyklus gitt av saker som innvilger ny stønadsperiode som påvirker aktuell saks stønadsperiode
+ */
+@Entity(name = "NestesakGrunnlag")
+@Table(name = "GR_NESTESAK")
+public class NesteSakGrunnlagEntitet extends BaseEntitet {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "SEQ_GR_NESTESAK")
+    private Long id;
+
+    @Convert(converter = BooleanToStringConverter.class)
+    @Column(name = "aktiv", nullable = false)
+    private boolean aktiv = true;
+
+    @Column(name = "behandling_id", nullable = false, updatable = false)
+    private Long behandlingId;
+
+    @Embedded
+    @AttributeOverrides(@AttributeOverride(name = "saksnummer", column = @Column(name = "saksnummer", updatable = false, nullable=false)))
+    private Saksnummer saksnummer;
+
+    @Column(name = "startdato")
+    @ChangeTracked
+    private LocalDate startdato;
+
+
+
+    NesteSakGrunnlagEntitet() {
+    }
+
+    NesteSakGrunnlagEntitet(NesteSakGrunnlagEntitet grunnlag) {
+        this.saksnummer = grunnlag.saksnummer;
+        this.startdato = grunnlag.startdato;
+    }
+
+    Long getId() {
+        return id;
+    }
+
+    public long getBehandlingId() {
+        return behandlingId;
+    }
+
+    public boolean isAktiv() {
+        return aktiv;
+    }
+
+    public void deaktiver() {
+        this.aktiv = false;
+    }
+
+    public Saksnummer getSaksnummer() {
+        return saksnummer;
+    }
+
+    public LocalDate getStartdato() {
+        return startdato;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof NesteSakGrunnlagEntitet that)) return false;
+        return Objects.equals(behandlingId, that.behandlingId) &&
+            Objects.equals(saksnummer, that.saksnummer) &&
+            Objects.equals(startdato, that.startdato);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(behandlingId, saksnummer, startdato);
+    }
+
+    public static class Builder {
+
+        private NesteSakGrunnlagEntitet kladd;
+
+        private Builder(NesteSakGrunnlagEntitet kladd) {
+            this.kladd = kladd;
+        }
+
+        private static Builder nytt() {
+            return new Builder(new NesteSakGrunnlagEntitet());
+        }
+
+        private static Builder oppdatere(NesteSakGrunnlagEntitet kladd) {
+            return new Builder(new NesteSakGrunnlagEntitet(kladd));
+        }
+
+        public static Builder oppdatere(Optional<NesteSakGrunnlagEntitet> kladd) {
+            return kladd.map(Builder::oppdatere).orElseGet(Builder::nytt);
+        }
+
+        public Builder medBehandlingId(Long behandlingId) {
+            this.kladd.behandlingId = behandlingId;
+            return this;
+        }
+
+        public Builder medSaksnummer(Saksnummer saksnummer) {
+            this.kladd.saksnummer = saksnummer;
+            return this;
+        }
+
+        public Builder medStartdato(LocalDate startdato) {
+            this.kladd.startdato = startdato;
+            return this;
+        }
+
+        public NesteSakGrunnlagEntitet build() {
+            Objects.requireNonNull(this.kladd.behandlingId, "Utviklerfeil: behandlingId skal være satt");
+            Objects.requireNonNull(this.kladd.saksnummer, "Utviklerfeil: saksnummer skal være satt");
+            Objects.requireNonNull(this.kladd.startdato, "Utviklerfeil: startdato skal være satt");
+            return this.kladd;
+        }
+    }
+}

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/nestesak/NesteSakRepository.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/nestesak/NesteSakRepository.java
@@ -1,0 +1,76 @@
+package no.nav.foreldrepenger.behandlingslager.behandling.nestesak;
+
+import java.time.LocalDate;
+import java.util.Objects;
+import java.util.Optional;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import javax.persistence.EntityManager;
+
+import no.nav.foreldrepenger.domene.typer.Saksnummer;
+import no.nav.vedtak.felles.jpa.HibernateVerktøy;
+
+@ApplicationScoped
+public class NesteSakRepository {
+
+    private EntityManager entityManager;
+
+    @Inject
+    public NesteSakRepository(EntityManager entityManager) {
+        Objects.requireNonNull(entityManager, "entityManager"); //$NON-NLS-1$
+        this.entityManager = entityManager;
+    }
+
+    NesteSakRepository() {
+        // CDI proxy
+    }
+
+    public void lagreNesteSak(Long behandlingId, Saksnummer saksnummer, LocalDate startdato) {
+        var aktivtGrunnlag = hentGrunnlag(behandlingId);
+        var nyttGrunnlag = NesteSakGrunnlagEntitet.Builder.oppdatere(aktivtGrunnlag)
+            .medBehandlingId(behandlingId)
+            .medSaksnummer(saksnummer)
+            .medStartdato(startdato);
+        lagreGrunnlag(aktivtGrunnlag, nyttGrunnlag);
+    }
+
+    public void fjernEventuellNesteSak(Long behandlingId) {
+        hentGrunnlag(behandlingId).ifPresent(eksisterendeGrunnlag -> {
+            eksisterendeGrunnlag.deaktiver();
+            entityManager.persist(eksisterendeGrunnlag);
+        });
+    }
+
+    private void lagreGrunnlag(Optional<NesteSakGrunnlagEntitet> aktivtGrunnlag, NesteSakGrunnlagEntitet.Builder builder) {
+        var nyttGrunnlag = builder.build();
+
+        if (!Objects.equals(aktivtGrunnlag.orElse(null), nyttGrunnlag)) {
+            aktivtGrunnlag.ifPresent(eksisterendeGrunnlag -> {
+                eksisterendeGrunnlag.deaktiver();
+                entityManager.persist(eksisterendeGrunnlag);
+            });
+            entityManager.persist(nyttGrunnlag);
+            entityManager.flush();
+        }
+    }
+
+    public Optional<NesteSakGrunnlagEntitet> hentGrunnlag(Long behandlingId) {
+        final var query = entityManager.createQuery(
+            "FROM NestesakGrunnlag n WHERE n.behandlingId = :behandlingId AND n.aktiv = true",
+                NesteSakGrunnlagEntitet.class)
+            .setParameter("behandlingId", behandlingId);
+
+        return HibernateVerktøy.hentUniktResultat(query);
+    }
+
+    public void kopierGrunnlagFraEksisterendeBehandling(Long orginalBehandlingId, Long nyBehandlingId) {
+        var eksisterendeGrunnlag = hentGrunnlag(orginalBehandlingId);
+        eksisterendeGrunnlag.ifPresent(g -> {
+            var nyttgrunnlag = NesteSakGrunnlagEntitet.Builder.oppdatere(eksisterendeGrunnlag)
+                .medBehandlingId(nyBehandlingId);
+            lagreGrunnlag(Optional.empty(), nyttgrunnlag);
+        });
+    }
+
+}

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/repository/BehandlingGrunnlagRepositoryProvider.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/repository/BehandlingGrunnlagRepositoryProvider.java
@@ -1,0 +1,105 @@
+package no.nav.foreldrepenger.behandlingslager.behandling.repository;
+
+import java.util.Objects;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import javax.persistence.EntityManager;
+
+import no.nav.foreldrepenger.behandlingslager.behandling.familiehendelse.FamilieHendelseRepository;
+import no.nav.foreldrepenger.behandlingslager.behandling.medlemskap.MedlemskapRepository;
+import no.nav.foreldrepenger.behandlingslager.behandling.nestesak.NesteSakRepository;
+import no.nav.foreldrepenger.behandlingslager.behandling.opptjening.utlanddok.OpptjeningIUtlandDokStatusRepository;
+import no.nav.foreldrepenger.behandlingslager.behandling.personopplysning.PersonopplysningRepository;
+import no.nav.foreldrepenger.behandlingslager.behandling.pleiepenger.PleiepengerRepository;
+import no.nav.foreldrepenger.behandlingslager.behandling.søknad.SøknadRepository;
+import no.nav.foreldrepenger.behandlingslager.behandling.tilrettelegging.SvangerskapspengerRepository;
+import no.nav.foreldrepenger.behandlingslager.behandling.ufore.UføretrygdRepository;
+import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.YtelsesFordelingRepository;
+
+/**
+ * Provider for å enklere å kunne hente ut ulike behandlingsgrunnlagrepository uten for mange injection points.
+ */
+@ApplicationScoped
+public class BehandlingGrunnlagRepositoryProvider {
+
+    private EntityManager entityManager;
+    private PersonopplysningRepository personopplysningRepository;
+    private MedlemskapRepository medlemskapRepository;
+    private FamilieHendelseRepository familieHendelseRepository;
+    private PleiepengerRepository pleiepengerRepository;
+    private UføretrygdRepository uføretrygdRepository;
+    private SøknadRepository søknadRepository;
+    private NesteSakRepository nesteSakRepository;
+    private YtelsesFordelingRepository ytelsesFordelingRepository;
+    private SvangerskapspengerRepository svangerskapspengerRepository;
+    private OpptjeningIUtlandDokStatusRepository opptjeningIUtlandDokStatusRepository;
+
+    BehandlingGrunnlagRepositoryProvider() {
+        // for CDI proxy
+    }
+
+    @Inject
+    public BehandlingGrunnlagRepositoryProvider(EntityManager entityManager) {
+        Objects.requireNonNull(entityManager, "entityManager"); //$NON-NLS-1$
+        this.entityManager = entityManager;
+
+        // Generelle grunnlag
+        this.familieHendelseRepository = new FamilieHendelseRepository(entityManager);
+        this.medlemskapRepository = new MedlemskapRepository(entityManager);
+        this.personopplysningRepository = new PersonopplysningRepository(entityManager);
+        this.pleiepengerRepository = new PleiepengerRepository(entityManager);
+        this.uføretrygdRepository = new UføretrygdRepository(entityManager);
+        this.søknadRepository = new SøknadRepository(entityManager, new BehandlingRepository(entityManager));
+        this.opptjeningIUtlandDokStatusRepository = new OpptjeningIUtlandDokStatusRepository(entityManager);
+        this.nesteSakRepository = new NesteSakRepository(entityManager);
+
+        // Ytelsespesifikke grunnlag
+        this.ytelsesFordelingRepository = new YtelsesFordelingRepository(entityManager);
+        this.svangerskapspengerRepository = new SvangerskapspengerRepository(entityManager);
+    }
+
+    public EntityManager getEntityManager() {
+        return entityManager;
+    }
+
+    public PersonopplysningRepository getPersonopplysningRepository() {
+        return personopplysningRepository;
+    }
+
+    public MedlemskapRepository getMedlemskapRepository() {
+        return medlemskapRepository;
+    }
+
+    public FamilieHendelseRepository getFamilieHendelseRepository() {
+        return familieHendelseRepository;
+    }
+
+    public PleiepengerRepository getPleiepengerRepository() {
+        return pleiepengerRepository;
+    }
+
+    public UføretrygdRepository getUføretrygdRepository() {
+        return uføretrygdRepository;
+    }
+
+    public SøknadRepository getSøknadRepository() {
+        return søknadRepository;
+    }
+
+    public YtelsesFordelingRepository getYtelsesFordelingRepository() {
+        return ytelsesFordelingRepository;
+    }
+
+    public SvangerskapspengerRepository getSvangerskapspengerRepository() {
+        return svangerskapspengerRepository;
+    }
+
+    public OpptjeningIUtlandDokStatusRepository getOpptjeningIUtlandDokStatusRepository() {
+        return opptjeningIUtlandDokStatusRepository;
+    }
+
+    public NesteSakRepository getNesteSakRepository() {
+        return nesteSakRepository;
+    }
+}

--- a/behandlingslager/domene/src/main/resources/META-INF/pu-default.grunnlag.orm.xml
+++ b/behandlingslager/domene/src/main/resources/META-INF/pu-default.grunnlag.orm.xml
@@ -9,12 +9,16 @@
 
     <sequence-generator name="SEQ_GR_UFORETRYGD" allocation-size="50" sequence-name="SEQ_GR_UFORETRYGD" />
 
+    <sequence-generator name="SEQ_GR_NESTESAK" allocation-size="50" sequence-name="SEQ_GR_NESTESAK" />
+
     <!-- Andre grunnlag -->
     <entity class="no.nav.foreldrepenger.behandlingslager.behandling.pleiepenger.PleiepengerGrunnlagEntitet"/>
     <entity class="no.nav.foreldrepenger.behandlingslager.behandling.pleiepenger.PleiepengerPerioderEntitet"/>
     <entity class="no.nav.foreldrepenger.behandlingslager.behandling.pleiepenger.PleiepengerInnleggelseEntitet"/>
 
     <entity class="no.nav.foreldrepenger.behandlingslager.behandling.ufore.UføretrygdGrunnlagEntitet"/>
+
+    <entity class="no.nav.foreldrepenger.behandlingslager.behandling.nestesak.NesteSakGrunnlagEntitet"/>
 
 
 </entity-mappings>

--- a/behandlingslager/testutil/src/main/java/no/nav/foreldrepenger/behandlingslager/testutilities/behandling/AbstractTestScenario.java
+++ b/behandlingslager/testutil/src/main/java/no/nav/foreldrepenger/behandlingslager/testutilities/behandling/AbstractTestScenario.java
@@ -68,14 +68,12 @@ import no.nav.foreldrepenger.behandlingslager.behandling.personopplysning.Person
 import no.nav.foreldrepenger.behandlingslager.behandling.personopplysning.PersonopplysningVersjonType;
 import no.nav.foreldrepenger.behandlingslager.behandling.personopplysning.RelasjonsRolleType;
 import no.nav.foreldrepenger.behandlingslager.behandling.personopplysning.SivilstandType;
-import no.nav.foreldrepenger.behandlingslager.behandling.pleiepenger.PleiepengerRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingLås;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingLåsRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepositoryProvider;
 import no.nav.foreldrepenger.behandlingslager.behandling.søknad.SøknadEntitet;
 import no.nav.foreldrepenger.behandlingslager.behandling.søknad.SøknadRepository;
-import no.nav.foreldrepenger.behandlingslager.behandling.ufore.UføretrygdRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.vedtak.BehandlingVedtak;
 import no.nav.foreldrepenger.behandlingslager.behandling.vedtak.BehandlingVedtakRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.vedtak.VedtakResultatType;
@@ -237,8 +235,6 @@ public abstract class AbstractTestScenario<S extends AbstractTestScenario<S>> {
         lenient().when(repositoryProvider.getPersonopplysningRepository()).thenReturn(mockPersonopplysningRepository);
         lenient().when(repositoryProvider.getFamilieHendelseRepository()).thenReturn(familieHendelseRepository);
         lenient().when(repositoryProvider.getMedlemskapRepository()).thenReturn(mockMedlemskapRepository);
-        lenient().when(repositoryProvider.getPleiepengerRepository()).thenReturn(mock(PleiepengerRepository.class));
-        lenient().when(repositoryProvider.getUføretrygdRepository()).thenReturn(mock(UføretrygdRepository.class));
         lenient().when(repositoryProvider.getSøknadRepository()).thenReturn(søknadRepository);
         lenient().when(repositoryProvider.getBehandlingVedtakRepository()).thenReturn(behandlingVedtakRepository);
         lenient().when(repositoryProvider.getFagsakLåsRepository()).thenReturn(fagsakLåsRepository);

--- a/behandlingsprosess/src/main/java/no/nav/foreldrepenger/behandling/steg/foreslåresultat/svp/ForeslåBehandlingsresultatTjenesteImpl.java
+++ b/behandlingsprosess/src/main/java/no/nav/foreldrepenger/behandling/steg/foreslåresultat/svp/ForeslåBehandlingsresultatTjenesteImpl.java
@@ -38,9 +38,10 @@ class ForeslåBehandlingsresultatTjenesteImpl implements ForeslåBehandlingsresu
 
     @Inject
     ForeslåBehandlingsresultatTjenesteImpl(BehandlingRepositoryProvider repositoryProvider,
+            SvangerskapspengerUttakResultatRepository uttakResultatRepository,
             DokumentBehandlingTjeneste dokumentBehandlingTjeneste,
             @FagsakYtelseTypeRef("SVP") RevurderingBehandlingsresultatutlederFelles revurderingBehandlingsresultatutlederFelles) {
-        this.svangerskapspengerUttakResultatRepository = repositoryProvider.getSvangerskapspengerUttakResultatRepository();
+        this.svangerskapspengerUttakResultatRepository = uttakResultatRepository;
         this.fagsakRepository = repositoryProvider.getFagsakRepository();
         this.revurderingBehandlingsresultatutlederFelles = revurderingBehandlingsresultatutlederFelles;
         this.dokumentBehandlingTjeneste = dokumentBehandlingTjeneste;

--- a/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/avklarfakta/svp/KontrollerFaktaStegImplTest.java
+++ b/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/avklarfakta/svp/KontrollerFaktaStegImplTest.java
@@ -65,7 +65,7 @@ public class KontrollerFaktaStegImplTest {
     public KontrollerFaktaStegImplTest(EntityManager em) {
         repositoryProvider = new BehandlingRepositoryProvider(em);
         behandlingRepository = repositoryProvider.getBehandlingRepository();
-        svangerskapspengerRepository = repositoryProvider.getSvangerskapspengerRepository();
+        svangerskapspengerRepository = new SvangerskapspengerRepository(em);
 
     }
 

--- a/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/foreslåresultat/svp/ForeslåBehandlingsresultatTjenesteTest.java
+++ b/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/foreslåresultat/svp/ForeslåBehandlingsresultatTjenesteTest.java
@@ -45,6 +45,7 @@ import no.nav.foreldrepenger.behandlingslager.uttak.svp.PeriodeIkkeOppfyltÅrsak
 import no.nav.foreldrepenger.behandlingslager.uttak.svp.SvangerskapspengerUttakResultatArbeidsforholdEntitet;
 import no.nav.foreldrepenger.behandlingslager.uttak.svp.SvangerskapspengerUttakResultatEntitet;
 import no.nav.foreldrepenger.behandlingslager.uttak.svp.SvangerskapspengerUttakResultatPeriodeEntitet;
+import no.nav.foreldrepenger.behandlingslager.uttak.svp.SvangerskapspengerUttakResultatRepository;
 import no.nav.foreldrepenger.behandlingslager.virksomhet.Arbeidsgiver;
 import no.nav.foreldrepenger.dbstoette.EntityManagerAwareTest;
 import no.nav.foreldrepenger.dokumentbestiller.DokumentBehandlingTjeneste;
@@ -81,13 +82,16 @@ public class ForeslåBehandlingsresultatTjenesteTest extends EntityManagerAwareT
         behandlingRepository = repositoryProvider.getBehandlingRepository();
         behandlingVedtakRepository = repositoryProvider.getBehandlingVedtakRepository();
         beregningsgrunnlagTjeneste = new HentOgLagreBeregningsgrunnlagTjeneste(entityManager);
+        var svpUttakRepository = new SvangerskapspengerUttakResultatRepository(entityManager);
         revurderingBehandlingsresultatutleder = spy(new RevurderingBehandlingsresultatutleder(repositoryProvider,
+                svpUttakRepository,
                 beregningsgrunnlagTjeneste,
                 opphørUttakTjeneste,
                 skjæringstidspunktTjeneste,
                 medlemTjeneste));
 
         tjeneste = new ForeslåBehandlingsresultatTjenesteImpl(repositoryProvider,
+                svpUttakRepository,
                 dokumentBehandlingTjeneste,
                 revurderingBehandlingsresultatutleder);
     }

--- a/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/uttak/svp/FastsettUttaksgrunnlagOgVurderSøknadsfristStegTest.java
+++ b/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/uttak/svp/FastsettUttaksgrunnlagOgVurderSøknadsfristStegTest.java
@@ -22,6 +22,7 @@ import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.Aksjonspun
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepositoryProvider;
 import no.nav.foreldrepenger.behandlingslager.behandling.søknad.SøknadEntitet;
+import no.nav.foreldrepenger.behandlingslager.behandling.tilrettelegging.SvangerskapspengerRepository;
 import no.nav.foreldrepenger.dbstoette.CdiDbAwareTest;
 import no.nav.foreldrepenger.domene.uttak.svp.FørsteLovligeUttaksdatoTjeneste;
 import no.nav.foreldrepenger.domene.uttak.svp.RegelmodellSøknaderMapper;
@@ -34,6 +35,9 @@ public class FastsettUttaksgrunnlagOgVurderSøknadsfristStegTest {
 
     @Inject
     private BehandlingRepository behandlingRepository;
+
+    @Inject
+    private SvangerskapspengerRepository svangerskapspengerRepository;
 
     @Inject
     private FørsteLovligeUttaksdatoTjeneste førsteLovligeUttaksdatoTjeneste;
@@ -49,7 +53,7 @@ public class FastsettUttaksgrunnlagOgVurderSøknadsfristStegTest {
     @BeforeEach
     public void setup(EntityManager em) {
 
-        svpHelper = new SvpHelper(repositoryProvider);
+        svpHelper = new SvpHelper(repositoryProvider, svangerskapspengerRepository);
         behandling = svpHelper.lagreBehandling();
         em.flush();
         em.clear();

--- a/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/uttak/svp/SvpHelper.java
+++ b/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/uttak/svp/SvpHelper.java
@@ -10,6 +10,7 @@ import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
 import no.nav.foreldrepenger.behandlingslager.behandling.familiehendelse.FamilieHendelseBuilder;
 import no.nav.foreldrepenger.behandlingslager.behandling.familiehendelse.HendelseVersjonType;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepositoryProvider;
+import no.nav.foreldrepenger.behandlingslager.behandling.tilrettelegging.SvangerskapspengerRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.tilrettelegging.SvpGrunnlagEntitet;
 import no.nav.foreldrepenger.behandlingslager.behandling.tilrettelegging.SvpTilretteleggingEntitet;
 import no.nav.foreldrepenger.behandlingslager.testutilities.behandling.ScenarioMorSøkerSvangerskapspenger;
@@ -20,9 +21,11 @@ import no.nav.foreldrepenger.domene.typer.AktørId;
 class SvpHelper {
 
     private BehandlingRepositoryProvider behandlingRepositoryProvider;
+    private SvangerskapspengerRepository svangerskapspengerRepository;
 
-    public SvpHelper(BehandlingRepositoryProvider behandlingRepositoryProvider) {
+    public SvpHelper(BehandlingRepositoryProvider behandlingRepositoryProvider, SvangerskapspengerRepository svpRepository) {
         this.behandlingRepositoryProvider = behandlingRepositoryProvider;
+        this.svangerskapspengerRepository = svpRepository;
     }
 
     Behandling lagreBehandling() {
@@ -48,7 +51,7 @@ class SvpHelper {
                 .medBehandlingId(behandling.getId())
                 .medOpprinneligeTilrettelegginger(List.of(tilrettelegging))
                 .build();
-        behandlingRepositoryProvider.getSvangerskapspengerRepository().lagreOgFlush(svpGrunnlag);
+        svangerskapspengerRepository.lagreOgFlush(svpGrunnlag);
     }
 
     private FamilieHendelseBuilder byggAggregat(LocalDate termindato, LocalDate... fødselsdatoer) {

--- a/domenetjenester/behandling-revurdering/src/main/java/no/nav/foreldrepenger/behandling/revurdering/satsregulering/AutomatiskArenaReguleringBatchTjeneste.java
+++ b/domenetjenester/behandling-revurdering/src/main/java/no/nav/foreldrepenger/behandling/revurdering/satsregulering/AutomatiskArenaReguleringBatchTjeneste.java
@@ -11,7 +11,6 @@ import org.slf4j.LoggerFactory;
 
 import no.nav.foreldrepenger.batch.BatchArguments;
 import no.nav.foreldrepenger.batch.BatchTjeneste;
-import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepositoryProvider;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRevurderingRepository;
 import no.nav.foreldrepenger.domene.typer.AktørId;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTaskData;
@@ -33,10 +32,10 @@ public class AutomatiskArenaReguleringBatchTjeneste implements BatchTjeneste {
     private ProsessTaskTjeneste taskTjeneste;
 
     @Inject
-    public AutomatiskArenaReguleringBatchTjeneste(BehandlingRepositoryProvider repositoryProvider,
+    public AutomatiskArenaReguleringBatchTjeneste(BehandlingRevurderingRepository behandlingRevurderingRepository,
             ProsessTaskTjeneste taskTjeneste) {
         this.taskTjeneste = taskTjeneste;
-        this.behandlingRevurderingRepository = repositoryProvider.getBehandlingRevurderingRepository();
+        this.behandlingRevurderingRepository = behandlingRevurderingRepository;
     }
 
     @Override

--- a/domenetjenester/behandling-revurdering/src/main/java/no/nav/foreldrepenger/behandling/revurdering/ytelse/es/RevurderingTjenesteImpl.java
+++ b/domenetjenester/behandling-revurdering/src/main/java/no/nav/foreldrepenger/behandling/revurdering/ytelse/es/RevurderingTjenesteImpl.java
@@ -17,8 +17,8 @@ import no.nav.foreldrepenger.behandlingslager.behandling.familiehendelse.Familie
 import no.nav.foreldrepenger.behandlingslager.behandling.medlemskap.MedlemskapRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.opptjening.utlanddok.OpptjeningIUtlandDokStatusRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.personopplysning.PersonopplysningRepository;
+import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingGrunnlagRepositoryProvider;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepository;
-import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepositoryProvider;
 import no.nav.foreldrepenger.behandlingslager.behandling.søknad.SøknadRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.verge.VergeRepository;
 import no.nav.foreldrepenger.behandlingslager.fagsak.Fagsak;
@@ -42,18 +42,19 @@ public class RevurderingTjenesteImpl implements RevurderingTjeneste {
     }
 
     @Inject
-    public RevurderingTjenesteImpl(BehandlingRepositoryProvider repositoryProvider,
+    public RevurderingTjenesteImpl(BehandlingRepository behandlingRepository,
+                                   BehandlingGrunnlagRepositoryProvider grunnlagRepositoryProvider,
                                    BehandlingskontrollTjeneste behandlingskontrollTjeneste,
                                    @FagsakYtelseTypeRef("ES") RevurderingEndring revurderingEndring,
                                    RevurderingTjenesteFelles revurderingTjenesteFelles,
                                    VergeRepository vergeRepository) {
-        this.behandlingRepository = repositoryProvider.getBehandlingRepository();
+        this.behandlingRepository = behandlingRepository;
         this.behandlingskontrollTjeneste = behandlingskontrollTjeneste;
-        this.familieHendelseRepository = repositoryProvider.getFamilieHendelseRepository();
-        this.personopplysningRepository = repositoryProvider.getPersonopplysningRepository();
-        this.medlemskapRepository = repositoryProvider.getMedlemskapRepository();
-        this.søknadRepository = repositoryProvider.getSøknadRepository();
-        this.opptjeningIUtlandDokStatusRepository = repositoryProvider.getOpptjeningIUtlandDokStatusRepository();
+        this.familieHendelseRepository = grunnlagRepositoryProvider.getFamilieHendelseRepository();
+        this.personopplysningRepository = grunnlagRepositoryProvider.getPersonopplysningRepository();
+        this.medlemskapRepository = grunnlagRepositoryProvider.getMedlemskapRepository();
+        this.søknadRepository = grunnlagRepositoryProvider.getSøknadRepository();
+        this.opptjeningIUtlandDokStatusRepository = grunnlagRepositoryProvider.getOpptjeningIUtlandDokStatusRepository();
         this.revurderingEndring = revurderingEndring;
         this.revurderingTjenesteFelles = revurderingTjenesteFelles;
         this.vergeRepository = vergeRepository;

--- a/domenetjenester/behandling-revurdering/src/main/java/no/nav/foreldrepenger/behandling/revurdering/ytelse/fp/RevurderingTjenesteImpl.java
+++ b/domenetjenester/behandling-revurdering/src/main/java/no/nav/foreldrepenger/behandling/revurdering/ytelse/fp/RevurderingTjenesteImpl.java
@@ -22,9 +22,11 @@ import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingÅrsakType;
 import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.AksjonspunktDefinisjon;
 import no.nav.foreldrepenger.behandlingslager.behandling.familiehendelse.FamilieHendelseRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.medlemskap.MedlemskapRepository;
+import no.nav.foreldrepenger.behandlingslager.behandling.nestesak.NesteSakRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.opptjening.utlanddok.OpptjeningIUtlandDokStatusRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.personopplysning.PersonopplysningRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.pleiepenger.PleiepengerRepository;
+import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingGrunnlagRepositoryProvider;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepositoryProvider;
 import no.nav.foreldrepenger.behandlingslager.behandling.søknad.SøknadEntitet;
@@ -48,6 +50,7 @@ public class RevurderingTjenesteImpl implements RevurderingTjeneste {
     private MedlemskapRepository medlemskapRepository;
     private PleiepengerRepository pleiepengerRepository;
     private UføretrygdRepository uføretrygdRepository;
+    private NesteSakRepository nesteSakRepository;
     private YtelsesFordelingRepository ytelsesFordelingRepository;
     private OpptjeningIUtlandDokStatusRepository opptjeningIUtlandDokStatusRepository;
     private RevurderingTjenesteFelles revurderingTjenesteFelles;
@@ -62,6 +65,7 @@ public class RevurderingTjenesteImpl implements RevurderingTjeneste {
 
     @Inject
     public RevurderingTjenesteImpl(BehandlingRepositoryProvider repositoryProvider,
+                                   BehandlingGrunnlagRepositoryProvider grunnlagProvider,
                                    BehandlingskontrollTjeneste behandlingskontrollTjeneste,
                                    InntektArbeidYtelseTjeneste iayTjeneste,
                                    @FagsakYtelseTypeRef("FP") RevurderingEndring revurderingEndring,
@@ -71,17 +75,18 @@ public class RevurderingTjenesteImpl implements RevurderingTjeneste {
         this.behandlingRepository = repositoryProvider.getBehandlingRepository();
         this.behandlingsresultatRepository = repositoryProvider.getBehandlingsresultatRepository();
         this.behandlingskontrollTjeneste = behandlingskontrollTjeneste;
-        this.ytelsesFordelingRepository = repositoryProvider.getYtelsesFordelingRepository();
-        this.familieHendelseRepository = repositoryProvider.getFamilieHendelseRepository();
-        this.personopplysningRepository = repositoryProvider.getPersonopplysningRepository();
-        this.medlemskapRepository = repositoryProvider.getMedlemskapRepository();
-        this.pleiepengerRepository = repositoryProvider.getPleiepengerRepository();
-        this.uføretrygdRepository = repositoryProvider.getUføretrygdRepository();
-        this.opptjeningIUtlandDokStatusRepository = repositoryProvider.getOpptjeningIUtlandDokStatusRepository();
+        this.ytelsesFordelingRepository = grunnlagProvider.getYtelsesFordelingRepository();
+        this.familieHendelseRepository = grunnlagProvider.getFamilieHendelseRepository();
+        this.personopplysningRepository = grunnlagProvider.getPersonopplysningRepository();
+        this.medlemskapRepository = grunnlagProvider.getMedlemskapRepository();
+        this.pleiepengerRepository = grunnlagProvider.getPleiepengerRepository();
+        this.uføretrygdRepository = grunnlagProvider.getUføretrygdRepository();
+        this.opptjeningIUtlandDokStatusRepository = grunnlagProvider.getOpptjeningIUtlandDokStatusRepository();
+        this.nesteSakRepository = grunnlagProvider.getNesteSakRepository();
         this.revurderingEndring = revurderingEndring;
         this.revurderingTjenesteFelles = revurderingTjenesteFelles;
         this.vergeRepository = vergeRepository;
-        this.søknadRepository = repositoryProvider.getSøknadRepository();
+        this.søknadRepository = grunnlagProvider.getSøknadRepository();
     }
 
     @Override
@@ -136,6 +141,7 @@ public class RevurderingTjenesteImpl implements RevurderingTjeneste {
         medlemskapRepository.kopierGrunnlagFraEksisterendeBehandling(originalBehandlingId, nyBehandlingId);
         pleiepengerRepository.kopierGrunnlagFraEksisterendeBehandling(originalBehandlingId, nyBehandlingId);
         uføretrygdRepository.kopierGrunnlagFraEksisterendeBehandling(originalBehandlingId, nyBehandlingId);
+        nesteSakRepository.kopierGrunnlagFraEksisterendeBehandling(originalBehandlingId, nyBehandlingId);
 
         if (BehandlingType.REVURDERING.equals(ny.getType())) {
             ytelsesFordelingRepository.kopierGrunnlagFraEksisterendeBehandling(originalBehandlingId, nyBehandlingId);
@@ -153,8 +159,7 @@ public class RevurderingTjenesteImpl implements RevurderingTjeneste {
             });
         }
         vergeRepository.kopierGrunnlagFraEksisterendeBehandling(originalBehandlingId, nyBehandlingId);
-        opptjeningIUtlandDokStatusRepository.kopierGrunnlagFraEksisterendeBehandling(originalBehandlingId,
-            nyBehandlingId);
+        opptjeningIUtlandDokStatusRepository.kopierGrunnlagFraEksisterendeBehandling(originalBehandlingId, nyBehandlingId);
 
         // gjør til slutt, innebærer kall til abakus
         iayTjeneste.kopierGrunnlagFraEksisterendeBehandling(originalBehandlingId, nyBehandlingId);

--- a/domenetjenester/behandling-revurdering/src/main/java/no/nav/foreldrepenger/behandling/revurdering/ytelse/fp/UttakGrunnlagTjeneste.java
+++ b/domenetjenester/behandling-revurdering/src/main/java/no/nav/foreldrepenger/behandling/revurdering/ytelse/fp/UttakGrunnlagTjeneste.java
@@ -17,8 +17,11 @@ import no.nav.foreldrepenger.behandlingslager.behandling.familiehendelse.Familie
 import no.nav.foreldrepenger.behandlingslager.behandling.familiehendelse.FamilieHendelseGrunnlagEntitet;
 import no.nav.foreldrepenger.behandlingslager.behandling.familiehendelse.FamilieHendelseType;
 import no.nav.foreldrepenger.behandlingslager.behandling.familiehendelse.TerminbekreftelseEntitet;
+import no.nav.foreldrepenger.behandlingslager.behandling.nestesak.NesteSakGrunnlagEntitet;
+import no.nav.foreldrepenger.behandlingslager.behandling.nestesak.NesteSakRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.pleiepenger.PleiepengerGrunnlagEntitet;
 import no.nav.foreldrepenger.behandlingslager.behandling.pleiepenger.PleiepengerRepository;
+import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingGrunnlagRepositoryProvider;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepositoryProvider;
 import no.nav.foreldrepenger.behandlingslager.behandling.søknad.SøknadEntitet;
@@ -53,9 +56,11 @@ public class UttakGrunnlagTjeneste implements YtelsesesspesifiktGrunnlagTjeneste
     private SøknadRepository søknadRepository;
     private PleiepengerRepository pleiepengerRepository;
     private UføretrygdRepository uføretrygdRepository;
+    private NesteSakRepository nesteSakRepository;
 
     @Inject
     public UttakGrunnlagTjeneste(BehandlingRepositoryProvider behandlingRepositoryProvider,
+                                 BehandlingGrunnlagRepositoryProvider grunnlagRepositoryProvider,
                                  RelatertBehandlingTjeneste relatertBehandlingTjeneste,
                                  FamilieHendelseTjeneste familieHendelseTjeneste) {
         this.behandlingRepository = behandlingRepositoryProvider.getBehandlingRepository();
@@ -63,9 +68,10 @@ public class UttakGrunnlagTjeneste implements YtelsesesspesifiktGrunnlagTjeneste
         this.behandlingVedtakRepository = behandlingRepositoryProvider.getBehandlingVedtakRepository();
         this.relatertBehandlingTjeneste = relatertBehandlingTjeneste;
         this.familieHendelseTjeneste = familieHendelseTjeneste;
-        this.søknadRepository = behandlingRepositoryProvider.getSøknadRepository();
-        this.pleiepengerRepository = behandlingRepositoryProvider.getPleiepengerRepository();
-        this.uføretrygdRepository = behandlingRepositoryProvider.getUføretrygdRepository();
+        this.søknadRepository = grunnlagRepositoryProvider.getSøknadRepository();
+        this.pleiepengerRepository = grunnlagRepositoryProvider.getPleiepengerRepository();
+        this.uføretrygdRepository = grunnlagRepositoryProvider.getUføretrygdRepository();
+        this.nesteSakRepository = grunnlagRepositoryProvider.getNesteSakRepository();
     }
 
     UttakGrunnlagTjeneste() {
@@ -92,7 +98,8 @@ public class UttakGrunnlagTjeneste implements YtelsesesspesifiktGrunnlagTjeneste
             .medFamilieHendelser(familiehendelser)
             .medOriginalBehandling(originalBehandling.orElse(null))
             .medPleiepengerGrunnlag(pleiepengerGrunnlag(ref).orElse(null))
-            .medUføretrygdGrunnlag(uføretrygdGrunnlag(ref).orElse(null));
+            .medUføretrygdGrunnlag(uføretrygdGrunnlag(ref).orElse(null))
+            .medNesteSakGrunnlag(nesteSakGrunnlag(ref).orElse(null));
         if (fagsakRelasjon.isPresent()) {
             var annenpart = annenpart(fagsakRelasjon.get(), familiehendelser, behandling);
             grunnlag = grunnlag.medAnnenpart(annenpart.orElse(null));
@@ -106,6 +113,10 @@ public class UttakGrunnlagTjeneste implements YtelsesesspesifiktGrunnlagTjeneste
 
     private Optional<UføretrygdGrunnlagEntitet> uføretrygdGrunnlag(BehandlingReferanse ref) {
         return uføretrygdRepository.hentGrunnlag(ref.getBehandlingId());
+    }
+
+    private Optional<NesteSakGrunnlagEntitet> nesteSakGrunnlag(BehandlingReferanse ref) {
+        return nesteSakRepository.hentGrunnlag(ref.getBehandlingId());
     }
 
     private Optional<Annenpart> annenpart(FagsakRelasjon fagsakRelasjon,

--- a/domenetjenester/behandling-revurdering/src/main/java/no/nav/foreldrepenger/behandling/revurdering/ytelse/svp/RevurderingBehandlingsresultatutleder.java
+++ b/domenetjenester/behandling-revurdering/src/main/java/no/nav/foreldrepenger/behandling/revurdering/ytelse/svp/RevurderingBehandlingsresultatutleder.java
@@ -13,8 +13,8 @@ import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepositoryProvider;
 import no.nav.foreldrepenger.behandlingslager.behandling.vedtak.BehandlingVedtakRepository;
 import no.nav.foreldrepenger.behandlingslager.uttak.svp.SvangerskapspengerUttakResultatRepository;
-import no.nav.foreldrepenger.domene.prosess.HentOgLagreBeregningsgrunnlagTjeneste;
 import no.nav.foreldrepenger.domene.medlem.MedlemTjeneste;
+import no.nav.foreldrepenger.domene.prosess.HentOgLagreBeregningsgrunnlagTjeneste;
 import no.nav.foreldrepenger.domene.uttak.OpphørUttakTjeneste;
 import no.nav.foreldrepenger.skjæringstidspunkt.SkjæringstidspunktTjeneste;
 
@@ -27,7 +27,8 @@ public class RevurderingBehandlingsresultatutleder extends RevurderingBehandling
     private BehandlingVedtakRepository behandlingVedtakRepository;
 
     @Inject
-    public RevurderingBehandlingsresultatutleder(BehandlingRepositoryProvider repositoryProvider, // NOSONAR
+    public RevurderingBehandlingsresultatutleder(BehandlingRepositoryProvider repositoryProvider,
+            SvangerskapspengerUttakResultatRepository uttakResultatRepository,
             HentOgLagreBeregningsgrunnlagTjeneste beregningsgrunnlagTjeneste,
             OpphørUttakTjeneste opphørUttakTjeneste,
             @FagsakYtelseTypeRef("SVP") SkjæringstidspunktTjeneste skjæringstidspunktTjeneste,
@@ -37,7 +38,7 @@ public class RevurderingBehandlingsresultatutleder extends RevurderingBehandling
                 medlemTjeneste,
                 opphørUttakTjeneste,
                 skjæringstidspunktTjeneste);
-        this.uttakRepository = repositoryProvider.getSvangerskapspengerUttakResultatRepository();
+        this.uttakRepository = uttakResultatRepository;
         this.behandlingVedtakRepository = repositoryProvider.getBehandlingVedtakRepository();
     }
 

--- a/domenetjenester/behandling-revurdering/src/main/java/no/nav/foreldrepenger/behandling/revurdering/ytelse/svp/RevurderingTjenesteImpl.java
+++ b/domenetjenester/behandling-revurdering/src/main/java/no/nav/foreldrepenger/behandling/revurdering/ytelse/svp/RevurderingTjenesteImpl.java
@@ -17,10 +17,11 @@ import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingType;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingÅrsakType;
 import no.nav.foreldrepenger.behandlingslager.behandling.familiehendelse.FamilieHendelseRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.medlemskap.MedlemskapRepository;
+import no.nav.foreldrepenger.behandlingslager.behandling.nestesak.NesteSakRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.opptjening.utlanddok.OpptjeningIUtlandDokStatusRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.personopplysning.PersonopplysningRepository;
+import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingGrunnlagRepositoryProvider;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepository;
-import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepositoryProvider;
 import no.nav.foreldrepenger.behandlingslager.behandling.tilrettelegging.SvangerskapspengerRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.verge.VergeRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.vilkår.VilkårType;
@@ -45,27 +46,30 @@ public class RevurderingTjenesteImpl implements RevurderingTjeneste {
     private RevurderingEndring revurderingEndring;
     private InntektArbeidYtelseTjeneste iayTjeneste;
     private VergeRepository vergeRepository;
+    private NesteSakRepository nesteSakRepository;
 
     public RevurderingTjenesteImpl() {
         // for CDI proxy
     }
 
     @Inject
-    public RevurderingTjenesteImpl(BehandlingRepositoryProvider repositoryProvider,
+    public RevurderingTjenesteImpl(BehandlingRepository behandlingRepository,
+                                   BehandlingGrunnlagRepositoryProvider grunnlagRepositoryProvider,
                                    BehandlingskontrollTjeneste behandlingskontrollTjeneste,
                                    InntektArbeidYtelseTjeneste iayTjeneste,
                                    @FagsakYtelseTypeRef("SVP") RevurderingEndring revurderingEndring,
                                    RevurderingTjenesteFelles revurderingTjenesteFelles,
                                    VergeRepository vergeRepository) {
         this.iayTjeneste = iayTjeneste;
-        this.behandlingRepository = repositoryProvider.getBehandlingRepository();
+        this.behandlingRepository = behandlingRepository;
         this.behandlingskontrollTjeneste = behandlingskontrollTjeneste;
-        this.ytelsesFordelingRepository = repositoryProvider.getYtelsesFordelingRepository();
-        this.familieHendelseRepository = repositoryProvider.getFamilieHendelseRepository();
-        this.personopplysningRepository = repositoryProvider.getPersonopplysningRepository();
-        this.medlemskapRepository = repositoryProvider.getMedlemskapRepository();
-        this.svangerskapspengerRepository = repositoryProvider.getSvangerskapspengerRepository();
-        this.opptjeningIUtlandDokStatusRepository = repositoryProvider.getOpptjeningIUtlandDokStatusRepository();
+        this.ytelsesFordelingRepository = grunnlagRepositoryProvider.getYtelsesFordelingRepository();
+        this.familieHendelseRepository = grunnlagRepositoryProvider.getFamilieHendelseRepository();
+        this.personopplysningRepository = grunnlagRepositoryProvider.getPersonopplysningRepository();
+        this.medlemskapRepository = grunnlagRepositoryProvider.getMedlemskapRepository();
+        this.svangerskapspengerRepository = grunnlagRepositoryProvider.getSvangerskapspengerRepository();
+        this.nesteSakRepository = grunnlagRepositoryProvider.getNesteSakRepository();
+        this.opptjeningIUtlandDokStatusRepository = grunnlagRepositoryProvider.getOpptjeningIUtlandDokStatusRepository();
         this.revurderingEndring = revurderingEndring;
         this.revurderingTjenesteFelles = revurderingTjenesteFelles;
         this.vergeRepository = vergeRepository;
@@ -133,8 +137,8 @@ public class RevurderingTjenesteImpl implements RevurderingTjeneste {
             });
         }
         vergeRepository.kopierGrunnlagFraEksisterendeBehandling(originalBehandlingId, nyBehandlingId);
-        opptjeningIUtlandDokStatusRepository.kopierGrunnlagFraEksisterendeBehandling(originalBehandlingId,
-            nyBehandlingId);
+        opptjeningIUtlandDokStatusRepository.kopierGrunnlagFraEksisterendeBehandling(originalBehandlingId,nyBehandlingId);
+        nesteSakRepository.kopierGrunnlagFraEksisterendeBehandling(originalBehandlingId, nyBehandlingId);
 
         // gjør til slutt, innebærer kall til abakus
         iayTjeneste.kopierGrunnlagFraEksisterendeBehandling(originalBehandlingId, nyBehandlingId);

--- a/domenetjenester/behandling-revurdering/src/main/java/no/nav/foreldrepenger/behandling/revurdering/ytelse/svp/UttakGrunnlagTjeneste.java
+++ b/domenetjenester/behandling-revurdering/src/main/java/no/nav/foreldrepenger/behandling/revurdering/ytelse/svp/UttakGrunnlagTjeneste.java
@@ -11,6 +11,7 @@ import no.nav.foreldrepenger.behandling.revurdering.ytelse.YtelsesesspesifiktGru
 import no.nav.foreldrepenger.behandlingskontroll.FagsakYtelseTypeRef;
 import no.nav.foreldrepenger.behandlingslager.behandling.familiehendelse.FamilieHendelseGrunnlagEntitet;
 import no.nav.foreldrepenger.behandlingslager.behandling.familiehendelse.FamilieHendelseRepository;
+import no.nav.foreldrepenger.behandlingslager.behandling.nestesak.NesteSakRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.tilrettelegging.SvangerskapspengerRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.tilrettelegging.SvpGrunnlagEntitet;
 import no.nav.foreldrepenger.domene.uttak.input.Barn;
@@ -23,11 +24,15 @@ public class UttakGrunnlagTjeneste implements YtelsesesspesifiktGrunnlagTjeneste
 
     private FamilieHendelseRepository familieHendelseRepository;
     private SvangerskapspengerRepository svangerskapspengerRepository;
+    private NesteSakRepository nesteSakRepository;
 
     @Inject
-    public UttakGrunnlagTjeneste(FamilieHendelseRepository familieHendelseRepository, SvangerskapspengerRepository svangerskapspengerRepository) {
+    public UttakGrunnlagTjeneste(FamilieHendelseRepository familieHendelseRepository,
+                                 SvangerskapspengerRepository svangerskapspengerRepository,
+                                 NesteSakRepository nesteSakRepository) {
         this.familieHendelseRepository = familieHendelseRepository;
         this.svangerskapspengerRepository = svangerskapspengerRepository;
+        this.nesteSakRepository = nesteSakRepository;
     }
 
     UttakGrunnlagTjeneste() {
@@ -43,6 +48,7 @@ public class UttakGrunnlagTjeneste implements YtelsesesspesifiktGrunnlagTjeneste
         var grunnlag = new SvangerskapspengerGrunnlag()
                 .medFamilieHendelse(familieHendelse.get())
                 .medSvpGrunnlagEntitet(svpGrunnEntitet(ref).orElse(null));
+        nesteSakRepository.hentGrunnlag(ref.getBehandlingId()).ifPresent(g -> grunnlag.medNesteSakEntitet(g));
         return Optional.of(grunnlag);
     }
 

--- a/domenetjenester/behandling-revurdering/src/test/java/no/nav/foreldrepenger/behandling/revurdering/felles/ErEndringIBeregningTest.java
+++ b/domenetjenester/behandling-revurdering/src/test/java/no/nav/foreldrepenger/behandling/revurdering/felles/ErEndringIBeregningTest.java
@@ -27,15 +27,16 @@ import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingStegType;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingÅrsakType;
 import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.AksjonspunktDefinisjon;
+import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingGrunnlagRepositoryProvider;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepositoryProvider;
 import no.nav.foreldrepenger.behandlingslager.behandling.vedtak.VedtakResultatType;
 import no.nav.foreldrepenger.behandlingslager.behandling.verge.VergeRepository;
 import no.nav.foreldrepenger.behandlingslager.testutilities.behandling.ScenarioMorSøkerForeldrepenger;
 import no.nav.foreldrepenger.dbstoette.CdiDbAwareTest;
+import no.nav.foreldrepenger.domene.arbeidsforhold.InntektArbeidYtelseTjeneste;
 import no.nav.foreldrepenger.domene.modell.BeregningsgrunnlagEntitet;
 import no.nav.foreldrepenger.domene.modell.BeregningsgrunnlagRepository;
 import no.nav.foreldrepenger.domene.modell.BeregningsgrunnlagTilstand;
-import no.nav.foreldrepenger.domene.arbeidsforhold.InntektArbeidYtelseTjeneste;
 import no.nav.foreldrepenger.domene.tid.ÅpenDatoIntervallEntitet;
 import no.nav.foreldrepenger.domene.uttak.uttaksgrunnlag.fp.EndringsdatoRevurderingUtlederImpl;
 
@@ -59,6 +60,8 @@ public class ErEndringIBeregningTest {
 
     @Inject
     private BeregningsgrunnlagRepository beregningsgrunnlagRepository;
+    @Inject
+    private BehandlingGrunnlagRepositoryProvider grunnlagRepositoryProvider;
 
     @Inject
     private BehandlingRepositoryProvider repositoryProvider;
@@ -85,7 +88,7 @@ public class ErEndringIBeregningTest {
         var behandlingskontrollTjeneste = new BehandlingskontrollTjenesteImpl(serviceProvider);
         var revurderingTjenesteFelles = new RevurderingTjenesteFelles(repositoryProvider);
         RevurderingTjeneste revurderingTjeneste = new RevurderingTjenesteImpl(repositoryProvider,
-                behandlingskontrollTjeneste,
+                grunnlagRepositoryProvider, behandlingskontrollTjeneste,
                 iayTjeneste, revurderingEndring, revurderingTjenesteFelles, vergeRepository);
         revurdering = revurderingTjeneste
                 .opprettAutomatiskRevurdering(behandlingSomSkalRevurderes.getFagsak(),

--- a/domenetjenester/behandling-revurdering/src/test/java/no/nav/foreldrepenger/behandling/revurdering/felles/ErKunEndringIFordelingAvYtelsenTest.java
+++ b/domenetjenester/behandling-revurdering/src/test/java/no/nav/foreldrepenger/behandling/revurdering/felles/ErKunEndringIFordelingAvYtelsenTest.java
@@ -34,6 +34,7 @@ import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingÅrsakType;
 import no.nav.foreldrepenger.behandlingslager.behandling.KonsekvensForYtelsen;
 import no.nav.foreldrepenger.behandlingslager.behandling.RettenTil;
 import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.AksjonspunktDefinisjon;
+import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingGrunnlagRepositoryProvider;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepositoryProvider;
 import no.nav.foreldrepenger.behandlingslager.behandling.vedtak.VedtakResultatType;
 import no.nav.foreldrepenger.behandlingslager.behandling.vedtak.Vedtaksbrev;
@@ -41,13 +42,13 @@ import no.nav.foreldrepenger.behandlingslager.behandling.verge.VergeRepository;
 import no.nav.foreldrepenger.behandlingslager.testutilities.behandling.ScenarioMorSøkerForeldrepenger;
 import no.nav.foreldrepenger.behandlingslager.virksomhet.Arbeidsgiver;
 import no.nav.foreldrepenger.dbstoette.CdiDbAwareTest;
+import no.nav.foreldrepenger.domene.arbeidsforhold.InntektArbeidYtelseTjeneste;
 import no.nav.foreldrepenger.domene.modell.AktivitetStatus;
 import no.nav.foreldrepenger.domene.modell.BGAndelArbeidsforhold;
 import no.nav.foreldrepenger.domene.modell.BeregningsgrunnlagAktivitetStatus;
 import no.nav.foreldrepenger.domene.modell.BeregningsgrunnlagEntitet;
 import no.nav.foreldrepenger.domene.modell.BeregningsgrunnlagPeriode;
 import no.nav.foreldrepenger.domene.modell.BeregningsgrunnlagPrStatusOgAndel;
-import no.nav.foreldrepenger.domene.arbeidsforhold.InntektArbeidYtelseTjeneste;
 import no.nav.foreldrepenger.domene.tid.ÅpenDatoIntervallEntitet;
 import no.nav.foreldrepenger.domene.typer.InternArbeidsforholdRef;
 import no.nav.fpsak.tidsserie.LocalDateInterval;
@@ -76,6 +77,8 @@ public class ErKunEndringIFordelingAvYtelsenTest {
 
     @Inject
     private BehandlingRepositoryProvider repositoryProvider;
+    @Inject
+    private BehandlingGrunnlagRepositoryProvider grunnlagRepositoryProvider;
     private Behandling behandlingSomSkalRevurderes;
     private Behandling revurdering;
     private Behandlingsresultat revurderingResultat;
@@ -96,8 +99,8 @@ public class ErKunEndringIFordelingAvYtelsenTest {
         revurderingTestUtil.avsluttBehandling(behandlingSomSkalRevurderes);
         var behandlingskontrollTjeneste = new BehandlingskontrollTjenesteImpl(serviceProvider);
         var revurderingTjenesteFelles = new RevurderingTjenesteFelles(repositoryProvider);
-        var revurderingTjeneste = new RevurderingTjenesteImpl(repositoryProvider, behandlingskontrollTjeneste,
-                iayTjeneste, revurderingEndring, revurderingTjenesteFelles, vergeRepository);
+        var revurderingTjeneste = new RevurderingTjenesteImpl(repositoryProvider, grunnlagRepositoryProvider,
+            behandlingskontrollTjeneste, iayTjeneste, revurderingEndring, revurderingTjenesteFelles, vergeRepository);
         revurdering = revurderingTjeneste
                 .opprettAutomatiskRevurdering(behandlingSomSkalRevurderes.getFagsak(),
                         BehandlingÅrsakType.RE_HENDELSE_FØDSEL, new OrganisasjonsEnhet("1234", "Test"));

--- a/domenetjenester/behandling-revurdering/src/test/java/no/nav/foreldrepenger/behandling/revurdering/felles/ErSisteUttakAvslåttMedÅrsakTest.java
+++ b/domenetjenester/behandling-revurdering/src/test/java/no/nav/foreldrepenger/behandling/revurdering/felles/ErSisteUttakAvslåttMedÅrsakTest.java
@@ -30,6 +30,7 @@ import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingStegType;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingÅrsakType;
 import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.AksjonspunktDefinisjon;
+import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingGrunnlagRepositoryProvider;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepositoryProvider;
 import no.nav.foreldrepenger.behandlingslager.behandling.vedtak.VedtakResultatType;
 import no.nav.foreldrepenger.behandlingslager.behandling.verge.VergeRepository;
@@ -76,6 +77,8 @@ public class ErSisteUttakAvslåttMedÅrsakTest {
 
     @Inject
     private BehandlingRepositoryProvider repositoryProvider;
+    @Inject
+    private BehandlingGrunnlagRepositoryProvider grunnlagRepositoryProvider;
     private FpUttakRepository fpUttakRepository;
     private EndringsdatoRevurderingUtlederImpl endringsdatoRevurderingUtlederImpl = mock(
             EndringsdatoRevurderingUtlederImpl.class);
@@ -99,8 +102,8 @@ public class ErSisteUttakAvslåttMedÅrsakTest {
         revurderingTestUtil.avsluttBehandling(behandlingSomSkalRevurderes);
         var behandlingskontrollTjeneste = new BehandlingskontrollTjenesteImpl(serviceProvider);
         var revurderingTjenesteFelles = new RevurderingTjenesteFelles(repositoryProvider);
-        var revurderingTjeneste = new RevurderingTjenesteImpl(repositoryProvider, behandlingskontrollTjeneste,
-                iayTjeneste, revurderingEndring, revurderingTjenesteFelles, vergeRepository);
+        var revurderingTjeneste = new RevurderingTjenesteImpl(repositoryProvider, grunnlagRepositoryProvider,
+            behandlingskontrollTjeneste, iayTjeneste, revurderingEndring, revurderingTjenesteFelles, vergeRepository);
         revurdering = revurderingTjeneste
                 .opprettAutomatiskRevurdering(behandlingSomSkalRevurderes.getFagsak(),
                         BehandlingÅrsakType.RE_HENDELSE_FØDSEL, new OrganisasjonsEnhet("1234", "Test"));

--- a/domenetjenester/behandling-revurdering/src/test/java/no/nav/foreldrepenger/behandling/revurdering/felles/OppfyllerIkkeInngangsvilkårPåSkjæringstidsspunktTest.java
+++ b/domenetjenester/behandling-revurdering/src/test/java/no/nav/foreldrepenger/behandling/revurdering/felles/OppfyllerIkkeInngangsvilkårPåSkjæringstidsspunktTest.java
@@ -26,6 +26,7 @@ import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingÅrsakType;
 import no.nav.foreldrepenger.behandlingslager.behandling.KonsekvensForYtelsen;
 import no.nav.foreldrepenger.behandlingslager.behandling.RettenTil;
 import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.AksjonspunktDefinisjon;
+import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingGrunnlagRepositoryProvider;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepositoryProvider;
 import no.nav.foreldrepenger.behandlingslager.behandling.vedtak.VedtakResultatType;
 import no.nav.foreldrepenger.behandlingslager.behandling.vedtak.Vedtaksbrev;
@@ -58,6 +59,8 @@ public class OppfyllerIkkeInngangsvilkårPåSkjæringstidsspunktTest {
 
     @Inject
     private BehandlingRepositoryProvider repositoryProvider;
+    @Inject
+    private BehandlingGrunnlagRepositoryProvider grunnlagRepositoryProvider;
 
     private Behandling revurdering;
     private Behandlingsresultat revurderingResultat;
@@ -77,8 +80,8 @@ public class OppfyllerIkkeInngangsvilkårPåSkjæringstidsspunktTest {
         revurderingTestUtil.avsluttBehandling(behandlingSomSkalRevurderes);
         var behandlingskontrollTjeneste = new BehandlingskontrollTjenesteImpl(serviceProvider);
         var revurderingTjenesteFelles = new RevurderingTjenesteFelles(repositoryProvider);
-        var revurderingTjeneste = new RevurderingTjenesteImpl(repositoryProvider, behandlingskontrollTjeneste,
-                iayTjeneste, revurderingEndring, revurderingTjenesteFelles, vergeRepository);
+        var revurderingTjeneste = new RevurderingTjenesteImpl(repositoryProvider, grunnlagRepositoryProvider,
+            behandlingskontrollTjeneste, iayTjeneste, revurderingEndring, revurderingTjenesteFelles, vergeRepository);
         revurdering = revurderingTjeneste
                 .opprettAutomatiskRevurdering(behandlingSomSkalRevurderes.getFagsak(),
                         BehandlingÅrsakType.RE_HENDELSE_FØDSEL, new OrganisasjonsEnhet("1234", "Test"));

--- a/domenetjenester/behandling-revurdering/src/test/java/no/nav/foreldrepenger/behandling/revurdering/satsregulering/AutomatiskArenaReguleringBatchTjenesteTest.java
+++ b/domenetjenester/behandling-revurdering/src/test/java/no/nav/foreldrepenger/behandling/revurdering/satsregulering/AutomatiskArenaReguleringBatchTjenesteTest.java
@@ -23,9 +23,14 @@ import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingResultatType;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingStatus;
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandlingsresultat;
 import no.nav.foreldrepenger.behandlingslager.behandling.beregning.BeregningSatsType;
+import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingLåsRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepositoryProvider;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRevurderingRepository;
+import no.nav.foreldrepenger.behandlingslager.behandling.søknad.SøknadRepository;
+import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.YtelsesFordelingRepository;
+import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakLåsRepository;
+import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakRelasjonRepository;
 import no.nav.foreldrepenger.behandlingslager.testutilities.behandling.ScenarioMorSøkerForeldrepenger;
 import no.nav.foreldrepenger.behandlingslager.uttak.fp.StønadskontoType;
 import no.nav.foreldrepenger.behandlingslager.uttak.fp.UttakResultatPerioderEntitet;
@@ -66,7 +71,9 @@ public class AutomatiskArenaReguleringBatchTjenesteTest {
             .getVerdi();
         var nySatsDato = cutoff.plusWeeks(3).plusDays(2);
         var taskTjenesteMock = mock(ProsessTaskTjeneste.class);
-        tjeneste = new AutomatiskArenaReguleringBatchTjeneste(repositoryProvider,
+        tjeneste = new AutomatiskArenaReguleringBatchTjeneste(new BehandlingRevurderingRepository(entityManager, behandlingRepository,
+            new FagsakRelasjonRepository(entityManager, new YtelsesFordelingRepository(entityManager), new FagsakLåsRepository(entityManager)),
+            new SøknadRepository(entityManager, behandlingRepository), new BehandlingLåsRepository(entityManager)),
                 taskTjenesteMock);
         Map<String, String> arguments = new HashMap<>();
         arguments.put(AutomatiskArenaReguleringBatchArguments.REVURDER_KEY, "True");

--- a/domenetjenester/behandling-revurdering/src/test/java/no/nav/foreldrepenger/behandling/revurdering/ytelse/es/RevurderingTjenesteImplTest.java
+++ b/domenetjenester/behandling-revurdering/src/test/java/no/nav/foreldrepenger/behandling/revurdering/ytelse/es/RevurderingTjenesteImplTest.java
@@ -19,6 +19,7 @@ import no.nav.foreldrepenger.behandlingslager.aktør.OrganisasjonsEnhet;
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingÅrsakType;
 import no.nav.foreldrepenger.behandlingslager.behandling.beregning.LegacyESBeregningRepository;
+import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingGrunnlagRepositoryProvider;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingLåsRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepositoryProvider;
@@ -31,12 +32,14 @@ import no.nav.foreldrepenger.dbstoette.FPsakEntityManagerAwareExtension;
 public class RevurderingTjenesteImplTest {
 
     private BehandlingRepositoryProvider repositoryProvider;
+    private BehandlingGrunnlagRepositoryProvider grunnlagProvider;
     private BehandlingRepository behandlingRepository;
     private RevurderingTjeneste revurderingTjeneste;
 
     @BeforeEach
     public void setup(EntityManager entityManager) {
         repositoryProvider = new BehandlingRepositoryProvider(entityManager);
+        grunnlagProvider = new BehandlingGrunnlagRepositoryProvider(entityManager);
         behandlingRepository = new BehandlingRepository(entityManager);
         var serviceProvider = new BehandlingskontrollServiceProvider(entityManager,
                 new BehandlingModellRepository(), null);
@@ -44,7 +47,7 @@ public class RevurderingTjenesteImplTest {
                 new LegacyESBeregningRepository(entityManager), repositoryProvider.getBehandlingsresultatRepository());
         var vergeRepository = new VergeRepository(entityManager, new BehandlingLåsRepository(entityManager));
         var revurderingTjenesteFelles = new RevurderingTjenesteFelles(repositoryProvider);
-        revurderingTjeneste = new RevurderingTjenesteImpl(repositoryProvider,
+        revurderingTjeneste = new RevurderingTjenesteImpl(behandlingRepository, grunnlagProvider,
                 new BehandlingskontrollTjenesteImpl(serviceProvider), revurderingEndringES, revurderingTjenesteFelles,
                 vergeRepository);
     }

--- a/domenetjenester/behandling-revurdering/src/test/java/no/nav/foreldrepenger/behandling/revurdering/ytelse/fp/ErEndringIUttakTest.java
+++ b/domenetjenester/behandling-revurdering/src/test/java/no/nav/foreldrepenger/behandling/revurdering/ytelse/fp/ErEndringIUttakTest.java
@@ -33,6 +33,7 @@ import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingStegType;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingÅrsakType;
 import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.AksjonspunktDefinisjon;
 import no.nav.foreldrepenger.behandlingslager.behandling.beregning.BeregningsresultatRepository;
+import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingGrunnlagRepositoryProvider;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingLåsRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepositoryProvider;
 import no.nav.foreldrepenger.behandlingslager.behandling.vedtak.VedtakResultatType;
@@ -40,12 +41,12 @@ import no.nav.foreldrepenger.behandlingslager.behandling.verge.VergeRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.årsak.OppholdÅrsak;
 import no.nav.foreldrepenger.behandlingslager.testutilities.behandling.ScenarioMorSøkerForeldrepenger;
 import no.nav.foreldrepenger.behandlingslager.uttak.PeriodeResultatType;
+import no.nav.foreldrepenger.behandlingslager.uttak.Utbetalingsgrad;
 import no.nav.foreldrepenger.behandlingslager.uttak.UttakArbeidType;
 import no.nav.foreldrepenger.behandlingslager.uttak.fp.FpUttakRepository;
 import no.nav.foreldrepenger.behandlingslager.uttak.fp.PeriodeResultatÅrsak;
 import no.nav.foreldrepenger.behandlingslager.uttak.fp.StønadskontoType;
 import no.nav.foreldrepenger.behandlingslager.uttak.fp.Trekkdager;
-import no.nav.foreldrepenger.behandlingslager.uttak.Utbetalingsgrad;
 import no.nav.foreldrepenger.behandlingslager.uttak.fp.UttakAktivitetEntitet;
 import no.nav.foreldrepenger.behandlingslager.uttak.fp.UttakResultatEntitet;
 import no.nav.foreldrepenger.behandlingslager.uttak.fp.UttakResultatPeriodeAktivitetEntitet;
@@ -76,6 +77,7 @@ public class ErEndringIUttakTest {
     private final EndringsdatoRevurderingUtlederImpl datoRevurderingUtlederImpl = mock(
             EndringsdatoRevurderingUtlederImpl.class);
     private BehandlingRepositoryProvider repositoryProvider;
+    private BehandlingGrunnlagRepositoryProvider grunnlagRepositoryProvider;
 
     @BeforeEach
     public void setUp(EntityManager entityManager) {
@@ -84,6 +86,7 @@ public class ErEndringIUttakTest {
         serviceProvider = new BehandlingskontrollServiceProvider(entityManager, new BehandlingModellRepository(), null);
         iayTjeneste = new AbakusInMemoryInntektArbeidYtelseTjeneste();
         repositoryProvider = new BehandlingRepositoryProvider(entityManager);
+        grunnlagRepositoryProvider = new BehandlingGrunnlagRepositoryProvider(entityManager);
         revurderingTestUtil = new BeregningRevurderingTestUtil(repositoryProvider);
         vergeRepository = new VergeRepository(entityManager, new BehandlingLåsRepository(entityManager));
         revurderingEndring = new no.nav.foreldrepenger.behandling.revurdering.ytelse.fp.RevurderingEndring();
@@ -93,7 +96,7 @@ public class ErEndringIUttakTest {
         var behandlingskontrollTjeneste = new BehandlingskontrollTjenesteImpl(
                 serviceProvider);
         var revurderingTjenesteFelles = new RevurderingTjenesteFelles(repositoryProvider);
-        RevurderingTjeneste revurderingTjeneste = new RevurderingTjenesteImpl(repositoryProvider,
+        RevurderingTjeneste revurderingTjeneste = new RevurderingTjenesteImpl(repositoryProvider, grunnlagRepositoryProvider,
                 behandlingskontrollTjeneste, iayTjeneste, revurderingEndring, revurderingTjenesteFelles, vergeRepository);
         var dato = LocalDate.now().minusMonths(3);
         when(datoRevurderingUtlederImpl.utledEndringsdato(any())).thenReturn(dato);

--- a/domenetjenester/behandling-revurdering/src/test/java/no/nav/foreldrepenger/behandling/revurdering/ytelse/fp/RevurderingTjenesteImplTest.java
+++ b/domenetjenester/behandling-revurdering/src/test/java/no/nav/foreldrepenger/behandling/revurdering/ytelse/fp/RevurderingTjenesteImplTest.java
@@ -37,6 +37,7 @@ import no.nav.foreldrepenger.behandlingslager.behandling.historikk.HistorikkOppl
 import no.nav.foreldrepenger.behandlingslager.behandling.historikk.HistorikkRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.historikk.Historikkinnslag;
 import no.nav.foreldrepenger.behandlingslager.behandling.historikk.HistorikkinnslagType;
+import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingGrunnlagRepositoryProvider;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepositoryProvider;
 import no.nav.foreldrepenger.behandlingslager.behandling.vedtak.VedtakResultatType;
 import no.nav.foreldrepenger.behandlingslager.behandling.verge.VergeRepository;
@@ -59,6 +60,9 @@ public class RevurderingTjenesteImplTest {
 
     @Inject
     private BehandlingRepositoryProvider repositoryProvider;
+    @Inject
+    private BehandlingGrunnlagRepositoryProvider grunnlagRepositoryProvider;
+
     HistorikkRepository historikkRepository;
     private Behandling behandling;
 
@@ -149,7 +153,7 @@ public class RevurderingTjenesteImplTest {
                 serviceProvider);
         var revurderingTjenesteFelles = new RevurderingTjenesteFelles(repositoryProvider);
         RevurderingTjeneste revurderingTjeneste = new RevurderingTjenesteImpl(repositoryProvider,
-                behandlingskontrollTjeneste,
+                grunnlagRepositoryProvider, behandlingskontrollTjeneste,
                 iayTjeneste, revurderingEndringES, revurderingTjenesteFelles, vergeRepository);
 
         // Act

--- a/domenetjenester/behandling-revurdering/src/test/java/no/nav/foreldrepenger/behandling/revurdering/ytelse/fp/UttakGrunnlagTjenesteTest.java
+++ b/domenetjenester/behandling-revurdering/src/test/java/no/nav/foreldrepenger/behandling/revurdering/ytelse/fp/UttakGrunnlagTjenesteTest.java
@@ -14,6 +14,7 @@ import no.nav.foreldrepenger.behandling.BehandlingReferanse;
 import no.nav.foreldrepenger.behandling.RelatertBehandlingTjeneste;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingÅrsakType;
 import no.nav.foreldrepenger.behandlingslager.behandling.familiehendelse.FamilieHendelseRepository;
+import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingGrunnlagRepositoryProvider;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepositoryProvider;
 import no.nav.foreldrepenger.behandlingslager.testutilities.behandling.ScenarioMorSøkerEngangsstønad;
 import no.nav.foreldrepenger.dbstoette.FPsakEntityManagerAwareExtension;
@@ -23,16 +24,18 @@ import no.nav.foreldrepenger.familiehendelse.FamilieHendelseTjeneste;
 public class UttakGrunnlagTjenesteTest {
 
     private BehandlingRepositoryProvider repositoryProvider;
+    private BehandlingGrunnlagRepositoryProvider grunnlagRepositoryProvider;
 
     private UttakGrunnlagTjeneste tjeneste;
 
     @BeforeEach
     void setUp(EntityManager entityManager) {
         repositoryProvider = new BehandlingRepositoryProvider(entityManager);
+        grunnlagRepositoryProvider = new BehandlingGrunnlagRepositoryProvider(entityManager);
         var relatertBehandlingTjeneste = new RelatertBehandlingTjeneste(repositoryProvider);
         var familieHendelseRepository = new FamilieHendelseRepository(entityManager);
         var familieHendelseTjeneste = new FamilieHendelseTjeneste(null, familieHendelseRepository);
-        tjeneste = new UttakGrunnlagTjeneste(repositoryProvider, relatertBehandlingTjeneste,
+        tjeneste = new UttakGrunnlagTjeneste(repositoryProvider, grunnlagRepositoryProvider, relatertBehandlingTjeneste,
                 familieHendelseTjeneste);
     }
 

--- a/domenetjenester/behandling-revurdering/src/test/java/no/nav/foreldrepenger/behandling/revurdering/ytelse/svp/RevurderingBehandlingsresultatutlederHarEtablertYtelseTest.java
+++ b/domenetjenester/behandling-revurdering/src/test/java/no/nav/foreldrepenger/behandling/revurdering/ytelse/svp/RevurderingBehandlingsresultatutlederHarEtablertYtelseTest.java
@@ -40,7 +40,8 @@ public class RevurderingBehandlingsresultatutlederHarEtablertYtelseTest {
         repositoryProvider = new BehandlingRepositoryProvider(entityManager);
         revurderingTestUtil = new BeregningRevurderingTestUtil(repositoryProvider);
         uttakRepository = repositoryProvider.getSvangerskapspengerUttakResultatRepository();
-        resultatUtleder = new RevurderingBehandlingsresultatutleder(repositoryProvider, null,
+        resultatUtleder = new RevurderingBehandlingsresultatutleder(repositoryProvider,
+            new SvangerskapspengerUttakResultatRepository(entityManager), null,
                 null, null, null);
     }
 

--- a/domenetjenester/behandling-revurdering/src/test/java/no/nav/foreldrepenger/behandling/revurdering/ytelse/svp/RevurderingBehandlingsresultatutlederTest.java
+++ b/domenetjenester/behandling-revurdering/src/test/java/no/nav/foreldrepenger/behandling/revurdering/ytelse/svp/RevurderingBehandlingsresultatutlederTest.java
@@ -43,6 +43,7 @@ import no.nav.foreldrepenger.behandlingslager.behandling.KonsekvensForYtelsen;
 import no.nav.foreldrepenger.behandlingslager.behandling.RettenTil;
 import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.AksjonspunktDefinisjon;
 import no.nav.foreldrepenger.behandlingslager.behandling.beregning.BeregningsresultatRepository;
+import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingGrunnlagRepositoryProvider;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepositoryProvider;
 import no.nav.foreldrepenger.behandlingslager.behandling.vedtak.VedtakResultatType;
@@ -97,7 +98,11 @@ public class RevurderingBehandlingsresultatutlederTest {
     @Inject
     private BehandlingRepositoryProvider repositoryProvider;
     @Inject
+    private BehandlingGrunnlagRepositoryProvider grunnlagRepositoryProvider;
+    @Inject
     private YtelsesFordelingRepository ytelsesFordelingRepository;
+    @Inject
+    private SvangerskapspengerUttakResultatRepository uttakResultatRepository;
     @Inject
     private BehandlingRepository behandlingRepository;
     private RevurderingTjeneste revurderingTjeneste;
@@ -135,6 +140,7 @@ public class RevurderingBehandlingsresultatutlederTest {
         revurderingTestUtil.avsluttBehandling(behandlingSomSkalRevurderes);
 
         revurderingBehandlingsresultatutleder = new RevurderingBehandlingsresultatutleder(repositoryProvider,
+                uttakResultatRepository,
                 hentBeregningsgrunnlagTjeneste,
                 opphørUttakTjeneste,
                 skjæringstidspunktTjeneste,
@@ -143,7 +149,7 @@ public class RevurderingBehandlingsresultatutlederTest {
         var behandlingskontrollTjeneste = new BehandlingskontrollTjenesteImpl(
                 serviceProvider);
         var revurderingTjenesteFelles = new RevurderingTjenesteFelles(repositoryProvider);
-        revurderingTjeneste = new RevurderingTjenesteImpl(repositoryProvider, behandlingskontrollTjeneste,
+        revurderingTjeneste = new RevurderingTjenesteImpl(repositoryProvider, grunnlagRepositoryProvider, behandlingskontrollTjeneste,
                 iayTjeneste, revurderingEndring, revurderingTjenesteFelles, vergeRepository);
         revurdering = revurderingTjeneste
                 .opprettAutomatiskRevurdering(behandlingSomSkalRevurderes.getFagsak(),

--- a/domenetjenester/beregning-ytelse/src/main/java/no/nav/foreldrepenger/ytelse/beregning/svp/UttakResultatMapper.java
+++ b/domenetjenester/beregning-ytelse/src/main/java/no/nav/foreldrepenger/ytelse/beregning/svp/UttakResultatMapper.java
@@ -4,7 +4,6 @@ import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
 import no.nav.foreldrepenger.behandlingskontroll.FagsakYtelseTypeRef;
-import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepositoryProvider;
 import no.nav.foreldrepenger.behandlingslager.uttak.svp.SvangerskapspengerUttakResultatRepository;
 import no.nav.foreldrepenger.domene.uttak.input.UttakInput;
 import no.nav.foreldrepenger.ytelse.beregning.UttakResultatRepoMapper;
@@ -22,8 +21,8 @@ public class UttakResultatMapper implements UttakResultatRepoMapper {
     }
 
     @Inject
-    public UttakResultatMapper(BehandlingRepositoryProvider repositoryProvider, MapUttakResultatFraVLTilRegel mapUttakResultatFraVLTilRegelSVP) {
-        this.svangerskapspengerUttakResultatRepository = repositoryProvider.getSvangerskapspengerUttakResultatRepository();
+    public UttakResultatMapper(SvangerskapspengerUttakResultatRepository uttakResultatRepository, MapUttakResultatFraVLTilRegel mapUttakResultatFraVLTilRegelSVP) {
+        this.svangerskapspengerUttakResultatRepository = uttakResultatRepository;
         this.mapper = mapUttakResultatFraVLTilRegelSVP;
     }
 

--- a/domenetjenester/datavarehus/src/main/java/no/nav/foreldrepenger/datavarehus/xml/svp/UttakXmlTjenesteImpl.java
+++ b/domenetjenester/datavarehus/src/main/java/no/nav/foreldrepenger/datavarehus/xml/svp/UttakXmlTjenesteImpl.java
@@ -10,7 +10,6 @@ import javax.inject.Inject;
 
 import no.nav.foreldrepenger.behandlingskontroll.FagsakYtelseTypeRef;
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
-import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepositoryProvider;
 import no.nav.foreldrepenger.behandlingslager.behandling.tilrettelegging.SvangerskapspengerRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.tilrettelegging.SvpTilretteleggingEntitet;
 import no.nav.foreldrepenger.behandlingslager.behandling.tilrettelegging.TilretteleggingFOM;
@@ -41,10 +40,11 @@ public class UttakXmlTjenesteImpl {
     }
 
     @Inject
-    public UttakXmlTjenesteImpl(BehandlingRepositoryProvider repositoryProvider) {
+    public UttakXmlTjenesteImpl(SvangerskapspengerRepository svangerskapspengerRepository,
+                                SvangerskapspengerUttakResultatRepository uttakRepository) {
         this.uttakObjectFactory = new ObjectFactory();
-        this.uttakRepository = repositoryProvider.getSvangerskapspengerUttakResultatRepository();
-        this.svangerskapspengerRepository = repositoryProvider.getSvangerskapspengerRepository();
+        this.uttakRepository = uttakRepository;
+        this.svangerskapspengerRepository = svangerskapspengerRepository;
     }
 
     public void setUttak(Beregningsresultat beregningsresultat, Behandling behandling) {

--- a/domenetjenester/datavarehus/src/test/java/no/nav/foreldrepenger/datavarehus/xml/svp/VedtakXmlTest.java
+++ b/domenetjenester/datavarehus/src/test/java/no/nav/foreldrepenger/datavarehus/xml/svp/VedtakXmlTest.java
@@ -118,7 +118,7 @@ public class VedtakXmlTest {
         entityManager = em;
         repositoryProvider = new BehandlingRepositoryProvider(em);
         behandlingRepository = repositoryProvider.getBehandlingRepository();
-        svangerskapspengerRepository = repositoryProvider.getSvangerskapspengerRepository();
+        svangerskapspengerRepository = new SvangerskapspengerRepository(em);
         var skjæringstidspunktTjeneste = mock(SkjæringstidspunktTjeneste.class);
         var stp = Skjæringstidspunkt.builder().medUtledetSkjæringstidspunkt(LocalDate.now()).build();
         Mockito.when(skjæringstidspunktTjeneste.getSkjæringstidspunkter(Mockito.any())).thenReturn(stp);

--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/dokumentpersiterer/impl/søknad/v3/SøknadOversetter.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/dokumentpersiterer/impl/søknad/v3/SøknadOversetter.java
@@ -32,6 +32,7 @@ import no.nav.foreldrepenger.behandlingslager.behandling.medlemskap.MedlemskapRe
 import no.nav.foreldrepenger.behandlingslager.behandling.personopplysning.OppgittAnnenPartBuilder;
 import no.nav.foreldrepenger.behandlingslager.behandling.personopplysning.PersonopplysningRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.personopplysning.RelasjonsRolleType;
+import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingGrunnlagRepositoryProvider;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepositoryProvider;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRevurderingRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.søknad.FarSøkerType;
@@ -139,6 +140,7 @@ public class SøknadOversetter implements MottattDokumentOversetter<SøknadWrapp
 
     @Inject
     public SøknadOversetter(BehandlingRepositoryProvider repositoryProvider,
+                            BehandlingGrunnlagRepositoryProvider grunnlagRepositoryProvider,
                             VirksomhetTjeneste virksomhetTjeneste,
                             InntektArbeidYtelseTjeneste iayTjeneste,
                             PersoninfoAdapter personinfoAdapter,
@@ -146,17 +148,17 @@ public class SøknadOversetter implements MottattDokumentOversetter<SøknadWrapp
                             OppgittPeriodeTidligstMottattDatoTjeneste oppgittPeriodeTidligstMottattDatoTjeneste,
                             AnnenPartOversetter annenPartOversetter) {
         this.iayTjeneste = iayTjeneste;
-        this.familieHendelseRepository = repositoryProvider.getFamilieHendelseRepository();
-        this.søknadRepository = repositoryProvider.getSøknadRepository();
-        this.medlemskapRepository = repositoryProvider.getMedlemskapRepository();
-        this.personopplysningRepository = repositoryProvider.getPersonopplysningRepository();
-        this.ytelsesFordelingRepository = repositoryProvider.getYtelsesFordelingRepository();
+        this.familieHendelseRepository = grunnlagRepositoryProvider.getFamilieHendelseRepository();
+        this.søknadRepository = grunnlagRepositoryProvider.getSøknadRepository();
+        this.medlemskapRepository = grunnlagRepositoryProvider.getMedlemskapRepository();
+        this.personopplysningRepository = grunnlagRepositoryProvider.getPersonopplysningRepository();
+        this.ytelsesFordelingRepository = grunnlagRepositoryProvider.getYtelsesFordelingRepository();
         this.virksomhetTjeneste = virksomhetTjeneste;
         this.personinfoAdapter = personinfoAdapter;
         this.behandlingRevurderingRepository = repositoryProvider.getBehandlingRevurderingRepository();
         this.datavarehusTjeneste = datavarehusTjeneste;
         this.fagsakRepository = repositoryProvider.getFagsakRepository();
-        this.svangerskapspengerRepository = repositoryProvider.getSvangerskapspengerRepository();
+        this.svangerskapspengerRepository = grunnlagRepositoryProvider.getSvangerskapspengerRepository();
         this.oppgittPeriodeTidligstMottattDatoTjeneste = oppgittPeriodeTidligstMottattDatoTjeneste;
         this.annenPartOversetter = annenPartOversetter;
     }

--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/vurderfagsystem/svp/VurderFagsystemTjenesteImpl.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/vurderfagsystem/svp/VurderFagsystemTjenesteImpl.java
@@ -19,7 +19,6 @@ import no.nav.foreldrepenger.behandling.BehandlendeFagsystem;
 import no.nav.foreldrepenger.behandlingskontroll.FagsakYtelseTypeRef;
 import no.nav.foreldrepenger.behandlingslager.behandling.familiehendelse.FamilieHendelseEntitet;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepository;
-import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepositoryProvider;
 import no.nav.foreldrepenger.behandlingslager.behandling.tilrettelegging.SvangerskapspengerRepository;
 import no.nav.foreldrepenger.behandlingslager.fagsak.Fagsak;
 import no.nav.foreldrepenger.mottak.vurderfagsystem.VurderFagsystem;
@@ -45,9 +44,10 @@ public class VurderFagsystemTjenesteImpl implements VurderFagsystemTjeneste {
 
     @Inject
     public VurderFagsystemTjenesteImpl(VurderFagsystemFellesUtils utils,
-                                       BehandlingRepositoryProvider repositoryProvider) {
-        this.behandlingRepository = repositoryProvider.getBehandlingRepository();
-        this.svangerskapspengerRepository = repositoryProvider.getSvangerskapspengerRepository();
+                                       BehandlingRepository behandlingRepository,
+                                       SvangerskapspengerRepository svangerskapspengerRepository) {
+        this.behandlingRepository = behandlingRepository;
+        this.svangerskapspengerRepository = svangerskapspengerRepository;
         this.fellesUtils = utils;
     }
 

--- a/domenetjenester/mottak/src/test/java/no/nav/foreldrepenger/mottak/vurderfagsystem/svp/VurderFagsystemTjenesteImplTest.java
+++ b/domenetjenester/mottak/src/test/java/no/nav/foreldrepenger/mottak/vurderfagsystem/svp/VurderFagsystemTjenesteImplTest.java
@@ -65,12 +65,11 @@ public class VurderFagsystemTjenesteImplTest {
         var repositoryProvider = mock(BehandlingRepositoryProvider.class);
         lenient().when(repositoryProvider.getFamilieHendelseRepository()).thenReturn(grunnlagRepository);
         lenient().when(repositoryProvider.getFagsakRepository()).thenReturn(fagsakRepository);
-        lenient().when(repositoryProvider.getSvangerskapspengerRepository()).thenReturn(svangerskapspengerRepository);
         lenient().when(repositoryProvider.getBehandlingRepository()).thenReturn(behandlingRepository);
         var fagsakTjeneste = new FagsakTjeneste(repositoryProvider.getFagsakRepository(), repositoryProvider.getSøknadRepository(), null);
         var familieTjeneste = new FamilieHendelseTjeneste(null, grunnlagRepository);
         var fellesUtils = new VurderFagsystemFellesUtils(repositoryProvider, familieTjeneste, mottatteDokumentTjeneste, null, null);
-        var svpTjeneste = new VurderFagsystemTjenesteImpl(fellesUtils, repositoryProvider);
+        var svpTjeneste = new VurderFagsystemTjenesteImpl(fellesUtils, behandlingRepository, svangerskapspengerRepository);
         tjeneste = new VurderFagsystemFellesTjeneste(fagsakTjeneste, fellesUtils, new UnitTestLookupInstanceImpl<>(svpTjeneste));
     }
 

--- a/domenetjenester/registerinnhenting/src/main/java/no/nav/foreldrepenger/domene/registerinnhenting/RegisterdataInnhenter.java
+++ b/domenetjenester/registerinnhenting/src/main/java/no/nav/foreldrepenger/domene/registerinnhenting/RegisterdataInnhenter.java
@@ -42,8 +42,8 @@ import no.nav.foreldrepenger.behandlingslager.behandling.pleiepenger.Pleiepenger
 import no.nav.foreldrepenger.behandlingslager.behandling.pleiepenger.PleiepengerInnleggelseEntitet;
 import no.nav.foreldrepenger.behandlingslager.behandling.pleiepenger.PleiepengerPerioderEntitet;
 import no.nav.foreldrepenger.behandlingslager.behandling.pleiepenger.PleiepengerRepository;
+import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingGrunnlagRepositoryProvider;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepository;
-import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepositoryProvider;
 import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakYtelseType;
 import no.nav.foreldrepenger.domene.abakus.AbakusTjeneste;
 import no.nav.foreldrepenger.domene.abakus.mapping.KodeverkMapper;
@@ -106,18 +106,19 @@ public class RegisterdataInnhenter {
     @Inject
     public RegisterdataInnhenter(PersonopplysningInnhenter personopplysningInnhenter,
                                  MedlemTjeneste medlemTjeneste,
-                                 BehandlingRepositoryProvider repositoryProvider,
+                                 BehandlingRepository behandlingRepository,
+                                 BehandlingGrunnlagRepositoryProvider grunnlagRepositoryProvider,
                                  FamilieHendelseTjeneste familieHendelseTjeneste,
                                  MedlemskapRepository medlemskapRepository,
                                  OpplysningsPeriodeTjeneste opplysningsPeriodeTjeneste,
                                  AbakusTjeneste abakusTjeneste) {
         this.personopplysningInnhenter = personopplysningInnhenter;
         this.medlemTjeneste = medlemTjeneste;
-        this.personopplysningRepository = repositoryProvider.getPersonopplysningRepository();
-        this.behandlingRepository = repositoryProvider.getBehandlingRepository();
+        this.personopplysningRepository = grunnlagRepositoryProvider.getPersonopplysningRepository();
+        this.behandlingRepository = behandlingRepository;
         this.familieHendelseTjeneste = familieHendelseTjeneste;
         this.medlemskapRepository = medlemskapRepository;
-        this.pleiepengerRepository = repositoryProvider.getPleiepengerRepository();
+        this.pleiepengerRepository = grunnlagRepositoryProvider.getPleiepengerRepository();
         this.opplysningsPeriodeTjeneste = opplysningsPeriodeTjeneste;
         this.abakusTjeneste = abakusTjeneste;
     }

--- a/domenetjenester/registerinnhenting/src/main/java/no/nav/foreldrepenger/domene/registerinnhenting/task/InnhentMedlemskapOpplysningerTask.java
+++ b/domenetjenester/registerinnhenting/src/main/java/no/nav/foreldrepenger/domene/registerinnhenting/task/InnhentMedlemskapOpplysningerTask.java
@@ -47,11 +47,7 @@ public class InnhentMedlemskapOpplysningerTask extends BehandlingProsessTask {
     protected void prosesser(ProsessTaskData prosessTaskData, Long behandlingId) {
         var behandling = behandlingRepository.hentBehandling(behandlingId);
         LOG.info("Innhenter medlemskapsopplysninger for behandling: {}", behandling.getId());
-        try {
-            stønadsperioderInnhenter.finnSenereStønadsperioderLoggResultat(behandling);
-        } catch (Exception e) {
-            LOG.info("NESTEBARN noe gikk galt", e);
-        }
+        stønadsperioderInnhenter.innhentNesteSak(behandling);
         registerdataInnhenter.innhentMedlemskapsOpplysning(behandling);
         uføreInnhenter.innhentUføretrygd(behandling);
     }

--- a/domenetjenester/registerinnhenting/src/test/java/no/nav/foreldrepenger/domene/registerinnhenting/RegisterdataEndringshåndtererTest.java
+++ b/domenetjenester/registerinnhenting/src/test/java/no/nav/foreldrepenger/domene/registerinnhenting/RegisterdataEndringshåndtererTest.java
@@ -30,7 +30,6 @@ import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingÅrsak;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingÅrsakType;
 import no.nav.foreldrepenger.behandlingslager.behandling.EndringsresultatDiff;
 import no.nav.foreldrepenger.behandlingslager.behandling.EndringsresultatSnapshot;
-import no.nav.foreldrepenger.behandlingslager.behandling.medlemskap.MedlemskapRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.personopplysning.PersonInformasjonEntitet;
 import no.nav.foreldrepenger.behandlingslager.behandling.personopplysning.RelasjonsRolleType;
 import no.nav.foreldrepenger.behandlingslager.behandling.personopplysning.SivilstandType;
@@ -40,16 +39,11 @@ import no.nav.foreldrepenger.behandlingslager.hendelser.StartpunktType;
 import no.nav.foreldrepenger.behandlingslager.testutilities.behandling.ScenarioMorSøkerEngangsstønad;
 import no.nav.foreldrepenger.behandlingslager.testutilities.behandling.ScenarioMorSøkerForeldrepenger;
 import no.nav.foreldrepenger.dbstoette.EntityManagerAwareTest;
-import no.nav.foreldrepenger.domene.abakus.AbakusTjeneste;
-import no.nav.foreldrepenger.domene.medlem.MedlemTjeneste;
-import no.nav.foreldrepenger.domene.person.PersoninfoAdapter;
-import no.nav.foreldrepenger.domene.personopplysning.PersonopplysningInnhenter;
 import no.nav.foreldrepenger.domene.registerinnhenting.impl.Endringskontroller;
 import no.nav.foreldrepenger.domene.typer.AktørId;
 import no.nav.foreldrepenger.domene.typer.PersonIdent;
 import no.nav.foreldrepenger.familiehendelse.FamilieHendelseTjeneste;
 import no.nav.foreldrepenger.familiehendelse.event.FamiliehendelseEventPubliserer;
-import no.nav.foreldrepenger.skjæringstidspunkt.OpplysningsPeriodeTjeneste;
 
 @ExtendWith(MockitoExtension.class)
 public class RegisterdataEndringshåndtererTest extends EntityManagerAwareTest {
@@ -258,24 +252,5 @@ public class RegisterdataEndringshåndtererTest extends EntityManagerAwareTest {
             .medSivilstandType(SivilstandType.UGIFT)
             .medFamilierelasjon(singleton(familierelasjon))
             .build();
-    }
-
-    private static class TestRegisterdataInnhenter extends RegisterdataInnhenter {
-
-        TestRegisterdataInnhenter(PersoninfoAdapter personinfoAdapter,
-                                  MedlemTjeneste medlemTjeneste,
-                                  BehandlingRepositoryProvider repositoryProvider,
-                                  FamilieHendelseTjeneste familieHendelseTjeneste,
-                                  AbakusTjeneste abakusTjeneste,
-                                  MedlemskapRepository medlemskapRepository,
-                                  OpplysningsPeriodeTjeneste opplysningsPeriodeTjeneste) {
-            super(new PersonopplysningInnhenter(personinfoAdapter),
-                medlemTjeneste,
-                repositoryProvider,
-                familieHendelseTjeneste,
-                medlemskapRepository,
-                opplysningsPeriodeTjeneste,
-                abakusTjeneste);
-        }
     }
 }

--- a/domenetjenester/registerinnhenting/src/test/java/no/nav/foreldrepenger/domene/registerinnhenting/StønadsperiodeInnhenterTest.java
+++ b/domenetjenester/registerinnhenting/src/test/java/no/nav/foreldrepenger/domene/registerinnhenting/StønadsperiodeInnhenterTest.java
@@ -22,6 +22,7 @@ import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingResultatType;
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandlingsresultat;
 import no.nav.foreldrepenger.behandlingslager.behandling.familiehendelse.FamilieHendelseEntitet;
 import no.nav.foreldrepenger.behandlingslager.behandling.familiehendelse.FamilieHendelseGrunnlagEntitet;
+import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingGrunnlagRepositoryProvider;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepositoryProvider;
 import no.nav.foreldrepenger.behandlingslager.behandling.søknad.SøknadAnnenPartType;
 import no.nav.foreldrepenger.behandlingslager.behandling.vedtak.VedtakResultatType;
@@ -52,6 +53,7 @@ public class StønadsperiodeInnhenterTest extends EntityManagerAwareTest {
 
 
     private BehandlingRepositoryProvider repositoryProvider;
+    private BehandlingGrunnlagRepositoryProvider grunnlagRepositoryProvider;
 
     @Mock
     private StønadsperiodeTjeneste stønadsperiodeTjeneste;
@@ -76,7 +78,8 @@ public class StønadsperiodeInnhenterTest extends EntityManagerAwareTest {
     public void setUp() {
         var entityManager = getEntityManager();
         repositoryProvider = new BehandlingRepositoryProvider(entityManager);
-        stønadsperioderInnhenter = new StønadsperioderInnhenter(repositoryProvider, familieHendelseTjeneste, stønadsperiodeTjeneste, skjæringstidspunktTjeneste);
+        grunnlagRepositoryProvider = new BehandlingGrunnlagRepositoryProvider(entityManager);
+        stønadsperioderInnhenter = new StønadsperioderInnhenter(repositoryProvider, grunnlagRepositoryProvider, familieHendelseTjeneste, stønadsperiodeTjeneste, skjæringstidspunktTjeneste);
     }
 
     /*
@@ -107,7 +110,7 @@ public class StønadsperiodeInnhenterTest extends EntityManagerAwareTest {
         when(skjæringstidspunkt.getUtledetSkjæringstidspunkt()).thenReturn(STP_NORMAL);
         when(stønadsperiodeTjeneste.stønadsperiodeStartdato(behandling.getFagsak())).thenReturn(Optional.of(STP_NORMAL));
 
-        var muligSak = stønadsperioderInnhenter.finnSenereStønadsperioderLoggResultat(behandling);
+        var muligSak = stønadsperioderInnhenter.finnSenereStønadsperiode(behandling);
         assertThat(muligSak).isEmpty();
     }
 
@@ -127,7 +130,7 @@ public class StønadsperiodeInnhenterTest extends EntityManagerAwareTest {
         when(skjæringstidspunkt.getUtledetSkjæringstidspunkt()).thenReturn(STP_NORMAL);
         when(stønadsperiodeTjeneste.stønadsperiodeStartdato(behandling.getFagsak())).thenReturn(Optional.of(STP_NORMAL));
 
-        var muligSak = stønadsperioderInnhenter.finnSenereStønadsperioderLoggResultat(behandling);
+        var muligSak = stønadsperioderInnhenter.finnSenereStønadsperiode(behandling);
         assertThat(muligSak).hasValueSatisfying(v -> {
             assertThat(v.saksnummer()).isEqualTo(nyereBehandling.getFagsak().getSaksnummer());
             assertThat(v.startdato()).isEqualTo(FH_DATO_YNGRE);
@@ -151,7 +154,7 @@ public class StønadsperiodeInnhenterTest extends EntityManagerAwareTest {
         when(skjæringstidspunkt.getUtledetSkjæringstidspunkt()).thenReturn(FH_DATO.minusWeeks(12));
         when(stønadsperiodeTjeneste.stønadsperiodeStartdato(nyBehSVPOverlapper.getFagsak())).thenReturn(Optional.of(FH_DATO.minusWeeks(12)));
 
-        var muligSak = stønadsperioderInnhenter.finnSenereStønadsperioderLoggResultat(nyBehSVPOverlapper);
+        var muligSak = stønadsperioderInnhenter.finnSenereStønadsperiode(nyBehSVPOverlapper);
         assertThat(muligSak).hasValueSatisfying(v -> {
             assertThat(v.saksnummer()).isEqualTo(avsluttetFPBehMor.getFagsak().getSaksnummer());
             assertThat(v.startdato()).isEqualTo(STP_NORMAL);
@@ -177,7 +180,7 @@ public class StønadsperiodeInnhenterTest extends EntityManagerAwareTest {
 
         assertThat(repositoryProvider.getPersonopplysningRepository().fagsakerMedOppgittAnnenPart(MEDF_AKTØR_ID)).isNotEmpty();
 
-        var muligSak = stønadsperioderInnhenter.finnSenereStønadsperioderLoggResultat(behandling);
+        var muligSak = stønadsperioderInnhenter.finnSenereStønadsperiode(behandling);
         assertThat(muligSak).hasValueSatisfying(v -> {
             assertThat(v.saksnummer()).isEqualTo(nyereBehandling.getFagsak().getSaksnummer());
             assertThat(v.startdato()).isEqualTo(FH_DATO_YNGRE.minusWeeks(3));
@@ -202,7 +205,7 @@ public class StønadsperiodeInnhenterTest extends EntityManagerAwareTest {
 
         assertThat(repositoryProvider.getPersonopplysningRepository().fagsakerMedOppgittAnnenPart(MEDF_AKTØR_ID)).isNotEmpty();
 
-        var muligSak = stønadsperioderInnhenter.finnSenereStønadsperioderLoggResultat(behandling);
+        var muligSak = stønadsperioderInnhenter.finnSenereStønadsperiode(behandling);
         assertThat(muligSak).hasValueSatisfying(v -> {
             assertThat(v.saksnummer()).isEqualTo(nyereBehandling.getFagsak().getSaksnummer());
             assertThat(v.startdato()).isEqualTo(FH_DATO_YNGRE.minusWeeks(3));
@@ -228,7 +231,7 @@ public class StønadsperiodeInnhenterTest extends EntityManagerAwareTest {
 
         when(stønadsperiodeTjeneste.stønadsperiodeStartdato(nyBehSVPOverlapper.getFagsak())).thenReturn(Optional.of(FH_DATO.minusWeeks(12)));
 
-        var muligSak = stønadsperioderInnhenter.finnSenereStønadsperioderLoggResultat(nyBehSVPOverlapper);
+        var muligSak = stønadsperioderInnhenter.finnSenereStønadsperiode(nyBehSVPOverlapper);
         assertThat(muligSak).isEmpty();
     }
 

--- a/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/input/ForeldrepengerGrunnlag.java
+++ b/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/input/ForeldrepengerGrunnlag.java
@@ -2,6 +2,7 @@ package no.nav.foreldrepenger.domene.uttak.input;
 
 import java.util.Optional;
 
+import no.nav.foreldrepenger.behandlingslager.behandling.nestesak.NesteSakGrunnlagEntitet;
 import no.nav.foreldrepenger.behandlingslager.behandling.pleiepenger.PleiepengerGrunnlagEntitet;
 import no.nav.foreldrepenger.behandlingslager.behandling.ufore.UføretrygdGrunnlagEntitet;
 
@@ -13,18 +14,20 @@ public class ForeldrepengerGrunnlag implements YtelsespesifiktGrunnlag {
     private Annenpart annenpart;
     private PleiepengerGrunnlagEntitet pleiepengerGrunnlag;
     private UføretrygdGrunnlagEntitet uføretrygdGrunnlag;
+    private NesteSakGrunnlagEntitet nesteSakEntitet;
 
     public ForeldrepengerGrunnlag() {
 
     }
 
     public ForeldrepengerGrunnlag(ForeldrepengerGrunnlag foreldrepengerGrunnlag) {
-        berørtBehandling = foreldrepengerGrunnlag.berørtBehandling;
-        familieHendelser = foreldrepengerGrunnlag.familieHendelser;
-        originalBehandling = foreldrepengerGrunnlag.originalBehandling;
-        annenpart = foreldrepengerGrunnlag.annenpart;
-        pleiepengerGrunnlag = foreldrepengerGrunnlag.pleiepengerGrunnlag;
-        uføretrygdGrunnlag = foreldrepengerGrunnlag.uføretrygdGrunnlag;
+        this.berørtBehandling = foreldrepengerGrunnlag.berørtBehandling;
+        this.familieHendelser = foreldrepengerGrunnlag.familieHendelser;
+        this.originalBehandling = foreldrepengerGrunnlag.originalBehandling;
+        this.annenpart = foreldrepengerGrunnlag.annenpart;
+        this.pleiepengerGrunnlag = foreldrepengerGrunnlag.pleiepengerGrunnlag;
+        this.uføretrygdGrunnlag = foreldrepengerGrunnlag.uføretrygdGrunnlag;
+        this.nesteSakEntitet = foreldrepengerGrunnlag.nesteSakEntitet;
     }
 
     public boolean isBerørtBehandling() {
@@ -49,6 +52,10 @@ public class ForeldrepengerGrunnlag implements YtelsespesifiktGrunnlag {
 
     public Optional<UføretrygdGrunnlagEntitet> getUføretrygdGrunnlag() {
         return Optional.ofNullable(uføretrygdGrunnlag);
+    }
+
+    public Optional<NesteSakGrunnlagEntitet> getNesteSakGrunnlag() {
+        return Optional.ofNullable(nesteSakEntitet);
     }
 
     public ForeldrepengerGrunnlag medErBerørtBehandling(boolean berørtBehandling) {
@@ -84,6 +91,12 @@ public class ForeldrepengerGrunnlag implements YtelsespesifiktGrunnlag {
     public ForeldrepengerGrunnlag medUføretrygdGrunnlag(UføretrygdGrunnlagEntitet uføretrygdGrunnlag) {
         var nyttGrunnlag = new ForeldrepengerGrunnlag(this);
         nyttGrunnlag.uføretrygdGrunnlag = uføretrygdGrunnlag;
+        return nyttGrunnlag;
+    }
+
+    public ForeldrepengerGrunnlag medNesteSakGrunnlag(NesteSakGrunnlagEntitet nesteSakGrunnlag) {
+        var nyttGrunnlag = new ForeldrepengerGrunnlag(this);
+        nyttGrunnlag.nesteSakEntitet = nesteSakGrunnlag;
         return nyttGrunnlag;
     }
 }

--- a/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/input/SvangerskapspengerGrunnlag.java
+++ b/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/input/SvangerskapspengerGrunnlag.java
@@ -2,20 +2,23 @@ package no.nav.foreldrepenger.domene.uttak.input;
 
 import java.util.Optional;
 
+import no.nav.foreldrepenger.behandlingslager.behandling.nestesak.NesteSakGrunnlagEntitet;
 import no.nav.foreldrepenger.behandlingslager.behandling.tilrettelegging.SvpGrunnlagEntitet;
 
 public class SvangerskapspengerGrunnlag implements YtelsespesifiktGrunnlag {
 
     private FamilieHendelse familieHendelse;
     private SvpGrunnlagEntitet svpGrunnlagEntitet;
+    private NesteSakGrunnlagEntitet nesteSakGrunnlagEntitet;
 
     public SvangerskapspengerGrunnlag() {
 
     }
 
     public SvangerskapspengerGrunnlag(SvangerskapspengerGrunnlag svangerskapspengerGrunnlag) {
-        familieHendelse = svangerskapspengerGrunnlag.familieHendelse;
-        svpGrunnlagEntitet = svangerskapspengerGrunnlag.svpGrunnlagEntitet;
+        this.familieHendelse = svangerskapspengerGrunnlag.familieHendelse;
+        this.svpGrunnlagEntitet = svangerskapspengerGrunnlag.svpGrunnlagEntitet;
+        this.nesteSakGrunnlagEntitet = svangerskapspengerGrunnlag.nesteSakGrunnlagEntitet;
     }
 
     public FamilieHendelse getFamilieHendelse() {
@@ -24,6 +27,10 @@ public class SvangerskapspengerGrunnlag implements YtelsespesifiktGrunnlag {
 
     public Optional<SvpGrunnlagEntitet> getGrunnlagEntitet() {
         return Optional.ofNullable(svpGrunnlagEntitet);
+    }
+
+    public Optional<NesteSakGrunnlagEntitet> nesteSakEntitet() {
+        return Optional.ofNullable(nesteSakGrunnlagEntitet);
     }
 
     public SvangerskapspengerGrunnlag medFamilieHendelse(FamilieHendelse familieHendelse) {
@@ -35,6 +42,12 @@ public class SvangerskapspengerGrunnlag implements YtelsespesifiktGrunnlag {
     public SvangerskapspengerGrunnlag medSvpGrunnlagEntitet(SvpGrunnlagEntitet entitet) {
         var nyttGrunnlag = new SvangerskapspengerGrunnlag(this);
         nyttGrunnlag.svpGrunnlagEntitet = entitet;
+        return nyttGrunnlag;
+    }
+
+    public SvangerskapspengerGrunnlag medNesteSakEntitet(NesteSakGrunnlagEntitet entitet) {
+        var nyttGrunnlag = new SvangerskapspengerGrunnlag(this);
+        nyttGrunnlag.nesteSakGrunnlagEntitet = entitet;
         return nyttGrunnlag;
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -46,14 +46,14 @@
         <prosesstask.version>3.1.7</prosesstask.version>
         <ukelonn.felles.version>2.0.23</ukelonn.felles.version>
 
-        <fp-kontrakter.version>6.1.4</fp-kontrakter.version>
+        <fp-kontrakter.version>6.1.6</fp-kontrakter.version>
         <fp-tidsserie.version>2.5.8</fp-tidsserie.version>
         <fp-nare.version>2.1.5</fp-nare.version>
         <kalkulus.version>1.5.12</kalkulus.version>
         <abakus-kontrakt.version>1.3.26</abakus-kontrakt.version>
 
         <swaggercore.version>2.1.13</swaggercore.version>
-        <flyway.version>8.4.4</flyway.version>
+        <flyway.version>8.5.0</flyway.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
     </properties>
@@ -588,7 +588,7 @@
             <dependency>
                 <groupId>org.glassfish</groupId>
                 <artifactId>jakarta.el</artifactId>
-                <version>3.0.3</version>
+                <version>3.0.4</version>
             </dependency>
 
 

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/svp/BekreftSvangerskapspengerOppdaterer.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/svp/BekreftSvangerskapspengerOppdaterer.java
@@ -22,7 +22,7 @@ import no.nav.foreldrepenger.behandlingslager.behandling.familiehendelse.Familie
 import no.nav.foreldrepenger.behandlingslager.behandling.familiehendelse.FamilieHendelseRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.familiehendelse.TerminbekreftelseEntitet;
 import no.nav.foreldrepenger.behandlingslager.behandling.historikk.HistorikkEndretFeltType;
-import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepositoryProvider;
+import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingGrunnlagRepositoryProvider;
 import no.nav.foreldrepenger.behandlingslager.behandling.skjermlenke.SkjermlenkeType;
 import no.nav.foreldrepenger.behandlingslager.behandling.tilrettelegging.SvangerskapspengerRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.tilrettelegging.SvpTilretteleggingEntitet;
@@ -52,7 +52,6 @@ public class BekreftSvangerskapspengerOppdaterer implements AksjonspunktOppdater
 
     private SvangerskapspengerRepository svangerskapspengerRepository;
     private HistorikkTjenesteAdapter historikkAdapter;
-    private BehandlingRepositoryProvider repositoryProvider;
     private FamilieHendelseRepository familieHendelseRepository;
     private TilgangerTjeneste tilgangerTjeneste;
     private InntektArbeidYtelseTjeneste inntektArbeidYtelseTjeneste;
@@ -63,12 +62,11 @@ public class BekreftSvangerskapspengerOppdaterer implements AksjonspunktOppdater
 
     @Inject
     public BekreftSvangerskapspengerOppdaterer(HistorikkTjenesteAdapter historikkAdapter,
-                                               BehandlingRepositoryProvider repositoryProvider,
+                                               BehandlingGrunnlagRepositoryProvider repositoryProvider,
                                                TilgangerTjeneste tilgangerTjeneste,
                                                InntektArbeidYtelseTjeneste inntektArbeidYtelseTjeneste) {
         this.svangerskapspengerRepository = repositoryProvider.getSvangerskapspengerRepository();
         this.historikkAdapter = historikkAdapter;
-        this.repositoryProvider = repositoryProvider;
         this.familieHendelseRepository = repositoryProvider.getFamilieHendelseRepository();
         this.tilgangerTjeneste = tilgangerTjeneste;
         this.inntektArbeidYtelseTjeneste = inntektArbeidYtelseTjeneste;
@@ -309,7 +307,7 @@ public class BekreftSvangerskapspengerOppdaterer implements AksjonspunktOppdater
 
     private boolean oppdaterFamiliehendelse(BekreftSvangerskapspengerDto dto, Behandling behandling) {
         var behandlingId = behandling.getId();
-        var grunnlag = repositoryProvider.getFamilieHendelseRepository().hentAggregat(behandlingId);
+        var grunnlag = familieHendelseRepository.hentAggregat(behandlingId);
 
         var termindatoOppdatert = oppdaterTermindato(dto, behandling, grunnlag);
         var fødselsdatoOppdatert = oppdaterFødselsdato(dto, behandling, grunnlag);

--- a/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/svp/BekreftSvangerskapspengerOppdatererTest.java
+++ b/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/svp/BekreftSvangerskapspengerOppdatererTest.java
@@ -25,6 +25,7 @@ import no.nav.foreldrepenger.behandling.aksjonspunkt.AksjonspunktOppdaterParamet
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingStegType;
 import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.AksjonspunktDefinisjon;
+import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingGrunnlagRepositoryProvider;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepositoryProvider;
 import no.nav.foreldrepenger.behandlingslager.behandling.tilrettelegging.SvpGrunnlagEntitet;
 import no.nav.foreldrepenger.behandlingslager.behandling.tilrettelegging.SvpTilretteleggingEntitet;
@@ -68,13 +69,15 @@ public class BekreftSvangerskapspengerOppdatererTest {
 
     private BekreftSvangerskapspengerOppdaterer oppdaterer;
     private BehandlingRepositoryProvider repositoryProvider;
+    private BehandlingGrunnlagRepositoryProvider grunnlagProvider;
 
     @BeforeEach
     public void beforeEach(EntityManager entityManager) {
         repositoryProvider = new BehandlingRepositoryProvider(entityManager);
+        grunnlagProvider = new BehandlingGrunnlagRepositoryProvider(entityManager);
         var historikkAdapter = new HistorikkTjenesteAdapter(
             repositoryProvider.getHistorikkRepository(), null, repositoryProvider.getBehandlingRepository());
-        oppdaterer = new BekreftSvangerskapspengerOppdaterer(historikkAdapter, repositoryProvider,
+        oppdaterer = new BekreftSvangerskapspengerOppdaterer(historikkAdapter, grunnlagProvider,
             tilgangerTjenesteMock, inntektArbeidYtelseTjeneste);
     }
 
@@ -181,7 +184,7 @@ public class BekreftSvangerskapspengerOppdatererTest {
         var resultat = oppdaterer.oppdater(dto, param);
 
         assertThat(resultat.kreverTotrinnsKontroll()).isTrue();
-        var oppdatertGrunnlag = repositoryProvider.getSvangerskapspengerRepository().hentGrunnlag(behandling.getId());
+        var oppdatertGrunnlag = grunnlagProvider.getSvangerskapspengerRepository().hentGrunnlag(behandling.getId());
         var tilrettelegginger = new TilretteleggingFilter(
             oppdatertGrunnlag.orElseThrow()).getAktuelleTilretteleggingerUfiltrert();
         assertThat(tilrettelegginger).hasSize(1);
@@ -306,7 +309,7 @@ public class BekreftSvangerskapspengerOppdatererTest {
         var svpGrunnlag = new SvpGrunnlagEntitet.Builder().medBehandlingId(behandling.getId())
             .medOpprinneligeTilrettelegginger(List.of(tilrettelegging))
             .build();
-        repositoryProvider.getSvangerskapspengerRepository().lagreOgFlush(svpGrunnlag);
+        grunnlagProvider.getSvangerskapspengerRepository().lagreOgFlush(svpGrunnlag);
         return svpGrunnlag;
     }
 

--- a/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/registrering/fp/EndringssøknadSøknadMapperTest.java
+++ b/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/registrering/fp/EndringssøknadSøknadMapperTest.java
@@ -18,6 +18,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
 import no.nav.foreldrepenger.behandlingslager.behandling.DokumentTypeId;
 import no.nav.foreldrepenger.behandlingslager.behandling.MottattDokument;
+import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingGrunnlagRepositoryProvider;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepositoryProvider;
 import no.nav.foreldrepenger.behandlingslager.fagsak.Fagsak;
 import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakYtelseType;
@@ -47,10 +48,12 @@ public class EndringssøknadSøknadMapperTest {
     private DatavarehusTjeneste datavarehusTjeneste;
     private final SøknadMapper ytelseSøknadMapper = new EndringssøknadSøknadMapper();
     private BehandlingRepositoryProvider repositoryProvider;
+    private BehandlingGrunnlagRepositoryProvider grunnlagRepositoryProvider;
 
     @BeforeEach
     public void setUp(EntityManager entityManager) {
         repositoryProvider = new BehandlingRepositoryProvider(entityManager);
+        grunnlagRepositoryProvider = new BehandlingGrunnlagRepositoryProvider(entityManager);
     }
 
     @Test
@@ -63,7 +66,7 @@ public class EndringssøknadSøknadMapperTest {
 
         var oppgittPeriodeMottattDatoTjeneste = new OppgittPeriodeTidligstMottattDatoTjeneste(
             new YtelseFordelingTjeneste(repositoryProvider.getYtelsesFordelingRepository()));
-        var oversetter = new SøknadOversetter(repositoryProvider,
+        var oversetter = new SøknadOversetter(repositoryProvider, grunnlagRepositoryProvider,
             virksomhetTjeneste, iayTjeneste, personinfoAdapter, datavarehusTjeneste, oppgittPeriodeMottattDatoTjeneste,
             new AnnenPartOversetter(personinfoAdapter));
 

--- a/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/registrering/fp/SøknadMapperTest.java
+++ b/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/registrering/fp/SøknadMapperTest.java
@@ -45,6 +45,7 @@ import no.nav.foreldrepenger.behandlingslager.aktør.NavBrukerKjønn;
 import no.nav.foreldrepenger.behandlingslager.aktør.PersoninfoKjønn;
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
 import no.nav.foreldrepenger.behandlingslager.behandling.MottattDokument;
+import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingGrunnlagRepositoryProvider;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepositoryProvider;
 import no.nav.foreldrepenger.behandlingslager.behandling.søknad.ForeldreType;
 import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.årsak.OppholdÅrsak;
@@ -91,10 +92,12 @@ public class SøknadMapperTest {
     private OppgittPeriodeTidligstMottattDatoTjeneste oppgittPeriodeMottattDato;
     private PersoninfoKjønn kvinne;
     private BehandlingRepositoryProvider repositoryProvider;
+    private BehandlingGrunnlagRepositoryProvider grunnlagRepositoryProvider;
 
     @BeforeEach
     public void before(EntityManager entityManager) {
         repositoryProvider = new BehandlingRepositoryProvider(entityManager);
+        grunnlagRepositoryProvider = new BehandlingGrunnlagRepositoryProvider(entityManager);
         oppgittPeriodeMottattDato = new OppgittPeriodeTidligstMottattDatoTjeneste(
             new YtelseFordelingTjeneste(repositoryProvider.getYtelsesFordelingRepository()));
 
@@ -385,7 +388,7 @@ public class SøknadMapperTest {
         when(personinfoAdapter.hentBrukerKjønnForAktør(any(AktørId.class))).thenReturn(Optional.of(kvinne));
         when(personinfoAdapter.hentAktørForFnr(any())).thenReturn(Optional.of(STD_KVINNE_AKTØR_ID));
         var soeknad = ytelseSøknadMapper.mapSøknad(dto, navBruker);
-        var oversetter = new SøknadOversetter(repositoryProvider, virksomhetTjeneste, iayTjeneste,
+        var oversetter = new SøknadOversetter(repositoryProvider, grunnlagRepositoryProvider, virksomhetTjeneste, iayTjeneste,
             personinfoAdapter, datavarehusTjeneste, oppgittPeriodeMottattDato, new AnnenPartOversetter(personinfoAdapter));
         var fagsak = Fagsak.opprettNy(FagsakYtelseType.FORELDREPENGER, navBruker);
         var behandling = Behandling.forFørstegangssøknad(fagsak).build();
@@ -441,7 +444,7 @@ public class SøknadMapperTest {
         when(personinfoAdapter.hentAktørForFnr(any())).thenReturn(Optional.of(STD_KVINNE_AKTØR_ID));
 
         var soeknad = ytelseSøknadMapper.mapSøknad(manuellRegistreringForeldrepengerDto, navBruker);
-        var oversetter = new SøknadOversetter(repositoryProvider, virksomhetTjeneste, iayTjeneste,
+        var oversetter = new SøknadOversetter(repositoryProvider, grunnlagRepositoryProvider, virksomhetTjeneste, iayTjeneste,
             personinfoAdapter, datavarehusTjeneste, oppgittPeriodeMottattDato, new AnnenPartOversetter(personinfoAdapter));
         var fagsak = Fagsak.opprettNy(FagsakYtelseType.FORELDREPENGER, navBruker);
         var behandling = Behandling.forFørstegangssøknad(fagsak).build();
@@ -546,7 +549,7 @@ public class SøknadMapperTest {
         var mottattDokument = new MottattDokument.Builder().medMottattDato(LocalDate.now())
             .medFagsakId(behandling.getFagsakId())
             .medElektroniskRegistrert(true);
-        var oversetter = new SøknadOversetter(repositoryProvider, virksomhetTjeneste, iayTjeneste,
+        var oversetter = new SøknadOversetter(repositoryProvider, grunnlagRepositoryProvider, virksomhetTjeneste, iayTjeneste,
             personinfoAdapter, datavarehusTjeneste, oppgittPeriodeMottattDato, new AnnenPartOversetter(personinfoAdapter));
 
         oversetter.trekkUtDataOgPersister(
@@ -589,7 +592,7 @@ public class SøknadMapperTest {
         var mottattDokument = new MottattDokument.Builder().medMottattDato(LocalDate.now())
             .medFagsakId(behandling.getFagsakId())
             .medElektroniskRegistrert(true);
-        var oversetter = new SøknadOversetter(repositoryProvider, virksomhetTjeneste, iayTjeneste,
+        var oversetter = new SøknadOversetter(repositoryProvider, grunnlagRepositoryProvider, virksomhetTjeneste, iayTjeneste,
             personinfoAdapter, datavarehusTjeneste, oppgittPeriodeMottattDato, new AnnenPartOversetter(personinfoAdapter));
 
         oversetter.trekkUtDataOgPersister(


### PR DESCRIPTION
Hovedendringen er StønadsperiodeInnhenter som nå lagrer etter lengre tids logging

Den andre er å begynne å skille ut behandlingsgrunnlagene i en egen BehandlingGrunnlagRepositoryProvider
Har flyttet Pleiepenger, Uføretrygd, Utlandsopphold og Svangerskapspenger
De andre grunnlagene er litt mer jobb (Personopplysning, Familiehendelse, Medlemskap, Søknad, Ytelsesfordeling)

Men enda bedre er å injecte respektive tjenester heller enn repositories.