### PR TITLE
TFP-4708 - dev - brevbestilling med REST

### DIFF
--- a/domenetjenester/dokumentbestiller/pom.xml
+++ b/domenetjenester/dokumentbestiller/pom.xml
@@ -66,6 +66,11 @@
             <artifactId>hendelse-dokumentbestilling</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>no.nav.foreldrepenger.kontrakter</groupId>
+            <artifactId>fp-formidling-v1</artifactId>
+        </dependency>
+
 
         <!-- Test -->
 		<dependency>

--- a/domenetjenester/dokumentbestiller/src/main/java/no/nav/foreldrepenger/dokumentbestiller/DokumentBestillerTjeneste.java
+++ b/domenetjenester/dokumentbestiller/src/main/java/no/nav/foreldrepenger/dokumentbestiller/DokumentBestillerTjeneste.java
@@ -7,7 +7,9 @@ import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRe
 import no.nav.foreldrepenger.behandlingslager.behandling.vedtak.BehandlingVedtak;
 import no.nav.foreldrepenger.behandlingslager.behandling.vedtak.Vedtaksbrev;
 import no.nav.foreldrepenger.dokumentbestiller.dto.BestillBrevDto;
+import no.nav.foreldrepenger.dokumentbestiller.formidling.DokumentBestiller;
 import no.nav.foreldrepenger.dokumentbestiller.kafka.DokumentKafkaBestiller;
+import no.nav.foreldrepenger.konfig.Environment;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
@@ -17,12 +19,15 @@ import static no.nav.foreldrepenger.dokumentbestiller.vedtak.VedtaksbrevUtleder.
 @ApplicationScoped
 public class DokumentBestillerTjeneste {
 
+    private final static Environment ENV = Environment.current();
+
     private BehandlingRepository behandlingRepository;
     private KlageRepository klageRepository;
     private AnkeRepository ankeRepository;
 
     private BrevHistorikkinnslag brevHistorikkinnslag;
     private DokumentKafkaBestiller dokumentKafkaBestiller;
+    private DokumentBestiller dokumentBestiller;
 
     public DokumentBestillerTjeneste() {
         // for cdi proxy
@@ -33,12 +38,14 @@ public class DokumentBestillerTjeneste {
                                      KlageRepository klageRepository,
                                      AnkeRepository ankeRepository,
                                      BrevHistorikkinnslag brevHistorikkinnslag,
-                                     DokumentKafkaBestiller dokumentKafkaBestiller) {
+                                     DokumentKafkaBestiller dokumentKafkaBestiller,
+                                     DokumentBestiller dokumentBestiller) {
         this.behandlingRepository = behandlingRepository;
         this.klageRepository = klageRepository;
         this.ankeRepository = ankeRepository;
         this.brevHistorikkinnslag = brevHistorikkinnslag;
         this.dokumentKafkaBestiller = dokumentKafkaBestiller;
+        this.dokumentBestiller = dokumentBestiller;
     }
 
     public void produserVedtaksbrev(BehandlingVedtak behandlingVedtak) {
@@ -51,8 +58,11 @@ public class DokumentBestillerTjeneste {
         var behandling = behandlingRepository.hentBehandling(behandlingsresultat.getBehandlingId());
         var dokumentMal = velgDokumentMalForVedtak(behandling, behandlingsresultat, behandlingVedtak,
             klageRepository, ankeRepository);
-
-        dokumentKafkaBestiller.bestillBrev(behandling, dokumentMal, null, null, HistorikkAktør.VEDTAKSLØSNINGEN);
+        if (ENV.isProd()) {
+            dokumentKafkaBestiller.bestillBrev(behandling, dokumentMal, null, null, HistorikkAktør.VEDTAKSLØSNINGEN);
+        } else {
+            dokumentBestiller.bestillBrev(behandling, dokumentMal, null, null, HistorikkAktør.VEDTAKSLØSNINGEN);
+        }
     }
 
     public void bestillDokument(BestillBrevDto bestillBrevDto, HistorikkAktør aktør) {
@@ -66,6 +76,11 @@ public class DokumentBestillerTjeneste {
             brevHistorikkinnslag.opprettHistorikkinnslagForManueltBestiltBrev(aktør, behandling,
                 DokumentMalType.fraKode(bestillBrevDto.getBrevmalkode()));
         }
-        dokumentKafkaBestiller.bestillBrevFraKafka(bestillBrevDto, aktør);
+
+        if (ENV.isProd()) {
+            dokumentKafkaBestiller.bestillBrevFraKafka(bestillBrevDto, aktør);
+        } else {
+            dokumentBestiller.bestillBrev(bestillBrevDto, aktør);
+        }
     }
 }

--- a/domenetjenester/dokumentbestiller/src/main/java/no/nav/foreldrepenger/dokumentbestiller/formidling/Brev.java
+++ b/domenetjenester/dokumentbestiller/src/main/java/no/nav/foreldrepenger/dokumentbestiller/formidling/Brev.java
@@ -1,0 +1,13 @@
+package no.nav.foreldrepenger.dokumentbestiller.formidling;
+
+import no.nav.foreldrepenger.kontrakter.formidling.v1.DokumentbestillingV2Dto;
+
+public interface Brev {
+
+    /**
+     * Produserer og journalfører et dokument definert i dtoen.
+     * @param dokumentbestillingV2Dto
+     */
+    void bestill(DokumentbestillingV2Dto dokumentbestillingV2Dto);
+
+}

--- a/domenetjenester/dokumentbestiller/src/main/java/no/nav/foreldrepenger/dokumentbestiller/formidling/DokumentBestiller.java
+++ b/domenetjenester/dokumentbestiller/src/main/java/no/nav/foreldrepenger/dokumentbestiller/formidling/DokumentBestiller.java
@@ -1,0 +1,74 @@
+package no.nav.foreldrepenger.dokumentbestiller.formidling;
+
+import java.util.UUID;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
+import no.nav.foreldrepenger.behandlingslager.behandling.RevurderingVarslingÅrsak;
+import no.nav.foreldrepenger.behandlingslager.behandling.historikk.HistorikkAktør;
+import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepository;
+import no.nav.foreldrepenger.dokumentbestiller.BrevHistorikkinnslag;
+import no.nav.foreldrepenger.dokumentbestiller.DokumentBehandlingTjeneste;
+import no.nav.foreldrepenger.dokumentbestiller.DokumentMalType;
+import no.nav.foreldrepenger.dokumentbestiller.dto.BestillBrevDto;
+import no.nav.foreldrepenger.dokumentbestiller.kafka.DokumentBestillerKafkaTask;
+import no.nav.foreldrepenger.domene.json.StandardJsonConfig;
+import no.nav.vedtak.felles.prosesstask.api.ProsessTaskData;
+import no.nav.vedtak.felles.prosesstask.api.ProsessTaskTjeneste;
+
+@ApplicationScoped
+public class DokumentBestiller {
+    private BehandlingRepository behandlingRepository;
+    private ProsessTaskTjeneste taskTjeneste;
+    private BrevHistorikkinnslag brevHistorikkinnslag;
+    private DokumentBehandlingTjeneste dokumentBehandlingTjeneste;
+
+    public DokumentBestiller() {
+        //CDI
+    }
+
+    @Inject
+    public DokumentBestiller(BehandlingRepository behandlingRepository,
+                             ProsessTaskTjeneste taskTjeneste,
+                             BrevHistorikkinnslag brevHistorikkinnslag,
+                             DokumentBehandlingTjeneste dokumentBehandlingTjeneste) {
+        this.behandlingRepository = behandlingRepository;
+        this.taskTjeneste = taskTjeneste;
+        this.brevHistorikkinnslag = brevHistorikkinnslag;
+        this.dokumentBehandlingTjeneste = dokumentBehandlingTjeneste;
+    }
+
+    public void bestillBrev(BestillBrevDto bestillBrevDto, HistorikkAktør aktør) {
+
+        var behandling = bestillBrevDto.getBehandlingUuid() == null ? behandlingRepository.hentBehandling(bestillBrevDto.getBehandlingId())
+            : behandlingRepository.hentBehandling(bestillBrevDto.getBehandlingUuid());
+        bestillBrev(behandling,
+                    DokumentMalType.fraKode(bestillBrevDto.getBrevmalkode()),
+                    bestillBrevDto.getFritekst(),
+                    bestillBrevDto.getÅrsakskode(),
+                    aktør);
+    }
+
+    public void bestillBrev(Behandling behandling, DokumentMalType dokumentMalType, String fritekst, String årsak, HistorikkAktør aktør) {
+        var bestillingUuid = UUID.randomUUID();
+        opprettBrevTask(behandling, dokumentMalType, fritekst, årsak, aktør, bestillingUuid);
+
+        dokumentBehandlingTjeneste.loggDokumentBestilt(behandling, dokumentMalType, bestillingUuid);
+        brevHistorikkinnslag.opprettHistorikkinnslagForBestiltBrevFraKafka(aktør, behandling, dokumentMalType);
+    }
+
+    private void opprettBrevTask(Behandling behandling, DokumentMalType dokumentMalType, String fritekst, String årsak, HistorikkAktør aktør, UUID bestillingUuid) {
+        var prosessTaskData = ProsessTaskData.forProsessTask(DokumentBestillerTask.class);
+        prosessTaskData.setPayload(StandardJsonConfig.toJson(fritekst));
+        prosessTaskData.setProperty(DokumentBestillerKafkaTask.BEHANDLING_ID, behandling.getId().toString());
+        prosessTaskData.setProperty(DokumentBestillerKafkaTask.DOKUMENT_MAL_TYPE, dokumentMalType.getKode());
+        prosessTaskData.setProperty(DokumentBestillerKafkaTask.REVURDERING_VARSLING_ÅRSAK, årsak);
+        prosessTaskData.setProperty(DokumentBestillerKafkaTask.HISTORIKK_AKTØR, aktør.getKode());
+        prosessTaskData.setProperty(DokumentBestillerKafkaTask.BESTILLING_UUID, String.valueOf(bestillingUuid));
+        prosessTaskData.setProperty(DokumentBestillerKafkaTask.BEHANDLENDE_ENHET_NAVN, behandling.getBehandlendeOrganisasjonsEnhet().enhetNavn());
+        prosessTaskData.setCallIdFraEksisterende();
+        taskTjeneste.lagre(prosessTaskData);
+    }
+}

--- a/domenetjenester/dokumentbestiller/src/main/java/no/nav/foreldrepenger/dokumentbestiller/formidling/DokumentBestillerTask.java
+++ b/domenetjenester/dokumentbestiller/src/main/java/no/nav/foreldrepenger/dokumentbestiller/formidling/DokumentBestillerTask.java
@@ -7,7 +7,6 @@ import javax.inject.Inject;
 
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepository;
 import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakProsesstaskRekkefølge;
-import no.nav.foreldrepenger.domene.json.StandardJsonConfig;
 import no.nav.foreldrepenger.kontrakter.formidling.kodeverk.HistorikkAktør;
 import no.nav.foreldrepenger.kontrakter.formidling.kodeverk.YtelseType;
 import no.nav.foreldrepenger.kontrakter.formidling.v1.DokumentbestillingV2Dto;
@@ -21,7 +20,6 @@ import no.nav.vedtak.felles.prosesstask.api.ProsessTaskHandler;
 @FagsakProsesstaskRekkefølge(gruppeSekvens = false)
 public class DokumentBestillerTask implements ProsessTaskHandler {
 
-    public static final String BEHANDLING_ID = "behandlingId";
     public static final String DOKUMENT_MAL_TYPE = "dokumentMalType";
     public static final String REVURDERING_VARSLING_ÅRSAK = "revurderingVarslingAarsak";
     public static final String HISTORIKK_AKTØR = "historikkAktoer";
@@ -47,7 +45,7 @@ public class DokumentBestillerTask implements ProsessTaskHandler {
     }
 
     private DokumentbestillingV2Dto mapDokumentbestilling(ProsessTaskData prosessTaskData) {
-        var behandling = behandlingRepository.hentBehandling(Long.valueOf(prosessTaskData.getPropertyValue(BEHANDLING_ID)));
+        var behandling = behandlingRepository.hentBehandling(prosessTaskData.getBehandlingUuid());
 
         return new DokumentbestillingV2Dto(
             behandling.getUuid(),
@@ -55,9 +53,9 @@ public class DokumentBestillerTask implements ProsessTaskHandler {
             mapYtelse(behandling.getFagsakYtelseType()),
             mapHistorikkAktør(prosessTaskData.getPropertyValue(HISTORIKK_AKTØR)),
             prosessTaskData.getPropertyValue(DOKUMENT_MAL_TYPE),
-            StandardJsonConfig.fromJson(prosessTaskData.getPayloadAsString(), String.class),
             prosessTaskData.getPropertyValue(BEHANDLENDE_ENHET_NAVN),
-            prosessTaskData.getPropertyValue(REVURDERING_VARSLING_ÅRSAK)
+            prosessTaskData.getPropertyValue(REVURDERING_VARSLING_ÅRSAK),
+            prosessTaskData.getPayloadAsString()
         );
     }
 

--- a/domenetjenester/dokumentbestiller/src/main/java/no/nav/foreldrepenger/dokumentbestiller/formidling/DokumentBestillerTask.java
+++ b/domenetjenester/dokumentbestiller/src/main/java/no/nav/foreldrepenger/dokumentbestiller/formidling/DokumentBestillerTask.java
@@ -1,0 +1,83 @@
+package no.nav.foreldrepenger.dokumentbestiller.formidling;
+
+import java.util.UUID;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepository;
+import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakProsesstaskRekkefølge;
+import no.nav.foreldrepenger.domene.json.StandardJsonConfig;
+import no.nav.foreldrepenger.kontrakter.formidling.kodeverk.HistorikkAktør;
+import no.nav.foreldrepenger.kontrakter.formidling.kodeverk.YtelseType;
+import no.nav.foreldrepenger.kontrakter.formidling.v1.DokumentbestillingV2Dto;
+import no.nav.vedtak.exception.TekniskException;
+import no.nav.vedtak.felles.prosesstask.api.ProsessTask;
+import no.nav.vedtak.felles.prosesstask.api.ProsessTaskData;
+import no.nav.vedtak.felles.prosesstask.api.ProsessTaskHandler;
+
+@ApplicationScoped
+@ProsessTask("dokumentbestiller.bestilldokument")
+@FagsakProsesstaskRekkefølge(gruppeSekvens = false)
+public class DokumentBestillerTask implements ProsessTaskHandler {
+
+    public static final String BEHANDLING_ID = "behandlingId";
+    public static final String DOKUMENT_MAL_TYPE = "dokumentMalType";
+    public static final String REVURDERING_VARSLING_ÅRSAK = "revurderingVarslingAarsak";
+    public static final String HISTORIKK_AKTØR = "historikkAktoer";
+    public static final String BESTILLING_UUID = "bestillingUuid";
+    public static final String BEHANDLENDE_ENHET_NAVN = "behandlendeEnhetNavn";
+
+    private BehandlingRepository behandlingRepository;
+    private Brev brev;
+
+    DokumentBestillerTask() {
+        // for CDI proxy
+    }
+
+    @Inject
+    public DokumentBestillerTask(BehandlingRepository behandlingRepository, Brev brev) {
+        this.behandlingRepository = behandlingRepository;
+        this.brev = brev;
+    }
+
+    @Override
+    public void doTask(ProsessTaskData prosessTaskData) {
+        brev.bestill(mapDokumentbestilling(prosessTaskData));
+    }
+
+    private DokumentbestillingV2Dto mapDokumentbestilling(ProsessTaskData prosessTaskData) {
+        var behandling = behandlingRepository.hentBehandling(Long.valueOf(prosessTaskData.getPropertyValue(BEHANDLING_ID)));
+
+        return new DokumentbestillingV2Dto(
+            behandling.getUuid(),
+            UUID.fromString(prosessTaskData.getPropertyValue(BESTILLING_UUID)),
+            mapYtelse(behandling.getFagsakYtelseType()),
+            mapHistorikkAktør(prosessTaskData.getPropertyValue(HISTORIKK_AKTØR)),
+            prosessTaskData.getPropertyValue(DOKUMENT_MAL_TYPE),
+            StandardJsonConfig.fromJson(prosessTaskData.getPayloadAsString(), String.class),
+            prosessTaskData.getPropertyValue(BEHANDLENDE_ENHET_NAVN),
+            prosessTaskData.getPropertyValue(REVURDERING_VARSLING_ÅRSAK)
+        );
+    }
+
+    private static YtelseType mapYtelse(no.nav.foreldrepenger.behandlingslager.fagsak.FagsakYtelseType fpsakYtelseKode) {
+        return switch (fpsakYtelseKode) {
+            case ENGANGSTØNAD -> YtelseType.ES;
+            case FORELDREPENGER -> YtelseType.FP;
+            case SVANGERSKAPSPENGER -> YtelseType.SVP;
+            default -> throw new TekniskException("FP-533280", "Klarte ikke utlede ytelsetype: %s. Kan ikke bestille dokument");
+        };
+    }
+
+    private static HistorikkAktør mapHistorikkAktør(String historikkAtkør) {
+        return switch(historikkAtkør) {
+            case "BESL" -> HistorikkAktør.BESLUTTER;
+            case "SBH" -> HistorikkAktør.SAKSBEHANDLER;
+            case "SOKER" -> HistorikkAktør.SØKER;
+            case "ARBEIDSGIVER" -> HistorikkAktør.ARBEIDSGIVER;
+            case "VL" -> HistorikkAktør.VEDTAKSLØSNINGEN;
+            default -> null;
+        };
+    }
+}

--- a/domenetjenester/dokumentbestiller/src/main/java/no/nav/foreldrepenger/dokumentbestiller/formidling/klient/FormidlingRestKlient.java
+++ b/domenetjenester/dokumentbestiller/src/main/java/no/nav/foreldrepenger/dokumentbestiller/formidling/klient/FormidlingRestKlient.java
@@ -1,0 +1,44 @@
+package no.nav.foreldrepenger.dokumentbestiller.formidling.klient;
+
+import java.net.URI;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import javax.ws.rs.core.UriBuilder;
+
+import no.nav.foreldrepenger.dokumentbestiller.formidling.Brev;
+import no.nav.foreldrepenger.konfig.Environment;
+import no.nav.foreldrepenger.kontrakter.formidling.v1.DokumentbestillingV2Dto;
+import no.nav.vedtak.felles.integrasjon.rest.OidcRestClient;
+
+@ApplicationScoped
+public class FormidlingRestKlient implements Brev {
+
+    private OidcRestClient restClient;
+
+    FormidlingRestKlient() {
+        //for cdi proxy
+    }
+
+    @Inject
+    public FormidlingRestKlient(OidcRestClient restClient) {
+        this.restClient = restClient;
+    }
+
+    @Override
+    public void bestill(DokumentbestillingV2Dto dokumentbestillingV2Dto) {
+        restClient.post(toUri(baseUrl(), "/api/brev/bestill"), dokumentbestillingV2Dto);
+    }
+
+    private URI baseUrl() {
+        return Environment.current().getRequiredProperty("fpformidling.base.url", URI.class);
+    }
+
+    private URI toUri(URI baseURI, String path) {
+        try {
+            return UriBuilder.fromUri(baseURI).path(path).build();
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Ugyldig uri: " + baseURI + path, e);
+        }
+    }
+}

--- a/domenetjenester/dokumentbestiller/src/test/java/no/nav/foreldrepenger/dokumentbestiller/DokumentBestillerTjenesteTest.java
+++ b/domenetjenester/dokumentbestiller/src/test/java/no/nav/foreldrepenger/dokumentbestiller/DokumentBestillerTjenesteTest.java
@@ -18,6 +18,7 @@ import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRe
 import no.nav.foreldrepenger.behandlingslager.testutilities.behandling.AbstractTestScenario;
 import no.nav.foreldrepenger.behandlingslager.testutilities.behandling.ScenarioMorSøkerEngangsstønad;
 import no.nav.foreldrepenger.dokumentbestiller.dto.BestillBrevDto;
+import no.nav.foreldrepenger.dokumentbestiller.formidling.DokumentBestiller;
 import no.nav.foreldrepenger.dokumentbestiller.kafka.DokumentKafkaBestiller;
 
 @ExtendWith(MockitoExtension.class)
@@ -27,6 +28,9 @@ public class DokumentBestillerTjenesteTest {
 
     @Mock
     private DokumentKafkaBestiller dokumentKafkaBestiller;
+
+    @Mock
+    private DokumentBestiller dokumentBestiller;
 
 
     private Behandling behandling;
@@ -44,7 +48,8 @@ public class DokumentBestillerTjenesteTest {
                 null,
                 null,
                 brevHistorikkinnslag,
-                dokumentKafkaBestiller);
+                dokumentKafkaBestiller,
+                dokumentBestiller);
     }
 
     @Test
@@ -61,7 +66,7 @@ public class DokumentBestillerTjenesteTest {
         tjeneste.bestillDokument(bestillBrevDto, historikkAktør, false);
 
         // Assert
-        verify(dokumentKafkaBestiller).bestillBrevFraKafka(bestillBrevDto, historikkAktør);
+        verify(dokumentBestiller).bestillBrev(bestillBrevDto, historikkAktør);
     }
 
     @Test
@@ -78,7 +83,7 @@ public class DokumentBestillerTjenesteTest {
         tjeneste.bestillDokument(bestillBrevDto, historikkAktør, true);
 
         // Assert
-        verify(dokumentKafkaBestiller).bestillBrevFraKafka(bestillBrevDto, historikkAktør);
+        verify(dokumentBestiller).bestillBrev(bestillBrevDto, historikkAktør);
 
         var historikkinnslagCaptor = ArgumentCaptor.forClass(Historikkinnslag.class);
         verify(historikkRepositoryMock).lagre(historikkinnslagCaptor.capture());

--- a/pom.xml
+++ b/pom.xml
@@ -212,6 +212,11 @@
                 <version>${fp-kontrakter.version}</version>
             </dependency>
             <dependency>
+                <groupId>no.nav.foreldrepenger.kontrakter</groupId>
+                <artifactId>fp-formidling-v1</artifactId>
+                <version>${fp-kontrakter.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>no.nav.foreldrepenger.abakus</groupId>
                 <artifactId>abakus-kontrakt</artifactId>
                 <version>${abakus-kontrakt.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
         <prosesstask.version>3.1.7</prosesstask.version>
         <fp-jms.version>2.1.2</fp-jms.version>
 
-        <fp-kontrakter.version>6.1.9</fp-kontrakter.version>
+        <fp-kontrakter.version>6.1.10</fp-kontrakter.version>
         <fp-tidsserie.version>2.5.8</fp-tidsserie.version>
         <fp-nare.version>2.1.5</fp-nare.version>
         <abakus-kontrakt.version>1.3.28</abakus-kontrakt.version>

--- a/web/src/main/resources/application-dev-fss.properties
+++ b/web/src/main/resources/application-dev-fss.properties
@@ -2,3 +2,5 @@ loadbalancer.url=https://app-q1.adeo.no
 
 OpenIdConnect.username=fpsak-q1
 OpenIdConnect.issoHost=https://isso-q.adeo.no:443/isso/oauth2
+
+fpformidling.base.url=http://fpformidling/fpformidling

--- a/web/src/main/resources/application-prod-fss.properties
+++ b/web/src/main/resources/application-prod-fss.properties
@@ -2,3 +2,5 @@ loadbalancer.url=https://app.adeo.no
 
 OpenIdConnect.username=fpsak-p
 OpenIdConnect.issoHost=https://isso.adeo.no/isso/oauth2
+
+fpformidling.base.url=http://fpformidling/fpformidling


### PR DESCRIPTION
Prøver å erstatte kafka med REST.

Neste steg er nok å forenkle kontrakten - årsak til revurdering brukes kun i VarselOmRevurdering brevet - mulig man kan innhente dette fra fpsak og ikke sende over APIet.

DokumentMalType - er også noe man kunne forbedre istedenfor mappe på bege sidene. 

Er generelt litt chaos ved enums og mapping fra fpsak enum -> prosess task data string -> kontrakt enum.

Forbedringsforslag tas gjerne imot. 