### PR TITLE
TFP-4708: Oppdaterer journalpostId fra brev kvittering.

### DIFF
--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/dokument/BehandlingDokumentBestiltEntitet.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/dokument/BehandlingDokumentBestiltEntitet.java
@@ -40,6 +40,10 @@ public class BehandlingDokumentBestiltEntitet extends BaseEntitet {
         // for hibernate
     }
 
+    public Long getId() {
+        return id;
+    }
+
     public BehandlingDokumentEntitet getBehandlingDokument() {
         return behandlingDokument;
     }
@@ -54,6 +58,10 @@ public class BehandlingDokumentBestiltEntitet extends BaseEntitet {
 
     public JournalpostId getJournalpostId() {
         return journalpostId;
+    }
+
+    public void setJournalpostId(JournalpostId journalpostId) {
+        this.journalpostId = journalpostId;
     }
 
     @Override

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/dokument/BehandlingDokumentRepository.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/dokument/BehandlingDokumentRepository.java
@@ -2,6 +2,7 @@ package no.nav.foreldrepenger.behandlingslager.behandling.dokument;
 
 import java.util.Objects;
 import java.util.Optional;
+import java.util.UUID;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
@@ -21,6 +22,22 @@ public class BehandlingDokumentRepository {
     @Inject
     public BehandlingDokumentRepository(EntityManager entityManager) {
         this.entityManager = entityManager;
+    }
+
+    public Optional<BehandlingDokumentBestiltEntitet> hentHvisEksisterer(UUID bestillingUuid) {
+        var query = entityManager.createQuery("from BehandlingDokumentBestilt where bestillingUuid = :bestillingUuid", BehandlingDokumentBestiltEntitet.class);
+        query.setParameter("bestillingUuid", bestillingUuid);
+        return HibernateVerktøy.hentUniktResultat(query);
+    }
+
+    public void lagreOgFlush(BehandlingDokumentBestiltEntitet behandlingDokument) {
+        Objects.requireNonNull(behandlingDokument, "behandlingDokument");
+        if (behandlingDokument.getId() == null) {
+            entityManager.persist(behandlingDokument);
+        } else {
+            entityManager.merge(behandlingDokument);
+        }
+        entityManager.flush();
     }
 
     public Optional<BehandlingDokumentEntitet> hentHvisEksisterer(Long behandlingId) {

--- a/domenetjenester/behandling/src/test/java/no/nav/foreldrepenger/historikk/kafka/LagreHistorikkTaskTest.java
+++ b/domenetjenester/behandling/src/test/java/no/nav/foreldrepenger/historikk/kafka/LagreHistorikkTaskTest.java
@@ -10,6 +10,7 @@ import javax.persistence.EntityManager;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
+import no.nav.foreldrepenger.behandlingslager.behandling.dokument.BehandlingDokumentRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.historikk.HistorikkRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.historikk.HistorikkinnslagType;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepository;
@@ -32,9 +33,10 @@ public class LagreHistorikkTaskTest {
                 Files.readAllBytes(Paths.get(ClassLoader.getSystemResource("historikkinnslagmelding.json").toURI())))
                         .replace("PLACEHOLDER-UUID", behandling.getUuid().toString());
         var historikkRepository = new HistorikkRepository(entityManager);
+        var dokumentBehandlingRepository = new BehandlingDokumentRepository(entityManager);
         var historikkFraDtoMapper = new HistorikkFraDtoMapper(
                 new BehandlingRepository(entityManager), new FagsakRepository(entityManager));
-        var task = new LagreHistorikkTask(historikkRepository, historikkFraDtoMapper);
+        var task = new LagreHistorikkTask(historikkRepository, historikkFraDtoMapper, dokumentBehandlingRepository);
 
         var data = ProsessTaskData.forProsessTask(LagreHistorikkTask.class);
         data.setPayload(melding);


### PR DESCRIPTION
Neste steg er å implementer REST for brev kvittering med ny kontrakt - og sanere Kafka.

Lurer på opprettetTidspunkt i HistorikkInnslagV1 - dette er tidspunkt +/- når brevet ble produsert i formidling.
Dette lagres i fpsak i HistorikkInnslag under historikk_tid kolonne men brukes ikke til noe fornuftig senere siden det vanlige opprettetTidspunkt brukes til å sortere historikkInnslagene i fronetend.
Skal vi sanere dette? Hva syns dere @jolarsen og @AnjaAalerud ? Tror dette ble introdusert siden kafka er asynkron og noen BREV_SENDT historikk innslag ble opprettet etter behandlingen ble avsluttet - men jeg ser at det ble aldri tatt i bruk egentlig.