### PR TITLE
TFP-4903 manglet dokumentlink-knytning

### DIFF
--- a/domenetjenester/behandling-klage/src/main/java/no/nav/foreldrepenger/behandling/kabal/KabalTjeneste.java
+++ b/domenetjenester/behandling-klage/src/main/java/no/nav/foreldrepenger/behandling/kabal/KabalTjeneste.java
@@ -305,11 +305,12 @@ public class KabalTjeneste {
 
         new HistorikkInnslagTekstBuilder().medHendelse(HistorikkinnslagType.BREV_SENT).medBegrunnelse("").build(historikkInnslag);
 
-        new HistorikkinnslagDokumentLink.Builder().medHistorikkinnslag(historikkInnslag)
+        var doklink = new HistorikkinnslagDokumentLink.Builder().medHistorikkinnslag(historikkInnslag)
             .medLinkTekst(journalPost.getTittel())
             .medDokumentId(journalPost.getDokumentId())
             .medJournalpostId(journalPost.getJournalpostId())
             .build();
+        historikkInnslag.setDokumentLinker(List.of(doklink));
 
         historikkRepository.lagre(historikkInnslag);
     }


### PR DESCRIPTION
Manglet en linje for å få lagret hele historikkinnslaget. Nå ble det innslag uten dokumentlenke. Denne bør løse problemet