### PR TITLE
Utvide vedtak fattet med topic-enums

### DIFF
--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/vedtak/kafka/VedtaksHendelseHåndterer.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/vedtak/kafka/VedtaksHendelseHåndterer.java
@@ -5,6 +5,7 @@ import java.time.LocalDateTime;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -19,7 +20,9 @@ import org.slf4j.LoggerFactory;
 
 import no.nav.abakus.iaygrunnlag.kodeverk.Fagsystem;
 import no.nav.abakus.iaygrunnlag.kodeverk.YtelseType;
+import no.nav.abakus.vedtak.ytelse.Kildesystem;
 import no.nav.abakus.vedtak.ytelse.Ytelse;
+import no.nav.abakus.vedtak.ytelse.Ytelser;
 import no.nav.abakus.vedtak.ytelse.v1.YtelseV1;
 import no.nav.foreldrepenger.behandling.FagsakTjeneste;
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
@@ -57,7 +60,10 @@ public class VedtaksHendelseHåndterer {
             YtelseType.ENGANGSTØNAD, FagsakYtelseType.ENGANGSTØNAD,
             YtelseType.FORELDREPENGER, FagsakYtelseType.FORELDREPENGER,
             YtelseType.SVANGERSKAPSPENGER, FagsakYtelseType.SVANGERSKAPSPENGER);
-    private static final Set<YtelseType> DB_LOGGES = Set.of(YtelseType.FRISINN, YtelseType.OMSORGSPENGER);
+    private static final Map<Ytelser, FagsakYtelseType> YTELSER_MAP = Map.of(
+        Ytelser.ENGANGSTØNAD, FagsakYtelseType.ENGANGSTØNAD,
+        Ytelser.FORELDREPENGER, FagsakYtelseType.FORELDREPENGER,
+        Ytelser.SVANGERSKAPSPENGER, FagsakYtelseType.SVANGERSKAPSPENGER);
     private static final Set<FagsakYtelseType> VURDER_OVERLAPP = Set.of(FagsakYtelseType.FORELDREPENGER, FagsakYtelseType.SVANGERSKAPSPENGER);
     private static final boolean isProd = Environment.current().isProd();
 
@@ -100,40 +106,54 @@ public class VedtaksHendelseHåndterer {
             return;
         var ytelse = (YtelseV1) mottattVedtak;
 
-        if (Fagsystem.FPSAK.equals(ytelse.getFagsystem())) {
+        if (Fagsystem.FPSAK.equals(ytelse.getFagsystem()) || (ytelse.getKildesystem() != null && Kildesystem.FPSAK.equals(ytelse.getKildesystem()))) {
             oprettTasksForFpsakVedtak(ytelse);
-        } else if (DB_LOGGES.contains(ytelse.getType())) {
+        } else if (skalLoggeOverlappDB(ytelse)) {
             var fagsaker = getFagsakerFor(ytelse);
             loggVedtakOverlapp(ytelse, fagsaker);
-        } else if (YtelseType.PLEIEPENGER_SYKT_BARN == ytelse.getType()) {
+        } else if (YtelseType.PLEIEPENGER_SYKT_BARN.equals(ytelse.getType()) || (ytelse.getYtelse() != null && Ytelser.PLEIEPENGER_SYKT_BARN.equals(ytelse.getYtelse()))) {
             var fagsaker = getFagsakerFor(ytelse);
             var callID = UUID.randomUUID();
             fagsakerMedVedtakOverlapp(ytelse, fagsaker)
                 .forEach(f -> opprettHåndterOverlappTaskPleiepenger(f, callID));
         } else {
-            LOG.info("Vedtatt-Ytelse mottok vedtak fra system {} saksnummer {} ytelse {}", ytelse.getFagsystem(), ytelse.getSaksnummer(), ytelse.getType());
+            var system = Optional.ofNullable(ytelse.getKildesystem()).map(Kildesystem::name)
+                .orElseGet(() -> Optional.ofNullable(ytelse.getFagsystem()).map(Fagsystem::getKode).orElse(null));
+            var ytelseTypeTekst = Optional.ofNullable(ytelse.getYtelse()).map(Ytelser::name)
+                .orElseGet(() -> Optional.ofNullable(ytelse.getType()).map(YtelseType::getKode).orElse(null));
+            LOG.info("Vedtatt-Ytelse mottok vedtak fra system {} saksnummer {} ytelse {}", system,
+                ytelse.getSaksnummer(), ytelseTypeTekst);
             var fagsaker = getFagsakerFor(ytelse);
             LOG.info("Vedtatt-Ytelse VL har disse sakene for bruker med vedtak {} - saker {}",
-                ytelse.getType(), fagsaker.stream().map(Fagsak::getSaksnummer).collect(Collectors.toList()));
+                ytelseTypeTekst, fagsaker.stream().map(Fagsak::getSaksnummer).collect(Collectors.toList()));
 
             var fagsakerMedOverlapp = fagsakerMedVedtakOverlapp(ytelse, fagsaker);
             if (!fagsakerMedOverlapp.isEmpty()) {
                 var overlappSaksnummerList =
                     fagsakerMedOverlapp.stream().map(Fagsak::getSaksnummer).map(Saksnummer::getVerdi).collect(Collectors.toList());
                 var beskrivelse = String.format("Vedtak om %s sak %s overlapper saker i VL: %s",
-                    ytelse.getType().getNavn(), ytelse.getSaksnummer(), String.join(", ", overlappSaksnummerList));
+                    ytelseTypeTekst, ytelse.getSaksnummer(), String.join(", ", overlappSaksnummerList));
                 LOG.warn("Vedtatt-Ytelse KONTAKT PRODUKTEIER UMIDDELBART! - {}", beskrivelse);
                 loggVedtakOverlapp(ytelse, fagsakerMedOverlapp);
             }
         }
     }
 
+    private boolean skalLoggeOverlappDB(YtelseV1 ytelse) {
+        return Set.of(YtelseType.FRISINN, YtelseType.OMSORGSPENGER).contains(ytelse.getType())
+            || (ytelse.getYtelse() != null && Set.of(Ytelser.FRISINN, Ytelser.OMSORGSPENGER).contains(ytelse.getYtelse()));
+    }
+
     private void oprettTasksForFpsakVedtak(YtelseV1 ytelse) {
-        var fagsakYtelseType = YTELSE_TYPE_MAP.getOrDefault(ytelse.getType(), FagsakYtelseType.UDEFINERT);
+        var fagsakYtelseType = Optional.ofNullable(ytelse.getYtelse()).map(YTELSER_MAP::get)
+            .orElseGet(() -> Optional.ofNullable(ytelse.getType()).map(YTELSE_TYPE_MAP::get).orElse(FagsakYtelseType.UDEFINERT));
 
         if (!VURDER_OVERLAPP.contains(fagsakYtelseType)) {
             if (FagsakYtelseType.UDEFINERT.equals(fagsakYtelseType)) {
-                LOG.error("Vedtatt-Ytelse Utviklerfeil: ukjent ytelsestype for innkommende vedtak {}", ytelse.getType());
+                var ytelseTypeTekst = Optional.ofNullable(ytelse.getYtelse()).map(Ytelser::name)
+                    .orElseGet(() -> Optional.ofNullable(ytelse.getType()).map(YtelseType::getKode).orElse(null));
+
+                LOG.error("Vedtatt-Ytelse Utviklerfeil: ukjent ytelsestype for innkommende vedtak {}", ytelseTypeTekst);
             }
             return;
         }

--- a/domenetjenester/mottak/src/test/java/no/nav/foreldrepenger/mottak/vedtak/kafka/VedtaksHendelseHåndtererTest.java
+++ b/domenetjenester/mottak/src/test/java/no/nav/foreldrepenger/mottak/vedtak/kafka/VedtaksHendelseHåndtererTest.java
@@ -25,7 +25,10 @@ import no.nav.abakus.iaygrunnlag.kodeverk.YtelseStatus;
 import no.nav.abakus.iaygrunnlag.kodeverk.YtelseType;
 import no.nav.abakus.vedtak.ytelse.Aktør;
 import no.nav.abakus.vedtak.ytelse.Desimaltall;
+import no.nav.abakus.vedtak.ytelse.Kildesystem;
 import no.nav.abakus.vedtak.ytelse.Periode;
+import no.nav.abakus.vedtak.ytelse.Status;
+import no.nav.abakus.vedtak.ytelse.Ytelser;
 import no.nav.abakus.vedtak.ytelse.v1.YtelseV1;
 import no.nav.abakus.vedtak.ytelse.v1.anvisning.Anvisning;
 import no.nav.foreldrepenger.behandling.FagsakTjeneste;
@@ -450,12 +453,15 @@ public class VedtaksHendelseHåndtererTest extends EntityManagerAwareTest {
 
         var ytelse = new YtelseV1();
         ytelse.setFagsystem(Fagsystem.FPSAK);
+        ytelse.setKildesystem(Kildesystem.FPSAK);
         ytelse.setSaksnummer(behandling.getFagsak().getSaksnummer().getVerdi());
         ytelse.setVedtattTidspunkt(vedtak.getVedtakstidspunkt());
         ytelse.setVedtakReferanse(behandling.getUuid().toString());
         ytelse.setAktør(aktør);
         ytelse.setType(map(behandling.getFagsakYtelseType()));
         ytelse.setStatus(map(behandling.getFagsak().getStatus()));
+        ytelse.setYtelse(mapYtelser(behandling.getFagsakYtelseType()));
+        ytelse.setYtelseStatus(mapStatus(behandling.getFagsak().getStatus()));
         ytelse.setPeriode(null);
         ytelse.setAnvist(null);
         return ytelse;
@@ -463,13 +469,16 @@ public class VedtaksHendelseHåndtererTest extends EntityManagerAwareTest {
 
     private YtelseV1 genererYtelseAbakus(YtelseType type, Aktør aktør, Periode periode, List<Anvisning> anvist) {
         var ytelse = new YtelseV1();
-        ytelse.setFagsystem(Fagsystem.FPABAKUS);
+        ytelse.setFagsystem(Fagsystem.K9SAK);
+        ytelse.setKildesystem(Kildesystem.K9SAK);
         ytelse.setSaksnummer("6T5NM");
         ytelse.setVedtattTidspunkt(LocalDateTime.now());
         ytelse.setVedtakReferanse("1001-ABC");
         ytelse.setAktør(aktør);
         ytelse.setType(type);
+        ytelse.setYtelse(mapYtelseType(type));
         ytelse.setStatus(YtelseStatus.LØPENDE);
+        ytelse.setYtelseStatus(Status.LØPENDE);
         ytelse.setPeriode(periode);
         ytelse.setAnvist(anvist);
         return ytelse;
@@ -491,29 +500,52 @@ public class VedtaksHendelseHåndtererTest extends EntityManagerAwareTest {
     }
 
     private YtelseType map(FagsakYtelseType type) {
-        if (FagsakYtelseType.ENGANGSTØNAD.equals(type)) {
-            return YtelseType.ENGANGSTØNAD;
-        }
-        if (FagsakYtelseType.FORELDREPENGER.equals(type)) {
-            return YtelseType.FORELDREPENGER;
-        }
-        return YtelseType.SVANGERSKAPSPENGER;
+        return switch (type) {
+            case ENGANGSTØNAD -> YtelseType.ENGANGSTØNAD;
+            case FORELDREPENGER -> YtelseType.FORELDREPENGER;
+            case SVANGERSKAPSPENGER -> YtelseType.SVANGERSKAPSPENGER;
+            default -> throw new IllegalStateException("Ukjent ytelsestype " + type);
+        };
+    }
+
+    private Ytelser mapYtelser(FagsakYtelseType type) {
+        return switch (type) {
+            case ENGANGSTØNAD -> Ytelser.ENGANGSTØNAD;
+            case FORELDREPENGER -> Ytelser.FORELDREPENGER;
+            case SVANGERSKAPSPENGER -> Ytelser.SVANGERSKAPSPENGER;
+            default -> throw new IllegalStateException("Ukjent ytelsestype " + type);
+        };
+    }
+
+    private Ytelser mapYtelseType(YtelseType type) {
+        return switch (type) {
+            case ENGANGSTØNAD -> Ytelser.ENGANGSTØNAD;
+            case FORELDREPENGER -> Ytelser.FORELDREPENGER;
+            case SVANGERSKAPSPENGER -> Ytelser.SVANGERSKAPSPENGER;
+            case OMSORGSPENGER -> Ytelser.OMSORGSPENGER;
+            case PLEIEPENGER_SYKT_BARN -> Ytelser.PLEIEPENGER_SYKT_BARN;
+            case PLEIEPENGER_NÆRSTÅENDE -> Ytelser.PLEIEPENGER_NÆRSTÅENDE;
+            case OPPLÆRINGSPENGER -> Ytelser.OPPLÆRINGSPENGER;
+            case FRISINN -> Ytelser.FRISINN;
+            default -> throw new IllegalStateException("Ukjent ytelsestype " + type);
+        };
     }
 
     private YtelseStatus map(FagsakStatus kode) {
-        YtelseStatus typeKode;
-        if (FagsakStatus.OPPRETTET.equals(kode)) {
-            typeKode = YtelseStatus.OPPRETTET;
-        } else if (FagsakStatus.UNDER_BEHANDLING.equals(kode)) {
-            typeKode = YtelseStatus.UNDER_BEHANDLING;
-        } else if (FagsakStatus.LØPENDE.equals(kode)) {
-            typeKode = YtelseStatus.LØPENDE;
-        } else if (FagsakStatus.AVSLUTTET.equals(kode)) {
-            typeKode = YtelseStatus.AVSLUTTET;
-        } else {
-            typeKode = YtelseStatus.OPPRETTET;
-        }
-        return typeKode;
+        return switch (kode) {
+            case OPPRETTET -> YtelseStatus.OPPRETTET;
+            case UNDER_BEHANDLING -> YtelseStatus.UNDER_BEHANDLING;
+            case LØPENDE -> YtelseStatus.LØPENDE;
+            case AVSLUTTET -> YtelseStatus.AVSLUTTET;
+        };
+    }
+
+    private Status mapStatus(FagsakStatus kode) {
+        return switch (kode) {
+            case OPPRETTET, UNDER_BEHANDLING -> Status.UNDER_BEHANDLING;
+            case LØPENDE -> Status.LØPENDE;
+            case AVSLUTTET -> Status.AVSLUTTET;
+        };
     }
 
 }

--- a/domenetjenester/registerinnhenting/src/main/java/no/nav/foreldrepenger/domene/registerinnhenting/RegisterdataInnhenter.java
+++ b/domenetjenester/registerinnhenting/src/main/java/no/nav/foreldrepenger/domene/registerinnhenting/RegisterdataInnhenter.java
@@ -28,6 +28,8 @@ import no.nav.abakus.iaygrunnlag.kodeverk.Fagsystem;
 import no.nav.abakus.iaygrunnlag.kodeverk.YtelseType;
 import no.nav.abakus.iaygrunnlag.request.InnhentRegisterdataRequest;
 import no.nav.abakus.iaygrunnlag.request.RegisterdataType;
+import no.nav.abakus.vedtak.ytelse.Kildesystem;
+import no.nav.abakus.vedtak.ytelse.Ytelser;
 import no.nav.abakus.vedtak.ytelse.v1.YtelseV1;
 import no.nav.foreldrepenger.behandling.BehandlingReferanse;
 import no.nav.foreldrepenger.behandlingslager.aktør.FødtBarnInfo;
@@ -161,8 +163,8 @@ public class RegisterdataInnhenter {
 
         var potensielleVedtak = abakusTjeneste.hentVedtakForAktørId(request).stream()
             .map(y -> (YtelseV1)y)
-            .filter(y -> Fagsystem.K9SAK.equals(y.getFagsystem()))
-            .filter(y -> YtelseType.PLEIEPENGER_SYKT_BARN.equals(y.getType()))
+            .filter(y -> Fagsystem.K9SAK.equals(y.getFagsystem()) || (y.getKildesystem() != null && Kildesystem.K9SAK.equals(y.getKildesystem())))
+            .filter(y -> YtelseType.PLEIEPENGER_SYKT_BARN.equals(y.getType())  || (y.getYtelse() != null && Ytelser.PLEIEPENGER_SYKT_BARN.equals(y.getYtelse())))
             .filter(y -> y.getTilleggsopplysninger() != null && !y.getTilleggsopplysninger().isBlank())
             .collect(Collectors.toList());
 

--- a/domenetjenester/vedtak/src/main/java/no/nav/foreldrepenger/domene/vedtak/observer/VedtattYtelseMapper.java
+++ b/domenetjenester/vedtak/src/main/java/no/nav/foreldrepenger/domene/vedtak/observer/VedtattYtelseMapper.java
@@ -15,6 +15,7 @@ import no.nav.abakus.vedtak.ytelse.Desimaltall;
 import no.nav.abakus.vedtak.ytelse.Periode;
 import no.nav.abakus.vedtak.ytelse.v1.anvisning.Anvisning;
 import no.nav.abakus.vedtak.ytelse.v1.anvisning.AnvistAndel;
+import no.nav.abakus.vedtak.ytelse.v1.anvisning.Inntektklasse;
 import no.nav.foreldrepenger.behandlingslager.behandling.beregning.BeregningsresultatAndel;
 import no.nav.foreldrepenger.behandlingslager.behandling.beregning.BeregningsresultatEntitet;
 import no.nav.foreldrepenger.behandlingslager.behandling.beregning.BeregningsresultatPeriode;
@@ -52,7 +53,7 @@ class VedtattYtelseMapper {
     List<Anvisning> mapForeldrepenger(BeregningsresultatEntitet tilkjent) {
         return tilkjent.getBeregningsresultatPerioder().stream()
             .filter(periode -> periode.getDagsats() > 0)
-            .map(p -> mapForeldrepengerPeriode(p))
+            .map(this::mapForeldrepengerPeriode)
             .collect(Collectors.toList());
     }
 
@@ -125,8 +126,24 @@ class VedtattYtelseMapper {
             new Desimaltall(finnTotalBeløp(e.getValue())),
             finnUtbetalingsgrad(e.getValue()),
             new Desimaltall(finnRefusjonsgrad(e.getValue())),
-            no.nav.abakus.iaygrunnlag.kodeverk.Inntektskategori.fraKode(e.getKey().inntektskategori().getKode())
+            mapInntektklasse(e.getKey().inntektskategori())
         );
+    }
+
+    private static Inntektklasse mapInntektklasse(Inntektskategori inntektskategori) {
+        return switch(inntektskategori) {
+            case ARBEIDSTAKER -> Inntektklasse.ARBEIDSTAKER;
+            case ARBEIDSTAKER_UTEN_FERIEPENGER -> Inntektklasse.ARBEIDSTAKER_UTEN_FERIEPENGER;
+            case FRILANSER -> Inntektklasse.FRILANSER;
+            case SELVSTENDIG_NÆRINGSDRIVENDE -> Inntektklasse.SELVSTENDIG_NÆRINGSDRIVENDE;
+            case DAGPENGER -> Inntektklasse.DAGPENGER;
+            case ARBEIDSAVKLARINGSPENGER -> Inntektklasse.ARBEIDSAVKLARINGSPENGER;
+            case SJØMANN -> Inntektklasse.MARITIM;
+            case DAGMAMMA -> Inntektklasse.DAGMAMMA;
+            case JORDBRUKER -> Inntektklasse.JORDBRUKER;
+            case FISKER -> Inntektklasse.FISKER;
+            default -> Inntektklasse.INGEN;
+        };
     }
 
     private static BigDecimal finnRefusjonsgrad(List<BeregningsresultatAndel> resultatAndeler) {

--- a/domenetjenester/vedtak/src/main/java/no/nav/foreldrepenger/domene/vedtak/observer/VedtattYtelseTjeneste.java
+++ b/domenetjenester/vedtak/src/main/java/no/nav/foreldrepenger/domene/vedtak/observer/VedtattYtelseTjeneste.java
@@ -12,8 +12,11 @@ import no.nav.abakus.iaygrunnlag.kodeverk.Fagsystem;
 import no.nav.abakus.iaygrunnlag.kodeverk.YtelseStatus;
 import no.nav.abakus.iaygrunnlag.kodeverk.YtelseType;
 import no.nav.abakus.vedtak.ytelse.Aktør;
+import no.nav.abakus.vedtak.ytelse.Kildesystem;
 import no.nav.abakus.vedtak.ytelse.Periode;
+import no.nav.abakus.vedtak.ytelse.Status;
 import no.nav.abakus.vedtak.ytelse.Ytelse;
+import no.nav.abakus.vedtak.ytelse.Ytelser;
 import no.nav.abakus.vedtak.ytelse.v1.YtelseV1;
 import no.nav.abakus.vedtak.ytelse.v1.anvisning.Anvisning;
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
@@ -64,12 +67,15 @@ public class VedtattYtelseTjeneste {
         aktør.setVerdi(behandling.getAktørId().getId());
         final var ytelse = new YtelseV1();
         ytelse.setFagsystem(Fagsystem.FPSAK);
+        ytelse.setKildesystem(Kildesystem.FPSAK);
         ytelse.setSaksnummer(behandling.getFagsak().getSaksnummer().getVerdi());
         ytelse.setVedtattTidspunkt(vedtak.getVedtakstidspunkt());
         ytelse.setVedtakReferanse(behandling.getUuid().toString());
         ytelse.setAktør(aktør);
         ytelse.setType(map(behandling.getFagsakYtelseType()));
+        ytelse.setYtelse(mapYtelser(behandling.getFagsakYtelseType()));
         ytelse.setStatus(map(behandling.getFagsak().getStatus()));
+        ytelse.setYtelseStatus(mapStatus(behandling.getFagsak().getStatus()));
 
         ytelse.setPeriode(utledPeriode(behandling, vedtak, berResultat.orElse(null)));
         ytelse.setAnvist(map(behandling, berResultat.orElse(null), mapArbeidsforhold));
@@ -150,12 +156,29 @@ public class VedtattYtelseTjeneste {
         };
     }
 
+    private Ytelser mapYtelser(FagsakYtelseType type) {
+        return switch (type) {
+            case ENGANGSTØNAD -> Ytelser.ENGANGSTØNAD;
+            case FORELDREPENGER -> Ytelser.FORELDREPENGER;
+            case SVANGERSKAPSPENGER -> Ytelser.SVANGERSKAPSPENGER;
+            default -> throw new IllegalStateException("Ukjent ytelsestype " + type);
+        };
+    }
+
     private YtelseStatus map(FagsakStatus kode) {
         return switch (kode) {
             case OPPRETTET -> YtelseStatus.OPPRETTET;
             case UNDER_BEHANDLING -> YtelseStatus.UNDER_BEHANDLING;
             case LØPENDE -> YtelseStatus.LØPENDE;
             case AVSLUTTET -> YtelseStatus.AVSLUTTET;
+        };
+    }
+
+    private Status mapStatus(FagsakStatus kode) {
+        return switch (kode) {
+            case OPPRETTET, UNDER_BEHANDLING -> Status.UNDER_BEHANDLING;
+            case LØPENDE -> Status.LØPENDE;
+            case AVSLUTTET -> Status.AVSLUTTET;
         };
     }
 

--- a/domenetjenester/vedtak/src/test/java/no/nav/foreldrepenger/domene/vedtak/observer/VedtattYtelseForeldrepengerMapperTest.java
+++ b/domenetjenester/vedtak/src/test/java/no/nav/foreldrepenger/domene/vedtak/observer/VedtattYtelseForeldrepengerMapperTest.java
@@ -10,6 +10,7 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 
 import no.nav.abakus.vedtak.ytelse.v1.anvisning.Anvisning;
+import no.nav.abakus.vedtak.ytelse.v1.anvisning.Inntektklasse;
 import no.nav.foreldrepenger.behandlingslager.behandling.beregning.BeregningsresultatAndel;
 import no.nav.foreldrepenger.behandlingslager.behandling.beregning.BeregningsresultatEntitet;
 import no.nav.foreldrepenger.behandlingslager.behandling.beregning.BeregningsresultatPeriode;
@@ -62,6 +63,7 @@ class VedtattYtelseForeldrepengerMapperTest {
         assertThat(anvisninger.get(0).getAndeler().get(0).getArbeidsgiver().getIdent()).isEqualTo(arbeidsgiver.getIdentifikator());
         assertThat(anvisninger.get(0).getAndeler().get(0).getArbeidsforholdId()).isEqualTo(eksternReferanse);
         assertThat(anvisninger.get(0).getAndeler().get(0).getInntektskategori()).isEqualTo(no.nav.abakus.iaygrunnlag.kodeverk.Inntektskategori.ARBEIDSTAKER);
+        assertThat(anvisninger.get(0).getAndeler().get(0).getInntektklasse()).isEqualTo(Inntektklasse.ARBEIDSTAKER);
         assertThat(anvisninger.get(0).getAndeler().get(0).getUtbetalingsgrad().getVerdi()).isEqualByComparingTo(BigDecimal.valueOf(100));
         assertThat(anvisninger.get(0).getAndeler().get(0).getDagsats().getVerdi()).isEqualByComparingTo(BigDecimal.valueOf(dagsats));
         assertThat(anvisninger.get(0).getAndeler().get(0).getRefusjonsgrad().getVerdi()).isEqualByComparingTo(BigDecimal.ZERO);
@@ -102,6 +104,7 @@ class VedtattYtelseForeldrepengerMapperTest {
         assertThat(anvisninger.get(0).getAndeler().get(0).getArbeidsgiver().getIdent()).isEqualTo(arbeidsgiver1.getIdentifikator());
         assertThat(anvisninger.get(0).getAndeler().get(0).getArbeidsforholdId()).isEqualTo(eksternReferanse1);
         assertThat(anvisninger.get(0).getAndeler().get(0).getInntektskategori()).isEqualTo(no.nav.abakus.iaygrunnlag.kodeverk.Inntektskategori.ARBEIDSTAKER);
+        assertThat(anvisninger.get(0).getAndeler().get(0).getInntektklasse()).isEqualTo(Inntektklasse.ARBEIDSTAKER);
         assertThat(anvisninger.get(0).getAndeler().get(0).getUtbetalingsgrad().getVerdi()).isEqualByComparingTo(BigDecimal.valueOf(100));
         assertThat(anvisninger.get(0).getAndeler().get(0).getDagsats().getVerdi()).isEqualByComparingTo(BigDecimal.valueOf(dagsats1));
         assertThat(anvisninger.get(0).getAndeler().get(0).getRefusjonsgrad().getVerdi()).isEqualByComparingTo(BigDecimal.valueOf(100));
@@ -110,6 +113,7 @@ class VedtattYtelseForeldrepengerMapperTest {
         assertThat(anvisninger.get(0).getAndeler().get(1).getArbeidsgiver().getIdent()).isEqualTo(arbeidsgiver2.getIdentifikator());
         assertThat(anvisninger.get(0).getAndeler().get(1).getArbeidsforholdId()).isEqualTo(eksternReferanse2);
         assertThat(anvisninger.get(0).getAndeler().get(1).getInntektskategori()).isEqualTo(no.nav.abakus.iaygrunnlag.kodeverk.Inntektskategori.ARBEIDSTAKER);
+        assertThat(anvisninger.get(0).getAndeler().get(0).getInntektklasse()).isEqualTo(Inntektklasse.ARBEIDSTAKER);
         assertThat(anvisninger.get(0).getAndeler().get(1).getUtbetalingsgrad().getVerdi()).isEqualByComparingTo(BigDecimal.valueOf(100));
         assertThat(anvisninger.get(0).getAndeler().get(1).getDagsats().getVerdi()).isEqualByComparingTo(BigDecimal.valueOf(dagsats2));
         assertThat(anvisninger.get(0).getAndeler().get(1).getRefusjonsgrad().getVerdi()).isEqualByComparingTo(BigDecimal.valueOf(100));
@@ -147,6 +151,7 @@ class VedtattYtelseForeldrepengerMapperTest {
         assertThat(anvisninger.get(0).getAndeler().get(0).getArbeidsgiver().getIdent()).isEqualTo(arbeidsgiver.getIdentifikator());
         assertThat(anvisninger.get(0).getAndeler().get(0).getArbeidsforholdId()).isEqualTo(eksternReferanse);
         assertThat(anvisninger.get(0).getAndeler().get(0).getInntektskategori()).isEqualTo(no.nav.abakus.iaygrunnlag.kodeverk.Inntektskategori.ARBEIDSTAKER);
+        assertThat(anvisninger.get(0).getAndeler().get(0).getInntektklasse()).isEqualTo(Inntektklasse.ARBEIDSTAKER);
         assertThat(anvisninger.get(0).getAndeler().get(0).getUtbetalingsgrad().getVerdi()).isEqualByComparingTo(BigDecimal.valueOf(100));
         assertThat(anvisninger.get(0).getAndeler().get(0).getDagsats().getVerdi()).isEqualByComparingTo(BigDecimal.valueOf(dagsats));
         assertThat(anvisninger.get(0).getAndeler().get(0).getRefusjonsgrad().getVerdi()).isEqualByComparingTo(BigDecimal.valueOf(100));
@@ -179,6 +184,7 @@ class VedtattYtelseForeldrepengerMapperTest {
         assertThat(anvisninger.get(0).getAndeler().get(0).getArbeidsgiver().getIdent()).isEqualTo(arbeidsgiver.getIdentifikator());
         assertThat(anvisninger.get(0).getAndeler().get(0).getArbeidsforholdId()).isEqualTo(null);
         assertThat(anvisninger.get(0).getAndeler().get(0).getInntektskategori()).isEqualTo(no.nav.abakus.iaygrunnlag.kodeverk.Inntektskategori.ARBEIDSTAKER);
+        assertThat(anvisninger.get(0).getAndeler().get(0).getInntektklasse()).isEqualTo(Inntektklasse.ARBEIDSTAKER);
         assertThat(anvisninger.get(0).getAndeler().get(0).getUtbetalingsgrad().getVerdi()).isEqualByComparingTo(BigDecimal.valueOf(100));
         assertThat(anvisninger.get(0).getAndeler().get(0).getDagsats().getVerdi()).isEqualByComparingTo(BigDecimal.valueOf(dagsats));
         assertThat(anvisninger.get(0).getAndeler().get(0).getRefusjonsgrad().getVerdi()).isEqualByComparingTo(BigDecimal.valueOf(100));
@@ -215,6 +221,7 @@ class VedtattYtelseForeldrepengerMapperTest {
         assertThat(anvisninger.size()).isEqualTo(1);
         assertThat(anvisninger.get(0).getAndeler().size()).isEqualTo(1);
         assertThat(anvisninger.get(0).getAndeler().get(0).getInntektskategori()).isEqualTo(no.nav.abakus.iaygrunnlag.kodeverk.Inntektskategori.DAGPENGER);
+        assertThat(anvisninger.get(0).getAndeler().get(0).getInntektklasse()).isEqualTo(Inntektklasse.DAGPENGER);
         assertThat(anvisninger.get(0).getAndeler().get(0).getUtbetalingsgrad().getVerdi()).isEqualByComparingTo(BigDecimal.valueOf(100));
         assertThat(anvisninger.get(0).getAndeler().get(0).getDagsats().getVerdi()).isEqualByComparingTo(BigDecimal.valueOf(dagsats));
         assertThat(anvisninger.get(0).getAndeler().get(0).getRefusjonsgrad().getVerdi()).isEqualByComparingTo(BigDecimal.ZERO);

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
         <fp-kontrakter.version>6.1.19</fp-kontrakter.version>
         <fp-tidsserie.version>2.5.8</fp-tidsserie.version>
         <fp-nare.version>2.2.2</fp-nare.version>
-        <abakus-kontrakt.version>1.3.28</abakus-kontrakt.version>
+        <abakus-kontrakt.version>1.3.29</abakus-kontrakt.version>
         <kalkulus.version>1.5.30</kalkulus.version>
 
         <swaggercore.version>2.1.13</swaggercore.version>


### PR DESCRIPTION
Expand/contract for at vedtakFattet kun bruker pakkelokale plain enums isf enums fra abakus kodeverk som serialiseres som kodeverdi-objekt