### PR TITLE
Fikser feil der ingen fødte barn ble tolket som om alle barna var døde

### DIFF
--- a/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/input/FamilieHendelse.java
+++ b/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/input/FamilieHendelse.java
@@ -86,7 +86,11 @@ public class FamilieHendelse {
     }
 
     public boolean erAlleBarnDøde() {
-        return getBarna().stream().allMatch(b -> b.getDødsdato().isPresent());
+        var barna = getBarna();
+        if (barna.isEmpty()) {
+            return false;
+        }
+        return barna.stream().allMatch(b -> b.getDødsdato().isPresent());
     }
 
     public boolean gjelderFødsel() {


### PR DESCRIPTION
Ser ikke ut til å være noe i bruk i uttak-reglene så lenge ikke det finnes barn, men ser rart ut i regelsporinga.
Brukes også itleder for omsorg-AP som ser ut til å aldri kunne oppfylles