### PR TITLE
Revert "Revert "TFP-4960 TFP-4935 FAB minsterett BFHR + smheng/flerbarn""

### DIFF
--- a/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/fastsetteperioder/grunnlagbyggere/KontoerGrunnlagBygger.java
+++ b/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/fastsetteperioder/grunnlagbyggere/KontoerGrunnlagBygger.java
@@ -22,8 +22,14 @@ import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.Kontoer;
 @ApplicationScoped
 public class KontoerGrunnlagBygger {
 
-    private static final int MINSTEDAGER_100_PROSENT = 75;
-    private static final int MINSTEDAGER_80_PROSENT = 95;
+    // TODO (TFP-4846) flytt til Stønadskontoberegning og lagre på FR el Fagsak
+    private static final int MINSTEDAGER_UFØRE_100_PROSENT = 75;
+    private static final int MINSTEDAGER_UFØRE_80_PROSENT = 95;
+
+    private static final int MINSTERETT_BFHR_100_PROSENT = 40;
+    private static final int MINSTERETT_BFHR_80_PROSENT = 50;
+
+
     private FagsakRelasjonRepository fagsakRelasjonRepository;
 
     @Inject
@@ -42,18 +48,16 @@ public class KontoerGrunnlagBygger {
      * - gir mulighet til å innvilge perioder selv om aktivitetskravet ikke er oppfylt
      * - vil ikke påvirke stønadsperioden dvs må tas ut fortløpende. Ingen utsettelse uten at aktivitetskrav oppfylt
      * - Skal alltid brukes på tilfelle som krever sammenhengende uttak
-     * - TFP-4842 tillat at avslått aktivitetskrav kan innvilges fra utenAktivitetskravDager
      *
      * minsterettDager
      * - gir mulighet til å innvilge perioder selv om aktivitetskravet ikke er oppfylt
      * - automatiske trekk pga manglende søkt, avslag mv vil ikke påvirke minsterett
      * - kan utsettes og  utvide stønadsperioden
-     * - TBD når kan denne brukes framfor utenAktivitetskravDager
+     * - Brukes framfor utenAktivitetskravDager fom FAB
      */
     public Kontoer.Builder byggGrunnlag(BehandlingReferanse ref, ForeldrepengerGrunnlag foreldrepengerGrunnlag) {
         var stønadskontoer = hentStønadskontoer(ref);
-        return new Kontoer.Builder()
-            .utenAktivitetskravDager(minsterettDager(ref, foreldrepengerGrunnlag, stønadskontoer))
+        return getBuilder(ref, foreldrepengerGrunnlag, stønadskontoer)
             .kontoList(stønadskontoer.stream().map(this::map).collect(Collectors.toList()));
     }
 
@@ -72,16 +76,29 @@ public class KontoerGrunnlagBygger {
     /*
      * TFP-4846 legge inn regler for minsterett i stønadskontoutregningen
      */
-    private int minsterettDager(BehandlingReferanse ref, ForeldrepengerGrunnlag foreldrepengerGrunnlag, Set<Stønadskonto> stønadskontoer) {
+    private Kontoer.Builder getBuilder(BehandlingReferanse ref, ForeldrepengerGrunnlag foreldrepengerGrunnlag, Set<Stønadskonto> stønadskontoer) {
+        var builder = new Kontoer.Builder();
+        var erMor = RelasjonsRolleType.MORA.equals(ref.getRelasjonsRolleType());
+        var erForeldrepenger = stønadskontoer.stream().map(Stønadskonto::getStønadskontoType).anyMatch(StønadskontoType.FORELDREPENGER::equals);
+        var minsterettAnnenpart = !ref.getSkjæringstidspunkt().utenMinsterett();
         var morHarUføretrygd = foreldrepengerGrunnlag.getUføretrygdGrunnlag()
             .filter(UføretrygdGrunnlagEntitet::annenForelderMottarUføretrygd)
             .isPresent();
-        var erMor = RelasjonsRolleType.MORA.equals(ref.getRelasjonsRolleType());
-        var erForeldrepenger = stønadskontoer.stream().map(Stønadskonto::getStønadskontoType).anyMatch(StønadskontoType.FORELDREPENGER::equals);
-        if (morHarUføretrygd && !erMor && erForeldrepenger) {
+        if (!erMor && erForeldrepenger && (minsterettAnnenpart || morHarUføretrygd)) {
             var dekningsgrad = fagsakRelasjonRepository.finnRelasjonFor(ref.getSaksnummer()).getGjeldendeDekningsgrad();
-            return Dekningsgrad._80.equals(dekningsgrad) ? MINSTEDAGER_80_PROSENT : MINSTEDAGER_100_PROSENT;
+            var antallDager = 0;
+            if (minsterettAnnenpart) {
+                antallDager = Dekningsgrad._80.equals(dekningsgrad) ? MINSTERETT_BFHR_80_PROSENT : MINSTERETT_BFHR_100_PROSENT;
+            }
+            if (morHarUføretrygd) {
+                antallDager = Dekningsgrad._80.equals(dekningsgrad) ? MINSTEDAGER_UFØRE_80_PROSENT : MINSTEDAGER_UFØRE_100_PROSENT;
+            }
+            if (minsterettAnnenpart) {
+                builder.minsterettDager(antallDager);
+            } else {
+                builder.utenAktivitetskravDager(antallDager);
+            }
         }
-        return 0;
+        return builder;
     }
 }

--- a/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/fastsetteperioder/validering/SaldoValidering.java
+++ b/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/fastsetteperioder/validering/SaldoValidering.java
@@ -43,6 +43,12 @@ public class SaldoValidering implements OverstyrUttakPerioderValidering {
                 throw OverstyrUttakValideringFeil.trekkdagerOverskriderKontoMaksDager();
             }
         }
+        if (saldoUtregning.getMaxDagerMinsterett().merEnn0()) {
+            var restSaldoDagerMinsterett = saldoUtregning.restSaldoMinsterett();
+            if (restSaldoDagerMinsterett.mindreEnn0()) {
+                throw OverstyrUttakValideringFeil.trekkdagerOverskriderKontoMaksDager();
+            }
+        }
     }
 
     public SaldoValideringResultat valider(Stønadskontotype stønadskontoType) {

--- a/domenetjenester/uttak/src/test/java/no/nav/foreldrepenger/domene/uttak/fastsetteperioder/validering/SaldoValideringTest.java
+++ b/domenetjenester/uttak/src/test/java/no/nav/foreldrepenger/domene/uttak/fastsetteperioder/validering/SaldoValideringTest.java
@@ -114,7 +114,21 @@ public class SaldoValideringTest {
         var saldoUtregning = mock(SaldoUtregning.class);
         when(saldoUtregning.negativSaldo(FORELDREPENGER)).thenReturn(false);
         when(saldoUtregning.getMaxDagerUtenAktivitetskrav()).thenReturn(new Trekkdager(10));
+        when(saldoUtregning.getMaxDagerMinsterett()).thenReturn(Trekkdager.ZERO);
         when(saldoUtregning.restSaldoDagerUtenAktivitetskrav()).thenReturn(new Trekkdager(-5));
+        var validering = new SaldoValidering(saldoUtregning, false, false);
+
+        assertThat(validering.valider(FORELDREPENGER).isGyldig()).isTrue();
+        assertThatExceptionOfType(TekniskException.class).isThrownBy(() -> validering.utfør(List.of()));
+    }
+
+    @Test
+    public void ikke_kunne_gå_negativ_på_minsterett() {
+        var saldoUtregning = mock(SaldoUtregning.class);
+        when(saldoUtregning.negativSaldo(FORELDREPENGER)).thenReturn(false);
+        when(saldoUtregning.getMaxDagerUtenAktivitetskrav()).thenReturn(Trekkdager.ZERO);
+        when(saldoUtregning.getMaxDagerMinsterett()).thenReturn(new Trekkdager(10));
+        when(saldoUtregning.restSaldoMinsterett()).thenReturn(new Trekkdager(-5));
         var validering = new SaldoValidering(saldoUtregning, false, false);
 
         assertThat(validering.valider(FORELDREPENGER).isGyldig()).isTrue();

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
         <sha1 />
         <changelist>-SNAPSHOT</changelist>
         <jupiter.version>5.7.2</jupiter.version>
-        <fp-uttak.version>11.5.2</fp-uttak.version>
+        <fp-uttak.version>11.5.3</fp-uttak.version>
         <svp-uttak.version>2.3.1</svp-uttak.version>
         <felles.version>4.1.23</felles.version>
         <prosesstask.version>3.1.7</prosesstask.version>

--- a/pom.xml
+++ b/pom.xml
@@ -40,14 +40,14 @@
         <sha1 />
         <changelist>-SNAPSHOT</changelist>
         <jupiter.version>5.7.2</jupiter.version>
-        <fp-uttak.version>11.4.6</fp-uttak.version>
+        <fp-uttak.version>11.5.2</fp-uttak.version>
         <svp-uttak.version>2.3.1</svp-uttak.version>
         <felles.version>4.1.23</felles.version>
         <prosesstask.version>3.1.7</prosesstask.version>
         <fp-jms.version>2.1.3</fp-jms.version>
 
         <fp-kontrakter.version>6.1.19</fp-kontrakter.version>
-        <fp-tidsserie.version>2.5.8</fp-tidsserie.version>
+        <fp-tidsserie.version>2.6.2</fp-tidsserie.version>
         <fp-nare.version>2.2.2</fp-nare.version>
         <abakus-kontrakt.version>1.3.30</abakus-kontrakt.version>
         <kalkulus.version>1.5.30</kalkulus.version>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -15,7 +15,7 @@
     <name>FPSAK :: Web - Webapp</name>
     <properties>
         <simpleclient.version>0.15.0</simpleclient.version>
-        <swagger-ui.version>4.8.1</swagger-ui.version>
+        <swagger-ui.version>4.9.1</swagger-ui.version>
         <jersey.version>2.35</jersey.version>
     </properties>
     <dependencies>

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/dto/behandling/BehandlingDtoTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/dto/behandling/BehandlingDtoTjeneste.java
@@ -414,6 +414,7 @@ public class BehandlingDtoTjeneste {
                 }
             } else {
                 dto.leggTil(get(UttakRestTjeneste.SAMMENHENGENDE_UTTAK_PATH, "krever-sammenhengende-uttak", uuidDto));
+                dto.leggTil(get(UttakRestTjeneste.UTEN_MINSTERETT_PATH, "uten-minsterett", uuidDto));
                 if (!kontrollerAktivitetskravDtoTjeneste.lagDtos(uuidDto).isEmpty()) {
                     dto.leggTil(get(UttakRestTjeneste.KONTROLLER_AKTIVTETSKRAV_PATH, "uttak-kontroller-aktivitetskrav", uuidDto));
                 }

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/dto/behandling/BehandlingFormidlingDtoTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/dto/behandling/BehandlingFormidlingDtoTjeneste.java
@@ -234,6 +234,7 @@ public class BehandlingFormidlingDtoTjeneste {
                 dto.leggTil(get(FormidlingRestTjeneste.DOKMAL_INNVFP_PATH, "dokmal-innvfp", uuidDto));
                 dto.leggTil(get(FormidlingRestTjeneste.UTSATT_START_PATH, "utsatt-oppstart", uuidDto));
                 dto.leggTil(get(UttakRestTjeneste.SAMMENHENGENDE_UTTAK_PATH, "krever-sammenhengende-uttak", uuidDto));
+                dto.leggTil(get(UttakRestTjeneste.UTEN_MINSTERETT_PATH, "uten-minsterett", uuidDto));
             }
         }
 

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/uttak/UttakRestTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/uttak/UttakRestTjeneste.java
@@ -46,6 +46,7 @@ import no.nav.foreldrepenger.web.app.tjenester.behandling.uttak.dto.KontrollerFa
 import no.nav.foreldrepenger.web.app.tjenester.behandling.uttak.dto.KreverSammenhengendeUttakDto;
 import no.nav.foreldrepenger.web.app.tjenester.behandling.uttak.dto.SaldoerDto;
 import no.nav.foreldrepenger.web.app.tjenester.behandling.uttak.dto.SvangerskapspengerUttakResultatDto;
+import no.nav.foreldrepenger.web.app.tjenester.behandling.uttak.dto.UtenMinsterettDto;
 import no.nav.foreldrepenger.web.app.tjenester.behandling.uttak.dto.UttakPeriodegrenseDto;
 import no.nav.foreldrepenger.web.app.tjenester.behandling.uttak.dto.UttakResultatPerioderDto;
 import no.nav.foreldrepenger.web.server.abac.AppAbacAttributtType;
@@ -78,6 +79,8 @@ public class UttakRestTjeneste {
     public static final String STONADSKONTOER_PATH = BASE_PATH + STONADSKONTOER_PART_PATH;
     private static final String SAMMENHENGENDE_UTTAK_PART_PATH = "/krever-sammenhengende-uttak";
     public static final String SAMMENHENGENDE_UTTAK_PATH = BASE_PATH + SAMMENHENGENDE_UTTAK_PART_PATH;
+    private static final String UTEN_MINSTERETT_PART_PATH = "/uten-minsterett";
+    public static final String UTEN_MINSTERETT_PATH = BASE_PATH + UTEN_MINSTERETT_PART_PATH;
 
     private static final Logger LOG = LoggerFactory.getLogger(UttakRestTjeneste.class);
 
@@ -220,6 +223,18 @@ public class UttakRestTjeneste {
         var behandling = hentBehandling(uuidDto);
         var skjæringstidspunkt = skjæringstidspunktTjeneste.getSkjæringstidspunkter(behandling.getId());
         return new KreverSammenhengendeUttakDto(skjæringstidspunkt.kreverSammenhengendeUttak());
+    }
+
+    @GET
+    @Path(UTEN_MINSTERETT_PART_PATH)
+    @Operation(description = "Gir svar på om behandlingen er uten minsterett iht FAB-direktiv",
+        summary = "Gir svar på om behandlingen er uten minsterett", tags = "uttak")
+    @BeskyttetRessurs(action = READ, resource = FAGSAK)
+    public UtenMinsterettDto utenMinsterett(@TilpassetAbacAttributt(supplierClass = UuidAbacDataSupplier.class)
+                                                                  @NotNull @QueryParam(UuidDto.NAME) @Parameter(description = UuidDto.DESC) @Valid UuidDto uuidDto) {
+        var behandling = hentBehandling(uuidDto);
+        var skjæringstidspunkt = skjæringstidspunktTjeneste.getSkjæringstidspunkter(behandling.getId());
+        return new UtenMinsterettDto(skjæringstidspunkt.utenMinsterett());
     }
 
     private Behandling hentBehandling(UuidDto uuidDto) {

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/uttak/dto/SaldoerDto.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/uttak/dto/SaldoerDto.java
@@ -1,6 +1,5 @@
 package no.nav.foreldrepenger.web.app.tjenester.behandling.uttak.dto;
 
-import java.time.LocalDate;
 import java.util.Map;
 
 import no.nav.foreldrepenger.regler.uttak.felles.grunnlag.Stønadskontotype;
@@ -14,7 +13,8 @@ public record SaldoerDto(Map<SaldoVisningStønadskontoType, StønadskontoDto> st
         FORELDREPENGER,
         FORELDREPENGER_FØR_FØDSEL,
         FLERBARNSDAGER,
-        UTEN_AKTIVITETSKRAV;
+        UTEN_AKTIVITETSKRAV,
+        MINSTERETT;
 
         public static SaldoVisningStønadskontoType fra(Stønadskontotype stønadskontotype) {
             return switch (stønadskontotype) {

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/uttak/dto/UtenMinsterettDto.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/uttak/dto/UtenMinsterettDto.java
@@ -1,0 +1,4 @@
+package no.nav.foreldrepenger.web.app.tjenester.behandling.uttak.dto;
+
+public record UtenMinsterettDto(boolean utenMinsterett) {
+}


### PR DESCRIPTION
@grutkowska en liten utfordring: får du til å se hvordan selvbetjening liker følgende tilfelle

* mor søker først 3uker før fødsel, 15 uker mødrekvote, 16 uker fellesperiode + 17 uker fellesperiode/flerbarn/ikkeSamtidig
* far søker så samtidig med de 17 ukene: 4 uker fellesperiode/flerbarn/samtidig + 13 uker fedrekvote/samtidig og så 2 uker fedrekvote/ikkeSamtidig
* berørt på mor innvilger 13 av de 17 ukene fellesperiode/flerbarn/ikkeSamtidig og avslår de 4 siste (tom på konto)

Hvordan oppfører endringssøknad for mor seg når det innvilget 13 uker fellesperiode/flerbarn uten avkryssing for samtidig uttak - mens far tar ut 4uker fellesperiode/flerbarn og 11 uker fedrekvote og har valgt samtidig for alle.