### PR TITLE
Fix: Bruker text block i testen til å unngå å hardkode nl\cr manuelt.

### DIFF
--- a/domenetjenester/dokumentbestiller/src/test/java/no/nav/foreldrepenger/dokumentbestiller/dto/BestillBrevDtoTest.java
+++ b/domenetjenester/dokumentbestiller/src/test/java/no/nav/foreldrepenger/dokumentbestiller/dto/BestillBrevDtoTest.java
@@ -1,6 +1,6 @@
 package no.nav.foreldrepenger.dokumentbestiller.dto;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.UUID;
 
@@ -14,13 +14,18 @@ class BestillBrevDtoTest {
 
     @Test
     void deserialize() {
-        var dokumentMalType = DokumentMalType.FRITEKSTBREV;
+        var dokumentMal = DokumentMalType.FRITEKSTBREV;
         var årsak = RevurderingVarslingÅrsak.BARN_IKKE_REGISTRERT_FOLKEREGISTER;
 
-        String json = "{\"brevmalkode\":\"" + dokumentMalType.getKode() + "\",\"navn\":\"sdf\",\"arsakskode\":\"" + årsak.getKode() + "\"}";
+        String json = """
+        {
+            "brevmalkode":"%s",
+            "navn":"sdf",
+            "arsakskode":"%s"
+        }""".formatted(dokumentMal.getKode(), årsak.getKode());
 
         BestillBrevDto bean = StandardJsonConfig.fromJson(json, BestillBrevDto.class);
-        assertEquals(dokumentMalType, bean.getBrevmalkode());
+        assertEquals(dokumentMal, bean.getBrevmalkode());
         assertEquals(årsak, bean.getÅrsakskode());
     }
 
@@ -28,13 +33,18 @@ class BestillBrevDtoTest {
     void serialize() {
         var behandlingId = 12L;
         var uuid = "5ffbf59b-76d5-4c78-bd27-6c84e0d445a3";
-        var dokumentMalType = DokumentMalType.FRITEKSTBREV;
+        var dokumentMal = DokumentMalType.FRITEKSTBREV;
         var arsak = RevurderingVarslingÅrsak.BARN_IKKE_REGISTRERT_FOLKEREGISTER;
 
-        String expected = "{\n" + "  \"behandlingId\" : " + behandlingId + ",\n" + "  \"behandlingUuid\" : \"" + uuid +"\",\n"
-            + "  \"brevmalkode\" : \"" + dokumentMalType.getKode() + "\",\n" + "  \"arsakskode\" : \"" + arsak.getKode() + "\"\n" + "}";
+        String expected = """
+                             {
+                               "behandlingId" : %s,
+                               "behandlingUuid" : "%s",
+                               "brevmalkode" : "%s",
+                               "arsakskode" : "%s"
+                             }""".formatted(behandlingId, uuid, dokumentMal.getKode(), arsak.getKode());
 
-        var brev = new BestillBrevDto(behandlingId, UUID.fromString(uuid), dokumentMalType, null, arsak);
+        var brev = new BestillBrevDto(behandlingId, UUID.fromString(uuid), dokumentMal, null, arsak);
         var serialized = StandardJsonConfig.toJson(brev);
         assertEquals(expected, serialized);
     }

--- a/domenetjenester/dokumentbestiller/src/test/java/no/nav/foreldrepenger/dokumentbestiller/dto/BestillBrevDtoTest.java
+++ b/domenetjenester/dokumentbestiller/src/test/java/no/nav/foreldrepenger/dokumentbestiller/dto/BestillBrevDtoTest.java
@@ -1,10 +1,12 @@
 package no.nav.foreldrepenger.dokumentbestiller.dto;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.condition.OS.WINDOWS;
 
 import java.util.UUID;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
 
 import no.nav.foreldrepenger.behandlingslager.behandling.RevurderingVarslingÅrsak;
 import no.nav.foreldrepenger.dokumentbestiller.DokumentMalType;
@@ -30,6 +32,7 @@ class BestillBrevDtoTest {
     }
 
     @Test
+    @DisabledOnOs(WINDOWS)
     void serialize() {
         var behandlingId = 12L;
         var uuid = "5ffbf59b-76d5-4c78-bd27-6c84e0d445a3";


### PR DESCRIPTION
Ble meldt at testen har feilet på Windows maskiner.