### PR TITLE
Tester bruker FRI som i prod og FAB fra samme dato i 2021

### DIFF
--- a/web/src/main/resources/application-dev-fss.properties
+++ b/web/src/main/resources/application-dev-fss.properties
@@ -1,3 +1,6 @@
+# Dato for FAB
+dato.for.minsterett.forste=2022-01-01
+
 loadbalancer.url=https://app-q1.adeo.no
 
 OpenIdConnect.username=fpsak-q1

--- a/web/src/test/resources/application-local.properties
+++ b/web/src/test/resources/application-local.properties
@@ -100,10 +100,9 @@ fprisk.url=http://localhost:8075/fprisk
 application.name=fpsak
 environment.name=devimg
 loadbalancer.url=http://localhost:8080
-dato.for.nye.beregningsregler=2010-01-01
 
-# Dato for nye uttaksregler
-dato.for.nye.uttaksregler = 2020-01-01
+## WLB / FAB fase 1
+dato.for.minsterett.forste=2021-10-01
 
 # Auditlogger
 auditlogger.enabled=false


### PR DESCRIPTION
Sett dato for FRI til default i prod, dvs 2021-10-01
Setter FAB til samme dato.
Konfig for beregningsregler var ikke i bruk i fpsak (men i fordel og kalkulus)