### PR TITLE
TFP-4982 ikke berørt dersom FAB samtidig uttak rundt fødsel

### DIFF
--- a/domenetjenester/behandling-revurdering/src/test/java/no/nav/foreldrepenger/behandling/revurdering/BerørtBehandlingTjenesteTest.java
+++ b/domenetjenester/behandling-revurdering/src/test/java/no/nav/foreldrepenger/behandling/revurdering/BerørtBehandlingTjenesteTest.java
@@ -36,6 +36,7 @@ import no.nav.foreldrepenger.behandlingslager.uttak.fp.StønadskontoType;
 import no.nav.foreldrepenger.behandlingslager.uttak.fp.Trekkdager;
 import no.nav.foreldrepenger.behandlingslager.uttak.fp.UttakUtsettelseType;
 import no.nav.foreldrepenger.dbstoette.FPsakEntityManagerAwareExtension;
+import no.nav.foreldrepenger.domene.tid.VirkedagUtil;
 import no.nav.foreldrepenger.domene.uttak.ForeldrepengerUttak;
 import no.nav.foreldrepenger.domene.uttak.ForeldrepengerUttakAktivitet;
 import no.nav.foreldrepenger.domene.uttak.ForeldrepengerUttakPeriode;
@@ -144,14 +145,30 @@ class BerørtBehandlingTjenesteTest {
         return uttakInput;
     }
 
-    private UttakInput lagUttakInput(Behandling behandling, boolean kreverSammenhengendeUttak) {
+    private UttakInput lagUttakInputSammenhengendeUttak(Behandling behandling) {
         var fødselsdato = repositoryProvider.getFamilieHendelseRepository()
             .hentAggregat(behandling.getId())
             .getGjeldendeVersjon()
             .getFødselsdato().orElse(null);
         var stp = Skjæringstidspunkt.builder()
             .medUtledetSkjæringstidspunkt(fødselsdato)
-            .medKreverSammenhengendeUttak(kreverSammenhengendeUttak);
+            .medUtenMinsterett(true)
+            .medKreverSammenhengendeUttak(true);
+        var fpGrunnlag = new ForeldrepengerGrunnlag()
+            .medFamilieHendelser(new FamilieHendelser().medBekreftetHendelse(FamilieHendelse.forFødsel(null, fødselsdato, List.of(new Barn()), 1)));
+        var uttakInput = new UttakInput(BehandlingReferanse.fra(behandling, stp.build()), null, fpGrunnlag);
+        when(uttakInputTjeneste.lagInput(behandling.getId())).thenReturn(uttakInput);
+        return uttakInput;
+    }
+
+    private UttakInput lagUttakInputUtenMinsterett(Behandling behandling) {
+        var fødselsdato = repositoryProvider.getFamilieHendelseRepository()
+            .hentAggregat(behandling.getId())
+            .getGjeldendeVersjon()
+            .getFødselsdato().orElse(null);
+        var stp = Skjæringstidspunkt.builder()
+            .medUtledetSkjæringstidspunkt(fødselsdato)
+            .medUtenMinsterett(true);
         var fpGrunnlag = new ForeldrepengerGrunnlag()
             .medFamilieHendelser(new FamilieHendelser().medBekreftetHendelse(FamilieHendelse.forFødsel(null, fødselsdato, List.of(new Barn()), 1)));
         var uttakInput = new UttakInput(BehandlingReferanse.fra(behandling, stp.build()), null, fpGrunnlag);
@@ -352,13 +369,157 @@ class BerørtBehandlingTjenesteTest {
     }
 
     @Test
+    public void ikke_berørt_behandling_dersom_overlapp_kun_i_forbindelse_med_fødsel() {
+        var startDatoMor = VirkedagUtil.fomVirkedag(LocalDate.now());
+        var startDatoFar = startDatoMor;
+
+        var farBehandling = opprettBehandlingFar(startDatoMor);
+        var morBehandling = ScenarioMorSøkerForeldrepenger.forFødsel().medFødselAdopsjonsdato(startDatoMor).lagre(repositoryProvider);
+
+        lagUttakInput(farBehandling);
+
+        var morsPeriode = new ForeldrepengerUttakPeriode.Builder()
+            .medTidsperiode(startDatoMor, startDatoMor.plusWeeks(15).minusDays(1))
+            .medResultatÅrsak(PeriodeResultatÅrsak.KVOTE_ELLER_OVERFØRT_KVOTE)
+            .medAktiviteter(List.of(uttakPeriodeAktivitet(StønadskontoType.MØDREKVOTE)))
+            .build();
+        var farsFørstePeriode = new ForeldrepengerUttakPeriode.Builder()
+            .medTidsperiode(startDatoFar, startDatoFar.plusWeeks(1).minusDays(1))
+            .medResultatÅrsak(PeriodeResultatÅrsak.KVOTE_ELLER_OVERFØRT_KVOTE)
+            .medAktiviteter(List.of(uttakPeriodeAktivitet(StønadskontoType.FEDREKVOTE)))
+            .medSamtidigUttak(true)
+            .build();
+        var farsAndrePeriode = new ForeldrepengerUttakPeriode.Builder()
+            .medTidsperiode(startDatoFar.plusWeeks(15), startDatoFar.plusWeeks(17).minusDays(1))
+            .medResultatÅrsak(PeriodeResultatÅrsak.KVOTE_ELLER_OVERFØRT_KVOTE)
+            .medAktiviteter(List.of(uttakPeriodeAktivitet(StønadskontoType.FEDREKVOTE)))
+            .build();
+        var morUttak = new ForeldrepengerUttak(List.of(morsPeriode));
+        lagreUttak(morBehandling, morUttak);
+
+        var farUttak = new ForeldrepengerUttak(List.of(farsFørstePeriode, farsAndrePeriode));
+        lagreUttak(farBehandling, farUttak);
+
+        var resultat = skalBerørtOpprettes(farBehandling, morBehandling);
+        assertThat(resultat).isFalse();
+    }
+
+    @Test
+    public void berørt_behandling_dersom_overlapp_kun_i_forbindelse_med_fødsel_men_ikke_samtidig_uttak() {
+        var startDatoMor = VirkedagUtil.fomVirkedag(LocalDate.now());
+        var startDatoFar = startDatoMor;
+
+        var farBehandling = opprettBehandlingFar(startDatoMor);
+        var morBehandling = ScenarioMorSøkerForeldrepenger.forFødsel().medFødselAdopsjonsdato(startDatoMor).lagre(repositoryProvider);
+
+        lagUttakInput(farBehandling);
+
+        var morsPeriode = new ForeldrepengerUttakPeriode.Builder()
+            .medTidsperiode(startDatoMor, startDatoMor.plusWeeks(15).minusDays(1))
+            .medResultatÅrsak(PeriodeResultatÅrsak.KVOTE_ELLER_OVERFØRT_KVOTE)
+            .medAktiviteter(List.of(uttakPeriodeAktivitet(StønadskontoType.MØDREKVOTE)))
+            .build();
+        var farsFørstePeriode = new ForeldrepengerUttakPeriode.Builder()
+            .medTidsperiode(startDatoFar, startDatoFar.plusWeeks(1).minusDays(1))
+            .medResultatÅrsak(PeriodeResultatÅrsak.KVOTE_ELLER_OVERFØRT_KVOTE)
+            .medAktiviteter(List.of(uttakPeriodeAktivitet(StønadskontoType.FEDREKVOTE)))
+            .build();
+        var farsAndrePeriode = new ForeldrepengerUttakPeriode.Builder()
+            .medTidsperiode(startDatoFar.plusWeeks(15), startDatoFar.plusWeeks(17).minusDays(1))
+            .medResultatÅrsak(PeriodeResultatÅrsak.KVOTE_ELLER_OVERFØRT_KVOTE)
+            .medAktiviteter(List.of(uttakPeriodeAktivitet(StønadskontoType.FEDREKVOTE)))
+            .build();
+        var morUttak = new ForeldrepengerUttak(List.of(morsPeriode));
+        lagreUttak(morBehandling, morUttak);
+
+        var farUttak = new ForeldrepengerUttak(List.of(farsFørstePeriode, farsAndrePeriode));
+        lagreUttak(farBehandling, farUttak);
+
+        var resultat = skalBerørtOpprettes(farBehandling, morBehandling);
+        assertThat(resultat).isTrue();
+    }
+
+    @Test
+    public void berørt_behandling_dersom_overlapp_kun_i_forbindelse_med_fødsel_men_ikke_FAB() {
+        var startDatoMor = VirkedagUtil.fomVirkedag(LocalDate.of(2021, 11, 1));
+        var startDatoFar = startDatoMor;
+
+        var farBehandling = opprettBehandlingFar(startDatoMor);
+        var morBehandling = ScenarioMorSøkerForeldrepenger.forFødsel().medFødselAdopsjonsdato(startDatoMor).lagre(repositoryProvider);
+
+        lagUttakInputUtenMinsterett(farBehandling);
+
+        var morsPeriode = new ForeldrepengerUttakPeriode.Builder()
+            .medTidsperiode(startDatoMor, startDatoMor.plusWeeks(15).minusDays(1))
+            .medResultatÅrsak(PeriodeResultatÅrsak.KVOTE_ELLER_OVERFØRT_KVOTE)
+            .medAktiviteter(List.of(uttakPeriodeAktivitet(StønadskontoType.MØDREKVOTE)))
+            .build();
+        var farsFørstePeriode = new ForeldrepengerUttakPeriode.Builder()
+            .medTidsperiode(startDatoFar, startDatoFar.plusWeeks(1).minusDays(1))
+            .medResultatÅrsak(PeriodeResultatÅrsak.KVOTE_ELLER_OVERFØRT_KVOTE)
+            .medAktiviteter(List.of(uttakPeriodeAktivitet(StønadskontoType.FEDREKVOTE)))
+            .medSamtidigUttak(true)
+            .build();
+        var farsAndrePeriode = new ForeldrepengerUttakPeriode.Builder()
+            .medTidsperiode(startDatoFar.plusWeeks(15), startDatoFar.plusWeeks(17).minusDays(1))
+            .medResultatÅrsak(PeriodeResultatÅrsak.KVOTE_ELLER_OVERFØRT_KVOTE)
+            .medAktiviteter(List.of(uttakPeriodeAktivitet(StønadskontoType.FEDREKVOTE)))
+            .build();
+        var morUttak = new ForeldrepengerUttak(List.of(morsPeriode));
+        lagreUttak(morBehandling, morUttak);
+
+        var farUttak = new ForeldrepengerUttak(List.of(farsFørstePeriode, farsAndrePeriode));
+        lagreUttak(farBehandling, farUttak);
+
+        var resultat = skalBerørtOpprettes(farBehandling, morBehandling);
+        assertThat(resultat).isTrue();
+    }
+
+    @Test
+    public void berørt_behandling_dersom_overlapp_i_forbindelse_med_fødsel_og_senere() {
+        var startDatoMor = VirkedagUtil.fomVirkedag(LocalDate.now());
+        var startDatoFar = startDatoMor;
+
+        var farBehandling = opprettBehandlingFar(startDatoMor);
+        var morBehandling = ScenarioMorSøkerForeldrepenger.forFødsel().medFødselAdopsjonsdato(startDatoMor).lagre(repositoryProvider);
+
+        lagUttakInput(farBehandling);
+
+        var morsPeriode = new ForeldrepengerUttakPeriode.Builder()
+            .medTidsperiode(startDatoMor, startDatoMor.plusWeeks(15).minusDays(1))
+            .medResultatÅrsak(PeriodeResultatÅrsak.KVOTE_ELLER_OVERFØRT_KVOTE)
+            .medAktiviteter(List.of(uttakPeriodeAktivitet(StønadskontoType.MØDREKVOTE)))
+            .build();
+        var farsFørstePeriode = new ForeldrepengerUttakPeriode.Builder()
+            .medTidsperiode(startDatoFar, startDatoFar.plusWeeks(1).minusDays(1))
+            .medResultatÅrsak(PeriodeResultatÅrsak.KVOTE_ELLER_OVERFØRT_KVOTE)
+            .medAktiviteter(List.of(uttakPeriodeAktivitet(StønadskontoType.FEDREKVOTE)))
+            .medSamtidigUttak(true)
+            .build();
+        var farsAndrePeriode = new ForeldrepengerUttakPeriode.Builder()
+            .medTidsperiode(startDatoFar.plusWeeks(14), startDatoFar.plusWeeks(17).minusDays(1))
+            .medResultatÅrsak(PeriodeResultatÅrsak.KVOTE_ELLER_OVERFØRT_KVOTE)
+            .medAktiviteter(List.of(uttakPeriodeAktivitet(StønadskontoType.FEDREKVOTE)))
+            .build();
+        var morUttak = new ForeldrepengerUttak(List.of(morsPeriode));
+        lagreUttak(morBehandling, morUttak);
+
+        var farUttak = new ForeldrepengerUttak(List.of(farsFørstePeriode, farsAndrePeriode));
+        lagreUttak(farBehandling, farUttak);
+
+        var resultat = skalBerørtOpprettes(farBehandling, morBehandling);
+        assertThat(resultat).isTrue();
+    }
+
+    @Test
     public void berørt_behandling_hvis_et_avslag_fører_til_hull_felles_plan() {
         var startDatoMor = LocalDate.of(2020, 1, 1);
 
         var farBehandling = opprettBehandlingFar(startDatoMor);
         var morBehandling = ScenarioMorSøkerForeldrepenger.forFødsel().lagre(repositoryProvider);
 
-        lagUttakInput(farBehandling, true);
+
+        lagUttakInputSammenhengendeUttak(farBehandling);
 
         var morsFørstePeriode = new ForeldrepengerUttakPeriode.Builder()
             .medTidsperiode(startDatoMor, startDatoMor.plusWeeks(1))
@@ -401,7 +562,7 @@ class BerørtBehandlingTjenesteTest {
             .medFødselAdopsjonsdato(fødselsdato)
             .lagre(repositoryProvider);
 
-        lagUttakInput(farBehandling, false);
+        lagUttakInput(farBehandling);
 
         var morsFørstePeriode = new ForeldrepengerUttakPeriode.Builder()
             .medTidsperiode(fødselsdato, friPeriodeStart.minusDays(1))
@@ -515,7 +676,7 @@ class BerørtBehandlingTjenesteTest {
         var farBehandling = opprettBehandlingFar(startDatoMor);
         var morBehandling = ScenarioMorSøkerForeldrepenger.forFødsel().lagre(repositoryProvider);
 
-        lagUttakInput(farBehandling, true);
+        lagUttakInputSammenhengendeUttak(farBehandling);
 
         var morsFørstePeriode = new ForeldrepengerUttakPeriode.Builder()
             .medTidsperiode(startDatoMor, startDatoMor.plusWeeks(7))

--- a/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/TidsperiodeFarRundtFødsel.java
+++ b/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/TidsperiodeFarRundtFødsel.java
@@ -1,0 +1,24 @@
+package no.nav.foreldrepenger.domene.uttak;
+
+import java.util.Optional;
+
+import no.nav.foreldrepenger.domene.uttak.fastsetteperioder.grunnlagbyggere.DatoerGrunnlagBygger;
+import no.nav.foreldrepenger.domene.uttak.fastsetteperioder.grunnlagbyggere.KontoerGrunnlagBygger;
+import no.nav.foreldrepenger.domene.uttak.fastsetteperioder.grunnlagbyggere.SøknadGrunnlagBygger;
+import no.nav.foreldrepenger.domene.uttak.input.UttakInput;
+import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.FarUttakRundtFødsel;
+import no.nav.foreldrepenger.regler.uttak.konfig.StandardKonfigurasjon;
+import no.nav.fpsak.tidsserie.LocalDateInterval;
+
+public final class TidsperiodeFarRundtFødsel {
+
+
+    public static Optional<LocalDateInterval> intervallFarRundtFødsel(UttakInput uttakInput) {
+        var datoer = DatoerGrunnlagBygger.byggForenkletGrunnlagKunFamiliehendelse(uttakInput);
+        var type = SøknadGrunnlagBygger.type(uttakInput.getYtelsespesifiktGrunnlag());
+        var kontoerKunMinsterett = KontoerGrunnlagBygger.byggKunRettighetFarUttakRundtFødsel(uttakInput.getBehandlingReferanse());
+        return FarUttakRundtFødsel.utledFarsPeriodeRundtFødsel(datoer.build(), kontoerKunMinsterett.build(), type, StandardKonfigurasjon.KONFIGURASJON)
+            .map(p -> new LocalDateInterval(p.getFom(), p.getTom()));
+
+    }
+}

--- a/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/fastsetteperioder/grunnlagbyggere/KontoerGrunnlagBygger.java
+++ b/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/fastsetteperioder/grunnlagbyggere/KontoerGrunnlagBygger.java
@@ -64,6 +64,14 @@ public class KontoerGrunnlagBygger {
             .collect(Collectors.toList()));
     }
 
+    public static Kontoer.Builder byggKunRettighetFarUttakRundtFødsel(BehandlingReferanse ref) {
+        if (ref.getSkjæringstidspunkt().utenMinsterett()) {
+            return new Kontoer.Builder();
+        } else {
+            return new Kontoer.Builder().farUttakRundtFødselDager(UTTAK_RUNDT_FØDSEL_DAGER);
+        }
+    }
+
     private Konto.Builder map(Stønadskonto stønadskonto) {
         return new Konto.Builder()
             .trekkdager(stønadskonto.getMaxDager())

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
         <fp-jms.version>2.1.3</fp-jms.version>
 
         <fp-kontrakter.version>6.1.19</fp-kontrakter.version>
-        <fp-tidsserie.version>2.6.2</fp-tidsserie.version>
+        <fp-tidsserie.version>2.6.3</fp-tidsserie.version>
         <fp-nare.version>2.2.2</fp-nare.version>
         <abakus-kontrakt.version>1.3.30</abakus-kontrakt.version>
         <kalkulus.version>1.5.34</kalkulus.version>


### PR DESCRIPTION
Logikk: tar perioder med overlapp. Finner periode rundt fødsel med søkt samtidig uttak. 
Ikke berørt dersom eneste overlappsperiode er den rundt fødsel med samtidig uttak.