### PR TITLE
TFP-4976 justering etter utilsiktet feil

### DIFF
--- a/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/fastsetteperioder/grunnlagbyggere/KontoerGrunnlagBygger.java
+++ b/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/fastsetteperioder/grunnlagbyggere/KontoerGrunnlagBygger.java
@@ -128,9 +128,7 @@ public class KontoerGrunnlagBygger {
             }
             if (minsterett) {
                 builder.minsterettDager(antallDager);
-                if (!erMor) {
-                    builder.farUttakRundtFødselDager(UTTAK_RUNDT_FØDSEL_DAGER);
-                }
+                builder.farUttakRundtFødselDager(UTTAK_RUNDT_FØDSEL_DAGER); // Settes for begge. Brukes ifm berørt for begge og fakta uttak for far.
             } else {
                 builder.utenAktivitetskravDager(antallDager);
             }

--- a/domenetjenester/uttak/src/test/java/no/nav/foreldrepenger/domene/uttak/fakta/uttakperioder/AvklarFaktaUttakPerioderTjenesteTest.java
+++ b/domenetjenester/uttak/src/test/java/no/nav/foreldrepenger/domene/uttak/fakta/uttakperioder/AvklarFaktaUttakPerioderTjenesteTest.java
@@ -51,7 +51,7 @@ public class AvklarFaktaUttakPerioderTjenesteTest {
     public void skal_hente_kontroller_fakta_perioder_med_bekreftelse_far_aleneomsorg() {
         var fom = LocalDate.of(2021, 12, 1);
         var søknadsperiode = OppgittPeriodeBuilder.ny()
-            .medPeriodeType(UttakPeriodeType.FEDREKVOTE)
+            .medPeriodeType(UttakPeriodeType.FORELDREPENGER)
             .medPeriode(fom, fom.plusWeeks(2))
             .medPeriodeKilde(FordelingPeriodeKilde.SØKNAD)
             .build();

--- a/domenetjenester/uttak/src/test/java/no/nav/foreldrepenger/domene/uttak/fakta/uttakperioder/SøknadsperiodeDokKontrollererFamArbBalanseTest.java
+++ b/domenetjenester/uttak/src/test/java/no/nav/foreldrepenger/domene/uttak/fakta/uttakperioder/SøknadsperiodeDokKontrollererFamArbBalanseTest.java
@@ -8,6 +8,7 @@ import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
 
+import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.MorsAktivitet;
 import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.periode.OppgittPeriodeBuilder;
 import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.periode.UttakPeriodeType;
 import no.nav.fpsak.tidsserie.LocalDateInterval;
@@ -20,6 +21,7 @@ public class SøknadsperiodeDokKontrollererFamArbBalanseTest {
     public void farEllerMedmorSøktOmUttakRundtFødsel() {
         var oppgittPeriode = OppgittPeriodeBuilder.ny()
             .medPeriodeType(UttakPeriodeType.FEDREKVOTE)
+            .medSamtidigUttak(true)
             .medPeriode(FOM, FOM.plusWeeks(2).minusDays(3))
             .build();
 
@@ -37,6 +39,7 @@ public class SøknadsperiodeDokKontrollererFamArbBalanseTest {
     public void farEllerMedmorSøktOmUttakRundtFødselForLangPeriode() {
         var oppgittPeriode = OppgittPeriodeBuilder.ny()
             .medPeriodeType(UttakPeriodeType.FEDREKVOTE)
+            .medSamtidigUttak(true)
             .medPeriode(FOM, FOM.plusWeeks(3))
             .build();
 
@@ -50,5 +53,40 @@ public class SøknadsperiodeDokKontrollererFamArbBalanseTest {
         assertThat(kontrollerFaktaPeriode.isTidligOppstart()).isTrue();
     }
 
+    @Test
+    public void bfhrSøktOmUttakRundtFødselMorTrengerHjelp() {
+        var oppgittPeriode = OppgittPeriodeBuilder.ny()
+            .medPeriodeType(UttakPeriodeType.FORELDREPENGER)
+            .medMorsAktivitet(MorsAktivitet.TRENGER_HJELP)
+            .medPeriode(FOM, FOM.plusWeeks(2).minusDays(3))
+            .build();
+
+        var fødselsDatoTilTidligOppstart = FOM;
+        var kontrollerer = new SøknadsperiodeDokKontrollerer(List.of(), fødselsDatoTilTidligOppstart,
+            new UtsettelseDokKontrollererFrittUttak(fødselsDatoTilTidligOppstart), List.of(),
+            Optional.of(new LocalDateInterval(FOM, FOM.plusWeeks(2).minusDays(1))));
+
+        var kontrollerFaktaPeriode = kontrollerer.kontrollerSøknadsperiode(oppgittPeriode);
+        assertThat(kontrollerFaktaPeriode.erBekreftet()).isFalse();
+        assertThat(kontrollerFaktaPeriode.isTidligOppstart()).isTrue();
+    }
+
+    @Test
+    public void bfhrSøktOmUttakRundtFødselMorUfør() {
+        var oppgittPeriode = OppgittPeriodeBuilder.ny()
+            .medPeriodeType(UttakPeriodeType.FORELDREPENGER)
+            .medMorsAktivitet(MorsAktivitet.UFØRE)
+            .medPeriode(FOM, FOM.plusWeeks(2).minusDays(3))
+            .build();
+
+        var fødselsDatoTilTidligOppstart = FOM;
+        var kontrollerer = new SøknadsperiodeDokKontrollerer(List.of(), fødselsDatoTilTidligOppstart,
+            new UtsettelseDokKontrollererFrittUttak(fødselsDatoTilTidligOppstart), List.of(),
+            Optional.of(new LocalDateInterval(FOM, FOM.plusWeeks(2).minusDays(1))));
+
+        var kontrollerFaktaPeriode = kontrollerer.kontrollerSøknadsperiode(oppgittPeriode);
+        assertThat(kontrollerFaktaPeriode.erBekreftet()).isTrue();
+        assertThat(kontrollerFaktaPeriode.isTidligOppstart()).isFalse();
+    }
 
 }


### PR DESCRIPTION
Trenger farUttakRundtFødselDager() satt for begge parter for at berørt skal fungere.
Fakta uttak bruker infrastruktur for å sjekke om far/medmor og presiserer tilfelle som kan autogodkjennes