### PR TITLE
TFP-5000 ikke utlede aleneomsorg-aksjonspunkt i revurderinger

### DIFF
--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/kabal/KabalHendelseStream.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/kabal/KabalHendelseStream.java
@@ -79,7 +79,7 @@ public class KabalHendelseStream implements LivenessAware, ReadinessAware, AppSe
 
     @Override
     public boolean isAlive() {
-        return true; //(stream != null) && stream.state().isRunningOrRebalancing();
+        return !isDeployment || (stream != null && stream.state().isRunningOrRebalancing());
     }
 
     @Override

--- a/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/fakta/omsorg/BrukerHarAleneomsorgAksjonspunktUtleder.java
+++ b/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/fakta/omsorg/BrukerHarAleneomsorgAksjonspunktUtleder.java
@@ -9,6 +9,7 @@ import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
 import no.nav.foreldrepenger.behandlingskontroll.FagsakYtelseTypeRef;
+import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingType;
 import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.AksjonspunktDefinisjon;
 import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.YtelseFordelingAggregat;
 import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.YtelsesFordelingRepository;
@@ -41,6 +42,11 @@ public class BrukerHarAleneomsorgAksjonspunktUtleder implements FaktaUttakAksjon
     @Override
     public List<AksjonspunktDefinisjon> utledAksjonspunkterFor(UttakInput input) {
         var ref = input.getBehandlingReferanse();
+
+        if (!Objects.equals(ref.behandlingType(), BehandlingType.FØRSTEGANGSSØKNAD)) {
+            return List.of();
+        }
+
         var ytelseFordelingAggregat = ytelsesFordelingRepository.hentAggregat(ref.behandlingId());
 
         if (harOppgittÅHaAleneomsorg(ytelseFordelingAggregat)) {


### PR DESCRIPTION
Slutte å utlede 5060 for revurderinger (sbh referer uansett bare til 1gang)

+ kabal er blitt prod-safe