### PR TITLE
Fjerne legacy mors aktivitet

### DIFF
--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/ytelsefordeling/MorsAktivitet.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/ytelsefordeling/MorsAktivitet.java
@@ -3,6 +3,7 @@ package no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Set;
 
 import javax.persistence.AttributeConverter;
 import javax.persistence.Converter;
@@ -17,7 +18,6 @@ public enum MorsAktivitet implements Kodeverdi {
     UDEFINERT("-", "Ikke satt eller valgt kode"),
     ARBEID("ARBEID", "Er i arbeid"),
     UTDANNING("UTDANNING", "Tar utdanning på heltid"),
-    SAMTIDIGUTTAK("SAMTIDIGUTTAK", "Samtidig uttak flerbarnsfødsel"),
     KVALPROG("KVALPROG", "Deltar i kvalifiseringsprogrammet"),
     INTROPROG("INTROPROG", "Deltar i introduksjonsprogram for nykomne innvandrere"),
     TRENGER_HJELP("TRENGER_HJELP", "Er avhengig av hjelp til å ta seg av barnet"),
@@ -27,6 +27,8 @@ public enum MorsAktivitet implements Kodeverdi {
     IKKE_OPPGITT("IKKE_OPPGITT", "Periode uten oppgitt aktivitetskrav"),
     ;
     private static final Map<String, MorsAktivitet> KODER = new LinkedHashMap<>();
+
+    private static final Set<String> LEGACY_KODER = Set.of("SAMTIDIGUTTAK");
 
     public static final String KODEVERK = "MORS_AKTIVITET";
 
@@ -54,6 +56,9 @@ public enum MorsAktivitet implements Kodeverdi {
         }
         var ad = KODER.get(kode);
         if (ad == null) {
+            if (LEGACY_KODER.contains(kode)) {
+                return IKKE_OPPGITT;
+            }
             throw new IllegalArgumentException("Ukjent MorsAktivitet: " + kode);
         }
         return ad;

--- a/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/UttakEnumMapper.java
+++ b/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/UttakEnumMapper.java
@@ -222,7 +222,7 @@ public final class UttakEnumMapper {
 
     public static no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.MorsAktivitet map(MorsAktivitet morsAktivitet) {
         //Ikke relevant for regler
-        if (Set.of(MorsAktivitet.UDEFINERT, MorsAktivitet.SAMTIDIGUTTAK, MorsAktivitet.IKKE_OPPGITT).contains(morsAktivitet)) {
+        if (Set.of(MorsAktivitet.UDEFINERT, MorsAktivitet.IKKE_OPPGITT).contains(morsAktivitet)) {
             return null;
         }
         return MORS_AKTIVITET_MAPPER

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/registrering/fp/ManuellRegistreringSøknadValidator.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/registrering/fp/ManuellRegistreringSøknadValidator.java
@@ -72,7 +72,7 @@ public class ManuellRegistreringSøknadValidator {
             .map(TidsromPermisjonDto::getPermisjonsPerioder).orElse(List.of()).stream()
             .filter(p -> Set.of(UttakPeriodeType.FELLESPERIODE, UttakPeriodeType.FORELDREPENGER).contains(p.getPeriodeType()))
             .filter(p -> !p.isFlerbarnsdager())
-            .anyMatch(p -> p.getMorsAktivitet() == null || MorsAktivitet.UDEFINERT.equals(p.getMorsAktivitet()) || MorsAktivitet.SAMTIDIGUTTAK.equals(p.getMorsAktivitet()));
+            .anyMatch(p -> p.getMorsAktivitet() == null || MorsAktivitet.UDEFINERT.equals(p.getMorsAktivitet()));
         return manglerMorsAktivitet ? List.of(new FeltFeilDto("morsAktivitet", MANGLER_MORS_AKTIVITET)) : List.of();
     }
 

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/registrering/fp/YtelseSøknadMapper.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/registrering/fp/YtelseSøknadMapper.java
@@ -178,13 +178,11 @@ public class YtelseSøknadMapper implements SøknadMapper {
         uttaksperiodetyper.setKode(dto.getPeriodeType().getKode());
         uttaksperiode.setType(uttaksperiodetyper);
 
-        Optional.ofNullable(dto.getMorsAktivitet())
-            .filter(ma -> ma.getKode() != null && !ma.getKode().isEmpty() && !MorsAktivitet.SAMTIDIGUTTAK.equals(ma))
-            .ifPresent(ma -> {
-                var morsAktivitetsTyper = new MorsAktivitetsTyper();
-                morsAktivitetsTyper.setKode(ma.getKode());
-                uttaksperiode.setMorsAktivitetIPerioden(morsAktivitetsTyper);
-            });
+        Optional.ofNullable(dto.getMorsAktivitet()).ifPresent(ma -> {
+            var morsAktivitetsTyper = new MorsAktivitetsTyper();
+            morsAktivitetsTyper.setKode(ma.getKode());
+            uttaksperiode.setMorsAktivitetIPerioden(morsAktivitetsTyper);
+        });
 
         return uttaksperiode;
     }
@@ -275,13 +273,11 @@ public class YtelseSøknadMapper implements SøknadMapper {
         }
         utsettelsesperiode.setFom(utsettelserDto.getPeriodeFom());
         utsettelsesperiode.setTom(utsettelserDto.getPeriodeTom());
-        Optional.ofNullable(utsettelserDto.getMorsAktivitet())
-            .filter(ma -> !MorsAktivitet.SAMTIDIGUTTAK.equals(ma))
-            .ifPresent(ma -> {
-                var morsAktivitetsTyper = new MorsAktivitetsTyper();
-                morsAktivitetsTyper.setKode(ma.getKode());
-                utsettelsesperiode.setMorsAktivitetIPerioden(morsAktivitetsTyper);
-            });
+        Optional.ofNullable(utsettelserDto.getMorsAktivitet()).ifPresent(ma -> {
+            var morsAktivitetsTyper = new MorsAktivitetsTyper();
+            morsAktivitetsTyper.setKode(ma.getKode());
+            utsettelsesperiode.setMorsAktivitetIPerioden(morsAktivitetsTyper);
+        });
         return utsettelsesperiode;
     }
 


### PR DESCRIPTION
Så vi slipper å eksponere denne frontend. 
Kan vurdere å patche forekomster i YF_FORDELING_PERIODE + UTTAK_RESULTAT_PERIODE_SOKNAD.
Bør beholde i kontrakter siden den finnes i lagret XML som vi antagelig ikke ønsker å patche ...