### PR TITLE
TFP-5051 striktere sjekk for G-dato far ifm fødsel

### DIFF
--- a/domenetjenester/skjaeringstidspunkt/src/main/java/no/nav/foreldrepenger/skjæringstidspunkt/fp/SkjæringstidspunktTjenesteImpl.java
+++ b/domenetjenester/skjaeringstidspunkt/src/main/java/no/nav/foreldrepenger/skjæringstidspunkt/fp/SkjæringstidspunktTjenesteImpl.java
@@ -36,6 +36,7 @@ import no.nav.foreldrepenger.behandlingslager.uttak.fp.UttakResultatPerioderEnti
 import no.nav.foreldrepenger.skjæringstidspunkt.SkjæringstidspunktRegisterinnhentingTjeneste;
 import no.nav.foreldrepenger.skjæringstidspunkt.SkjæringstidspunktTjeneste;
 import no.nav.foreldrepenger.skjæringstidspunkt.overganger.MinsterettBehandling2022;
+import no.nav.foreldrepenger.skjæringstidspunkt.overganger.MinsterettCore2022;
 import no.nav.foreldrepenger.skjæringstidspunkt.overganger.UtsettelseBehandling2021;
 import no.nav.foreldrepenger.skjæringstidspunkt.overganger.UtsettelseCore2021;
 import no.nav.fpsak.tidsserie.LocalDateInterval;
@@ -99,7 +100,7 @@ public class SkjæringstidspunktTjenesteImpl implements SkjæringstidspunktTjene
         var førsteUttaksdatoOpt = Optional.ofNullable(førsteUttaksdag(behandling, sammenhengendeUttak));
         var førsteUttaksdato = førsteUttaksdatoOpt.orElseGet(LocalDate::now); // Mangler grunnlag for å angi dato, bruker midlertidig dagens dato pga Dtos etc.
         var familieHendelseGrunnlag = familieGrunnlagRepository.hentAggregatHvisEksisterer(behandlingId);
-        var førsteUttaksdatoFødselsjustert = førsteDatoHensyntattTidligFødsel(behandling, familieHendelseGrunnlag, førsteUttaksdato);
+        var førsteUttaksdatoFødselsjustert = førsteDatoHensyntattTidligFødsel(behandling, familieHendelseGrunnlag, førsteUttaksdato, utenMinsterett);
         var gjelderFødsel = familieHendelseGrunnlag.map(FamilieHendelseGrunnlagEntitet::getGjeldendeVersjon)
             .map(FamilieHendelseEntitet::getGjelderFødsel).orElse(true);
 
@@ -259,8 +260,9 @@ public class SkjæringstidspunktTjenesteImpl implements SkjæringstidspunktTjene
         return UtsettelseCore2021.finnSisteDatoFraUttakResultat(uttakResultatPerioder, kreverSammenhengendeUttak);
     }
 
-    private LocalDate førsteDatoHensyntattTidligFødsel(Behandling behandling, Optional<FamilieHendelseGrunnlagEntitet> grunnlag, LocalDate førsteUttaksdato) {
-        return grunnlag.map(g -> UtsettelseCore2021.førsteUttaksDatoForBeregning(behandling.getRelasjonsRolleType(), g, førsteUttaksdato))
+    private LocalDate førsteDatoHensyntattTidligFødsel(Behandling behandling, Optional<FamilieHendelseGrunnlagEntitet> grunnlag,
+                                                       LocalDate førsteUttaksdato, boolean utenMinsterett) {
+        return grunnlag.map(g -> MinsterettCore2022.førsteUttaksDatoForBeregning(behandling.getRelasjonsRolleType(), g, førsteUttaksdato, utenMinsterett))
             .orElse(førsteUttaksdato);
     }
 

--- a/domenetjenester/skjaeringstidspunkt/src/main/java/no/nav/foreldrepenger/skjæringstidspunkt/overganger/UtsettelseCore2021.java
+++ b/domenetjenester/skjaeringstidspunkt/src/main/java/no/nav/foreldrepenger/skjæringstidspunkt/overganger/UtsettelseCore2021.java
@@ -78,13 +78,12 @@ public class UtsettelseCore2021 {
         // 14-10 første ledd (mor)
         var termindatoMinusPeriode = familieHendelseGrunnlag.getGjeldendeTerminbekreftelse()
             .map(TerminbekreftelseEntitet::getTermindato)
-            .map(t -> t.minus(SENESTE_UTTAK_FØR_TERMIN))
-            .filter(førsteUttaksdato::isAfter);
+            .map(t -> t.minus(SENESTE_UTTAK_FØR_TERMIN));
         var fødselsdato = gjeldendeFH.getFødselsdato()
-            .filter(førsteUttaksdato::isAfter)
-            .filter(f -> termindatoMinusPeriode.isEmpty() || f.isBefore(termindatoMinusPeriode.get()));
-        var uttaksdato = fødselsdato.or(() -> termindatoMinusPeriode).orElse(førsteUttaksdato);
-        return VirkedagUtil.fomVirkedag(uttaksdato);
+            .filter(f -> termindatoMinusPeriode.isEmpty() || f.isBefore(termindatoMinusPeriode.get()))
+            .or(() -> termindatoMinusPeriode);
+        var senesteStartdatoMor = fødselsdato.filter(førsteUttaksdato::isAfter).orElse(førsteUttaksdato);
+        return VirkedagUtil.fomVirkedag(senesteStartdatoMor);
     }
 
     public static Optional<LocalDate> finnFørsteDatoFraUttakResultat(List<UttakResultatPeriodeEntitet> perioder, boolean kreverSammenhengendeUttak) {

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/saksbehandler/InitielleLinksRestTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/saksbehandler/InitielleLinksRestTjeneste.java
@@ -1,7 +1,6 @@
 package no.nav.foreldrepenger.web.app.tjenester.saksbehandler;
 
 import static no.nav.foreldrepenger.web.app.rest.ResourceLinks.get;
-import static no.nav.foreldrepenger.web.app.rest.ResourceLinks.post;
 import static no.nav.vedtak.sikkerhet.abac.BeskyttetRessursActionAttributt.READ;
 
 import java.util.ArrayList;


### PR DESCRIPTION
Gjelder logikk som setter første uttaksdato til bruk i beregning til å velge hvilken G (første uttaksdato)
* Med minsterett: Far kan ta ut tidligst to uker før fødsel 
* Uten minsterett + Adopsjon: Far kan ta ut tidligst ved fødsel 
* Mor må begynne ved fødsel eller 3 uker før termin.

På sikt kan antagelig beregning bruke STP/O som input. Det var bare mors maxdato som dro STP tilbake til lenge før uttak.

Det gjenstår en snag: lange utsettelser fom fødsel før 3 uker før termin pga PSB. STP/O er som før, men uttaket begynner ikke før det begynner (førsteUttaksdato velges ut fra min(søknad/ForrigeUR) - så PSB-revurderinger er ikke helt G-safe)