### PR TITLE
TFP-5031 TFP-5011 ny tekst uføre blir uten aktivitetskrav

### DIFF
--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/uttak/fp/PeriodeResultatÅrsak.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/uttak/fp/PeriodeResultatÅrsak.java
@@ -60,8 +60,8 @@ public enum PeriodeResultatÅrsak implements Kodeverdi, ÅrsakskodeMedLovreferan
     GRADERING_ALENEOMSORG("2032", "§14-15, jf. §14-16: Gradering foreldrepenger ved aleneomsorg", "{\"fagsakYtelseType\": {\"FP\": {\"lovreferanse\": \"14-15,14-16\"}}}", of(UTTAK), of(FORELDREPENGER)),
     GRADERING_FORELDREPENGER_KUN_FAR_HAR_RETT("2033", "§14-14, jf. §14-13, jf. §14-16: Gradering foreldrepenger, kun far har rett", "{\"fagsakYtelseType\": {\"FP\": {\"lovreferanse\": \"14-14,14-13,14-16\"}}}", of(UTTAK), of(FORELDREPENGER)),
     GRADERING_FORELDREPENGER_KUN_MOR_HAR_RETT("2034", "§14-10, jf. §14-16: Gradering foreldrepenger, kun mor har rett", "{\"fagsakYtelseType\": {\"FP\": {\"lovreferanse\": \"14-10,14-16\"}}}", of(UTTAK), of(FORELDREPENGER)),
-    GRADERING_KUN_FAR_HAR_RETT_MOR_UFØR("2035", "§14-14 tredje ledd, jf. §14-16: Gradering foreldrepenger, kun far har rett og mor er ufør", "{\"fagsakYtelseType\": {\"FP\": {\"lovreferanse\": \"14-14,14-16\"}}}", of(UTTAK), of(FORELDREPENGER)),
-    FORELDREPENGER_KUN_FAR_HAR_RETT_MOR_UFØR("2036", "§14-14 tredje ledd: Innvilget foreldrepenger, kun far har rett og mor er ufør", "{\"fagsakYtelseType\": {\"FP\": {\"lovreferanse\": \"14-14\"}}}", of(UTTAK), of(FORELDREPENGER)),
+    GRADERING_KUN_FAR_HAR_RETT_MOR_UFØR("2035", "§14-14 tredje ledd, jf. §14-16: Gradering foreldrepenger, kun far har rett - dager uten aktivitetskrav", "{\"fagsakYtelseType\": {\"FP\": {\"lovreferanse\": \"14-14,14-16\"}}}", of(UTTAK), of(FORELDREPENGER)),
+    FORELDREPENGER_KUN_FAR_HAR_RETT_MOR_UFØR("2036", "§14-14 tredje ledd: Innvilget foreldrepenger, kun far har rett - dager uten aktivitetskrav", "{\"fagsakYtelseType\": {\"FP\": {\"lovreferanse\": \"14-14\"}}}", of(UTTAK), of(FORELDREPENGER)),
     FORELDREPENGER_FELLESPERIODE_TIL_FAR("2037", "§14-9, jf. §14-13: Innvilget fellesperiode til far", "{\"fagsakYtelseType\": {\"FP\": {\"lovreferanse\": \"14-9\"}}}", of(UTTAK), of(FELLESPERIODE)),
     FORELDREPENGER_REDUSERT_GRAD_PGA_SAMTIDIG_UTTAK("2038", "§14-10 sjette ledd: Samtidig uttak", "{\"fagsakYtelseType\": {\"FP\": {\"lovreferanse\": \"14-10\"}}}", of(UTTAK)),
 

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/registrering/ManuellRegistreringOppdaterer.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/registrering/ManuellRegistreringOppdaterer.java
@@ -86,11 +86,7 @@ public class ManuellRegistreringOppdaterer implements AksjonspunktOppdaterer<Man
         }
 
         ManuellRegistreringValidator.validerOpplysninger(dto);
-        try {
-            ManuellRegistreringValidator.validerAktivitetskrav(behandling.getFagsak(), dto);
-        } catch (Exception e) {
-            LOG.warn("PAPIRSØKNAD mangler aktivitetskrav for periode(r) i sak {} behandling {}", behandling.getFagsak().getSaksnummer().getVerdi(), behandlingId);
-        }
+        ManuellRegistreringValidator.validerAktivitetskrav(behandling.getFagsak(), dto);
 
         var fagsak = fagsakRepository.finnEksaktFagsak(behandling.getFagsakId());
         var navBruker = fagsak.getNavBruker();

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/registrering/ManuellRegistreringValidatorTekster.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/registrering/ManuellRegistreringValidatorTekster.java
@@ -8,17 +8,13 @@ public class ManuellRegistreringValidatorTekster {
     public static final String STARTDATO_FØR_SLUTTDATO = "Startdato må være før sluttdato";
     public static final String MINDRE_ELLER_LIK_LENGDE = "Feltet må være mindre eller lik";
 
-    public static final String FREMTIDIG_DATO = "Må være frem i tid";
     public static final String TIDLIGERE_DATO = "Må være bak i tid";
     public static final String FØR_ELLER_LIK_DAGENS_DATO = "Må være før eller lik dagens dato";
     public static final String TERMINDATO_OG_FØDSELSDATO = "Ikke fyll ut både fødsel og termin";
     public static final String TERMINDATO_ELLER_FØDSELSDATO = "Fyll ut enten fødsel eller termin";
     public static final String LIKT_ANTALL_BARN_OG_FØDSELSDATOER = "Fødselsdatoer må fylles ut for alle barn";
-    public static final String OPPHOLDSDATO_IKKE_SATT = "Dato må fylles ut";
     public static final String OPPHOLDSSKJEMA_TOMT = "Oppholdsland og datoer må fylles ut";
     public static final String UGYLDIG_FØDSELSNUMMER = "Ugyldig Fødselsnummer";
-    public static final String UGYLDIG_VERDI = "Ugyldig verdi";
-    public static final String TERMINDATO_TIDLIGST_TRE_UKER_TILBAKE_I_TID = "Termindato kan ikke være tidligere enn tre uker før dagens dato";
     public static final String TERMINBEKREFTELSESDATO_FØR_TERMINDATO = "Terminbekreftelsesdato må være før termindato";
     public static final String LIK_ELLER_ETTER_MOTTATT_DATO = "Må være lik eller etter mottatt dato";
     public static final String MANGLER_MORS_AKTIVITET = "Mangler mors aktivitet";

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/registrering/fp/ManuellRegistreringSøknadValidator.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/registrering/fp/ManuellRegistreringSøknadValidator.java
@@ -56,7 +56,7 @@ public class ManuellRegistreringSøknadValidator {
         List<FeltFeilDto> feltFeil = new ArrayList<>();
         var feltnavn = "harArbeidetIEgenVirksomhet";
         if (egenVirksomhet.getHarArbeidetIEgenVirksomhet() == null) {
-            feltFeil.add(new FeltFeilDto(feltnavn, ManuellRegistreringValidatorTekster.PAAKREVD_FELT));
+            feltFeil.add(new FeltFeilDto(feltnavn, PAAKREVD_FELT));
         }
         if (Boolean.TRUE.equals(egenVirksomhet.getHarArbeidetIEgenVirksomhet())) {
             for (var virksomhet : egenVirksomhet.getVirksomheter()) {
@@ -78,20 +78,20 @@ public class ManuellRegistreringSøknadValidator {
 
     private static void leggTilFeilForVirksomhet(List<FeltFeilDto> feltFeil, VirksomhetDto virksomhet) {
         if (virksomhet.getNavn() == null) {
-            feltFeil.add(new FeltFeilDto("virksomhetNavn", ManuellRegistreringValidatorTekster.PAAKREVD_FELT));
+            feltFeil.add(new FeltFeilDto("virksomhetNavn", PAAKREVD_FELT));
         }
         if (virksomhet.getVirksomhetRegistrertINorge() == null) {
-            feltFeil.add(new FeltFeilDto("virksomhetRegistrertINorge", ManuellRegistreringValidatorTekster.PAAKREVD_FELT));
+            feltFeil.add(new FeltFeilDto("virksomhetRegistrertINorge", PAAKREVD_FELT));
         }
         if (virksomhet.getLandJobberFra() == null) {
-            feltFeil.add(new FeltFeilDto("landJobberFra", ManuellRegistreringValidatorTekster.PAAKREVD_FELT));
+            feltFeil.add(new FeltFeilDto("landJobberFra", PAAKREVD_FELT));
         }
         if (Boolean.TRUE.equals(virksomhet.getVirksomhetRegistrertINorge())) {
             if (virksomhet.getOrganisasjonsnummer() == null) {
-                feltFeil.add(new FeltFeilDto("virksomhetOrganisasjonsnummer", ManuellRegistreringValidatorTekster.PAAKREVD_FELT));
+                feltFeil.add(new FeltFeilDto("virksomhetOrganisasjonsnummer", PAAKREVD_FELT));
             }
         } else if (virksomhet.getFom() == null) {
-            feltFeil.add(new FeltFeilDto("utenlandskNæringsvirksomhetStartDato", ManuellRegistreringValidatorTekster.PAAKREVD_FELT));
+            feltFeil.add(new FeltFeilDto("utenlandskNæringsvirksomhetStartDato", PAAKREVD_FELT));
         }
     }
 


### PR DESCRIPTION
Endrer tekster for å innvilge perioder uten aktivitetskrav - fra mor ufør til dager uten aktivitetskrav - til bruk for minsterett

Enable validering av at papirsøknad har mors aktivitet for tilfelle av far, fellesperiode/foreldrepenger, ikke flerbarnsdager, ikke aleneomsorg. Det har stått på et par ukers tid og 5 tilfelle er logget - alle kunne vært satt.