### PR TITLE
TFP-5039 bruk max av apEndringsdato og dette uttaket

### DIFF
--- a/domenetjenester/behandling-revurdering/src/test/java/no/nav/foreldrepenger/behandling/revurdering/BerørtBehandlingTjenesteTest.java
+++ b/domenetjenester/behandling-revurdering/src/test/java/no/nav/foreldrepenger/behandling/revurdering/BerørtBehandlingTjenesteTest.java
@@ -122,8 +122,31 @@ class BerørtBehandlingTjenesteTest {
 
     @Test
     public void behandling_med_negativ_saldo_skal_opprette_berørt() {
-        var behandling = ScenarioMorSøkerForeldrepenger.forFødsel().lagre(repositoryProvider);
-        var behandlingAnnenpart = ScenarioFarSøkerForeldrepenger.forFødsel().lagre(repositoryProvider);
+        var basedato = LocalDate.now();
+
+        var behandling = ScenarioMorSøkerForeldrepenger.forFødsel().medFødselAdopsjonsdato(basedato.minusWeeks(7)).lagre(repositoryProvider);
+        var behandlingAnnenpart = ScenarioFarSøkerForeldrepenger.forFødsel().medFødselAdopsjonsdato(basedato.minusWeeks(7)).lagre(repositoryProvider);
+
+        var morsMK = new ForeldrepengerUttakPeriode.Builder()
+            .medTidsperiode(basedato.minusWeeks(7), basedato.minusWeeks(1).minusDays(1))
+            .medResultatÅrsak(PeriodeResultatÅrsak.KVOTE_ELLER_OVERFØRT_KVOTE)
+            .medAktiviteter(List.of(uttakPeriodeAktivitet(StønadskontoType.MØDREKVOTE)))
+            .build();
+        var morsPeriode = new ForeldrepengerUttakPeriode.Builder()
+            .medTidsperiode(basedato, basedato.plusWeeks(20).minusDays(1))
+            .medResultatÅrsak(PeriodeResultatÅrsak.KVOTE_ELLER_OVERFØRT_KVOTE)
+            .medAktiviteter(List.of(uttakPeriodeAktivitet(StønadskontoType.FELLESPERIODE)))
+            .build();
+        var farsPeriode = new ForeldrepengerUttakPeriode.Builder()
+            .medTidsperiode(basedato.plusWeeks(20), basedato.plusWeeks(33).minusDays(1))
+            .medResultatÅrsak(PeriodeResultatÅrsak.KVOTE_ELLER_OVERFØRT_KVOTE)
+            .medAktiviteter(List.of(uttakPeriodeAktivitet(StønadskontoType.FEDREKVOTE)))
+            .build();
+        var morUttak = new ForeldrepengerUttak(List.of(morsMK, morsPeriode));
+        lagreUttak(behandling, morUttak);
+
+        var farUttak = new ForeldrepengerUttak(List.of(farsPeriode));
+        lagreUttak(behandlingAnnenpart, farUttak);
 
         var uttakInput = lagUttakInput(behandling);
 
@@ -179,8 +202,31 @@ class BerørtBehandlingTjenesteTest {
 
     @Test
     public void behandling_med_endret_stønadskonto_skal_opprette_berørt() {
-        var behandling = ScenarioMorSøkerForeldrepenger.forFødsel().lagre(repositoryProvider);
-        var behandlingAnnenpart = ScenarioFarSøkerForeldrepenger.forFødsel().lagre(repositoryProvider);
+        var basedato = LocalDate.now();
+
+        var behandling = ScenarioMorSøkerForeldrepenger.forFødsel().medFødselAdopsjonsdato(basedato.minusWeeks(7)).lagre(repositoryProvider);
+        var behandlingAnnenpart = ScenarioFarSøkerForeldrepenger.forFødsel().medFødselAdopsjonsdato(basedato.minusWeeks(7)).lagre(repositoryProvider);
+
+        var morsMK = new ForeldrepengerUttakPeriode.Builder()
+            .medTidsperiode(basedato.minusWeeks(7), basedato.minusWeeks(1).minusDays(1))
+            .medResultatÅrsak(PeriodeResultatÅrsak.KVOTE_ELLER_OVERFØRT_KVOTE)
+            .medAktiviteter(List.of(uttakPeriodeAktivitet(StønadskontoType.MØDREKVOTE)))
+            .build();
+        var morsPeriode = new ForeldrepengerUttakPeriode.Builder()
+            .medTidsperiode(basedato, basedato.plusWeeks(20).minusDays(1))
+            .medResultatÅrsak(PeriodeResultatÅrsak.KVOTE_ELLER_OVERFØRT_KVOTE)
+            .medAktiviteter(List.of(uttakPeriodeAktivitet(StønadskontoType.FELLESPERIODE)))
+            .build();
+        var farsPeriode = new ForeldrepengerUttakPeriode.Builder()
+            .medTidsperiode(basedato.plusWeeks(20), basedato.plusWeeks(33).minusDays(1))
+            .medResultatÅrsak(PeriodeResultatÅrsak.KVOTE_ELLER_OVERFØRT_KVOTE)
+            .medAktiviteter(List.of(uttakPeriodeAktivitet(StønadskontoType.FORELDREPENGER)))
+            .build();
+        var morUttak = new ForeldrepengerUttak(List.of(morsMK, morsPeriode));
+        lagreUttak(behandling, morUttak);
+
+        var farUttak = new ForeldrepengerUttak(List.of(farsPeriode));
+        lagreUttak(behandlingAnnenpart, farUttak);
 
         lagUttakInput(behandling);
 

--- a/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/uttaksgrunnlag/fp/EndringsdatoRevurderingUtlederImpl.java
+++ b/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/uttaksgrunnlag/fp/EndringsdatoRevurderingUtlederImpl.java
@@ -67,8 +67,7 @@ public class EndringsdatoRevurderingUtlederImpl implements EndringsdatoRevurderi
         var endringsdatoTypeEnumSet = utledEndringsdatoTyper(input);
         if (endringsdatoTypeEnumSet.isEmpty()) {
             endringsdatoTypeEnumSet.add(EndringsdatoType.FØRSTE_UTTAKSDATO_GJELDENDE_VEDTAK);
-            LOG.info("Kunne ikke utlede endringsdato for revurdering med behandlingId=" + behandlingId
-                + ". Satte FØRSTE_UTTAKSDATO_GJELDENDE_VEDTAK.");
+            LOG.info("Kunne ikke utlede endringsdato for revurdering med behandlingId={}. Satte FØRSTE_UTTAKSDATO_GJELDENDE_VEDTAK.",  behandlingId);
         }
         var endringsdato = utledEndringsdato(ref, endringsdatoTypeEnumSet, input.getYtelsespesifiktGrunnlag());
         return endringsdato.orElseThrow(() -> FastsettUttaksgrunnlagFeil.kunneIkkeUtledeEndringsdato(behandlingId));
@@ -220,8 +219,8 @@ public class EndringsdatoRevurderingUtlederImpl implements EndringsdatoRevurderi
             .min(Comparator.comparing(UttakResultatPeriodeEntitet::getFom))
             .map(UttakResultatPeriodeEntitet::getFom);
         // Alle perioder er tapt til annenpart
-        if (førsteDatoSomIkkeErTaptTilAnnenpart.isEmpty() && uttakPerioder.size() > 0) {
-            return Optional.ofNullable(uttakPerioder.get(0).getFom());
+        if (førsteDatoSomIkkeErTaptTilAnnenpart.isEmpty()) {
+            return uttakPerioder.stream().map(UttakResultatPeriodeEntitet::getFom).min(Comparator.naturalOrder());
         }
         return førsteDatoSomIkkeErTaptTilAnnenpart;
     }
@@ -244,6 +243,11 @@ public class EndringsdatoRevurderingUtlederImpl implements EndringsdatoRevurderi
             .stream()
             .map(OppgittPeriodeEntitet::getFom)
             .min(LOCAL_DATE_COMPARATOR);
+    }
+
+    private Optional<LocalDate> finnEndringsdato(Long behandlingId) {
+        var ytelseFordelingAggregat = ytelsesFordelingRepository.hentAggregat(behandlingId);
+        return ytelseFordelingAggregat.getAvklarteDatoer().map(AvklarteUttakDatoerEntitet::getGjeldendeEndringsdato);
     }
 
     private Optional<UttakResultatPeriodeEntitet> finnVedtattPeriodeMedOverlapp(LocalDate førsteUttaksdatoSøknad,
@@ -328,20 +332,35 @@ public class EndringsdatoRevurderingUtlederImpl implements EndringsdatoRevurderi
         var annenpartsFørsteUttaksdato = finnFørsteUttaksdato(annenpartBehandling);
         var førsteUttaksdatoGjeldendeVedtak = finnFørsteUttaksdato(finnForrigeBehandling(ref));
 
+        LocalDate klassiskdato = null;
         if (førsteUttaksdatoGjeldendeVedtak.isPresent() && annenpartsFørsteUttaksdato.isPresent()) {
-            if (førsteUttaksdatoGjeldendeVedtak.get().isAfter(annenpartsFørsteUttaksdato.get())) {
-                datoer.add(førsteUttaksdatoGjeldendeVedtak.get());
-            } else {
-                datoer.add(annenpartsFørsteUttaksdato.get());
-            }
+            klassiskdato = førsteUttaksdatoGjeldendeVedtak.get().isAfter(annenpartsFørsteUttaksdato.get()) ? førsteUttaksdatoGjeldendeVedtak.get() : annenpartsFørsteUttaksdato.get();
         } else {
             if (førsteUttaksdatoGjeldendeVedtak.isPresent()) {
-                datoer.add(førsteUttaksdatoGjeldendeVedtak.get());
+                klassiskdato = førsteUttaksdatoGjeldendeVedtak.get();
             }
             if (annenpartsFørsteUttaksdato.isPresent()) {
-                datoer.add(annenpartsFørsteUttaksdato.get());
+                klassiskdato = annenpartsFørsteUttaksdato.get();
             }
         }
+        final var klassiskUtledetDato = klassiskdato;
+        var annenpartsEndringsdato = finnEndringsdato(annenpartBehandling).or(() -> Optional.ofNullable(klassiskUtledetDato));
+        if (annenpartsEndringsdato.isEmpty()) {
+            LOG.info("BERØRT ENDRINGSDATO: Annenparts endringsdato og klassisk dato er tom for behandling {}", ref.behandlingId());
+        } else if (klassiskUtledetDato == null) {
+            LOG.info("BERØRT ENDRINGSDATO: Annenparts endringsdato finnes for behandling {} klassisk dato tom, endringsdato {}", ref.behandlingId(), annenpartsEndringsdato.get());
+        }
+        annenpartsEndringsdato.ifPresent(apd -> {
+            if (klassiskUtledetDato != null && apd.isBefore(klassiskUtledetDato)) {
+                LOG.info("BERØRT ENDRINGSDATO: Annenparts endringsdato er før utledet for behandling {} klassisk dato {} endringsdato {}",
+                    ref.behandlingId(), klassiskUtledetDato, apd);
+                datoer.add(klassiskUtledetDato);
+            } else {
+                LOG.info("BERØRT ENDRINGSDATO: Annenparts endringsdato er etter utledet for behandling {} klassisk dato {} endringsdato {}",
+                    ref.behandlingId(), klassiskUtledetDato, apd);
+                datoer.add(apd);
+            }
+        });
     }
 
     private Long finnForrigeBehandling(BehandlingReferanse behandling) {

--- a/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/uttaksgrunnlag/fp/EndringsdatoRevurderingUtlederImpl.java
+++ b/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/uttaksgrunnlag/fp/EndringsdatoRevurderingUtlederImpl.java
@@ -354,13 +354,18 @@ public class EndringsdatoRevurderingUtlederImpl implements EndringsdatoRevurderi
             if (klassiskUtledetDato != null && apd.isBefore(klassiskUtledetDato)) {
                 LOG.info("BERØRT ENDRINGSDATO: Annenparts endringsdato er før utledet for behandling {} klassisk dato {} endringsdato {}",
                     ref.behandlingId(), klassiskUtledetDato, apd);
-                datoer.add(klassiskUtledetDato);
+                //datoer.add(klassiskUtledetDato);
+            } else if (apd.equals(klassiskUtledetDato)) {
+                LOG.info("BERØRT ENDRINGSDATO: Annenparts endringsdato er lik utledet for behandling {} klassisk dato {} endringsdato {}",
+                    ref.behandlingId(), klassiskUtledetDato, apd);
+                //datoer.add(klassiskUtledetDato);
             } else {
                 LOG.info("BERØRT ENDRINGSDATO: Annenparts endringsdato er etter utledet for behandling {} klassisk dato {} endringsdato {}",
                     ref.behandlingId(), klassiskUtledetDato, apd);
-                datoer.add(apd);
+                //datoer.add(apd);
             }
         });
+        Optional.ofNullable(klassiskUtledetDato).ifPresent(datoer::add);
     }
 
     private Long finnForrigeBehandling(BehandlingReferanse behandling) {

--- a/domenetjenester/uttak/src/test/java/no/nav/foreldrepenger/domene/uttak/uttaksgrunnlag/fp/EndringsdatoRevurderingUtlederImplTest.java
+++ b/domenetjenester/uttak/src/test/java/no/nav/foreldrepenger/domene/uttak/uttaksgrunnlag/fp/EndringsdatoRevurderingUtlederImplTest.java
@@ -312,12 +312,12 @@ public class EndringsdatoRevurderingUtlederImplTest {
     public void skal_utlede_at_endringsdato_på_mors_berørte_behandling_er_lik_fars_første_uttaksdag() {
         // Arrange førstegangsbehandling mor
         var behandling = testUtil.byggFørstegangsbehandlingForRevurderingBerørtSak(AKTØR_ID_MOR,
-            testUtil.uttaksresultatBerørtSak(FØRSTE_UTTAKSDATO_GJELDENDE_VEDTAK));
+            testUtil.uttaksresultatBerørtSak(FØRSTE_UTTAKSDATO_GJELDENDE_VEDTAK), testUtil.søknadsAggregatBerørtSak(FØRSTE_UTTAKSDATO_GJELDENDE_VEDTAK));
 
         // Arrange førstegangsbehandling far
         var fomFar = FØRSTE_UTTAKSDATO_GJELDENDE_VEDTAK.plusDays(11);
         var behandlingFar = testUtil.byggFørstegangsbehandlingForRevurderingBerørtSak(AKTØR_ID_FAR,
-            testUtil.uttaksresultatBerørtSak(fomFar), behandling.getFagsak());
+            testUtil.uttaksresultatBerørtSak(fomFar), testUtil.søknadsAggregatBerørtSak(fomFar), behandling.getFagsak());
 
         // Arrange berørt behandling mor
         var revurderingBerørtSak = testUtil.opprettRevurderingBerørtSak(AKTØR_ID_MOR, BERØRT_BEHANDLING,
@@ -347,12 +347,12 @@ public class EndringsdatoRevurderingUtlederImplTest {
     public void skal_utlede_at_endringsdato_på_mors_berørte_behandling_er_første_uttaksdag_fra_vedtaket_når_fars_endringsdato_er_tidligere() {
         // Arrange førstegangsbehandling mor
         var behandling = testUtil.byggFørstegangsbehandlingForRevurderingBerørtSak(AKTØR_ID_MOR,
-            testUtil.uttaksresultatBerørtSak(FØRSTE_UTTAKSDATO_GJELDENDE_VEDTAK));
+            testUtil.uttaksresultatBerørtSak(FØRSTE_UTTAKSDATO_GJELDENDE_VEDTAK), testUtil.søknadsAggregatBerørtSak(FØRSTE_UTTAKSDATO_GJELDENDE_VEDTAK));
 
         // Arrange førstegangsbehandling far
         var fomFar = FØRSTE_UTTAKSDATO_GJELDENDE_VEDTAK.minusDays(2L);
         var behandlingFar = testUtil.byggFørstegangsbehandlingForRevurderingBerørtSak(AKTØR_ID_FAR,
-            testUtil.uttaksresultatBerørtSak(fomFar), behandling.getFagsak());
+            testUtil.uttaksresultatBerørtSak(fomFar), testUtil.søknadsAggregatBerørtSak(fomFar), behandling.getFagsak());
 
         // Arrange berørt behandling mor
         var revurderingBerørtSak = testUtil.opprettRevurderingBerørtSak(AKTØR_ID_MOR, BERØRT_BEHANDLING,

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
         <fp-jms.version>2.1.3</fp-jms.version>
 
         <fp-kontrakter.version>6.1.21</fp-kontrakter.version>
-        <fp-tidsserie.version>2.6.3</fp-tidsserie.version>
+        <fp-tidsserie.version>2.6.4</fp-tidsserie.version>
         <fp-nare.version>2.2.2</fp-nare.version>
         <abakus-kontrakt.version>1.3.30</abakus-kontrakt.version>
         <kalkulus.version>1.5.42</kalkulus.version>


### PR DESCRIPTION
To ting:
* setter endringsdato i berørt = max(annenpartEndringsdato, denneSakensFørsteUttak)
* oppretter ikke berørt dersom eneste overlappet er samtidig uttak far rundt fødsel eller flerbarnsdager

TODO i neste runde: Flytte berørt-datosjekkene til Uttak og la endringsdatoutleder finne berøringsdato og logge denne ift apEndringsdato