### PR TITLE
TFP-5065 ikke vurder søknadsfrist for gjenkjente eldre perioder

### DIFF
--- a/behandlingsprosess/src/main/java/no/nav/foreldrepenger/behandling/steg/søknadsfrist/fp/SøknadsfristRegelAdapter.java
+++ b/behandlingsprosess/src/main/java/no/nav/foreldrepenger/behandling/steg/søknadsfrist/fp/SøknadsfristRegelAdapter.java
@@ -22,13 +22,16 @@ final class SøknadsfristRegelAdapter {
             throw new IllegalArgumentException("Prøver å kjøre søknadsfristregel uten oppgitte perioder");
         }
 
+        var søknadMottattDato = søknad.getMottattDato();
+
         var førsteUttaksdato = oppgittePerioder.stream()
             .filter(p -> !p.isUtsettelse())
+            .filter(p -> p.getTidligstMottattDato().filter(tmd -> tmd.isBefore(søknadMottattDato)).isEmpty()) // TMD er fra vedtatt original
             .min(Comparator.comparing(OppgittPeriodeEntitet::getFom))
             .map(o -> o.getFom());
 
         return SøknadsfristGrunnlag.builder()
-            .søknadMottattDato(søknad.getMottattDato())
+            .søknadMottattDato(søknadMottattDato)
             .førsteUttaksdato(førsteUttaksdato.orElse(null))
             .build();
     }

--- a/behandlingsprosess/src/main/java/no/nav/foreldrepenger/behandling/steg/søknadsfrist/fp/SøknadsfristRegelAdapter.java
+++ b/behandlingsprosess/src/main/java/no/nav/foreldrepenger/behandling/steg/søknadsfrist/fp/SøknadsfristRegelAdapter.java
@@ -1,10 +1,12 @@
 package no.nav.foreldrepenger.behandling.steg.søknadsfrist.fp;
 
+import java.time.LocalDate;
 import java.util.Comparator;
 import java.util.List;
 
 import no.nav.foreldrepenger.behandlingslager.behandling.søknad.SøknadEntitet;
 import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.periode.OppgittPeriodeEntitet;
+import no.nav.foreldrepenger.regler.SøknadsfristUtil;
 import no.nav.foreldrepenger.regler.soknadsfrist.SøknadsfristRegelOrkestrering;
 import no.nav.foreldrepenger.regler.soknadsfrist.SøknadsfristResultat;
 import no.nav.foreldrepenger.regler.soknadsfrist.grunnlag.SøknadsfristGrunnlag;
@@ -26,7 +28,7 @@ final class SøknadsfristRegelAdapter {
 
         var førsteUttaksdato = oppgittePerioder.stream()
             .filter(p -> !p.isUtsettelse())
-            .filter(p -> p.getTidligstMottattDato().filter(tmd -> tmd.isBefore(søknadMottattDato)).isEmpty()) // TMD er fra vedtatt original
+            .filter(p -> periodeSkalVurderes(p, søknadMottattDato))
             .min(Comparator.comparing(OppgittPeriodeEntitet::getFom))
             .map(o -> o.getFom());
 
@@ -34,5 +36,18 @@ final class SøknadsfristRegelAdapter {
             .søknadMottattDato(søknadMottattDato)
             .førsteUttaksdato(førsteUttaksdato.orElse(null))
             .build();
+    }
+
+    private static boolean periodeSkalVurderes(OppgittPeriodeEntitet periode, LocalDate søknadMottattDato) {
+        // Mangler tidligst mottatt dato, eller tidligst mottatt er >= søknadMottatt/periodeMottatt
+        if (periode.getTidligstMottattDato().isEmpty() || periode.getMottattDato() == null ||
+            periode.getTidligstMottattDato().filter(tmd -> tmd.isBefore(søknadMottattDato)).isEmpty() ||
+            periode.getTidligstMottattDato().filter(tmd -> tmd.isBefore(periode.getMottattDato())).isEmpty()) {
+            return true;
+        }
+        // Det skal finnes en tidligst mottatt dato og den skal være før mottatt dato. Perioden har vært behandlet i tidligere behandling
+        var tidligstedato = periode.getTidligstMottattDato().map(SøknadsfristUtil::finnFørsteLoveligeUttaksdag).orElseThrow();
+        // Sjekk perioder med for tidlig fom - de kan ha blitt underkjent i tidligere behandling (frist eller uttaksregler).
+        return periode.getFom().isBefore(tidligstedato);
     }
 }

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/forvaltning/MigrerTilOmsorgRettTask.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/forvaltning/MigrerTilOmsorgRettTask.java
@@ -4,10 +4,10 @@ import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
 import no.nav.foreldrepenger.behandlingskontroll.BehandlingskontrollTjeneste;
-import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingStegType;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepositoryProvider;
 import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakProsesstaskRekkefølge;
+import no.nav.foreldrepenger.behandlingslager.hendelser.StartpunktType;
 import no.nav.foreldrepenger.behandlingslager.task.BehandlingProsessTask;
 import no.nav.foreldrepenger.web.app.tjenester.behandling.aksjonspunkt.BehandlingsprosessTjeneste;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTask;
@@ -43,7 +43,7 @@ public class MigrerTilOmsorgRettTask extends BehandlingProsessTask {
         var kontekst = behandlingskontrollTjeneste.initBehandlingskontroll(behandlingId);
         var behandling = behandlingRepository.hentBehandling(behandlingId);
         behandlingskontrollTjeneste.taBehandlingAvVentSetAlleAutopunktUtført(behandling, kontekst);
-        behandlingskontrollTjeneste.behandlingTilbakeføringTilTidligereBehandlingSteg(kontekst, BehandlingStegType.KONTROLLER_OMSORG_RETT);
+        behandlingskontrollTjeneste.behandlingTilbakeføringTilTidligereBehandlingSteg(kontekst, StartpunktType.UTTAKSVILKÅR.getBehandlingSteg());
         if (behandling.isBehandlingPåVent()) {
             behandlingskontrollTjeneste.taBehandlingAvVentSetAlleAutopunktUtført(behandling, kontekst);
         }


### PR DESCRIPTION
SøknadOversetter setter tidligstMottattDato ut fra revurderingen sin originalBehandling - som skal være vedtatt og dermed allerede ha gjort evt fristavklaringer .

Man kunne stramme inn noe ved å kalle en variant av OppgittPeriodeTidligstMottattDatoTjeneste som sjekker original sin UR sine søknadsperioder gitt at UR-perioden ikke er avslått pga søknadsfrist (årsak 4020)