### PR TITLE
TFP-5039 berørt endringsdato velg seneste og logg utledet

### DIFF
--- a/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/uttak/fp/FastsettUttaksgrunnlagOgVurderSøknadsfristStegTest.java
+++ b/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/uttak/fp/FastsettUttaksgrunnlagOgVurderSøknadsfristStegTest.java
@@ -53,6 +53,7 @@ import no.nav.foreldrepenger.domene.uttak.KopierForeldrepengerUttaktjeneste;
 import no.nav.foreldrepenger.domene.uttak.RelevanteArbeidsforholdTjeneste;
 import no.nav.foreldrepenger.domene.uttak.SkalKopiereUttakTjeneste;
 import no.nav.foreldrepenger.domene.uttak.UttakRepositoryProvider;
+import no.nav.foreldrepenger.domene.uttak.saldo.StønadskontoSaldoTjeneste;
 import no.nav.foreldrepenger.domene.uttak.uttaksgrunnlag.fp.EndringsdatoFørstegangsbehandlingUtleder;
 import no.nav.foreldrepenger.domene.uttak.uttaksgrunnlag.fp.EndringsdatoRevurderingUtlederImpl;
 import no.nav.foreldrepenger.domene.uttak.uttaksgrunnlag.fp.FastsettUttaksgrunnlagTjeneste;
@@ -101,8 +102,9 @@ public class FastsettUttaksgrunnlagOgVurderSøknadsfristStegTest extends EntityM
         var fpUttakRepository = uttakRepositoryProvider.getFpUttakRepository();
         var relevanteArbeidsforholdTjeneste = new RelevanteArbeidsforholdTjeneste(
             fpUttakRepository);
+        var saldoTjeneste = mock(StønadskontoSaldoTjeneste.class);
         var endringsdatoRevurderingUtleder = new EndringsdatoRevurderingUtlederImpl(uttakRepositoryProvider, dekningsgradTjeneste,
-            relevanteArbeidsforholdTjeneste);
+            relevanteArbeidsforholdTjeneste, saldoTjeneste);
         var fastsettUttaksgrunnlagTjeneste = new FastsettUttaksgrunnlagTjeneste(uttakRepositoryProvider, endringsdatoFørstegangsbehandlingUtleder,
                 endringsdatoRevurderingUtleder);
         var ytelseFordelingTjeneste = new YtelseFordelingTjeneste(ytelsesFordelingRepository);

--- a/domenetjenester/behandling-revurdering/src/test/java/no/nav/foreldrepenger/behandling/revurdering/BerørtBehandlingTjenesteTest.java
+++ b/domenetjenester/behandling-revurdering/src/test/java/no/nav/foreldrepenger/behandling/revurdering/BerørtBehandlingTjenesteTest.java
@@ -67,7 +67,7 @@ class BerørtBehandlingTjenesteTest {
         foreldrepengerUttakTjeneste = mock(ForeldrepengerUttakTjeneste.class);
         uttakInputTjeneste = mock(UttakInputTjeneste.class);
         saldoTjeneste = mock(StønadskontoSaldoTjeneste.class);
-        tjeneste = new BerørtBehandlingTjeneste(saldoTjeneste, repositoryProvider, uttakInputTjeneste,
+        tjeneste = new BerørtBehandlingTjeneste(saldoTjeneste, uttakInputTjeneste,
             foreldrepengerUttakTjeneste,
             new YtelseFordelingTjeneste(repositoryProvider.getYtelsesFordelingRepository()));
     }
@@ -232,7 +232,7 @@ class BerørtBehandlingTjenesteTest {
 
         var br = Behandlingsresultat.builder().medEndretStønadskonto(true).buildFor(behandling);
 
-        var resultat = tjeneste.skalBerørtBehandlingOpprettes(br, behandling.getId(), behandlingAnnenpart.getId());
+        var resultat = tjeneste.skalBerørtBehandlingOpprettes(br, behandling, behandlingAnnenpart.getId());
 
         assertThat(resultat).isTrue();
     }
@@ -1111,7 +1111,7 @@ class BerørtBehandlingTjenesteTest {
     }
 
     private boolean skalBerørtOpprettes(Behandling behandling, Behandling annenpartsBehandling) {
-        return tjeneste.skalBerørtBehandlingOpprettes(getBehandlingsresultat(behandling.getId()), behandling.getId(),
+        return tjeneste.skalBerørtBehandlingOpprettes(getBehandlingsresultat(behandling.getId()), behandling,
             annenpartsBehandling.getId());
     }
 

--- a/domenetjenester/mottak/src/test/java/no/nav/foreldrepenger/mottak/sakskompleks/BerørtBehandlingKontrollerTest.java
+++ b/domenetjenester/mottak/src/test/java/no/nav/foreldrepenger/mottak/sakskompleks/BerørtBehandlingKontrollerTest.java
@@ -35,6 +35,7 @@ import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.Aksjonspun
 import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.AksjonspunktDefinisjon;
 import no.nav.foreldrepenger.behandlingslager.behandling.beregning.BeregningsresultatEntitet;
 import no.nav.foreldrepenger.behandlingslager.behandling.beregning.BeregningsresultatRepository;
+import no.nav.foreldrepenger.behandlingslager.behandling.historikk.HistorikkRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepositoryProvider;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRevurderingRepository;
@@ -69,6 +70,8 @@ public class BerørtBehandlingKontrollerTest {
     private BeregningsresultatRepository beregningsresultatRepository;
     @Mock
     private FpUttakRepository fpUttakRepository;
+    @Mock
+    private HistorikkRepository historikkRepository;
     @Mock
     private BehandlingskontrollTjeneste behandlingskontrollTjeneste;
     @Mock
@@ -106,6 +109,7 @@ public class BerørtBehandlingKontrollerTest {
         when(repositoryProvider.getYtelsesFordelingRepository()).thenReturn(ytelsesFordelingRepository);
         when(repositoryProvider.getSøknadRepository()).thenReturn(søknadRepository);
         when(repositoryProvider.getBeregningsresultatRepository()).thenReturn(beregningsresultatRepository);
+        when(repositoryProvider.getHistorikkRepository()).thenReturn(historikkRepository);
 
 
         fBehandling = lagBehandling();
@@ -288,7 +292,7 @@ public class BerørtBehandlingKontrollerTest {
         settOppKøBruker();
         settOppKøAnnenpart();
         køetBehandling.setOpprettetTidspunkt(LocalDateTime.now());
-        when(berørtBehandlingTjeneste.skalBerørtBehandlingOpprettes(any(), any(Long.class), any(Long.class))).thenReturn(false);
+        when(berørtBehandlingTjeneste.skalBerørtBehandlingOpprettes(any(), any(Behandling.class), any(Long.class))).thenReturn(false);
         // Act
         berørtBehandlingKontroller.vurderNesteOppgaveIBehandlingskø(fBehandling.getId());
         // Assert
@@ -304,7 +308,7 @@ public class BerørtBehandlingKontrollerTest {
         settOppAvsluttetBehandlingAnnenpart();
         settOppKøAnnenpart();
 
-        when(berørtBehandlingTjeneste.skalBerørtBehandlingOpprettes(any(), any(Long.class), any(Long.class))).thenReturn(true);
+        when(berørtBehandlingTjeneste.skalBerørtBehandlingOpprettes(any(), any(Behandling.class), any(Long.class))).thenReturn(true);
         // Act
         berørtBehandlingKontroller.vurderNesteOppgaveIBehandlingskø(fBehandling.getId());
         // Assert - oppretter berørt behandling på medforelder
@@ -319,7 +323,7 @@ public class BerørtBehandlingKontrollerTest {
         settOppAvsluttetBehandlingBruker();
         settOppAvsluttetBehandlingAnnenpart();
         settOppKøBruker();
-        when(berørtBehandlingTjeneste.skalBerørtBehandlingOpprettes(any(), any(Long.class), any(Long.class))).thenReturn(false);
+        when(berørtBehandlingTjeneste.skalBerørtBehandlingOpprettes(any(), any(Behandling.class), any(Long.class))).thenReturn(false);
         // Act
         berørtBehandlingKontroller.vurderNesteOppgaveIBehandlingskø(fBehandling.getId());
         // Assert
@@ -333,7 +337,7 @@ public class BerørtBehandlingKontrollerTest {
         // Arrange
         settOppAvsluttetBehandlingBruker();
         settOppAvsluttetBehandlingAnnenpart();
-        when(berørtBehandlingTjeneste.skalBerørtBehandlingOpprettes(any(), any(Long.class), any(Long.class))).thenReturn(true);
+        when(berørtBehandlingTjeneste.skalBerørtBehandlingOpprettes(any(), any(Behandling.class), any(Long.class))).thenReturn(true);
         // Act
         berørtBehandlingKontroller.vurderNesteOppgaveIBehandlingskø(fBehandling.getId());
         // Assert opprett berørt (for medforelder)
@@ -346,7 +350,7 @@ public class BerørtBehandlingKontrollerTest {
         // Arrange
         settOppAvsluttetBehandlingBruker();
         settOppAvsluttetBehandlingAnnenpart();
-        when(berørtBehandlingTjeneste.skalBerørtBehandlingOpprettes(any(), any(Long.class), any(Long.class))).thenReturn(true);
+        when(berørtBehandlingTjeneste.skalBerørtBehandlingOpprettes(any(), any(Behandling.class), any(Long.class))).thenReturn(true);
         when(behandlingRepository.hentÅpneYtelseBehandlingerForFagsakId(any())).thenReturn(List.of(berørt));
         // Act
         berørtBehandlingKontroller.vurderNesteOppgaveIBehandlingskø(fBehandlingMedforelder.getId());
@@ -361,7 +365,7 @@ public class BerørtBehandlingKontrollerTest {
         // Arrange
         settOppAvsluttetBehandlingBruker();
         settOppAvsluttetBehandlingAnnenpart();
-        when(berørtBehandlingTjeneste.skalBerørtBehandlingOpprettes(any(), any(Long.class), any(Long.class))).thenReturn(false);
+        when(berørtBehandlingTjeneste.skalBerørtBehandlingOpprettes(any(), any(Behandling.class), any(Long.class))).thenReturn(false);
         when(beregnFeriepenger.avvikBeregnetFeriepengerBeregningsresultat(any(), any())).thenReturn(true);
         when(beregningsresultatRepository.hentUtbetBeregningsresultat(any())).thenReturn(Optional.of(new BeregningsresultatEntitet()));
         when(behandlingRepository.hentÅpneYtelseBehandlingerForFagsakId(any())).thenReturn(List.of());
@@ -380,7 +384,7 @@ public class BerørtBehandlingKontrollerTest {
         settOppAvsluttetBehandlingAnnenpart();
         settOppKøBruker();
         settOppKøAnnenpart();
-        when(berørtBehandlingTjeneste.skalBerørtBehandlingOpprettes(any(), any(Long.class), any(Long.class))).thenReturn(false);
+        when(berørtBehandlingTjeneste.skalBerørtBehandlingOpprettes(any(), any(Behandling.class), any(Long.class))).thenReturn(false);
         // Act
         berørtBehandlingKontroller.vurderNesteOppgaveIBehandlingskø(fBehandling.getId());
         // Assert - dekø fra medforelders kø
@@ -396,7 +400,7 @@ public class BerørtBehandlingKontrollerTest {
         settOppAvsluttetBehandlingAnnenpart();
         settOppKøAnnenpart();
 
-        when(berørtBehandlingTjeneste.skalBerørtBehandlingOpprettes(any(), any(Long.class), any(Long.class))).thenReturn(false);
+        when(berørtBehandlingTjeneste.skalBerørtBehandlingOpprettes(any(), any(Behandling.class), any(Long.class))).thenReturn(false);
         // Act
         berørtBehandlingKontroller.vurderNesteOppgaveIBehandlingskø(fBehandling.getId());
         // Assert  - dekø fra medforelders kø
@@ -411,7 +415,7 @@ public class BerørtBehandlingKontrollerTest {
         settOppAvsluttetBehandlingBruker();
         settOppAvsluttetBehandlingAnnenpart();
         settOppKøBruker();
-        when(berørtBehandlingTjeneste.skalBerørtBehandlingOpprettes(any(), any(Long.class), any(Long.class))).thenReturn(false);
+        when(berørtBehandlingTjeneste.skalBerørtBehandlingOpprettes(any(), any(Behandling.class), any(Long.class))).thenReturn(false);
         // Act
         berørtBehandlingKontroller.vurderNesteOppgaveIBehandlingskø(fBehandling.getId());
         // Assert dekø fra egen kø
@@ -425,7 +429,7 @@ public class BerørtBehandlingKontrollerTest {
         // Arrange
         settOppAvsluttetBehandlingBruker();
         settOppAvsluttetBehandlingAnnenpart();
-        when(berørtBehandlingTjeneste.skalBerørtBehandlingOpprettes(any(), any(Long.class), any(Long.class))).thenReturn(false);
+        when(berørtBehandlingTjeneste.skalBerørtBehandlingOpprettes(any(), any(Behandling.class), any(Long.class))).thenReturn(false);
         // Act
         berørtBehandlingKontroller.vurderNesteOppgaveIBehandlingskø(fBehandling.getId());
         // Assert - skal ikke skje noe

--- a/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/TidsperiodeFarRundtFødsel.java
+++ b/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/TidsperiodeFarRundtFødsel.java
@@ -2,9 +2,8 @@ package no.nav.foreldrepenger.domene.uttak;
 
 import java.util.Optional;
 
-import no.nav.foreldrepenger.domene.uttak.fastsetteperioder.grunnlagbyggere.DatoerGrunnlagBygger;
-import no.nav.foreldrepenger.domene.uttak.fastsetteperioder.grunnlagbyggere.KontoerGrunnlagBygger;
-import no.nav.foreldrepenger.domene.uttak.fastsetteperioder.grunnlagbyggere.SøknadGrunnlagBygger;
+import no.nav.foreldrepenger.domene.uttak.input.FamilieHendelser;
+import no.nav.foreldrepenger.domene.uttak.input.ForeldrepengerGrunnlag;
 import no.nav.foreldrepenger.domene.uttak.input.UttakInput;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.FarUttakRundtFødsel;
 import no.nav.foreldrepenger.regler.uttak.konfig.StandardKonfigurasjon;
@@ -14,11 +13,14 @@ public final class TidsperiodeFarRundtFødsel {
 
 
     public static Optional<LocalDateInterval> intervallFarRundtFødsel(UttakInput uttakInput) {
-        var datoer = DatoerGrunnlagBygger.byggForenkletGrunnlagKunFamiliehendelse(uttakInput);
-        var type = SøknadGrunnlagBygger.type(uttakInput.getYtelsespesifiktGrunnlag());
-        var kontoerKunMinsterett = KontoerGrunnlagBygger.byggKunRettighetFarUttakRundtFødsel(uttakInput.getBehandlingReferanse());
-        return FarUttakRundtFødsel.utledFarsPeriodeRundtFødsel(datoer.build(), kontoerKunMinsterett.build(), type, StandardKonfigurasjon.KONFIGURASJON)
-            .map(p -> new LocalDateInterval(p.getFom(), p.getTom()));
+        ForeldrepengerGrunnlag fpGrunnlag = uttakInput.getYtelsespesifiktGrunnlag();
+        return intervallFarRundtFødsel(fpGrunnlag.getFamilieHendelser(), uttakInput.getBehandlingReferanse().getSkjæringstidspunkt().utenMinsterett());
+    }
 
+    public static Optional<LocalDateInterval> intervallFarRundtFødsel(FamilieHendelser familieHendelser, boolean utenMinsterett) {
+        var familiehendelse = familieHendelser.getGjeldendeFamilieHendelse();
+        return FarUttakRundtFødsel.utledFarsPeriodeRundtFødsel(utenMinsterett, familieHendelser.gjelderTerminFødsel(),
+                familiehendelse.getFamilieHendelseDato(), familiehendelse.getTermindato().orElse(null), StandardKonfigurasjon.KONFIGURASJON)
+            .map(p -> new LocalDateInterval(p.getFom(), p.getTom()));
     }
 }

--- a/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/fastsetteperioder/grunnlagbyggere/DatoerGrunnlagBygger.java
+++ b/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/fastsetteperioder/grunnlagbyggere/DatoerGrunnlagBygger.java
@@ -43,17 +43,6 @@ public class DatoerGrunnlagBygger {
         return db;
     }
 
-    public static Datoer.Builder byggForenkletGrunnlagKunFamiliehendelse(UttakInput input) {
-        ForeldrepengerGrunnlag ytelsespesifiktGrunnlag = input.getYtelsespesifiktGrunnlag();
-        var gjeldendeFamilieHendelse = ytelsespesifiktGrunnlag.getFamilieHendelser().getGjeldendeFamilieHendelse();
-        var db = new Datoer.Builder()
-            .fødsel(gjeldendeFamilieHendelse.getFødselsdato().orElse(null))
-            .termin(gjeldendeFamilieHendelse.getTermindato().orElse(null))
-            .omsorgsovertakelse(gjeldendeFamilieHendelse.getOmsorgsovertakelse().orElse(null));
-
-        return db;
-    }
-
     private Dødsdatoer.Builder byggDødsdatoer(ForeldrepengerGrunnlag foreldrepengerGrunnlag, BehandlingReferanse ref) {
         return new Dødsdatoer.Builder()
             .søkersDødsdato(personopplysninger.søkersDødsdato(ref).orElse(null))

--- a/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/fastsetteperioder/grunnlagbyggere/KontoerGrunnlagBygger.java
+++ b/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/fastsetteperioder/grunnlagbyggere/KontoerGrunnlagBygger.java
@@ -1,7 +1,5 @@
 package no.nav.foreldrepenger.domene.uttak.fastsetteperioder.grunnlagbyggere;
 
-import static no.nav.foreldrepenger.regler.uttak.beregnkontoer.Minsterett.UTTAK_RUNDT_FØDSEL_DAGER;
-
 import java.time.LocalDate;
 import java.util.Optional;
 import java.util.Set;
@@ -61,14 +59,6 @@ public class KontoerGrunnlagBygger {
         return getBuilder(uttakInput, stønadskontoer).kontoList(stønadskontoer.stream()
             //Flerbarnsdager er stønadskontotype i stønadskontoberegningen, men ikke i fastsette perioder
             .filter(sk -> !sk.getStønadskontoType().equals(StønadskontoType.FLERBARNSDAGER)).map(this::map).collect(Collectors.toList()));
-    }
-
-    public static Kontoer.Builder byggKunRettighetFarUttakRundtFødsel(BehandlingReferanse ref) {
-        if (ref.getSkjæringstidspunkt().utenMinsterett()) {
-            return new Kontoer.Builder();
-        } else {
-            return new Kontoer.Builder().farUttakRundtFødselDager(UTTAK_RUNDT_FØDSEL_DAGER);
-        }
     }
 
     private Konto.Builder map(Stønadskonto stønadskonto) {

--- a/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/fastsetteperioder/grunnlagbyggere/SøknadGrunnlagBygger.java
+++ b/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/fastsetteperioder/grunnlagbyggere/SøknadGrunnlagBygger.java
@@ -40,9 +40,9 @@ import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.PeriodeMedSy
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.PeriodeMedTiltakIRegiAvNav;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.PeriodeUtenOmsorg;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.SamtidigUttaksprosent;
+import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.Stønadskontotype;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.Søknad;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.Søknadstype;
-import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.Stønadskontotype;
 
 @ApplicationScoped
 public class SøknadGrunnlagBygger {
@@ -204,7 +204,7 @@ public class SøknadGrunnlagBygger {
         }
     }
 
-    public static Søknadstype type(ForeldrepengerGrunnlag fpGrunnlag) {
+    private static Søknadstype type(ForeldrepengerGrunnlag fpGrunnlag) {
         var hendelser = fpGrunnlag.getFamilieHendelser();
         if (hendelser.gjelderTerminFødsel() && hendelser.erSøktTermin()) {
             return Søknadstype.TERMIN;

--- a/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/saldo/StønadskontoSaldoTjeneste.java
+++ b/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/saldo/StønadskontoSaldoTjeneste.java
@@ -102,6 +102,12 @@ public class StønadskontoSaldoTjeneste {
         return saldoUtregning.negativSaldoPåNoenKonto();
     }
 
+    public boolean erOriginalNegativSaldoPåNoenKonto(UttakInput uttakInput) {
+        var perioderSøker = perioderSøker(uttakInput.getBehandlingReferanse().getOriginalBehandlingId().orElseThrow());
+        var saldoUtregning = finnSaldoUtregning(uttakInput, mapTilRegelPerioder(perioderSøker));
+        return saldoUtregning.negativSaldoPåNoenKonto();
+    }
+
     private List<FastsattUttakPeriode> mapTilRegelPerioder(List<UttakResultatPeriodeEntitet> perioder) {
         return perioder.stream().map(StønadskontoSaldoTjeneste::map).collect(Collectors.toList());
     }

--- a/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/saldo/StønadskontoSaldoTjeneste.java
+++ b/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/saldo/StønadskontoSaldoTjeneste.java
@@ -10,19 +10,21 @@ import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
 import no.nav.foreldrepenger.behandling.BehandlingReferanse;
+import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakRelasjon;
 import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakRelasjonRepository;
 import no.nav.foreldrepenger.behandlingslager.uttak.fp.FpUttakRepository;
 import no.nav.foreldrepenger.behandlingslager.uttak.fp.Stønadskonto;
+import no.nav.foreldrepenger.behandlingslager.uttak.fp.Stønadskontoberegning;
 import no.nav.foreldrepenger.behandlingslager.uttak.fp.UttakResultatEntitet;
 import no.nav.foreldrepenger.behandlingslager.uttak.fp.UttakResultatPeriodeAktivitetEntitet;
 import no.nav.foreldrepenger.behandlingslager.uttak.fp.UttakResultatPeriodeEntitet;
+import no.nav.foreldrepenger.behandlingslager.uttak.fp.UttakResultatPerioderEntitet;
 import no.nav.foreldrepenger.domene.uttak.UttakEnumMapper;
 import no.nav.foreldrepenger.domene.uttak.UttakRepositoryProvider;
 import no.nav.foreldrepenger.domene.uttak.fastsetteperioder.grunnlagbyggere.AnnenPartGrunnlagBygger;
 import no.nav.foreldrepenger.domene.uttak.fastsetteperioder.grunnlagbyggere.BehandlingGrunnlagBygger;
-import no.nav.foreldrepenger.domene.uttak.fastsetteperioder.grunnlagbyggere.DatoerGrunnlagBygger;
 import no.nav.foreldrepenger.domene.uttak.fastsetteperioder.grunnlagbyggere.KontoerGrunnlagBygger;
-import no.nav.foreldrepenger.domene.uttak.fastsetteperioder.grunnlagbyggere.SøknadGrunnlagBygger;
+import no.nav.foreldrepenger.domene.uttak.input.Annenpart;
 import no.nav.foreldrepenger.domene.uttak.input.ForeldrepengerGrunnlag;
 import no.nav.foreldrepenger.domene.uttak.input.UttakInput;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.FarUttakRundtFødsel;
@@ -83,9 +85,9 @@ public class StønadskontoSaldoTjeneste {
             // TODO: trengs dette eller kan vi sende inn en tom periode? SaldoValidering?
             if (!uttakInput.getBehandlingReferanse().getSkjæringstidspunkt().utenMinsterett()
                 && !BehandlingGrunnlagBygger.søkerErMor(uttakInput.getBehandlingReferanse())) {
-                var type = SøknadGrunnlagBygger.type(fpGrunnlag);
-                var datoer = DatoerGrunnlagBygger.byggForenkletGrunnlagKunFamiliehendelse(uttakInput).build();
-                periodeFar = FarUttakRundtFødsel.utledFarsPeriodeRundtFødsel(datoer, kontoer, type, StandardKonfigurasjon.KONFIGURASJON);
+                var familiehendelse  = fpGrunnlag.getFamilieHendelser().getGjeldendeFamilieHendelse();
+                periodeFar = FarUttakRundtFødsel.utledFarsPeriodeRundtFødsel(false, familiehendelse.gjelderFødsel(),
+                    familiehendelse.getFamilieHendelseDato(), familiehendelse.getTermindato().orElse(null), StandardKonfigurasjon.KONFIGURASJON);
             }
             return SaldoUtregningGrunnlag.forUtregningAvHeleUttaket(perioderSøker,
                 fpGrunnlag.isBerørtBehandling(), perioderAnnenpart, kontoer, søknadOpprettetTidspunkt,
@@ -115,33 +117,21 @@ public class StønadskontoSaldoTjeneste {
     }
 
     private Optional<UttakResultatEntitet> annenPartUttak(ForeldrepengerGrunnlag foreldrepengerGrunnlag) {
-        var annenpart = foreldrepengerGrunnlag.getAnnenpart();
-        if (annenpart.isPresent()) {
-            return fpUttakRepository.hentUttakResultatHvisEksisterer(annenpart.get().gjeldendeVedtakBehandlingId());
-        }
-        return Optional.empty();
+        return foreldrepengerGrunnlag.getAnnenpart()
+            .map(Annenpart::gjeldendeVedtakBehandlingId)
+            .flatMap(fpUttakRepository::hentUttakResultatHvisEksisterer);
     }
 
     private List<UttakResultatPeriodeEntitet> perioderSøker(Long behandlingId) {
-        var opt = fpUttakRepository.hentUttakResultatHvisEksisterer(behandlingId);
-        if (opt.isPresent()) {
-            return opt.get().getGjeldendePerioder().getPerioder();
-        }
-        return List.of();
+        return fpUttakRepository.hentUttakResultatHvisEksisterer(behandlingId)
+            .map(UttakResultatEntitet::getGjeldendePerioder)
+            .map(UttakResultatPerioderEntitet::getPerioder).orElse(List.of());
     }
 
     private Optional<Set<Stønadskonto>> stønadskontoer(BehandlingReferanse ref) {
-        var fagsakRelasjon = fagsakRelasjonRepository.finnRelasjonHvisEksisterer(ref.saksnummer());
-        if (fagsakRelasjon.isPresent() && fagsakRelasjon.get().getGjeldendeStønadskontoberegning().isPresent()) {
-            var stønadskontoer = fagsakRelasjon.get().getGjeldendeStønadskontoberegning().get().getStønadskontoer();
-            return Optional.ofNullable(stønadskontoer);
-        }
-
-        return Optional.empty();
-    }
-
-    public boolean erSluttPåStønadsdager(UttakInput uttakInput) {
-        return finnStønadRest(uttakInput) == 0;
+        return fagsakRelasjonRepository.finnRelasjonHvisEksisterer(ref.saksnummer())
+            .flatMap(FagsakRelasjon::getGjeldendeStønadskontoberegning)
+            .map(Stønadskontoberegning::getStønadskontoer);
     }
 
     public int finnStønadRest(UttakInput uttakInput) {

--- a/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/uttaksgrunnlag/fp/EndringsdatoBerørtUtleder.java
+++ b/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/uttaksgrunnlag/fp/EndringsdatoBerørtUtleder.java
@@ -1,0 +1,179 @@
+package no.nav.foreldrepenger.domene.uttak.uttaksgrunnlag.fp;
+
+import java.time.LocalDate;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import no.nav.foreldrepenger.behandlingslager.behandling.Behandlingsresultat;
+import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.YtelseFordelingAggregat;
+import no.nav.foreldrepenger.domene.tid.VirkedagUtil;
+import no.nav.foreldrepenger.domene.uttak.ForeldrepengerUttak;
+import no.nav.foreldrepenger.domene.uttak.ForeldrepengerUttakPeriode;
+import no.nav.foreldrepenger.domene.uttak.TidsperiodeFarRundtFødsel;
+import no.nav.foreldrepenger.domene.uttak.TidsperiodeForbeholdtMor;
+import no.nav.foreldrepenger.domene.uttak.input.FamilieHendelser;
+import no.nav.foreldrepenger.domene.uttak.input.ForeldrepengerGrunnlag;
+import no.nav.foreldrepenger.domene.uttak.input.UttakInput;
+import no.nav.fpsak.tidsserie.LocalDateInterval;
+import no.nav.fpsak.tidsserie.LocalDateSegment;
+import no.nav.fpsak.tidsserie.LocalDateTimeline;
+import no.nav.fpsak.tidsserie.StandardCombinators;
+
+public final class EndringsdatoBerørtUtleder {
+
+    private static final Logger LOG = LoggerFactory.getLogger(EndringsdatoBerørtUtleder.class);
+
+    public static Optional<LocalDate> utledEndringsdatoForBerørtBehandling(ForeldrepengerUttak utløsendeBehandlingUttak,
+                                                                           Optional<YtelseFordelingAggregat> utløsendeBehandlingYtelseFordeling,
+                                                                           Behandlingsresultat utløsendeBehandlingsresultat,
+                                                                           boolean neagtivSaldoNoenKonto,
+                                                                           Optional<ForeldrepengerUttak> berørtBehandlingUttak,
+                                                                           UttakInput uttakInput,
+                                                                           String loggPrefix) {
+        ForeldrepengerGrunnlag fpGrunnlag = uttakInput.getYtelsespesifiktGrunnlag();
+        var familieHendelser = fpGrunnlag.getFamilieHendelser();
+        var kreverSammenhengendeUttak = uttakInput.getBehandlingReferanse().getSkjæringstidspunkt().kreverSammenhengendeUttak();
+        var utenMinsterett = uttakInput.getBehandlingReferanse().getSkjæringstidspunkt().utenMinsterett();
+        //Må sjekke konsekvens pga overlapp med samtidig uttak
+        if (berørtBehandlingUttak.isEmpty() || finnMinAktivDato(berørtBehandlingUttak.get()).isEmpty() || finnMinAktivDato(utløsendeBehandlingUttak, berørtBehandlingUttak.get()).isEmpty()) {
+            return Optional.empty();
+        }
+        // Endring fra en søknadsperiode eller fra start?
+        var endringsdato = utløsendeBehandlingYtelseFordeling.flatMap(YtelseFordelingAggregat::getGjeldendeEndringsdatoHvisEksisterer)
+            .orElseGet(() -> finnMinAktivDato(utløsendeBehandlingUttak, berørtBehandlingUttak.get()).orElseThrow());
+
+        Set<LocalDate> berørtBehovDatoer = new HashSet<>();
+        if (utløsendeBehandlingsresultat.isEndretStønadskonto() || neagtivSaldoNoenKonto) {
+            LOG.info("{}: EndretKonto/NegativKonto endringsdato {}", loggPrefix, endringsdato);
+            berørtBehovDatoer.add(endringsdato);
+        }
+
+        var periodeTom = finnMaxAktivDato(utløsendeBehandlingUttak, berørtBehandlingUttak.get()).filter(endringsdato::isBefore).orElse(endringsdato);
+        var periodeFomEndringsdato = new LocalDateInterval(endringsdato, periodeTom);
+
+        var overlapp = overlappSomIkkeErFulltSamtidigUttak(familieHendelser, utenMinsterett, periodeFomEndringsdato, utløsendeBehandlingUttak, berørtBehandlingUttak.get());
+        if (overlapp.isPresent()) {
+            LOG.info("{}: OverlappUtenSamtidig fom {} endringsdato {}", loggPrefix, overlapp.get(), endringsdato);
+            berørtBehovDatoer.add(overlapp.get());
+        }
+
+        var fellesTidslinjeForSammenheng = tidslinjeForSammenhengendeUttaksplan(utløsendeBehandlingUttak, berørtBehandlingUttak.get());
+        // Sikre at periode reservert mor er komplett med uttak, utsettelser, overføringer
+        if (familieHendelser.gjelderTerminFødsel()) {
+            var familieHendelseDato = familieHendelser.getGjeldendeFamilieHendelse().getFamilieHendelseDato();
+            var førsteSeksUker = new LocalDateInterval(VirkedagUtil.lørdagSøndagTilMandag(familieHendelseDato),
+                TidsperiodeForbeholdtMor.tilOgMed(familieHendelseDato));
+            if (!fellesTidslinjeForSammenheng.isContinuous(førsteSeksUker)) {
+                var tidslinjeFørsteSeksUker = fellesTidslinjeForSammenheng.intersection(førsteSeksUker);
+                var tidligsteGap = Optional.ofNullable(tidslinjeFørsteSeksUker.firstDiscontinuity()).map(LocalDateInterval::getFomDato).orElse(endringsdato);
+                LOG.info("{}: Første 6 uker gap fom {} endringsdato {}", loggPrefix, tidligsteGap, endringsdato);
+                berørtBehovDatoer.add(tidligsteGap);
+            }
+        }
+
+        var opprett = kreverSammenhengendeUttak && !fellesTidslinjeForSammenheng.isContinuous(periodeFomEndringsdato);
+        if (opprett) {
+            var tidslinjeFomEndringsdato = fellesTidslinjeForSammenheng.intersection(periodeFomEndringsdato);
+            var tidligsteGap = Optional.ofNullable(tidslinjeFomEndringsdato.firstDiscontinuity()).map(LocalDateInterval::getFomDato).orElse(endringsdato);
+            LOG.info("{}: Sammenhengende etter uke 6 gap fom {} endringsdato {}", loggPrefix, tidligsteGap, endringsdato);
+            berørtBehovDatoer.add(tidligsteGap);
+        }
+        return berørtBehovDatoer.stream().min(Comparator.naturalOrder());
+    }
+
+    private static Optional<LocalDate> overlappSomIkkeErFulltSamtidigUttak(FamilieHendelser familieHendelser, boolean utenMinsterett, LocalDateInterval periodeFomEndringsdato,
+                                                                           ForeldrepengerUttak brukersUttak, ForeldrepengerUttak annenpartsUttak) {
+        var tidslinjeBruker = lagTidslinje(brukersUttak, p -> !p.isOpphold(), EndringsdatoBerørtUtleder::helgFomMandagSegment);
+        var tidslinjeAnnenpart = lagTidslinje(annenpartsUttak, p -> !p.isOpphold(), EndringsdatoBerørtUtleder::helgFomMandagSegment);
+        // Tidslinje der begge har uttak - fom endringsdato.
+        var tidslinjeOverlappendeUttakFomEndringsdato = tidslinjeAnnenpart.intersection(tidslinjeBruker).intersection(periodeFomEndringsdato);
+        if (tidslinjeOverlappendeUttakFomEndringsdato.isEmpty()) {
+            return Optional.empty();
+        }
+
+        var farRundtFødsel = TidsperiodeFarRundtFødsel.intervallFarRundtFødsel(familieHendelser, utenMinsterett).orElse(null);
+        var tidslinjeBrukerSamtidig = lagTidslinje(brukersUttak, p -> akseptertFulltSamtidigUttak(p, farRundtFødsel), EndringsdatoBerørtUtleder::helgFomMandagSegment);
+        var tidslinjeAnnenpartSamtidig = lagTidslinje(annenpartsUttak, p -> akseptertFulltSamtidigUttak(p, farRundtFødsel), EndringsdatoBerørtUtleder::helgFomMandagSegment);
+        var tidslinjeSamtidigUttak = slåSammenTidslinjer(tidslinjeBrukerSamtidig, tidslinjeAnnenpartSamtidig);
+
+        var overlappUtenomAkseptertFulltSamtidigUttak = tidslinjeOverlappendeUttakFomEndringsdato.disjoint(tidslinjeSamtidigUttak);
+        return overlappUtenomAkseptertFulltSamtidigUttak.isEmpty() ? Optional.empty() : Optional.of(overlappUtenomAkseptertFulltSamtidigUttak.getMinLocalDate());
+    }
+
+    private static boolean akseptertFulltSamtidigUttak(ForeldrepengerUttakPeriode periode, LocalDateInterval farRundtFødsel) {
+        var periodeRundtFødsel = Optional.ofNullable(farRundtFødsel).filter(f -> f.contains(periode.getTidsperiode())).isPresent();
+        return periode.isSamtidigUttak() && (periode.isFlerbarnsdager() || periodeRundtFødsel);
+    }
+
+    private static LocalDateTimeline<Boolean> tidslinjeForSammenhengendeUttaksplan(ForeldrepengerUttak brukersUttak, ForeldrepengerUttak annenpartsUttak) {
+        var tidslinjeBruker = lagTidslinje(brukersUttak, p -> true, EndringsdatoBerørtUtleder::helgTomSøndagSegment);
+        var tidslinjeAnnenpart = lagTidslinje(annenpartsUttak, p -> true, EndringsdatoBerørtUtleder::helgTomSøndagSegment);
+        return slåSammenTidslinjer(tidslinjeBruker, tidslinjeAnnenpart);
+    }
+
+    private static LocalDateTimeline<Boolean> slåSammenTidslinjer(LocalDateTimeline<Boolean> tidslinje1, LocalDateTimeline<Boolean> tidslinje2) {
+        // Slår sammen uttaksplanene med TRUE der en eller begge har uttak.
+        return tidslinje1.crossJoin(tidslinje2, StandardCombinators::alwaysTrueForMatch).compress();
+    }
+
+    private static LocalDateTimeline<Boolean> lagTidslinje(ForeldrepengerUttak uttak, Predicate<ForeldrepengerUttakPeriode> periodefilter,
+                                                    Function<ForeldrepengerUttakPeriode, LocalDateSegment<Boolean>> segmentMapper) {
+        var segmenter = uttak.getGjeldendePerioder().stream()
+            .filter(p -> isAktivtUttak(p))
+            .filter(periodefilter)
+            .map(segmentMapper)
+            .toList();
+        return new LocalDateTimeline<>(segmenter, StandardCombinators::alwaysTrueForMatch).compress();
+    }
+
+    private static boolean isAktivtUttak(ForeldrepengerUttakPeriode p) {
+        return p.harAktivtUttak() || p.isInnvilgetOpphold();
+    }
+
+    private static LocalDateSegment<Boolean> helgFomMandagSegment(ForeldrepengerUttakPeriode periode) {
+        var fom = VirkedagUtil.lørdagSøndagTilMandag(periode.getFom());
+        var tom = periode.getTom();
+        var brukFom = fom.isAfter(tom) ? periode.getFom() : fom;
+        return new LocalDateSegment<>(brukFom, tom, Boolean.TRUE);
+    }
+
+    private static LocalDateSegment<Boolean> helgTomSøndagSegment(ForeldrepengerUttakPeriode periode) {
+        var fom = periode.getFom();
+        var tom = VirkedagUtil.fredagLørdagTilSøndag(periode.getTom());
+        return new LocalDateSegment<>(fom, tom, Boolean.TRUE);
+    }
+
+    private static Optional<LocalDate> finnMinAktivDato(ForeldrepengerUttak uttak) {
+        return uttak.getGjeldendePerioder().stream()
+            .filter(EndringsdatoBerørtUtleder::isAktivtUttak)
+            .map(ForeldrepengerUttakPeriode::getFom)
+            .min(Comparator.naturalOrder());
+    }
+
+    private static Optional<LocalDate> finnMinAktivDato(ForeldrepengerUttak bruker, ForeldrepengerUttak annenpart) {
+        return Stream.concat(finnMinAktivDato(bruker).stream(), finnMinAktivDato(annenpart).stream())
+            .min(Comparator.naturalOrder());
+    }
+
+    // Mulig denne skal brukes om endringsdato mangler
+    private static Optional<LocalDate> finnSenesteMinAktivDato(ForeldrepengerUttak bruker, ForeldrepengerUttak annenpart) {
+        return Stream.concat(finnMinAktivDato(bruker).stream(), finnMinAktivDato(annenpart).stream())
+            .max(Comparator.naturalOrder());
+    }
+
+    private static Optional<LocalDate> finnMaxAktivDato(ForeldrepengerUttak bruker, ForeldrepengerUttak annenpart) {
+        return Stream.concat(bruker.getGjeldendePerioder().stream(), annenpart.getGjeldendePerioder().stream())
+            .filter(EndringsdatoBerørtUtleder::isAktivtUttak)
+            .map(ForeldrepengerUttakPeriode::getTom)
+            .max(Comparator.naturalOrder());
+    }
+
+}

--- a/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/uttaksgrunnlag/fp/EndringsdatoRevurderingUtlederImpl.java
+++ b/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/uttaksgrunnlag/fp/EndringsdatoRevurderingUtlederImpl.java
@@ -399,7 +399,7 @@ public class EndringsdatoRevurderingUtlederImpl implements EndringsdatoRevurderi
         return EndringsdatoBerørtUtleder.utledEndringsdatoForBerørtBehandling(utløsendeUttak,
             ytelsesFordelingRepository.hentAggregatHvisEksisterer(utløsendeBehandlingId),
             behandlingsresultatRepository.hent(utløsendeBehandlingId),
-            stønadskontoSaldoTjeneste.erOriginalNegativSaldoPåNoenKonto(input), // Gambler på samme resultat for input fra begge partene
+            stønadskontoSaldoTjeneste.erOriginalNegativSaldoPåNoenKontoForsiktig(input), // Gambler på samme resultat for input fra begge partene
             berørtUttak,
             input,
             "Berørt endringsdato");

--- a/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/uttaksgrunnlag/fp/EndringsdatoRevurderingUtlederImpl.java
+++ b/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/uttaksgrunnlag/fp/EndringsdatoRevurderingUtlederImpl.java
@@ -399,7 +399,7 @@ public class EndringsdatoRevurderingUtlederImpl implements EndringsdatoRevurderi
         return EndringsdatoBerørtUtleder.utledEndringsdatoForBerørtBehandling(utløsendeUttak,
             ytelsesFordelingRepository.hentAggregatHvisEksisterer(utløsendeBehandlingId),
             behandlingsresultatRepository.hent(utløsendeBehandlingId),
-            stønadskontoSaldoTjeneste.erNegativSaldoPåNoenKonto(input), // Gambler på samme resultat for input fra begge partene
+            stønadskontoSaldoTjeneste.erOriginalNegativSaldoPåNoenKonto(input), // Gambler på samme resultat for input fra begge partene
             berørtUttak,
             input,
             "Berørt endringsdato");

--- a/domenetjenester/uttak/src/test/java/no/nav/foreldrepenger/domene/uttak/uttaksgrunnlag/fp/EndringsdatoRevurderingUtlederImplTest.java
+++ b/domenetjenester/uttak/src/test/java/no/nav/foreldrepenger/domene/uttak/uttaksgrunnlag/fp/EndringsdatoRevurderingUtlederImplTest.java
@@ -12,6 +12,7 @@ import static no.nav.foreldrepenger.domene.uttak.UttakRevurderingTestUtil.FØDSE
 import static no.nav.foreldrepenger.domene.uttak.UttakRevurderingTestUtil.FØRSTE_UTTAKSDATO_GJELDENDE_VEDTAK;
 import static no.nav.foreldrepenger.domene.uttak.UttakRevurderingTestUtil.FØRSTE_UTTAKSDATO_SØKNAD_MOR_FPFF;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
@@ -71,6 +72,7 @@ import no.nav.foreldrepenger.domene.uttak.input.ForeldrepengerGrunnlag;
 import no.nav.foreldrepenger.domene.uttak.input.OriginalBehandling;
 import no.nav.foreldrepenger.domene.uttak.input.UttakInput;
 import no.nav.foreldrepenger.domene.uttak.input.YtelsespesifiktGrunnlag;
+import no.nav.foreldrepenger.domene.uttak.saldo.StønadskontoSaldoTjeneste;
 import no.nav.foreldrepenger.domene.uttak.testutilities.behandling.AbstractTestScenario;
 import no.nav.foreldrepenger.domene.uttak.testutilities.behandling.ScenarioMorSøkerForeldrepenger;
 import no.nav.foreldrepenger.domene.uttak.testutilities.behandling.UttakRepositoryStubProvider;
@@ -93,8 +95,9 @@ public class EndringsdatoRevurderingUtlederImplTest {
     private final DekningsgradTjeneste dekningsgradTjeneste = new DekningsgradTjeneste(fagsakRelasjonTjeneste,
         repositoryProvider.getBehandlingsresultatRepository());
     private final UttakRevurderingTestUtil testUtil = new UttakRevurderingTestUtil(repositoryProvider, iayTjeneste);
+    private final StønadskontoSaldoTjeneste saldoTjeneste = mock(StønadskontoSaldoTjeneste.class);
     private final EndringsdatoRevurderingUtlederImpl utleder = new EndringsdatoRevurderingUtlederImpl(
-        repositoryProvider, dekningsgradTjeneste, new RelevanteArbeidsforholdTjeneste(repositoryProvider.getFpUttakRepository()));
+        repositoryProvider, dekningsgradTjeneste, new RelevanteArbeidsforholdTjeneste(repositoryProvider.getFpUttakRepository()), saldoTjeneste);
 
     @Test
     public void skal_utlede_at_endringsdatoen_er_første_uttaksdato_til_startdato_for_uttak_når_dekningsgrad_er_endret() {

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
 
         <java.version>17</java.version>
 
-        <fp-uttak.version>12.4.4</fp-uttak.version>
+        <fp-uttak.version>12.4.5</fp-uttak.version>
         <svp-uttak.version>2.3.2</svp-uttak.version>
         <felles.version>4.1.23</felles.version>
         <prosesstask.version>3.1.7</prosesstask.version>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
 
         <java.version>17</java.version>
 
-        <fp-uttak.version>12.4.5</fp-uttak.version>
+        <fp-uttak.version>12.4.6</fp-uttak.version>
         <svp-uttak.version>2.3.2</svp-uttak.version>
         <felles.version>4.1.23</felles.version>
         <prosesstask.version>3.1.7</prosesstask.version>

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/forvaltning/BerørtBehandlingForvaltningTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/forvaltning/BerørtBehandlingForvaltningTjeneste.java
@@ -3,13 +3,13 @@ package no.nav.foreldrepenger.web.app.tjenester.forvaltning;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
-import no.nav.foreldrepenger.behandling.revurdering.BerørtBehandlingTjeneste;
 import no.nav.foreldrepenger.behandling.revurdering.RevurderingTjeneste;
 import no.nav.foreldrepenger.behandlingskontroll.FagsakYtelseTypeRef;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingÅrsakType;
 import no.nav.foreldrepenger.behandlingslager.fagsak.Fagsak;
 import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakYtelseType;
 import no.nav.foreldrepenger.behandlingsprosess.prosessering.BehandlingProsesseringTjeneste;
+import no.nav.foreldrepenger.mottak.sakskompleks.BerørtBehandlingKontroller;
 import no.nav.foreldrepenger.produksjonsstyring.behandlingenhet.BehandlendeEnhetTjeneste;
 
 @ApplicationScoped
@@ -17,7 +17,7 @@ public class BerørtBehandlingForvaltningTjeneste {
 
     private RevurderingTjeneste revurderingTjeneste;
     private BehandlendeEnhetTjeneste behandlendeEnhetTjeneste;
-    private BerørtBehandlingTjeneste berørtBehandlingTjeneste;
+    private BerørtBehandlingKontroller berørtBehandlingTjeneste;
     private BehandlingProsesseringTjeneste behandlingProsesseringTjeneste;
 
     BerørtBehandlingForvaltningTjeneste() {
@@ -27,7 +27,7 @@ public class BerørtBehandlingForvaltningTjeneste {
     @Inject
     public BerørtBehandlingForvaltningTjeneste(@FagsakYtelseTypeRef(FagsakYtelseType.FORELDREPENGER) RevurderingTjeneste revurderingTjeneste,
                                                BehandlendeEnhetTjeneste behandlendeEnhetTjeneste,
-                                               BerørtBehandlingTjeneste berørtBehandlingTjeneste,
+                                               BerørtBehandlingKontroller berørtBehandlingTjeneste,
                                                BehandlingProsesseringTjeneste behandlingProsesseringTjeneste) {
         this.revurderingTjeneste = revurderingTjeneste;
         this.behandlendeEnhetTjeneste = behandlendeEnhetTjeneste;

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/forvaltning/ForvaltningSvangerskapspengerRestTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/forvaltning/ForvaltningSvangerskapspengerRestTjeneste.java
@@ -20,7 +20,6 @@ import org.slf4j.LoggerFactory;
 
 import io.swagger.v3.oas.annotations.Operation;
 import no.nav.foreldrepenger.abac.FPSakBeskyttetRessursAttributt;
-import no.nav.foreldrepenger.behandling.revurdering.BerørtBehandlingTjeneste;
 import no.nav.foreldrepenger.behandling.revurdering.RevurderingTjeneste;
 import no.nav.foreldrepenger.behandlingskontroll.FagsakYtelseTypeRef;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingÅrsakType;
@@ -29,6 +28,7 @@ import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakRepository;
 import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakYtelseType;
 import no.nav.foreldrepenger.behandlingsprosess.prosessering.BehandlingProsesseringTjeneste;
 import no.nav.foreldrepenger.domene.typer.Saksnummer;
+import no.nav.foreldrepenger.mottak.sakskompleks.BerørtBehandlingKontroller;
 import no.nav.foreldrepenger.produksjonsstyring.behandlingenhet.BehandlendeEnhetTjeneste;
 import no.nav.foreldrepenger.web.app.tjenester.fagsak.dto.SaksnummerAbacSupplier;
 import no.nav.foreldrepenger.web.app.tjenester.fagsak.dto.SaksnummerDto;
@@ -44,7 +44,7 @@ public class ForvaltningSvangerskapspengerRestTjeneste {
 
     private SVPFeriepengekontrollTjeneste svpFeriepengekontrollTjeneste;
     private BehandlingRevurderingRepository behandlingRevurderingRepository;
-    private BerørtBehandlingTjeneste berørtBehandlingTjeneste;
+    private BerørtBehandlingKontroller berørtBehandlingTjeneste;
     private FagsakRepository fagsakRepository;
     private BehandlendeEnhetTjeneste behandlendeEnhetTjeneste;
     private RevurderingTjeneste revurderingTjeneste;
@@ -53,7 +53,7 @@ public class ForvaltningSvangerskapspengerRestTjeneste {
     @Inject
     public ForvaltningSvangerskapspengerRestTjeneste(SVPFeriepengekontrollTjeneste svpFeriepengekontrollTjeneste,
                                                      BehandlingRevurderingRepository behandlingRevurderingRepository,
-                                                     BerørtBehandlingTjeneste berørtBehandlingTjeneste,
+                                                     BerørtBehandlingKontroller berørtBehandlingTjeneste,
                                                      FagsakRepository fagsakRepository,
                                                      BehandlendeEnhetTjeneste behandlendeEnhetTjeneste,
                                                      @FagsakYtelseTypeRef(FagsakYtelseType.SVANGERSKAPSPENGER) RevurderingTjeneste revurderingTjeneste,


### PR DESCRIPTION
Ommøblere utledning av endringsdato for berørt til bruk for både berørt-opprettes-tjeneste og endringsdato-
Endringsdatoutleder logger utledet endringsdato for berørte

Endringsdatoutleder bruker seneste av sisteFørsteUttak og annenpartEndringsdato

Oppfølging: NegativSaldo - har gamblet på at stønadskontoSaldoTjeneste.erNegativSaldoPåNoenKonto(input) vil gi samme resultat om den kalles med UttakInput(pågåendeBerørt) som for UttakInput(avsluttettAnnenPart)

Skjønner ikke effekten av tapende behandling - Mulig man må bytte om søknadsdatoene - eller lagre en forenklet metode for å sjekke om det er negativ saldo - en som dumt teller opp forbruk uansett periodetype (uttak, opphold, etc)