### PR TITLE
TFP-5052 1gang tilbakehopp - nullstill manuelt vurderte vilkår

### DIFF
--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/vilkår/VilkårResultat.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/vilkår/VilkårResultat.java
@@ -290,16 +290,18 @@ public class VilkårResultat extends BaseEntitet {
             return this;
         }
 
-        public Builder nullstillVilkår(Vilkår vilkår) {
+        public Builder nullstillVilkår(Vilkår vilkår, boolean nullstillManuelt) {
             if (VilkårUtfallType.erFastsatt(vilkår.getVilkårUtfallOverstyrt())) {
                 throw new IllegalStateException("Utviklerfeil - vilkåret er overstyrt");
             }
-            if (VilkårUtfallType.erFastsatt(vilkår.getVilkårUtfallManuelt())) {
-                LOG.info("VILKÅR: Nullstiller vilkår {} som er manuelt vurdert {}", vilkår.getVilkårType(), vilkår.getVilkårUtfallManuelt());
+            if (!nullstillManuelt && VilkårUtfallType.erFastsatt(vilkår.getVilkårUtfallManuelt())) {
+                LOG.info("VILKÅR: Nullstiller ikke vilkår {} som er manuelt vurdert {}", vilkår.getVilkårType(), vilkår.getVilkårUtfallManuelt());
             }
             var builder = getBuilderFor(vilkår.getVilkårType())
                 .medVilkårUtfall(VilkårUtfallType.IKKE_VURDERT, VilkårUtfallMerknad.UDEFINERT);
-                // TODO(jol) sjekk logg og vurdere denne .medUtfallManuell(VilkårUtfallType.UDEFINERT, Avslagsårsak.UDEFINERT);
+            if (nullstillManuelt) {
+                builder.medUtfallManuell(VilkårUtfallType.UDEFINERT, Avslagsårsak.UDEFINERT);
+            }
             vilkårene.put(vilkår.getVilkårType(), builder.build());
             modifisert = true;
             return this;

--- a/behandlingsprosess/src/main/java/no/nav/foreldrepenger/behandling/steg/inngangsvilkår/InngangsvilkårStegImpl.java
+++ b/behandlingsprosess/src/main/java/no/nav/foreldrepenger/behandling/steg/inngangsvilkår/InngangsvilkårStegImpl.java
@@ -15,6 +15,7 @@ import no.nav.foreldrepenger.behandlingskontroll.BehandlingskontrollKontekst;
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingResultatType;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingStegType;
+import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingType;
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandlingsresultat;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingsresultatRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.AksjonspunktDefinisjon;
@@ -156,7 +157,7 @@ public abstract class InngangsvilkårStegImpl implements InngangsvilkårSteg {
         if (!erVilkårOverstyrt(kontekst.getBehandlingId())) {
             var behandling = behandlingRepository.hentBehandling(kontekst.getBehandlingId());
             var ryddVilkårTyper = new RyddVilkårTyper(repositoryProvider, behandling, kontekst);
-            ryddVilkårTyper.ryddVedTilbakeføring(vilkårHåndtertAvSteg());
+            ryddVilkårTyper.ryddVedTilbakeføring(vilkårHåndtertAvSteg(), BehandlingType.FØRSTEGANGSSØKNAD.equals(behandling.getType()));
             behandlingRepository.lagre(behandling, behandlingRepository.taSkriveLås(behandling));
         }
     }

--- a/behandlingsprosess/src/main/java/no/nav/foreldrepenger/behandling/steg/inngangsvilkår/RyddVilkårTyper.java
+++ b/behandlingsprosess/src/main/java/no/nav/foreldrepenger/behandling/steg/inngangsvilkår/RyddVilkårTyper.java
@@ -68,12 +68,12 @@ class RyddVilkårTyper {
 
     void ryddVedOverhoppFramover(List<VilkårType> vilkårTyper) {
         slettAvklarteFakta(vilkårTyper);
-        nullstillVilkår(vilkårTyper);
+        nullstillVilkår(vilkårTyper, false);
     }
 
-    void ryddVedTilbakeføring(List<VilkårType> vilkårTyper) {
+    void ryddVedTilbakeføring(List<VilkårType> vilkårTyper, boolean nullstillManueltAvklartVilkår) {
         nullstillInngangsvilkår();
-        nullstillVilkår(vilkårTyper);
+        nullstillVilkår(vilkårTyper, nullstillManueltAvklartVilkår);
         nullstillVedtaksresultat();
     }
 
@@ -111,7 +111,7 @@ class RyddVilkårTyper {
                 .buildFor(behandling));
     }
 
-    private void nullstillVilkår(List<VilkårType> vilkårTyper) {
+    private void nullstillVilkår(List<VilkårType> vilkårTyper, boolean nullstillManueltAvklartVilkår) {
         Optional.ofNullable(getBehandlingsresultat(behandling))
             .map(Behandlingsresultat::getVilkårResultat)
             .ifPresent(vilkårResultat -> {
@@ -121,7 +121,7 @@ class RyddVilkårTyper {
                     .collect(toList());
                 if (!vilkårSomSkalNullstilles.isEmpty()) {
                     var builder = VilkårResultat.builderFraEksisterende(vilkårResultat);
-                    vilkårSomSkalNullstilles.forEach(builder::nullstillVilkår);
+                    vilkårSomSkalNullstilles.forEach(v -> builder.nullstillVilkår(v, nullstillManueltAvklartVilkår));
                     builder.buildFor(behandling);
                 }
             });


### PR DESCRIPTION
Avklart å kun være ønskelig ved førstegangsbehandling . Handler om å få gjenåpnet fx manuell vurdering av opptjeningsvilkåret dersom man hopper tilbake av andre grunner.

Neste fase er å vurdere oppførsel for manuelt opprettet revurdering. Men det blir en egen PR