### PR TITLE
Beholde tidlistmottattdato dersom før ap-oppdaterer sin dato

### DIFF
--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/søknad/aksjonspunkt/VurderSøknadsfristOppdatererTjenesteFP.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/søknad/aksjonspunkt/VurderSøknadsfristOppdatererTjenesteFP.java
@@ -49,7 +49,11 @@ public class VurderSøknadsfristOppdatererTjenesteFP extends VurderSøknadsfrist
             .map(p -> {
                 var builder = OppgittPeriodeBuilder.fraEksisterende(p);
                 if (Objects.equals(p.getPeriodeKilde(), FordelingPeriodeKilde.SØKNAD)) {
-                    builder.medMottattDato(mottattDato).medTidligstMottattDato(mottattDato);
+                    builder.medMottattDato(mottattDato);
+                }
+                if (Objects.equals(p.getPeriodeKilde(), FordelingPeriodeKilde.SØKNAD) &&
+                    p.getTidligstMottattDato().filter(d -> d.isBefore(mottattDato)).isEmpty()) {
+                    builder.medTidligstMottattDato(mottattDato);
                 }
                 return builder.build();
             })

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/søknad/aksjonspunkt/VurderSøknadsfristOppdatererTjenesteFP.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/søknad/aksjonspunkt/VurderSøknadsfristOppdatererTjenesteFP.java
@@ -52,6 +52,7 @@ public class VurderSøknadsfristOppdatererTjenesteFP extends VurderSøknadsfrist
                     builder.medMottattDato(mottattDato);
                 }
                 if (Objects.equals(p.getPeriodeKilde(), FordelingPeriodeKilde.SØKNAD) &&
+                    p.getTidligstMottattDato().filter(d -> d.isBefore(p.getMottattDato())).isEmpty() && 
                     p.getTidligstMottattDato().filter(d -> d.isBefore(mottattDato)).isEmpty()) {
                     builder.medTidligstMottattDato(mottattDato);
                 }

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/søknad/aksjonspunkt/VurderSøknadsfristOppdatererTjenesteFP.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/søknad/aksjonspunkt/VurderSøknadsfristOppdatererTjenesteFP.java
@@ -52,8 +52,8 @@ public class VurderSøknadsfristOppdatererTjenesteFP extends VurderSøknadsfrist
                     builder.medMottattDato(mottattDato);
                 }
                 if (Objects.equals(p.getPeriodeKilde(), FordelingPeriodeKilde.SØKNAD) &&
-                    p.getTidligstMottattDato().filter(d -> d.isBefore(p.getMottattDato())).isEmpty() && 
-                    p.getTidligstMottattDato().filter(d -> d.isBefore(mottattDato)).isEmpty()) {
+                    (p.getTidligstMottattDato().filter(d -> d.isBefore(p.getMottattDato())).isEmpty() ||
+                        p.getTidligstMottattDato().filter(d -> d.isBefore(mottattDato)).isEmpty())) {
                     builder.medTidligstMottattDato(mottattDato);
                 }
                 return builder.build();


### PR DESCRIPTION
Som diskutert. La tidligstemottattdato ligge i fred dersom den er før mottattdato.
Trenger litt fintenking på utvalget - ikke helt sikker