### PR TITLE
Litt mer robust håndtering av behandlingstatusevents

### DIFF
--- a/domenetjenester/behandling/src/main/java/no/nav/foreldrepenger/behandling/FagsakStatusEventPubliserer.java
+++ b/domenetjenester/behandling/src/main/java/no/nav/foreldrepenger/behandling/FagsakStatusEventPubliserer.java
@@ -1,6 +1,7 @@
 package no.nav.foreldrepenger.behandling;
 
 import java.util.Objects;
+import java.util.Optional;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.event.Event;
@@ -9,7 +10,6 @@ import javax.inject.Inject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
 import no.nav.foreldrepenger.behandlingslager.fagsak.Fagsak;
 import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakStatus;
 
@@ -28,27 +28,20 @@ public class FagsakStatusEventPubliserer {
         this.fagsakStatusEvent = fagsakStatusEvent;
     }
 
-    public void fireEvent(Fagsak fagsak, Behandling behandling, FagsakStatus gammelStatusIn, FagsakStatus nyStatusIn) {
-        fireEventBehandlingId(fagsak, behandling != null ? behandling.getId() : null, gammelStatusIn, nyStatusIn);
-    }
-
-    public void fireEventBehandlingId(Fagsak fagsak, Long behandlingId, FagsakStatus gammelStatusIn, FagsakStatus nyStatusIn) {
-        if (((gammelStatusIn == null) && (nyStatusIn == null)) // NOSONAR
-                || Objects.equals(gammelStatusIn, nyStatusIn)) { // NOSONAR
-            // gjør ingenting
+    public void fireEvent(Fagsak fagsak, Long behandlingId, FagsakStatus gammelStatusIn, FagsakStatus nyStatusIn) {
+        if (Objects.equals(gammelStatusIn, nyStatusIn)) {
             return;
         }
-        if ((gammelStatusIn == null) && (nyStatusIn != null)) {// NOSONAR
+        if (gammelStatusIn == null) {
             LOG.info("Fagsak status opprettet: id [{}]; type [{}];", fagsak.getId(), fagsak.getYtelseType());
         } else {
-            var fagsakId = fagsak.getId();
-            var gammelStatus = gammelStatusIn.getKode(); // NOSONAR false positive NPE dereference
-            var nyStatus = nyStatusIn == null ? null : nyStatusIn.getKode();
+            var gammelStatus = gammelStatusIn.getKode();
+            var nyStatus = Optional.ofNullable(nyStatusIn).map(FagsakStatus::getKode).orElse("null");
 
             if (behandlingId != null) {
-                LOG.info("Fagsak status oppdatert: {} -> {}; fagsakId [{}] behandlingId [{}]", gammelStatus, nyStatus, fagsakId, behandlingId);
+                LOG.info("Fagsak status oppdatert: {} -> {}; fagsakId [{}] behandlingId [{}]", gammelStatus, nyStatus, fagsak.getId(), behandlingId);
             } else {
-                LOG.info("Fagsak status oppdatert: {} -> {}; fagsakId [{}]", gammelStatus, nyStatus, fagsakId); //$NON-NLS-1$
+                LOG.info("Fagsak status oppdatert: {} -> {}; fagsakId [{}]", gammelStatus, nyStatus, fagsak.getId()); //$NON-NLS-1$
             }
         }
 

--- a/domenetjenester/behandling/src/main/java/no/nav/foreldrepenger/behandling/FagsakStatusEventPubliserer.java
+++ b/domenetjenester/behandling/src/main/java/no/nav/foreldrepenger/behandling/FagsakStatusEventPubliserer.java
@@ -29,6 +29,10 @@ public class FagsakStatusEventPubliserer {
     }
 
     public void fireEvent(Fagsak fagsak, Behandling behandling, FagsakStatus gammelStatusIn, FagsakStatus nyStatusIn) {
+        fireEventBehandlingId(fagsak, behandling != null ? behandling.getId() : null, gammelStatusIn, nyStatusIn);
+    }
+
+    public void fireEventBehandlingId(Fagsak fagsak, Long behandlingId, FagsakStatus gammelStatusIn, FagsakStatus nyStatusIn) {
         if (((gammelStatusIn == null) && (nyStatusIn == null)) // NOSONAR
                 || Objects.equals(gammelStatusIn, nyStatusIn)) { // NOSONAR
             // gjør ingenting
@@ -41,9 +45,8 @@ public class FagsakStatusEventPubliserer {
             var gammelStatus = gammelStatusIn.getKode(); // NOSONAR false positive NPE dereference
             var nyStatus = nyStatusIn == null ? null : nyStatusIn.getKode();
 
-            if (behandling != null) {
-                LOG.info("Fagsak status oppdatert: {} -> {}; fagsakId [{}] behandlingId [{}]", gammelStatus, nyStatus, fagsakId, //$NON-NLS-1$
-                        behandling.getId());
+            if (behandlingId != null) {
+                LOG.info("Fagsak status oppdatert: {} -> {}; fagsakId [{}] behandlingId [{}]", gammelStatus, nyStatus, fagsakId, behandlingId);
             } else {
                 LOG.info("Fagsak status oppdatert: {} -> {}; fagsakId [{}]", gammelStatus, nyStatus, fagsakId); //$NON-NLS-1$
             }

--- a/domenetjenester/vedtak/src/main/java/no/nav/foreldrepenger/domene/vedtak/OppdaterFagsakStatusTjeneste.java
+++ b/domenetjenester/vedtak/src/main/java/no/nav/foreldrepenger/domene/vedtak/OppdaterFagsakStatusTjeneste.java
@@ -54,7 +54,7 @@ public class OppdaterFagsakStatusTjeneste {
     public void oppdaterFagsakNårBehandlingOpprettet(Fagsak fagsak, Long behandlingId, BehandlingStatus nyStatus) {
         //Fagsak har status under behandling eller løpende - det opprettes ny behandling
         if (erBehandlingOpprettetEllerUnderBehandling(nyStatus)) {
-            oppdaterFagsakStatusBehandlingId(fagsak, behandlingId, FagsakStatus.UNDER_BEHANDLING);
+            oppdaterFagsakStatus(fagsak, behandlingId, FagsakStatus.UNDER_BEHANDLING);
         } else {
             throw new IllegalStateException(String.format("Utviklerfeil: oppdaterFagsakNårBehandlingOpprettet ble trigget for behandlingId %s med status %s. Det skal ikke skje og må følges opp",
                 behandlingId , nyStatus));
@@ -77,7 +77,7 @@ public class OppdaterFagsakStatusTjeneste {
             throw new IllegalStateException(String.format("Utviklerfeil: BehandlingId: %s med ytelsestype %s skal ikke trigges av AutomatiskFagsakAvslutningTask. Noe er galt.",  behandling.getId() ,behandling.getStatus()));
         } else {
             if (alleAndreBehandlingerErLukket(fagsak, behandling)) {
-                oppdaterFagsakStatus(fagsak, behandling, FagsakStatus.AVSLUTTET);
+                oppdaterFagsakStatus(fagsak, behandling.getId(), FagsakStatus.AVSLUTTET);
                 return FagsakStatusOppdateringResultat.FAGSAK_AVSLUTTET;
             }
         }
@@ -91,21 +91,22 @@ public class OppdaterFagsakStatusTjeneste {
     public void settUnderBehandlingNårAktiveBehandlinger(Fagsak fagsak) {
         if (behandlingRepository.harÅpenOrdinærYtelseBehandlingerForFagsakId(fagsak.getId()) && FagsakStatus.LØPENDE.equals(fagsak.getStatus())) {
             var behandling = behandlingRepository.hentSisteYtelsesBehandlingForFagsakId(fagsak.getId()).orElseThrow();
-            oppdaterFagsakStatus(fagsak, behandling, FagsakStatus.UNDER_BEHANDLING);
+            oppdaterFagsakStatus(fagsak, behandling.getId(), FagsakStatus.UNDER_BEHANDLING);
         }
     }
 
     public FagsakStatusOppdateringResultat oppdaterFagsakStatusNårAlleBehandlingerErLukket(Fagsak fagsak, Behandling behandling) {
+        var behandlingId = behandling != null ? behandling.getId() : null;
         if (alleAndreBehandlingerErLukket(fagsak, behandling)) {
             if (FagsakYtelseType.ENGANGSTØNAD.equals(fagsak.getYtelseType())) {
-                oppdaterFagsakStatus(fagsak, behandling, FagsakStatus.AVSLUTTET);
+                oppdaterFagsakStatus(fagsak,behandlingId, FagsakStatus.AVSLUTTET);
                 return FagsakStatusOppdateringResultat.FAGSAK_AVSLUTTET;
             } else {
                 if (behandling == null || ingenLøpendeYtelseVedtak(behandling)) {
-                    oppdaterFagsakStatus(fagsak, behandling, FagsakStatus.AVSLUTTET);
+                    oppdaterFagsakStatus(fagsak, behandlingId, FagsakStatus.AVSLUTTET);
                     return FagsakStatusOppdateringResultat.FAGSAK_AVSLUTTET;
                 }
-                oppdaterFagsakStatus(fagsak, behandling, FagsakStatus.LØPENDE);
+                oppdaterFagsakStatus(fagsak, behandlingId, FagsakStatus.LØPENDE);
                 return FagsakStatusOppdateringResultat.FAGSAK_LØPENDE;
             }
         }
@@ -133,23 +134,13 @@ public class OppdaterFagsakStatusTjeneste {
         return BehandlingStatus.OPPRETTET.equals(status) || BehandlingStatus.UTREDES.equals(status) ;
     }
 
-    private void oppdaterFagsakStatus(Fagsak fagsak, Behandling behandling, FagsakStatus nyStatus) {
+    private void oppdaterFagsakStatus(Fagsak fagsak, Long behandlingId, FagsakStatus nyStatus) {
         var gammelStatus = fagsak.getStatus();
         var fagsakId = fagsak.getId();
         fagsakRepository.oppdaterFagsakStatus(fagsakId, nyStatus);
 
         if (fagsakStatusEventPubliserer != null) {
-            fagsakStatusEventPubliserer.fireEvent(fagsak, behandling, gammelStatus, nyStatus);
-        }
-    }
-
-    private void oppdaterFagsakStatusBehandlingId(Fagsak fagsak, Long behandlingId, FagsakStatus nyStatus) {
-        var gammelStatus = fagsak.getStatus();
-        var fagsakId = fagsak.getId();
-        fagsakRepository.oppdaterFagsakStatus(fagsakId, nyStatus);
-
-        if (fagsakStatusEventPubliserer != null) {
-            fagsakStatusEventPubliserer.fireEventBehandlingId(fagsak, behandlingId, gammelStatus, nyStatus);
+            fagsakStatusEventPubliserer.fireEvent(fagsak, behandlingId, gammelStatus, nyStatus);
         }
     }
 

--- a/domenetjenester/vedtak/src/main/java/no/nav/foreldrepenger/domene/vedtak/batch/FagsakStatusEventObserver.java
+++ b/domenetjenester/vedtak/src/main/java/no/nav/foreldrepenger/domene/vedtak/batch/FagsakStatusEventObserver.java
@@ -9,6 +9,7 @@ import org.slf4j.LoggerFactory;
 
 import no.nav.foreldrepenger.behandlingskontroll.events.BehandlingStatusEvent;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepository;
+import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakRepository;
 import no.nav.foreldrepenger.domene.vedtak.OppdaterFagsakStatusTjeneste;
 
 /**
@@ -21,26 +22,29 @@ public class FagsakStatusEventObserver {
 
     private OppdaterFagsakStatusTjeneste oppdaterFagsakStatusTjeneste;
     private BehandlingRepository behandlingRepository;
+    private FagsakRepository fagsakRepository;
 
     FagsakStatusEventObserver() {
         // For CDI
     }
 
     @Inject
-    public FagsakStatusEventObserver(OppdaterFagsakStatusTjeneste oppdaterFagsakStatusTjeneste, BehandlingRepository behandlingRepository) {
+    public FagsakStatusEventObserver(OppdaterFagsakStatusTjeneste oppdaterFagsakStatusTjeneste,
+                                     BehandlingRepository behandlingRepository,
+                                     FagsakRepository fagsakRepository) {
         this.oppdaterFagsakStatusTjeneste = oppdaterFagsakStatusTjeneste;
         this.behandlingRepository = behandlingRepository;
     }
 
     public void observerBehandlingOpprettetEvent(@Observes BehandlingStatusEvent.BehandlingOpprettetEvent event) {
         LOG.debug("Oppdaterer status på Fagsak etter endring i behandling {}", event.getBehandlingId());//NOSONAR
-        var behandling = behandlingRepository.hentBehandling(event.getBehandlingId());
-        oppdaterFagsakStatusTjeneste.oppdaterFagsakNårBehandlingOpprettet(behandling);
+        var fagsak = fagsakRepository.finnEksaktFagsak(event.getFagsakId());
+        oppdaterFagsakStatusTjeneste.oppdaterFagsakNårBehandlingOpprettet(fagsak, event.getBehandlingId(), event.getNyStatus());
     }
 
     public void observerBehandlingAvsluttetEvent(@Observes BehandlingStatusEvent.BehandlingAvsluttetEvent event) {
         LOG.debug("Oppdaterer status på Fagsak etter endring i behandling {}", event.getBehandlingId());//NOSONAR
         var behandling = behandlingRepository.hentBehandling(event.getBehandlingId());
-        oppdaterFagsakStatusTjeneste.oppdaterFagsakNårBehandlingAvsluttet(behandling);
+        oppdaterFagsakStatusTjeneste.oppdaterFagsakNårBehandlingAvsluttet(behandling, event.getNyStatus());
     }
 }

--- a/domenetjenester/vedtak/src/main/java/no/nav/foreldrepenger/domene/vedtak/batch/FagsakStatusEventObserver.java
+++ b/domenetjenester/vedtak/src/main/java/no/nav/foreldrepenger/domene/vedtak/batch/FagsakStatusEventObserver.java
@@ -34,6 +34,7 @@ public class FagsakStatusEventObserver {
                                      FagsakRepository fagsakRepository) {
         this.oppdaterFagsakStatusTjeneste = oppdaterFagsakStatusTjeneste;
         this.behandlingRepository = behandlingRepository;
+        this.fagsakRepository = fagsakRepository;
     }
 
     public void observerBehandlingOpprettetEvent(@Observes BehandlingStatusEvent.BehandlingOpprettetEvent event) {


### PR DESCRIPTION
Man kan prøve å erstatte mest mulig bruk av Behandling med behandlingId også for behandling-avsluttet.