### PR TITLE
TFP-5068 TFP-4974 nye uttak årsaker og utvide dto mhp klient-forenkling

### DIFF
--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/uttak/fp/PeriodeResultatÅrsak.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/uttak/fp/PeriodeResultatÅrsak.java
@@ -3,6 +3,7 @@ package no.nav.foreldrepenger.behandlingslager.uttak.fp;
 import static java.util.Set.of;
 import static no.nav.foreldrepenger.behandlingslager.uttak.fp.PeriodeResultatÅrsak.LovEndring.FRITT_UTTAK;
 import static no.nav.foreldrepenger.behandlingslager.uttak.fp.PeriodeResultatÅrsak.LovEndring.KREVER_SAMMENHENGENDE_UTTAK;
+import static no.nav.foreldrepenger.behandlingslager.uttak.fp.PeriodeResultatÅrsak.LovEndring.MINSTERETT_2022;
 import static no.nav.foreldrepenger.behandlingslager.uttak.fp.PeriodeResultatÅrsak.SynligFor.IKKE_MOR;
 import static no.nav.foreldrepenger.behandlingslager.uttak.fp.PeriodeResultatÅrsak.SynligFor.MOR;
 import static no.nav.foreldrepenger.behandlingslager.uttak.fp.StønadskontoType.FEDREKVOTE;
@@ -93,19 +94,19 @@ public enum PeriodeResultatÅrsak implements Kodeverdi, ÅrsakskodeMedLovreferan
             of(UTTAK), of(MØDREKVOTE, FEDREKVOTE)),
     UTSETTELSE_GYLDIG
         ("2024", "14-11", "§14-11: Gyldig utsettelse", "{\"fagsakYtelseType\": {\"FP\": {\"lovreferanse\": \"14-11\"}}}",
-            of(UTSETTELSE), null, of(FRITT_UTTAK), null),
+            of(UTSETTELSE), null, of(FRITT_UTTAK, MINSTERETT_2022), null),
     UTSETTELSE_GYLDIG_SEKS_UKER_INNLEGGELSE
         ("2025", "14-11", "§14-11: Gyldig utsettelse første 6 uker pga. innleggelse", "{\"fagsakYtelseType\": {\"FP\": {\"lovreferanse\": \"14-11\"}}}",
-            of(UTSETTELSE), of(MØDREKVOTE, FORELDREPENGER), of(FRITT_UTTAK), of(MOR)),
+            of(UTSETTELSE), of(MØDREKVOTE, FORELDREPENGER), of(FRITT_UTTAK, MINSTERETT_2022), of(MOR)),
     UTSETTELSE_GYLDIG_SEKS_UKER_FRI_BARN_INNLAGT
         ("2026", "14-11", "§14-11: Gyldig utsettelse første 6 uker pga. barn innlagt", "{\"fagsakYtelseType\": {\"FP\": {\"lovreferanse\": \"14-11\"}}}",
-            of(UTSETTELSE), of(MØDREKVOTE, FORELDREPENGER), of(FRITT_UTTAK), of(MOR)),
+            of(UTSETTELSE), of(MØDREKVOTE, FORELDREPENGER), of(FRITT_UTTAK, MINSTERETT_2022), of(MOR)),
     UTSETTELSE_GYLDIG_SEKS_UKER_FRI_SYKDOM
         ("2027", "14-11", "§14-11: Gyldig utsettelse første 6 uker pga. sykdom", "{\"fagsakYtelseType\": {\"FP\": {\"lovreferanse\": \"14-11\"}}}",
-            of(UTSETTELSE), of(MØDREKVOTE, FORELDREPENGER), of(FRITT_UTTAK), of(MOR)),
+            of(UTSETTELSE), of(MØDREKVOTE, FORELDREPENGER), of(FRITT_UTTAK, MINSTERETT_2022), of(MOR)),
     UTSETTELSE_GYLDIG_BFR_AKT_KRAV_OPPFYLT
         ("2028", "14-14", "§14-14, jf. 14-13: Bare far rett, aktivitetskravet oppfylt", "{\"fagsakYtelseType\": {\"FP\": {\"lovreferanse\": \"14-14,14-13\"}}}",
-            of(UTSETTELSE), of(FORELDREPENGER), of(FRITT_UTTAK), of(IKKE_MOR)),
+            of(UTSETTELSE), of(FORELDREPENGER), of(FRITT_UTTAK, MINSTERETT_2022), of(IKKE_MOR)),
     GRADERING_FELLESPERIODE_ELLER_FORELDREPENGER
         ("2030", "14-16", "§14-9, jf. §14-16: Gradering av fellesperiode/foreldrepenger", "{\"fagsakYtelseType\": {\"FP\": {\"lovreferanse\": \"14-9,14-16\"}}}",
             of(UTTAK), of(FELLESPERIODE, FORELDREPENGER)),
@@ -334,34 +335,41 @@ public enum PeriodeResultatÅrsak implements Kodeverdi, ÅrsakskodeMedLovreferan
         ("4100", "14-10-2", "§14-10 andre ledd: Uttak før omsorgsovertakelse", "", of(UTTAK)),
     BARE_FAR_RETT_IKKE_SØKT
         ("4102", "14-14", "§14-14, jf 14-13: Bare far har rett, mangler søknad uttak/aktivitetskrav", "{\"fagsakYtelseType\": {\"FP\": {\"lovreferanse\": \"14-14,14-13\"}}}",
-            of(UTTAK), of(FORELDREPENGER), of(FRITT_UTTAK), of(IKKE_MOR)),
+            of(UTTAK), of(FORELDREPENGER), of(FRITT_UTTAK, MINSTERETT_2022), of(IKKE_MOR)),
     MOR_FØRSTE_SEKS_UKER_IKKE_SØKT
         ("4103", "14-09-6", "§14-9 sjette ledd: Mangler søknad for første 6 uker etter fødsel", "{\"fagsakYtelseType\": {\"FP\": {\"lovreferanse\": \"14-9\"}}}",
-            of(UTTAK), of(MØDREKVOTE, FORELDREPENGER), of(FRITT_UTTAK), of(MOR)),
+            of(UTTAK), of(MØDREKVOTE, FORELDREPENGER), of(FRITT_UTTAK, MINSTERETT_2022), of(MOR)),
     STØNADSPERIODE_NYTT_BARN
         ("4104", "14-10-3", "§14-10 tredje ledd: Stønadsperiode for nytt barn", "{\"fagsakYtelseType\": {\"FP\": {\"lovreferanse\": \"14-10\"}}}",
             of(UTTAK, UTSETTELSE)),
     FAR_SØKT_FØR_FØDSEL
         ("4105", "14-09-6", "§14-9 sjette ledd: Far/medmor søker uttak før fødsel/omsorg", "{\"fagsakYtelseType\": {\"FP\": {\"lovreferanse\": \"14-9\"}}}",
             of(UTTAK)),
+    FAR_MER_ENN_TI_DAGER_FEDREKVOTE_IFM_FØDSEL
+        ("4106", "14-10-1", "§14-10 første ledd: Far/medmor søker mer enn 10 dager ifm fødsel", "{\"fagsakYtelseType\": {\"FP\": {\"lovreferanse\": \"14-10\"}}}",
+            of(UTTAK), of(FEDREKVOTE), of(MINSTERETT_2022), of(IKKE_MOR)),
+    // TODO (jol): vurdere å tilby denne for alle lov-versjoner
+    BARE_FAR_RETT_MANGLER_MORS_AKTIVITET
+        ("4107", "14-14", "§14-14, jf 14-13: Bare far har rett, aktivitetskravet ikke oppgitt eller ikke dokumentert", "{\"fagsakYtelseType\": {\"FP\": {\"lovreferanse\": \"14-14,14-13\"}}}",
+            of(UTTAK, UTSETTELSE), of(FORELDREPENGER), of(MINSTERETT_2022), of(IKKE_MOR)),
     SØKERS_SYKDOM_SKADE_SEKS_UKER_IKKE_OPPFYLT
         ("4110", "14-11", "§14-11: Søkers sykdom/skade første 6 uker ikke oppfylt", "{\"fagsakYtelseType\": {\"FP\": {\"lovreferanse\": \"14-11\"}}}",
-            of(UTSETTELSE), of(MØDREKVOTE, FORELDREPENGER), of(FRITT_UTTAK), of(MOR)),
+            of(UTSETTELSE), of(MØDREKVOTE, FORELDREPENGER), of(FRITT_UTTAK, MINSTERETT_2022), of(MOR)),
     SØKERS_INNLEGGELSE_SEKS_UKER_IKKE_OPPFYLT
         ("4111", "14-11", "§14-11: Søkers innleggelse første 6 uker ikke oppfylt", "{\"fagsakYtelseType\": {\"FP\": {\"lovreferanse\": \"14-11\"}}}",
-            of(UTSETTELSE), of(MØDREKVOTE, FORELDREPENGER), of(FRITT_UTTAK), of(MOR)),
+            of(UTSETTELSE), of(MØDREKVOTE, FORELDREPENGER), of(FRITT_UTTAK, MINSTERETT_2022), of(MOR)),
     BARNETS_INNLEGGELSE_SEKS_UKER_IKKE_OPPFYLT
         ("4112", "14-11", "§14-11: Barnets innleggelse første 6 uker ikke oppfylt", "{\"fagsakYtelseType\": {\"FP\": {\"lovreferanse\": \"14-11\"}}}",
-            of(UTSETTELSE), of(MØDREKVOTE, FORELDREPENGER), of(FRITT_UTTAK), of(MOR)),
+            of(UTSETTELSE), of(MØDREKVOTE, FORELDREPENGER), of(FRITT_UTTAK, MINSTERETT_2022), of(MOR)),
     SØKERS_SYKDOM_ELLER_SKADE_SEKS_UKER_IKKE_DOKUMENTERT
         ("4115", "14-11", "§14-11, jf §21-3: Søkers sykdom/skade første 6 uker ikke dokumentert", "{\"fagsakYtelseType\": {\"FP\": {\"lovreferanse\": \"14-11,21-3\"}}}",
-            of(UTSETTELSE), of(MØDREKVOTE, FORELDREPENGER), of(FRITT_UTTAK), of(MOR)),
+            of(UTSETTELSE), of(MØDREKVOTE, FORELDREPENGER), of(FRITT_UTTAK, MINSTERETT_2022), of(MOR)),
     SØKERS_INNLEGGELSE_SEKS_UKER_IKKE_DOKUMENTERT
         ("4116", "14-11", "§14-11, jf §21-3: Søkers innleggelse første 6 uker ikke dokumentert", "{\"fagsakYtelseType\": {\"FP\": {\"lovreferanse\": \"14-11,21-3\"}}}",
-            of(UTSETTELSE), of(MØDREKVOTE, FORELDREPENGER), of(FRITT_UTTAK), of(MOR)),
+            of(UTSETTELSE), of(MØDREKVOTE, FORELDREPENGER), of(FRITT_UTTAK, MINSTERETT_2022), of(MOR)),
     BARNETS_INNLEGGELSE_SEKS_UKER_IKKE_DOKUMENTERT
         ("4117", "14-11", "§14-11, jf §21-3: Barnets innleggelse første 6 uker ikke dokumentert", "{\"fagsakYtelseType\": {\"FP\": {\"lovreferanse\": \"14-11,21-3\"}}}",
-            of(UTSETTELSE), of(MØDREKVOTE, FORELDREPENGER), of(FRITT_UTTAK), of(MOR)),
+            of(UTSETTELSE), of(MØDREKVOTE, FORELDREPENGER), of(FRITT_UTTAK, MINSTERETT_2022), of(MOR)),
     ;
 
     private static final Map<String, PeriodeResultatÅrsak> KODER = new LinkedHashMap<>();
@@ -525,7 +533,8 @@ public enum PeriodeResultatÅrsak implements Kodeverdi, ÅrsakskodeMedLovreferan
 
     public enum LovEndring {
         KREVER_SAMMENHENGENDE_UTTAK,
-        FRITT_UTTAK
+        FRITT_UTTAK,
+        MINSTERETT_2022
     }
 
     public enum UtfallType {

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/uttak/UttakRestTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/uttak/UttakRestTjeneste.java
@@ -178,7 +178,8 @@ public class UttakRestTjeneste {
     public UttakResultatPerioderDto hentUttakResultatPerioder(@TilpassetAbacAttributt(supplierClass = UuidAbacDataSupplier.class)
             @NotNull @QueryParam(UuidDto.NAME) @Parameter(description = UuidDto.DESC) @Valid UuidDto uuidDto) {
         var behandling = hentBehandling(uuidDto);
-        return uttakResultatPerioderDtoTjeneste.mapFra(behandling).orElse(null);
+        var skjæringstidspunkt = skjæringstidspunktTjeneste.getSkjæringstidspunkter(behandling.getId());
+        return uttakResultatPerioderDtoTjeneste.mapFra(behandling, skjæringstidspunkt).orElse(null);
     }
 
     @GET

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/uttak/dto/UttakResultatPerioderDto.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/uttak/dto/UttakResultatPerioderDto.java
@@ -3,5 +3,7 @@ package no.nav.foreldrepenger.web.app.tjenester.behandling.uttak.dto;
 import java.util.List;
 
 public record UttakResultatPerioderDto(List<UttakResultatPeriodeDto> perioderSøker, List<UttakResultatPeriodeDto> perioderAnnenpart,
-                                       boolean søkerErMor, boolean annenForelderHarRett, boolean aleneomsorg) {
+                                       boolean søkerErMor, boolean annenForelderHarRett, boolean aleneomsorg, FilterDto årsakFilter) {
+
+    public record FilterDto(boolean kreverSammenhengendeUttak, boolean utenMinsterett, boolean søkerErMor) {}
 }

--- a/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/uttak/app/UttakPerioderDtoTjenesteTest.java
+++ b/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/uttak/app/UttakPerioderDtoTjenesteTest.java
@@ -122,6 +122,8 @@ public class UttakPerioderDtoTjenesteTest extends EntityManagerAwareTest {
         assertThat(result.get().perioderSøker().get(0).getAktiviteter().get(0).getProsentArbeid()).isEqualTo(periodeAktivitet.getArbeidsprosent());
         assertThat(result.get().perioderSøker().get(0).getAktiviteter().get(0).getUtbetalingsgrad()).isEqualTo(periodeAktivitet.getUtbetalingsgrad());
         assertThat(result.get().perioderSøker().get(0).getAktiviteter().get(0).getUttakArbeidType()).isEqualTo(periodeAktivitet.getUttakArbeidType());
+        assertThat(result.get().årsakFilter().søkerErMor()).isTrue();
+        assertThat(result.get().årsakFilter().kreverSammenhengendeUttak()).isFalse();
     }
 
     private Behandling morBehandlingMedUttak(UttakResultatPerioderEntitet perioder) {
@@ -183,6 +185,8 @@ public class UttakPerioderDtoTjenesteTest extends EntityManagerAwareTest {
         assertThat(result.get().perioderSøker()).hasSize(2);
         assertThat(result.get().perioderSøker().get(0).getAktiviteter()).hasSize(2);
         assertThat(result.get().perioderSøker().get(1).getAktiviteter()).hasSize(1);
+        assertThat(result.get().årsakFilter().søkerErMor()).isTrue();
+        assertThat(result.get().årsakFilter().kreverSammenhengendeUttak()).isFalse();
     }
 
     private UttakResultatPeriodeAktivitetEntitet periodeAktivitet(UttakResultatPeriodeEntitet periode, String orgnr) {
@@ -236,6 +240,8 @@ public class UttakPerioderDtoTjenesteTest extends EntityManagerAwareTest {
 
         assertThat(result.get().perioderAnnenpart()).hasSize(1);
         assertThat(result.get().perioderAnnenpart().get(0).getAktiviteter()).hasSize(1);
+        assertThat(result.get().årsakFilter().søkerErMor()).isTrue();
+        assertThat(result.get().årsakFilter().kreverSammenhengendeUttak()).isFalse();
     }
 
     @Test
@@ -277,6 +283,8 @@ public class UttakPerioderDtoTjenesteTest extends EntityManagerAwareTest {
 
         assertThat(result.get().perioderAnnenpart()).hasSize(1);
         assertThat(result.get().perioderAnnenpart().get(0).getAktiviteter()).hasSize(1);
+        assertThat(result.get().årsakFilter().søkerErMor()).isTrue();
+        assertThat(result.get().årsakFilter().kreverSammenhengendeUttak()).isFalse();
     }
 
     private ArbeidsforholdInformasjonBuilder lagFiktivtArbeidsforholdOverstyring(InternArbeidsforholdRef internArbeidsforholdRef) {
@@ -321,6 +329,8 @@ public class UttakPerioderDtoTjenesteTest extends EntityManagerAwareTest {
 
         assertThat(result.get().perioderSøker().get(0).isSamtidigUttak()).isEqualTo(periode.isSamtidigUttak());
         assertThat(result.get().perioderSøker().get(0).getSamtidigUttaksprosent()).isEqualTo(periode.getSamtidigUttaksprosent());
+        assertThat(result.get().årsakFilter().søkerErMor()).isTrue();
+        assertThat(result.get().årsakFilter().kreverSammenhengendeUttak()).isFalse();
     }
 
     @Test
@@ -335,6 +345,23 @@ public class UttakPerioderDtoTjenesteTest extends EntityManagerAwareTest {
         var result = tjeneste.mapFra(behandling);
         assertThat(result.get().annenForelderHarRett()).isFalse();
         assertThat(result.get().aleneomsorg()).isFalse();
+        assertThat(result.get().årsakFilter().søkerErMor()).isTrue();
+        assertThat(result.get().årsakFilter().kreverSammenhengendeUttak()).isFalse();
+    }
+
+    @Test
+    public void skal_setteFilterFar() {
+        var scenario = ScenarioFarSøkerForeldrepenger.forFødsel();
+        scenario.medFordeling(null);
+        var behandling = scenario.lagre(repositoryProvider);
+        repositoryProvider.getBehandlingRepository().lagre(behandling, repositoryProvider.getBehandlingLåsRepository().taLås(behandling.getId()));
+
+        var tjeneste = tjeneste();
+
+        var result = tjeneste.mapFra(behandling);
+        assertThat(result.get().annenForelderHarRett()).isFalse();
+        assertThat(result.get().aleneomsorg()).isFalse();
+        assertThat(result.get().årsakFilter().søkerErMor()).isFalse();
     }
 
     @Test
@@ -358,6 +385,8 @@ public class UttakPerioderDtoTjenesteTest extends EntityManagerAwareTest {
         var result = tjeneste().mapFra(behandling);
         assertThat(result.get().annenForelderHarRett()).isTrue();
         assertThat(result.get().aleneomsorg()).isTrue();
+        assertThat(result.get().årsakFilter().søkerErMor()).isTrue();
+        assertThat(result.get().årsakFilter().kreverSammenhengendeUttak()).isFalse();
     }
 
     private UttakResultatPeriodeEntitet.Builder periodeBuilder(LocalDate fom, LocalDate tom) {


### PR DESCRIPTION
To nye årsaker iht TFP'er med synlighet kun for "MINSTERETT_2022" (den skal opp fra 8 til 10 uker seneste 2024)

Utvider UR-Dto med et årsakFilter - til bruk frontend (og formidling ?) - kan sanere 2 restkall for å sjekke minstrett og sammenhengendeUttak

OBS: Disse to fra Dto:  boolean annenForelderHarRett, boolean aleneomsorg - brukes av formidling, ikke frontend