### PR TITLE
Mulig å vurdere opptjening på nytt ved tilbakeføring

### DIFF
--- a/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/opptjening/aksjonspunkt/AksjonspunktutlederForVurderOppgittOpptjening.java
+++ b/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/opptjening/aksjonspunkt/AksjonspunktutlederForVurderOppgittOpptjening.java
@@ -75,6 +75,11 @@ public class AksjonspunktutlederForVurderOppgittOpptjening implements Aksjonspun
         var opptjeningPeriode = DatoIntervallEntitet.fraOgMedTilOgMed(fastsattOpptjeningOptional.get().getFom(),
                 fastsattOpptjeningOptional.get().getTom());
 
+        if (harBrukerOppgittPerioderMed(oppgittOpptjening, opptjeningPeriode, Collections.singletonList(ArbeidType.FRILANSER)) == JA) {
+            LOG.info("Utleder AP 5051 fra oppgitt eller bekreftet frilans: behandlingId={}", behandlingId);
+            return opprettListeForAksjonspunkt(AksjonspunktDefinisjon.VURDER_PERIODER_MED_OPPTJENING);
+        }
+
         if (harBrukerOppgittPerioderMed(oppgittOpptjening, opptjeningPeriode, finnRelevanteKoder()) == JA) {
             LOG.info("Utleder AP 5051 fra oppgitt opptjening");
             return opprettListeForAksjonspunkt(AksjonspunktDefinisjon.VURDER_PERIODER_MED_OPPTJENING);
@@ -82,11 +87,6 @@ public class AksjonspunktutlederForVurderOppgittOpptjening implements Aksjonspun
 
         if (harBrukerOppgittArbeidsforholdMed(ArbeidType.UTENLANDSK_ARBEIDSFORHOLD, opptjeningPeriode, oppgittOpptjening) == JA) {
             LOG.info("Utleder AP 5051 fra utlandsk arbeidsforhold");
-            return opprettListeForAksjonspunkt(AksjonspunktDefinisjon.VURDER_PERIODER_MED_OPPTJENING);
-        }
-
-        if (harBrukerOppgittPerioderMed(oppgittOpptjening, opptjeningPeriode, Collections.singletonList(ArbeidType.FRILANSER)) == JA) {
-            LOG.info("Utleder AP 5051 fra oppgitt eller bekreftet frilans: behandlingId={}", behandlingId);
             return opprettListeForAksjonspunkt(AksjonspunktDefinisjon.VURDER_PERIODER_MED_OPPTJENING);
         }
 

--- a/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/aksjonspunkt/app/AksjonspunktOppdatererTest.java
+++ b/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/aksjonspunkt/app/AksjonspunktOppdatererTest.java
@@ -33,8 +33,9 @@ import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.Ytelses
 import no.nav.foreldrepenger.behandlingslager.testutilities.behandling.ScenarioFarSøkerEngangsstønad;
 import no.nav.foreldrepenger.behandlingslager.uttak.fp.FpUttakRepository;
 import no.nav.foreldrepenger.dbstoette.EntityManagerAwareTest;
-import no.nav.foreldrepenger.domene.prosess.HentOgLagreBeregningsgrunnlagTjeneste;
 import no.nav.foreldrepenger.domene.abakus.AbakusInMemoryInntektArbeidYtelseTjeneste;
+import no.nav.foreldrepenger.domene.arbeidsforhold.InntektArbeidYtelseTjeneste;
+import no.nav.foreldrepenger.domene.prosess.HentOgLagreBeregningsgrunnlagTjeneste;
 import no.nav.foreldrepenger.domene.vedtak.VedtakTjeneste;
 import no.nav.foreldrepenger.domene.vedtak.impl.FatterVedtakAksjonspunkt;
 import no.nav.foreldrepenger.domene.vedtak.impl.KlageAnkeVedtakTjeneste;
@@ -98,7 +99,7 @@ public class AksjonspunktOppdatererTest extends EntityManagerAwareTest {
                 totrinnTjeneste,
                 new AbakusInMemoryInntektArbeidYtelseTjeneste());
         fatterVedtakAksjonspunkt = new FatterVedtakAksjonspunkt(behandlingskontrollTjeneste, klageAnkeVedtakTjeneste, vedtakTjeneste,
-                totrinnTjeneste);
+                totrinnTjeneste, mock(InntektArbeidYtelseTjeneste.class));
     }
 
     @Test


### PR DESCRIPTION
Når man først så denne løsningen - så var det fort gjort å teste ut lokalt ifm en uttak-frontend-ting jeg holdt på med.

Det er ikke lekkert - men et greit sted å løse problemet og unngå fagsystem-saker mens vi tenker over tilnærming.
* Ca 5% av sakene har aksjonspunkt i opptjening - frilans fra aareg håndteres - så 0%, næring, oppgitt og noen til gjenstår
* Årsaker fra loggsøk på "Utleder AP 5051 fra" viser 57% 0%-stillinger, 35% næring og resten er oppgitt opptjening
* opptjening ble gjort veldig sticky pga mange aksjonspunkt og ofte tilbakehopp til opptjening ved registeroppdatering
* fortsatt har 7% av revurderingene (12000/mnd) startpunkt før opptjening - så vi vil ikke nødvendigvis re-evaluere

K9 har valgt å fokusere på vilkårsvurdering. Vi bør se på relasjon til beregning og se hva man skal kunne ta stilling til og hvordan det lagres
