### PR TITLE
Ikke utled berørt for sammenhengende i utide

### DIFF
--- a/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/uttaksgrunnlag/fp/EndringsdatoBerørtUtleder.java
+++ b/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/uttaksgrunnlag/fp/EndringsdatoBerørtUtleder.java
@@ -79,7 +79,8 @@ public final class EndringsdatoBerørtUtleder {
             }
         }
 
-        var opprett = kreverSammenhengendeUttak && !fellesTidslinjeForSammenheng.isContinuous(periodeFomEndringsdato);
+        var opprett = kreverSammenhengendeUttak && !fellesTidslinjeForSammenheng.intersection(periodeFomEndringsdato).isEmpty() &&
+            !fellesTidslinjeForSammenheng.isContinuous(periodeFomEndringsdato);
         if (opprett) {
             var tidslinjeFomEndringsdato = fellesTidslinjeForSammenheng.intersection(periodeFomEndringsdato);
             var tidligsteGap = Optional.ofNullable(tidslinjeFomEndringsdato.firstDiscontinuity()).map(LocalDateInterval::getFomDato).orElse(endringsdato);


### PR DESCRIPTION
tidslinje.isContinuous(periode)  er false dersom det ikke er overlapp mellom tidslinje og periode -> berørt i utide.
Sjekker derfor at det er innhold i snittet av tidslinje/periode før sjekk om kontinuerlig