### PR TITLE
Deterministisk vent før start berørt i prod

### DIFF
--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/vedtak/kafka/VedtaksHendelseHåndterer.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/vedtak/kafka/VedtaksHendelseHåndterer.java
@@ -156,8 +156,7 @@ public class VedtaksHendelseHåndterer {
             // Unngå gå i beina på på iverksettingstasker med sen respons
             if (FagsakYtelseType.FORELDREPENGER.equals(fagsakYtelseType)) {
                 if (isProd) {
-                    var startberørtdelay = 1 + LocalDateTime.now().getNano() % 3;
-                    lagreProsesstaskFor(behandling, TaskType.forProsessTask(StartBerørtBehandlingTask.class), startberørtdelay);
+                    lagreProsesstaskFor(behandling, TaskType.forProsessTask(StartBerørtBehandlingTask.class), 2);
                     lagreProsesstaskFor(behandling, TaskType.forProsessTask(VurderOpphørAvYtelserTask.class), 5);
                 } else {
                     lagreProsesstaskFor(behandling, TaskType.forProsessTask(StartBerørtBehandlingTask.class), 0);


### PR DESCRIPTION
Randomisering kan gi deadlock mellom berørte dersom begge endrer og de vedtas nær samtidig.