### PR TITLE
TFP-4969 utsettelser uten angitt aktivitet passerer

### DIFF
--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/ytelsefordeling/MorsAktivitet.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/ytelsefordeling/MorsAktivitet.java
@@ -67,6 +67,10 @@ public enum MorsAktivitet implements Kodeverdi {
         return Collections.unmodifiableMap(KODER);
     }
 
+    public static boolean forventerDokumentasjon(MorsAktivitet aktivitet) {
+        return aktivitet != null && !Set.of(UDEFINERT, UFØRE, IKKE_OPPGITT).contains(aktivitet);
+    }
+
     @Override
     public String getNavn() {
         return navn;

--- a/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/fakta/aktkrav/KontrollerAktivitetskravAksjonspunktUtleder.java
+++ b/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/fakta/aktkrav/KontrollerAktivitetskravAksjonspunktUtleder.java
@@ -33,7 +33,7 @@ import no.nav.foreldrepenger.regler.uttak.felles.Virkedager;
 public class KontrollerAktivitetskravAksjonspunktUtleder {
 
     private static final Set<UtsettelseÅrsak> BFHR_MED_AKTIVITETSKRAV = Set.of(UtsettelseÅrsak.ARBEID, UtsettelseÅrsak.FERIE,
-        UtsettelseÅrsak.SYKDOM, UtsettelseÅrsak.INSTITUSJON_BARN, UtsettelseÅrsak.INSTITUSJON_SØKER, UtsettelseÅrsak.FRI);
+        UtsettelseÅrsak.SYKDOM, UtsettelseÅrsak.INSTITUSJON_BARN, UtsettelseÅrsak.INSTITUSJON_SØKER);
 
     private YtelseFordelingTjeneste ytelseFordelingTjeneste;
     private ForeldrepengerUttakTjeneste foreldrepengerUttakTjeneste;
@@ -69,9 +69,8 @@ public class KontrollerAktivitetskravAksjonspunktUtleder {
             return ikkeKontrollerer();
         }
         var periodeType = periode.getPeriodeType();
-        var harKravTilAktivitet =
-            !periode.isFlerbarnsdager() && (periodeType.equals(UttakPeriodeType.FELLESPERIODE) || periodeType.equals(
-                UttakPeriodeType.FORELDREPENGER) || bareFarHarRettOgSøkerUtsettelse(periode, annenForelderHarRett));
+        var harKravTilAktivitet = !periode.isFlerbarnsdager() &&
+            (Set.of(UttakPeriodeType.FELLESPERIODE, UttakPeriodeType.FORELDREPENGER).contains(periodeType) || bareFarHarRettOgSøkerUtsettelse(periode, annenForelderHarRett));
         if (!harKravTilAktivitet) {
             return ikkeKontrollerer();
         }
@@ -91,7 +90,8 @@ public class KontrollerAktivitetskravAksjonspunktUtleder {
     private static boolean bareFarHarRettOgSøkerUtsettelse(OppgittPeriodeEntitet periode,
                                                            boolean annenForelderHarRett) {
         //Reglene sjekker ikke aktivitetskrav hvis tiltak nav eller hv
-        return !annenForelderHarRett && (BFHR_MED_AKTIVITETSKRAV.contains(periode.getÅrsak()));
+        return !annenForelderHarRett && (BFHR_MED_AKTIVITETSKRAV.contains(periode.getÅrsak()) ||
+            (UtsettelseÅrsak.FRI.equals(periode.getÅrsak()) && MorsAktivitet.forventerDokumentasjon(periode.getMorsAktivitet())));
     }
 
     private static Set<AktivitetskravPeriodeEntitet> finnAvklartePerioderSomDekkerSøknadsperiode(OppgittPeriodeEntitet periode,

--- a/domenetjenester/uttak/src/test/java/no/nav/foreldrepenger/domene/uttak/fakta/aktkrav/KontrollerAktivitetskravAksjonspunktUtlederTest.java
+++ b/domenetjenester/uttak/src/test/java/no/nav/foreldrepenger/domene/uttak/fakta/aktkrav/KontrollerAktivitetskravAksjonspunktUtlederTest.java
@@ -160,8 +160,32 @@ public class KontrollerAktivitetskravAksjonspunktUtlederTest {
     }
 
     @Test
-    public void utledeAPForFarSomHarSøktUtsettelseFriOgBareFarRett() {
+    public void utledeAPForFarSomHarSøktUtsettelseFriOgBareFarRettUdefinertAktivitet() {
         var uttakInput = bareFarRettMedSøktUtsettelse(UtsettelseÅrsak.FRI);
+        var ap = utleder.utledFor(uttakInput);
+
+        assertThat(ap).isEmpty();
+    }
+
+    @Test
+    public void utledeAPForFarSomHarSøktUtsettelseFriOgBareFarRettUføre() {
+        var uttakInput = bareFarRettMedSøktUtsettelse(UtsettelseÅrsak.FRI, MorsAktivitet.UFØRE);
+        var ap = utleder.utledFor(uttakInput);
+
+        assertThat(ap).isEmpty();
+    }
+
+    @Test
+    public void utledeAPForFarSomHarSøktUtsettelseFriOgBareFarRettUtenAktivitet() {
+        var uttakInput = bareFarRettMedSøktUtsettelse(UtsettelseÅrsak.FRI, MorsAktivitet.IKKE_OPPGITT);
+        var ap = utleder.utledFor(uttakInput);
+
+        assertThat(ap).isEmpty();
+    }
+
+    @Test
+    public void utledeAPForFarSomHarSøktUtsettelseFriOgBareFarRettMedAktivitet() {
+        var uttakInput = bareFarRettMedSøktUtsettelse(UtsettelseÅrsak.FRI, MorsAktivitet.UTDANNING);
         var ap = utleder.utledFor(uttakInput);
 
         assertThat(ap).containsOnly(KONTROLLER_AKTIVITETSKRAV);
@@ -184,9 +208,14 @@ public class KontrollerAktivitetskravAksjonspunktUtlederTest {
     }
 
     private UttakInput bareFarRettMedSøktUtsettelse(UtsettelseÅrsak utsettelseÅrsak) {
+        return bareFarRettMedSøktUtsettelse(utsettelseÅrsak, MorsAktivitet.UDEFINERT);
+    }
+
+    private UttakInput bareFarRettMedSøktUtsettelse(UtsettelseÅrsak utsettelseÅrsak, MorsAktivitet morsAktivitet) {
         var fødselsdato = LocalDate.of(2020, 1, 1);
         var søknadsperiode = OppgittPeriodeBuilder.ny()
             .medÅrsak(utsettelseÅrsak)
+            .medMorsAktivitet(morsAktivitet)
             .medPeriodeKilde(FordelingPeriodeKilde.SØKNAD)
             .medPeriode(fødselsdato, fødselsdato.plusWeeks(10))
             .build();

--- a/pom.xml
+++ b/pom.xml
@@ -33,15 +33,15 @@
 
         <java.version>17</java.version>
 
-        <fp-uttak.version>12.5.2</fp-uttak.version>
-        <svp-uttak.version>2.3.2</svp-uttak.version>
+        <fp-uttak.version>12.5.3</fp-uttak.version>
+        <svp-uttak.version>2.3.3</svp-uttak.version>
         <felles.version>4.1.30</felles.version>
         <prosesstask.version>3.1.8</prosesstask.version>
         <fp-jms.version>2.1.3</fp-jms.version>
 
         <fp-kontrakter.version>6.1.21</fp-kontrakter.version>
         <fp-tidsserie.version>2.6.4</fp-tidsserie.version>
-        <fp-nare.version>2.2.2</fp-nare.version>
+        <fp-nare.version>2.2.5</fp-nare.version>
         <abakus-kontrakt.version>1.3.30</abakus-kontrakt.version>
         <kalkulus.version>1.5.43</kalkulus.version>
 


### PR DESCRIPTION
Forsiktig start - fri utsettelse og dok-løse aktiviteter passerer uten aksjonspunkt (og avslås i regler)

Spm om vi skal utvide Set.of(MorsAktivitet.UFØRE, MorsAktivitet.IKKE_OPPGITT).contains med UDEFINERT, evt kun for FORELDREPENGER .... Inngangen skal være lav ...