### PR TITLE
FIX: Dato pattern regex trekkes ut i egen klasse + fikser regex

### DIFF
--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/forvaltning/dto/AvstemmingPeriodeDto.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/forvaltning/dto/AvstemmingPeriodeDto.java
@@ -1,5 +1,6 @@
 package no.nav.foreldrepenger.web.app.tjenester.forvaltning.dto;
 
+import static no.nav.foreldrepenger.web.app.tjenester.forvaltning.dto.InputValideringRegexDato.DATO_PATTERN;
 import static no.nav.vedtak.util.InputValideringRegex.FRITEKST;
 
 import java.time.LocalDate;
@@ -15,8 +16,6 @@ import no.nav.vedtak.sikkerhet.abac.AbacDataAttributter;
 import no.nav.vedtak.sikkerhet.abac.AbacDto;
 
 public class AvstemmingPeriodeDto implements AbacDto {
-
-    private static final String DATO_PATTERN = "(\\d{4}-\\d{2}-\\d{2})";
 
     @NotNull
     @Parameter(description = "key (secret)")

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/forvaltning/dto/BeregningSatsDto.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/forvaltning/dto/BeregningSatsDto.java
@@ -1,5 +1,7 @@
 package no.nav.foreldrepenger.web.app.tjenester.forvaltning.dto;
 
+import static no.nav.foreldrepenger.web.app.tjenester.forvaltning.dto.InputValideringRegexDato.DATO_PATTERN;
+
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 
@@ -18,8 +20,6 @@ import no.nav.vedtak.sikkerhet.abac.AbacDataAttributter;
 import no.nav.vedtak.sikkerhet.abac.AbacDto;
 
 public class BeregningSatsDto implements AbacDto {
-
-    private static final String DATO_PATTERN = "(\\d{4}-\\d{2}-\\d{2})";
 
     @NotNull
     @QueryParam("satsType")

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/forvaltning/dto/InputValideringRegexDato.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/forvaltning/dto/InputValideringRegexDato.java
@@ -1,0 +1,8 @@
+package no.nav.foreldrepenger.web.app.tjenester.forvaltning.dto;
+
+final class InputValideringRegexDato {
+    private InputValideringRegexDato() {
+    }
+
+    static final String DATO_PATTERN = "^(\\d{4}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01]))?$";
+}

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/forvaltning/dto/LeggTilOppgittFrilansDto.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/forvaltning/dto/LeggTilOppgittFrilansDto.java
@@ -1,5 +1,7 @@
 package no.nav.foreldrepenger.web.app.tjenester.forvaltning.dto;
 
+import static no.nav.foreldrepenger.web.app.tjenester.forvaltning.dto.InputValideringRegexDato.DATO_PATTERN;
+
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.UUID;
@@ -18,8 +20,6 @@ import no.nav.vedtak.sikkerhet.abac.AbacDataAttributter;
 import no.nav.vedtak.sikkerhet.abac.AbacDto;
 
 public class LeggTilOppgittFrilansDto implements AbacDto {
-
-    private static final String DATO_PATTERN = "(\\d{4}-\\d{2}-\\d{2})";
 
     @NotNull
     @QueryParam("behandlingUuid")

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/forvaltning/dto/LeggTilOppgittNæringDto.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/forvaltning/dto/LeggTilOppgittNæringDto.java
@@ -5,7 +5,6 @@ import static no.nav.foreldrepenger.web.app.tjenester.forvaltning.dto.LeggTilOpp
 import static no.nav.vedtak.util.InputValideringRegex.FRITEKST;
 
 import java.time.LocalDate;
-import java.time.format.DateTimeFormatter;
 import java.util.UUID;
 
 import javax.validation.Valid;
@@ -96,7 +95,7 @@ public class LeggTilOppgittNæringDto implements AbacDto {
     @AssertTrue(message = "Når [varigEndring] er JA, må også [endringsDato] være satt!")
     public boolean isEndringsdatoSattVedVarigEndringOK() {
         if (JA.equals(varigEndring)) {
-            return endringsDato != null;
+            return erDatoSatt(endringsDato);
         }
         return true;
     }
@@ -150,10 +149,14 @@ public class LeggTilOppgittNæringDto implements AbacDto {
     }
 
     private LocalDate getLocalDate(String datoString) {
-        if (datoString != null) {
-            return LocalDate.parse(datoString, DateTimeFormatter.ISO_LOCAL_DATE);
+        if (erDatoSatt(datoString)) {
+            return LocalDate.parse(datoString);
         }
         return null;
+    }
+
+    private boolean erDatoSatt(String datoString) {
+        return datoString != null && !datoString.isEmpty();
     }
 
     public enum Utfall {

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/forvaltning/dto/LeggTilOppgittNæringDto.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/forvaltning/dto/LeggTilOppgittNæringDto.java
@@ -1,5 +1,6 @@
 package no.nav.foreldrepenger.web.app.tjenester.forvaltning.dto;
 
+import static no.nav.foreldrepenger.web.app.tjenester.forvaltning.dto.InputValideringRegexDato.DATO_PATTERN;
 import static no.nav.foreldrepenger.web.app.tjenester.forvaltning.dto.LeggTilOppgittNæringDto.Utfall.JA;
 import static no.nav.vedtak.util.InputValideringRegex.FRITEKST;
 
@@ -25,8 +26,6 @@ import no.nav.vedtak.sikkerhet.abac.AbacDataAttributter;
 import no.nav.vedtak.sikkerhet.abac.AbacDto;
 
 public class LeggTilOppgittNæringDto implements AbacDto {
-
-    private static final String DATO_PATTERN = "^(\\d{4}-\\d{2}-\\d{2})?$";
 
     @Valid
     @NotNull

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/forvaltning/dto/SaksnummerTermindatoDto.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/forvaltning/dto/SaksnummerTermindatoDto.java
@@ -1,5 +1,6 @@
 package no.nav.foreldrepenger.web.app.tjenester.forvaltning.dto;
 
+import static no.nav.foreldrepenger.web.app.tjenester.forvaltning.dto.InputValideringRegexDato.DATO_PATTERN;
 import static no.nav.vedtak.util.InputValideringRegex.FRITEKST;
 
 import java.time.LocalDate;
@@ -16,8 +17,6 @@ import no.nav.vedtak.sikkerhet.abac.AbacDataAttributter;
 import no.nav.vedtak.sikkerhet.abac.AbacDto;
 
 public class SaksnummerTermindatoDto implements AbacDto {
-
-    private static final String DATO_PATTERN = "(\\d{4}-\\d{2}-\\d{2})";
 
     @NotNull
     @Parameter(description = "Saksnummer")


### PR DESCRIPTION
(\d{4}-\d{2}-\d{2}) vil matche så lenge det finnes et dato felt i strengen. Vil tillate f.eks. denne strengen 'uglydig ... 2020-12-12 masse tekst', '2020-12-12 masse tekst', '2020-12-122020-12-12', '2020-99-12', osv.

^(\d{4}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01]))?$ vil matche hele strengen, og bare ett tilfelle eller ingen. 
Gyldig: '2020-12-12' og ''
Ugyldig:  '2020-22-12', 'uglydig ... 2020-12-12 masse tekst', 'test' ,'2020-12-122020-12-12', osv. 