### PR TITLE
TFP-4809 Endret TapteDagerFpffTjeneste til å hente termindato fra gje…

### DIFF
--- a/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/TapteDagerFpffTjeneste.java
+++ b/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/TapteDagerFpffTjeneste.java
@@ -45,7 +45,7 @@ public class TapteDagerFpffTjeneste {
         var familieHendelser = fpGrunnlag.getFamilieHendelser();
         if (harSøktPåTermin(familieHendelser) && skjeddFødselFørTermin(fpGrunnlag)) {
             var virkedager = Virkedager.beregnAntallVirkedager(familieHendelser.getGjeldendeFamilieHendelse().getFødselsdato().orElseThrow(),
-                familieHendelser.getSøknadFamilieHendelse().getTermindato().orElseThrow().minusDays(1));
+                familieHendelser.getGjeldendeFamilieHendelse().getTermindato().orElseThrow().minusDays(1));
             var maxdagerFpff = finnMaksdagerFpff(input.getBehandlingReferanse().saksnummer());
             return Math.min(virkedager, maxdagerFpff);
         }
@@ -103,7 +103,7 @@ public class TapteDagerFpffTjeneste {
 
     private boolean skjeddFødselFørTermin(ForeldrepengerGrunnlag fpGrunnlag) {
         var familiehendelser = fpGrunnlag.getFamilieHendelser();
-        var termindato = familiehendelser.getSøknadFamilieHendelse().getTermindato().orElseThrow();
+        var termindato = familiehendelser.getGjeldendeFamilieHendelse().getTermindato().orElseThrow();
         var gjeldendeFødselsdato = familiehendelser.getGjeldendeFamilieHendelse().getFødselsdato();
         return gjeldendeFødselsdato.isPresent() && gjeldendeFødselsdato.get().isBefore(termindato);
     }

--- a/domenetjenester/uttak/src/test/java/no/nav/foreldrepenger/domene/uttak/TapteDagerFpffTjenesteTest.java
+++ b/domenetjenester/uttak/src/test/java/no/nav/foreldrepenger/domene/uttak/TapteDagerFpffTjenesteTest.java
@@ -150,6 +150,66 @@ public class TapteDagerFpffTjenesteTest {
         assertThat(resultat).isEqualTo(maksdager);
     }
 
+    @Test
+    public void ingen_tapte_dager_ut_ifra_gjeldendefødselshendelse() {
+        var søktFpff = OppgittPeriodeBuilder.ny()
+            .medPeriodeType(UttakPeriodeType.FORELDREPENGER_FØR_FØDSEL)
+            //15 virkedager
+            .medPeriode(LocalDate.of(2022, 5, 30), LocalDate.of(2022, 6, 19))
+            .build();
+        var mødrekvote = OppgittPeriodeBuilder.ny()
+            .medPeriodeType(UttakPeriodeType.MØDREKVOTE)
+            .medPeriode(LocalDate.of(2022, 6, 20), LocalDate.of(2022, 7, 30))
+            .build();
+        var scenario = ScenarioMorSøkerForeldrepenger.forFødsel()
+            .medFordeling(new OppgittFordelingEntitet(List.of(søktFpff, mødrekvote), true))
+            .medOppgittDekningsgrad(OppgittDekningsgradEntitet.bruk100());
+        var behandling = scenario.lagre(repositoryProvider);
+
+        opprettFagsakRelasjon(behandling, 15);
+
+        var termindato = LocalDate.of(2022, 7, 13);
+        var temindateBekreftetHendelse = LocalDate.of(2022, 6, 20);
+        var fødselsdato = LocalDate.of(2022, 6, 20);
+        var familieHendelser = new FamilieHendelser()
+            .medSøknadHendelse(familieHendelse(termindato, null))
+            .medBekreftetHendelse(familieHendelse(temindateBekreftetHendelse, fødselsdato));
+        var input = new UttakInput(BehandlingReferanse.fra(behandling), null, new ForeldrepengerGrunnlag().medFamilieHendelser(familieHendelser));
+        var resultat = tjeneste().antallTapteDagerFpff(input);
+
+        assertThat(resultat).isEqualTo(0);
+    }
+
+    @Test
+    public void tapte_dager_ut_ifra_gjeldendefødselshendelse() {
+        var søktFpff = OppgittPeriodeBuilder.ny()
+            .medPeriodeType(UttakPeriodeType.FORELDREPENGER_FØR_FØDSEL)
+            //15 virkedager
+            .medPeriode(LocalDate.of(2022, 5, 30), LocalDate.of(2022, 6, 19))
+            .build();
+        var mødrekvote = OppgittPeriodeBuilder.ny()
+            .medPeriodeType(UttakPeriodeType.MØDREKVOTE)
+            .medPeriode(LocalDate.of(2022, 6, 20), LocalDate.of(2022, 7, 30))
+            .build();
+        var scenario = ScenarioMorSøkerForeldrepenger.forFødsel()
+            .medFordeling(new OppgittFordelingEntitet(List.of(søktFpff, mødrekvote), true))
+            .medOppgittDekningsgrad(OppgittDekningsgradEntitet.bruk100());
+        var behandling = scenario.lagre(repositoryProvider);
+
+        opprettFagsakRelasjon(behandling, 15);
+
+        var termindato = LocalDate.of(2022, 7, 13);
+        var temindateBekreftetHendelse = LocalDate.of(2022, 6, 20);
+        var fødselsdato = LocalDate.of(2022, 6, 15);
+        var familieHendelser = new FamilieHendelser()
+            .medSøknadHendelse(familieHendelse(termindato, null))
+            .medBekreftetHendelse(familieHendelse(temindateBekreftetHendelse, fødselsdato));
+        var input = new UttakInput(BehandlingReferanse.fra(behandling), null, new ForeldrepengerGrunnlag().medFamilieHendelser(familieHendelser));
+        var resultat = tjeneste().antallTapteDagerFpff(input);
+
+        assertThat(resultat).isEqualTo(3);
+    }
+
     private void opprettFagsakRelasjon(Behandling behandling, int maksdagerFpff) {
         var stønadskontoberegning = new Stønadskontoberegning.Builder()
             .medStønadskonto(new Stønadskonto.Builder()


### PR DESCRIPTION
…ldende fødselshendelse, og ikke alltid fra søknadshendelsen. I dag er det en feil som gjør at ny førstegangssøknad hvor det allerede er en ytelsesbehandling lagres som bekreftet fødselshendelse i stedet for ny søknadshendelse. 

Neste blir å rette at ny førstegangssøknad lagres som en ny søknadshendelse..