### PR TITLE
Abakus-kontrakt som tar kodeverk som string eller objekt

### DIFF
--- a/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/abakus/AbakusTjeneste.java
+++ b/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/abakus/AbakusTjeneste.java
@@ -26,16 +26,14 @@ import com.fasterxml.jackson.databind.ObjectReader;
 import com.fasterxml.jackson.databind.ObjectWriter;
 
 import no.nav.abakus.iaygrunnlag.AktørIdPersonident;
-import no.nav.abakus.iaygrunnlag.IayGrunnlagJsonMapper;
+import no.nav.abakus.iaygrunnlag.JsonObjectMapper;
 import no.nav.abakus.iaygrunnlag.UuidDto;
 import no.nav.abakus.iaygrunnlag.arbeidsforhold.v1.ArbeidsforholdDto;
 import no.nav.abakus.iaygrunnlag.inntektsmelding.v1.InntektsmeldingerDto;
-import no.nav.abakus.iaygrunnlag.inntektsmelding.v1.RefusjonskravDatoerDto;
 import no.nav.abakus.iaygrunnlag.kodeverk.YtelseType;
 import no.nav.abakus.iaygrunnlag.request.AktørDatoRequest;
 import no.nav.abakus.iaygrunnlag.request.InnhentRegisterdataRequest;
 import no.nav.abakus.iaygrunnlag.request.InntektArbeidYtelseGrunnlagRequest;
-import no.nav.abakus.iaygrunnlag.request.InntektsmeldingDiffRequest;
 import no.nav.abakus.iaygrunnlag.request.InntektsmeldingerMottattRequest;
 import no.nav.abakus.iaygrunnlag.request.InntektsmeldingerRequest;
 import no.nav.abakus.iaygrunnlag.request.KopierGrunnlagRequest;
@@ -54,7 +52,7 @@ import no.nav.vedtak.felles.integrasjon.rest.OidcRestClientResponseHandler.Objec
 public class AbakusTjeneste {
 
     private static final Logger LOG = LoggerFactory.getLogger(AbakusTjeneste.class);
-    private final ObjectMapper iayMapper = IayGrunnlagJsonMapper.getMapper();
+    private final ObjectMapper iayMapper = JsonObjectMapper.getMapper();
     private final ObjectWriter iayJsonWriter = iayMapper.writerWithDefaultPrettyPrinter();
     private final ObjectReader iayGrunnlagReader = iayMapper.readerFor(InntektArbeidYtelseGrunnlagDto.class);
     private final ObjectReader arbeidsforholdReader = iayMapper.readerFor(ArbeidsforholdDto[].class);

--- a/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/abakus/mapping/MapOppgittOpptjening.java
+++ b/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/abakus/mapping/MapOppgittOpptjening.java
@@ -129,14 +129,14 @@ class MapOppgittOpptjening {
 
             var virksomhet = arbeidsforhold.getUtenlandskVirksomhet();
             if (virksomhet != null) {
-                var landKode = virksomhet.getLandkode() == null ? Landkode.NORGE : Landkode.fraKode(virksomhet.getLandkode().getKode());
+                var landKode = virksomhet.getLandkode() == null ? Landkode.NOR : Landkode.fraKode(virksomhet.getLandkode().getKode());
                 if (virksomhet.getNavn() != null) {
                     dto.medOppgittVirksomhetNavn(fjernUnicodeControlOgAlternativeWhitespaceCharacters(virksomhet.getNavn()), landKode);
                 } else {
                     dto.setLandkode(landKode);
                 }
             } else {
-                dto.setLandkode(Landkode.NORGE);
+                dto.setLandkode(Landkode.NOR);
             }
 
             return dto;
@@ -167,7 +167,7 @@ class MapOppgittOpptjening {
 
             var virksomhet = egenNæring.getVirksomhet();
             if (virksomhet != null) {
-                var landkode = virksomhet.getLandkode() == null ? Landkode.NORGE : Landkode.fraKode(virksomhet.getLandkode().getKode());
+                var landkode = virksomhet.getLandkode() == null ? Landkode.NOR : Landkode.fraKode(virksomhet.getLandkode().getKode());
                 var navn = virksomhet.getNavn();
                 if (navn != null) {
                     dto.medOppgittVirksomhetNavn(fjernUnicodeControlOgAlternativeWhitespaceCharacters(navn), landkode);
@@ -175,7 +175,7 @@ class MapOppgittOpptjening {
                     dto.setLandkode(landkode);
                 }
             } else {
-                dto.setLandkode(Landkode.NORGE);
+                dto.setLandkode(Landkode.NOR);
             }
 
             return dto;

--- a/domenetjenester/arbeidsforhold/src/test/java/no/nav/foreldrepenger/domene/abakus/mapping/IAYDtoMapperRoundtripTest.java
+++ b/domenetjenester/arbeidsforhold/src/test/java/no/nav/foreldrepenger/domene/abakus/mapping/IAYDtoMapperRoundtripTest.java
@@ -197,7 +197,7 @@ public class IAYDtoMapperRoundtripTest {
                                 .medArbeidsforhold(List.of(
                                         new OppgittArbeidsforholdDto(periode, ArbeidType.ORDINÆRT_ARBEIDSFORHOLD)
                                                 .medErUtenlandskInntekt(true)
-                                                .medOppgittVirksomhetNavn("GammelDansk", Landkode.DANMARK)))
+                                                .medOppgittVirksomhetNavn("GammelDansk", Landkode.DNK)))
                                 .medEgenNæring(List.of(
                                         new OppgittEgenNæringDto(periode)
                                                 .medBegrunnelse("MinBegrunnelse")
@@ -206,7 +206,7 @@ public class IAYDtoMapperRoundtripTest {
                                                 .medNyIArbeidslivet(false)
                                                 .medNyoppstartet(false)
                                                 .medNærRelasjon(false)
-                                                .medOppgittVirksomhetNavn("DuGamleDuFria", Landkode.SVERIGE)
+                                                .medOppgittVirksomhetNavn("DuGamleDuFria", Landkode.SWE)
                                                 .medRegnskapsførerNavn("Regnskapsfører")
                                                 .medRegnskapsførerTlf("+47902348732")
                                                 .medVarigEndring(true)

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
         <fp-kontrakter.version>6.1.21</fp-kontrakter.version>
         <fp-tidsserie.version>2.6.4</fp-tidsserie.version>
         <fp-nare.version>2.3.0</fp-nare.version>
-        <abakus-kontrakt.version>1.3.30</abakus-kontrakt.version>
+        <abakus-kontrakt.version>1.3.34</abakus-kontrakt.version>
         <kalkulus.version>1.5.45</kalkulus.version>
 
     </properties>


### PR DESCRIPTION
Noen andre renamet IayGrunnlagJsonMapper i april - rett etter forrige versjon. 
Ellers fjernet noen landkode convenices.
Merges etter abakus prodsatt.