### PR TITLE
LOgger cause exception ved parsing av xml

### DIFF
--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/dokumentpersiterer/xml/MottattDokumentXmlParser.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/dokumentpersiterer/xml/MottattDokumentXmlParser.java
@@ -48,12 +48,12 @@ public final class MottattDokumentXmlParser {
                 dokumentParserKonfig.additionalClasses);
             return MottattDokumentWrapper.tilXmlWrapper(mottattDokument);
         } catch (Exception e) {
-            throw parseException(namespace);
+            throw parseException(namespace, e);
         }
     }
 
-    private static TekniskException parseException(String namespace) {
-        return new TekniskException("FP-312346", "Feil ved parsing av ukjent journaldokument-type med namespace " + namespace);
+    private static TekniskException parseException(String namespace, Exception e) {
+        return new TekniskException("FP-312346", "Feil ved parsing av ukjent journaldokument-type med namespace " + namespace, e);
     }
 
     private static String hentNamespace(String xml) {
@@ -61,7 +61,7 @@ public final class MottattDokumentXmlParser {
         try {
             namespace = retrieveNameSpaceOfXML(xml);
         } catch (Exception e) {
-            throw parseException("ukjent");
+            throw parseException("ukjent", e);
         }
         return namespace;
     }


### PR DESCRIPTION
Noe grunn til å ikke gjøre dette? Kan det komme noe sensitivt i exception?