### PR TITLE
Legger til digdir-krr-proxy-tjeneste

### DIFF
--- a/domenetjenester/person/src/main/java/no/nav/foreldrepenger/domene/person/dkif/DkifSpråkKlient.java
+++ b/domenetjenester/person/src/main/java/no/nav/foreldrepenger/domene/person/dkif/DkifSpråkKlient.java
@@ -8,6 +8,8 @@ import java.util.Set;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
+import no.nav.foreldrepenger.domene.person.krr.KrrSpråkKlient;
+
 import org.apache.http.Header;
 import org.apache.http.client.utils.URIBuilder;
 import org.apache.http.message.BasicHeader;
@@ -15,6 +17,9 @@ import org.apache.http.message.BasicHeader;
 import no.nav.foreldrepenger.behandlingslager.geografisk.Språkkode;
 import no.nav.foreldrepenger.konfig.KonfigVerdi;
 import no.nav.vedtak.felles.integrasjon.rest.StsSystemRestKlient;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /*
  * Dokumentasjon Tjeneste for å hente digital kontaktinformasjon (mobil, epost, sdp og språkkode)
@@ -24,10 +29,13 @@ import no.nav.vedtak.felles.integrasjon.rest.StsSystemRestKlient;
 @ApplicationScoped
 public class DkifSpråkKlient {
 
+    private static final Logger LOG = LoggerFactory.getLogger(DkifSpråkKlient.class);
+
     private static final String ENDPOINT_KEY = "dkif.rs.url";
     private static final String DEFAULT_URI = "http://dkif.default/api/v1/personer/kontaktinformasjon";
 
     public static final String HEADER_NAV_PERSONIDENT = "Nav-Personidenter";
+    private KrrSpråkKlient krrSpråkKlient;
 
     private StsSystemRestKlient oidcRestClient;
     private URI endpoint;
@@ -37,9 +45,11 @@ public class DkifSpråkKlient {
 
     @Inject
     public DkifSpråkKlient(StsSystemRestKlient oidcRestClient,
-                           @KonfigVerdi(value = ENDPOINT_KEY, defaultVerdi = DEFAULT_URI) URI endpoint) {
+                           @KonfigVerdi(value = ENDPOINT_KEY, defaultVerdi = DEFAULT_URI) URI endpoint,
+                           KrrSpråkKlient krrSpråkKlient) {
         this.oidcRestClient = oidcRestClient;
         this.endpoint = endpoint;
+        this.krrSpråkKlient = krrSpråkKlient;
     }
 
     public Språkkode finnSpråkkodeForBruker(String fnr) {
@@ -48,7 +58,9 @@ public class DkifSpråkKlient {
                     .addParameter("inkluderSikkerDigitalPost", "false")
                     .build();
             var match = this.oidcRestClient.get(request, this.lagHeader(fnr), DigitalKontaktinfo.class);
-            return Optional.ofNullable(match).flatMap(m -> m.getSpraak(fnr)).map(String::toUpperCase).map(Språkkode::defaultNorsk).orElse(Språkkode.NB);
+            var språkkode = Optional.ofNullable(match).flatMap(m -> m.getSpraak(fnr)).map(String::toUpperCase).map(Språkkode::defaultNorsk).orElse(Språkkode.NB);
+            sammenlikneMedKrrKlient(språkkode, fnr);
+            return språkkode;
         } catch (URISyntaxException e) {
             throw new IllegalArgumentException("Utviklerfeil syntax-exception for finnSpråkkodeForBruker");
         }
@@ -56,5 +68,18 @@ public class DkifSpråkKlient {
 
     private Set<Header> lagHeader(String fnr) {
         return Set.of(new BasicHeader(HEADER_NAV_PERSONIDENT, fnr));
+    }
+
+    private void sammenlikneMedKrrKlient(Språkkode språkkode, String fnr) {
+        try {
+            var krrSpråkkode = krrSpråkKlient.finnSpråkkodeForBruker(fnr);
+            if (krrSpråkkode == språkkode) {
+                LOG.info("DkifSpråkKlient: sammenlikning dkif og krr gir likt resultat.");
+            } else {
+                LOG.info("DkifSpråkKlient: sammenlikning dkif og krr gir ulikt resultat.");
+            }
+        } catch (Exception e) {
+            LOG.info("DkifSpråkKlient: krr gir exception", e);
+        }
     }
 }

--- a/domenetjenester/person/src/main/java/no/nav/foreldrepenger/domene/person/krr/KrrScopedAzureAdClientProducer.java
+++ b/domenetjenester/person/src/main/java/no/nav/foreldrepenger/domene/person/krr/KrrScopedAzureAdClientProducer.java
@@ -1,0 +1,37 @@
+package no.nav.foreldrepenger.domene.person.krr;
+
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import javax.enterprise.context.Dependent;
+import javax.enterprise.inject.Produces;
+import javax.inject.Qualifier;
+
+import no.nav.foreldrepenger.konfig.KonfigVerdi;
+import no.nav.vedtak.felles.integrasjon.rest.AzureADRestClient;
+
+
+public class KrrScopedAzureAdClientProducer {
+
+    private static final String DEFAULT_KRR_AZURE_SCOPE = "api://prod-gcp.team-rocket.digdir-krr-proxy/.default";
+
+    @Produces
+    @KrrScoped
+    @Dependent
+    public AzureADRestClient provider(@KonfigVerdi(value = "krr.rs.scopes", defaultVerdi = DEFAULT_KRR_AZURE_SCOPE) String scope) {
+        return AzureADRestClient.builder().scope(scope).build();
+    }
+
+    @Qualifier
+    @Retention(RUNTIME)
+    @Target({METHOD, FIELD, PARAMETER, TYPE})
+    public @interface KrrScoped {}
+
+}

--- a/domenetjenester/person/src/main/java/no/nav/foreldrepenger/domene/person/krr/KrrSpråkKlient.java
+++ b/domenetjenester/person/src/main/java/no/nav/foreldrepenger/domene/person/krr/KrrSpråkKlient.java
@@ -1,0 +1,83 @@
+package no.nav.foreldrepenger.domene.person.krr;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Optional;
+import java.util.Set;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import javax.ws.rs.core.Response;
+
+import org.apache.http.Header;
+import org.apache.http.client.utils.URIBuilder;
+import org.apache.http.message.BasicHeader;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import no.nav.foreldrepenger.behandlingslager.geografisk.Språkkode;
+import no.nav.foreldrepenger.domene.person.krr.KrrScopedAzureAdClientProducer.KrrScoped;
+import no.nav.foreldrepenger.konfig.KonfigVerdi;
+import no.nav.vedtak.exception.IntegrasjonException;
+import no.nav.vedtak.exception.ManglerTilgangException;
+import no.nav.vedtak.felles.integrasjon.rest.AzureADRestClient;
+import no.nav.vedtak.log.mdc.MDCOperations;
+
+@ApplicationScoped
+public class KrrSpråkKlient {
+
+    private static final Logger LOG = LoggerFactory.getLogger(KrrSpråkKlient.class);
+    private final static String HEADER_NAV_PERSONIDENT = "Nav-Personident";
+    private final static String HEADER_NAV_CALLID = "Nav-Call-Id";
+    private URI endpoint;
+    private AzureADRestClient restClient;
+
+    public KrrSpråkKlient() {
+    }
+
+    @Inject
+    public KrrSpråkKlient(@KonfigVerdi(value = "krr.rs.uri") URI endpoint,
+                          @KrrScoped AzureADRestClient azureAdKlient) {
+        this.endpoint = endpoint;
+        this.restClient = azureAdKlient;
+    }
+
+    public Språkkode finnSpråkkodeForBruker(String fnr) {
+        try {
+            var request = new URIBuilder(endpoint)
+                .addParameter("inkluderSikkerDigitalPost", "false")
+                .build();
+            var respons = restClient.get(request, headere(fnr), KrrRespons.class);
+            return Optional.ofNullable(respons)
+                .map(KrrRespons::språk)
+                .map(Språkkode::defaultNorsk)
+                .orElse(Språkkode.NB);
+        } catch (ManglerTilgangException manglerTilgangException) {
+            LOG.info("KrrSpråkKlient: Mangler tilgang, returnerer default.");
+            return Språkkode.NB;
+        } catch (IntegrasjonException e) {
+            final var NOT_FOUND = String.valueOf(Response.Status.NOT_FOUND.getStatusCode());
+            var ie = e.getMessage();
+            if (ie.contains(NOT_FOUND)) {
+                LOG.info("KrrSpråkKlient: fant ikke bruker, returnerer default. Feilmelding: {}", ie);
+                return Språkkode.NB;
+            }
+            throw e;
+        } catch (URISyntaxException e) {
+            throw new IllegalArgumentException("Utviklerfeil syntax-exception for KrrSpråkKlient.finnSpråkkodeForBruker");
+        }
+    }
+
+    private Set<Header> headere(String fnr) {
+        var personIdentHeader = new BasicHeader(HEADER_NAV_PERSONIDENT, fnr);
+        var callId = Optional.ofNullable(MDCOperations.getCallId())
+            .orElseGet(MDCOperations::generateCallId);
+        var callIdHeader = new BasicHeader(HEADER_NAV_CALLID, callId);
+        return Set.of(personIdentHeader, callIdHeader);
+    }
+
+    record KrrRespons(@JsonProperty("spraak") String språk) { }
+
+}

--- a/domenetjenester/person/src/test/java/no/nav/foreldrepenger/domene/person/krr/KrrSpråkKlientTest.java
+++ b/domenetjenester/person/src/test/java/no/nav/foreldrepenger/domene/person/krr/KrrSpråkKlientTest.java
@@ -1,0 +1,63 @@
+package no.nav.foreldrepenger.domene.person.krr;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import java.net.URI;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import no.nav.foreldrepenger.behandlingslager.geografisk.Språkkode;
+import no.nav.foreldrepenger.domene.person.krr.KrrSpråkKlient.KrrRespons;
+import no.nav.vedtak.exception.IntegrasjonException;
+import no.nav.vedtak.felles.integrasjon.rest.AzureADRestClient;
+
+class KrrSpråkKlientTest {
+
+    private KrrSpråkKlient krrSpråkKlient;
+    private final AzureADRestClient azureKlientMock = Mockito.mock(AzureADRestClient.class);
+
+    private static final KrrRespons KRR_NYNORSK = new KrrRespons("NN");
+    private static final KrrRespons KRR_BOKMÅL = new KrrRespons("NB");
+    private static final KrrRespons KRR_ENGELSK = new KrrRespons("EN");
+    private static final KrrRespons KRR_UKJENT_VERDI = new KrrRespons("X");
+
+
+    @BeforeEach
+    public void setup() { krrSpråkKlient = new KrrSpråkKlient(URI.create("endpoint"), azureKlientMock);
+    }
+
+    @Test
+    public void krrResponsMappesTilSpråkkode() {
+        forventMappingFraKrrResponsTilSpråkkode(KRR_BOKMÅL, Språkkode.NB);
+        forventMappingFraKrrResponsTilSpråkkode(KRR_NYNORSK, Språkkode.NN);
+        forventMappingFraKrrResponsTilSpråkkode(KRR_ENGELSK, Språkkode.EN);
+
+        forventMappingFraKrrResponsTilSpråkkode(KRR_UKJENT_VERDI, Språkkode.NB);
+    }
+
+    @Test
+    public void defaultBokmålVed404() {
+        // biblioteket mapper 404 til IntegrasjonException
+        when(azureKlientMock.get(any(), any(), any())).thenThrow(new IntegrasjonException("A", "Fant ikke, så her har du en 404."));
+        var språk = krrSpråkKlient.finnSpråkkodeForBruker("123");
+        assertThat(språk).isEqualTo(Språkkode.NB);
+    }
+
+    @Test
+    public void propagerExceptionVedIntegrasjonExceptionUlik404() {
+        when(azureKlientMock.get(any(), any(), any())).thenThrow(new IntegrasjonException("B", "Noe annet feil."));
+        assertThatThrownBy(()-> krrSpråkKlient.finnSpråkkodeForBruker("123")).isInstanceOf(IntegrasjonException.class);
+    }
+
+    private void forventMappingFraKrrResponsTilSpråkkode(KrrRespons responsFraKrr, Språkkode språkkode) {
+        when(azureKlientMock.get(any(), any(), any())).thenReturn(responsFraKrr);
+        var språk = krrSpråkKlient.finnSpråkkodeForBruker("123");
+        assertThat(språk).isEqualTo(språkkode);
+    }
+
+}

--- a/web/src/main/resources/application-dev-fss.properties
+++ b/web/src/main/resources/application-dev-fss.properties
@@ -44,6 +44,8 @@ ufore.rs.url=http://pensjon-pen-q1.teampensjon/pen/springapi/sak/harUforegrad
 organisasjon.rs.url=https://modapp-q1.adeo.no/ereg/api/v1/organisasjon
 skjermet.person.rs.url=https://skjermede-personer-pip.dev.intern.nav.no/skjermet
 skjermet.person.rs.azure.scope=api://dev-gcp.nom.skjermede-personer-pip/.default
+krr.rs.scopes=api://dev-gcp.team-rocket.digdir-krr-proxy/.default
+krr.rs.uri=https://digdir-krr-proxy.dev.intern.nav.no
 
 # Kabal
 kabal.api.scopes=api://dev-gcp.klage.kabal-api/.default
@@ -55,4 +57,3 @@ SPOKELSE_GRUNNLAG_URL=http://spokelse.tbd/grunnlag
 
 # Dato for FAB
 dato.for.minsterett.forste=2022-01-01
-

--- a/web/src/main/resources/application-prod-fss.properties
+++ b/web/src/main/resources/application-prod-fss.properties
@@ -42,6 +42,8 @@ oppgave.rs.uri=http://oppgave.oppgavehandtering/api/v1/oppgaver
 saf.base.url=http://saf.teamdokumenthandtering
 ufore.rs.url=http://pensjon-pen.pensjondeployer/pen/springapi/sak/harUforegrad
 organisasjon.rs.url=https://modapp.adeo.no/ereg/api/v1/organisasjon
+krr.rs.scopes=api://prod-gcp.team-rocket.digdir-krr-proxy/.default
+krr.rs.uri=https://digdir-krr-proxy.intern.nav.no
 
 # Kabal
 kabal.api.scopes=api://prod-gcp.klage.kabal-api/.default
@@ -50,4 +52,3 @@ kabal.api.url=https://kabal-api.intern.nav.no/api/oversendelse/v3/sak
 # Spøkelse
 SPOKELSE_GRUNNLAG_SCOPES=api://prod-fss.tbd.spokelse/.default
 SPOKELSE_GRUNNLAG_URL=http://spokelse.tbd/grunnlag
-

--- a/web/src/test/resources/application-local.properties
+++ b/web/src/test/resources/application-local.properties
@@ -90,6 +90,8 @@ saf.base.url=http://localhost:8060/rest/api/saf
 dkif.rs.url=http://localhost:8060/rest/api/v1/personer/kontaktinformasjon
 ufore.rs.url=http://localhost:8060/rest/api/pesys/ufo
 skjermet.person.rs.url=http://localhost:8060/rest/api/nom/skjermet
+krr.api.scope=testscope.krr
+krr.api.uri=http://localhost:8060/rest/digdir/rest/v1/person
 
 fpsak.it.fp.grunnlag.url=http://localhost:8060/rest/infotrygd/grunnlag/foreldrepenger
 fpsak.it.sp.grunnlag.url=http://localhost:8060/rest/infotrygd/grunnlag/sykepenger

--- a/web/src/test/resources/application-local.properties
+++ b/web/src/test/resources/application-local.properties
@@ -47,6 +47,10 @@ oidc.open.am.openid.config.token.endpoint=http://localhost:8060/rest/isso/oauth2
 oidc.open.am.client.id=fpsak-localhost
 # oidc.open.am.client.secret=<trenges ikke>
 
+# AzureAD
+azure.app.well.known.url=http://localhost:8060/rest/AzureAd/vtp/v2.0/.well-known/openid-configuration
+azure.app.client.id=fpsak-localhost
+
 # SAML/STS
 securityTokenService.url=https://localhost:8063/soap/SecurityTokenServiceProvider/
 
@@ -90,8 +94,8 @@ saf.base.url=http://localhost:8060/rest/api/saf
 dkif.rs.url=http://localhost:8060/rest/api/v1/personer/kontaktinformasjon
 ufore.rs.url=http://localhost:8060/rest/api/pesys/ufo
 skjermet.person.rs.url=http://localhost:8060/rest/api/nom/skjermet
-krr.api.scope=testscope.krr
-krr.api.uri=http://localhost:8060/rest/digdir/rest/v1/person
+krr.rs.scope=testscope
+krr.rs.uri=http://localhost:8060/rest/digdir/rest/v1/person
 
 fpsak.it.fp.grunnlag.url=http://localhost:8060/rest/infotrygd/grunnlag/foreldrepenger
 fpsak.it.sp.grunnlag.url=http://localhost:8060/rest/infotrygd/grunnlag/sykepenger


### PR DESCRIPTION
Legger til digdir-krr-proxy-tjeneste. Logger i første omgang eventuelle avvik.

Preauth ok for dev og prod: https://github.com/navikt/digdir-krr/commit/1030963908ec394aed0d7aa7b5f100bf8db39c69

NB: 
- bruker @Produces-annotert metode for å lage scopet AzureADRestClient som kan injectes. Motivasjonen var test, om ønskelig kan den naturligvis tas ut
- la til vtp azuread-config