### PR TITLE
Logging for å se etter periodesplitt i søknadsoversetter

### DIFF
--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/dokumentmottak/impl/OppgittPeriodeTidligstMottattDatoTjeneste.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/dokumentmottak/impl/OppgittPeriodeTidligstMottattDatoTjeneste.java
@@ -1,9 +1,11 @@
 package no.nav.foreldrepenger.mottak.dokumentmottak.impl;
 
+import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import javax.enterprise.context.ApplicationScoped;
@@ -13,8 +15,17 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
+import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.YtelseFordelingAggregat;
+import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.periode.OppgittFordelingEntitet;
 import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.periode.OppgittPeriodeEntitet;
+import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.periode.UttakPeriodeType;
+import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.årsak.Årsak;
+import no.nav.foreldrepenger.behandlingslager.uttak.fp.SamtidigUttaksprosent;
+import no.nav.foreldrepenger.behandlingslager.virksomhet.Arbeidsgiver;
 import no.nav.foreldrepenger.domene.ytelsefordeling.YtelseFordelingTjeneste;
+import no.nav.fpsak.tidsserie.LocalDateSegment;
+import no.nav.fpsak.tidsserie.LocalDateTimeline;
+import no.nav.fpsak.tidsserie.StandardCombinators;
 
 @ApplicationScoped
 public class OppgittPeriodeTidligstMottattDatoTjeneste {
@@ -79,7 +90,50 @@ public class OppgittPeriodeTidligstMottattDatoTjeneste {
         return like;
     }
 
-    public boolean erOmsluttetAv(OppgittPeriodeEntitet periode1, OppgittPeriodeEntitet periode2) {
+    private boolean erOmsluttetAv(OppgittPeriodeEntitet periode1, OppgittPeriodeEntitet periode2) {
         return !periode2.getFom().isAfter(periode1.getFom()) && !periode2.getTom().isBefore(periode1.getTom());
+    }
+
+    public void sammenlignLoggMottattDato(Behandling behandling, List<OppgittPeriodeEntitet> nysøknad) {
+        var forrigesøknad = behandling.getOriginalBehandlingId()
+            .map(ytelseFordelingTjeneste::hentAggregat)
+            .map(YtelseFordelingAggregat::getGjeldendeSøknadsperioder)
+            .map(OppgittFordelingEntitet::getOppgittePerioder).orElse(List.of());
+
+        var tidslinjeSammenlignNy =  new LocalDateTimeline<>(nysøknad.stream().map(p -> new LocalDateSegment<>(p.getFom(), p.getTom(), new SammenligningPeriode(p))).toList());
+        var tidslinjeSammenlignGammel =  new LocalDateTimeline<>(forrigesøknad.stream().map(p -> new LocalDateSegment<>(p.getFom(), p.getTom(), new SammenligningPeriode(p))).toList());
+        var tidslinjeSammenfall = tidslinjeSammenlignNy.intersection(tidslinjeSammenlignGammel);
+
+        var tidslinjeTidligstMottattNy = new LocalDateTimeline<>(nysøknad.stream()
+            .map(p -> new LocalDateSegment<>(p.getFom(), p.getTom(), p.getTidligstMottattDato().orElseGet(p::getMottattDato))).toList());
+        var tidslinjeTidligstMottattGammel = new LocalDateTimeline<>(forrigesøknad.stream()
+            .map(p -> new LocalDateSegment<>(p.getFom(), p.getTom(), p.getTidligstMottattDato().orElseGet(p::getMottattDato))).toList());
+        var gammelMottattDatoForSammenfallende = tidslinjeTidligstMottattGammel.intersection(tidslinjeSammenfall);
+        var oppdatertTidsligstMottatt = tidslinjeTidligstMottattNy.combine(gammelMottattDatoForSammenfallende, StandardCombinators::min, LocalDateTimeline.JoinStyle.INNER_JOIN);
+        var nysøknadFom = nysøknad.stream().collect(Collectors.toMap(OppgittPeriodeEntitet::getFom, Function.identity()));
+        oppdatertTidsligstMottatt.toSegments().forEach(s -> {
+            if (nysøknadFom.containsKey(s.getFom())) {
+                var tidligst = nysøknadFom.get(s.getFom()).getTidligstMottattDato().orElseGet(() -> nysøknadFom.get(s.getFom()).getMottattDato());
+                if (!tidligst.equals(s.getValue())) {
+                    LOG.info("SØKNAD MOTTATT DATO funnet avvik mottatt dato behandling {} fom {}", behandling.getId(), s.getFom());
+                } else if (!s.getTom().equals(nysøknadFom.get(s.getFom()).getTom())) {
+                    LOG.info("SØKNAD MOTTATT DATO splitte mine perioder {} fom {} tom {}", behandling.getId(), s.getFom(), s.getTom());
+                }
+            } else {
+                LOG.info("SØKNAD MOTTATT DATO splittet mine perioder {} fom {} tom {}", behandling.getId(), s.getFom(), s.getTom());
+            }
+        });
+    }
+
+    private record SammenligningPeriode(Årsak årsak, UttakPeriodeType periodeType, SamtidigUttaksprosent samtidigUttaksprosent, SammenligningGradering gradering) {
+        SammenligningPeriode(OppgittPeriodeEntitet periode) {
+            this(periode.getÅrsak(), periode.getPeriodeType(), periode.getSamtidigUttaksprosent(), periode.isGradert() ? new SammenligningGradering(periode) : null);
+        }
+    }
+
+    private record SammenligningGradering(boolean erArbeidstaker, BigDecimal arbeidsprosent, Arbeidsgiver arbeidsgiver) {
+        SammenligningGradering(OppgittPeriodeEntitet periode) {
+            this(periode.isArbeidstaker(), periode.getArbeidsprosent(), periode.getArbeidsgiver());
+        }
     }
 }

--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/dokumentpersiterer/impl/søknad/v3/SøknadOversetter.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/dokumentpersiterer/impl/søknad/v3/SøknadOversetter.java
@@ -565,6 +565,11 @@ public class SøknadOversetter implements MottattDokumentOversetter<SøknadWrapp
         } catch (Exception e) {
             LOG.info("SØKNAD Datosammenligning ga feil", e);
         }
+        try {
+            oppgittPeriodeTidligstMottattDatoTjeneste.sjekkOmPerioderKanForkastesSomLike(behandling, oppgittPerioder);
+        } catch (Exception e) {
+            LOG.info("SØKNAD forkasting ga feil", e);
+        }
 
     }
 

--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/dokumentpersiterer/impl/søknad/v3/SøknadOversetter.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/dokumentpersiterer/impl/søknad/v3/SøknadOversetter.java
@@ -560,6 +560,12 @@ public class SøknadOversetter implements MottattDokumentOversetter<SøknadWrapp
                 oppgittPeriode.setTidligstMottattDato(mottattDatoFraSøknad);
             }
         }
+        try {
+            oppgittPeriodeTidligstMottattDatoTjeneste.sammenlignLoggMottattDato(behandling, oppgittPerioder);
+        } catch (Exception e) {
+            LOG.info("SØKNAD Datosammenligning ga feil", e);
+        }
+
     }
 
     private boolean inneholderVirkedager(List<OppgittPeriodeEntitet> perioder) {

--- a/domenetjenester/mottak/src/test/java/no/nav/foreldrepenger/mottak/dokumentmottak/impl/OppgittPeriodeTidligstMottattDatoTjenesteTest.java
+++ b/domenetjenester/mottak/src/test/java/no/nav/foreldrepenger/mottak/dokumentmottak/impl/OppgittPeriodeTidligstMottattDatoTjenesteTest.java
@@ -30,7 +30,7 @@ public class OppgittPeriodeTidligstMottattDatoTjenesteTest extends EntityManager
         repositoryProvider = new BehandlingRepositoryProvider(getEntityManager());
         var ytelseFordelingTjeneste = new YtelseFordelingTjeneste(new YtelsesFordelingRepository(getEntityManager()));
         tjeneste = new OppgittPeriodeTidligstMottattDatoTjeneste(
-            ytelseFordelingTjeneste);
+            ytelseFordelingTjeneste, null);
     }
 
     @Test

--- a/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/ForeldrepengerUttakPeriode.java
+++ b/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/ForeldrepengerUttakPeriode.java
@@ -196,7 +196,7 @@ public class ForeldrepengerUttakPeriode {
     }
 
     private boolean isSøktOverføring() {
-        return getOverføringÅrsak() != null;
+        return getOverføringÅrsak() != null && !OverføringÅrsak.UDEFINERT.equals(getOverføringÅrsak());
     }
 
     public boolean isSøktGradering() {

--- a/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/uttaksgrunnlag/fp/FastsettUttaksgrunnlagTjeneste.java
+++ b/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/uttaksgrunnlag/fp/FastsettUttaksgrunnlagTjeneste.java
@@ -31,7 +31,6 @@ public class FastsettUttaksgrunnlagTjeneste {
     private final EndringsdatoFørstegangsbehandlingUtleder endringsdatoFørstegangsbehandlingUtleder;
     private final EndringsdatoRevurderingUtleder endringsdatoRevurderingUtleder;
 
-    private final VedtaksperioderHelper vedtaksperioderHelper = new VedtaksperioderHelper();
     private final JusterFordelingTjeneste justerFordelingTjeneste = new JusterFordelingTjeneste();
 
     @Inject
@@ -154,7 +153,7 @@ public class FastsettUttaksgrunnlagTjeneste {
                                                                              Long forrigeBehandling) {
         //Kopier vedtaksperioder fom endringsdato.
         var uttakResultatEntitet = fpUttakRepository.hentUttakResultat(forrigeBehandling);
-        return vedtaksperioderHelper.opprettOppgittePerioder(uttakResultatEntitet, oppgittePerioder, endringsdato);
+        return VedtaksperioderHelper.opprettOppgittePerioder(uttakResultatEntitet, oppgittePerioder, endringsdato);
     }
 
     private static record FHSøknadGjeldende(Optional<LocalDate> søknad, LocalDate gjeldende) {

--- a/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/uttaksgrunnlag/fp/OppgittPeriodeUtil.java
+++ b/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/uttaksgrunnlag/fp/OppgittPeriodeUtil.java
@@ -46,27 +46,14 @@ class OppgittPeriodeUtil {
      * @return første dato fra søknad som ikke er en utsettelse.
      */
     static Optional<LocalDate> finnFørsteSøkteUttaksdato(List<OppgittPeriodeEntitet> oppgittePerioder) {
-        var sortertePerioder = sorterEtterFom(oppgittePerioder);
-        var perioderMedUttak = sortertePerioder
-            .stream()
+        return oppgittePerioder.stream()
             .filter(p -> Årsak.UKJENT.equals(p.getÅrsak()) || !p.isOpphold())
-            .collect(Collectors.toList());
-
-        if(perioderMedUttak.size() > 0) {
-            return Optional.of(perioderMedUttak.get(0).getFom());
-        }
-
-        return Optional.empty();
+            .map(OppgittPeriodeEntitet::getFom)
+            .min(Comparator.naturalOrder());
     }
 
     static Optional<LocalDate> finnFørsteSøknadsdato(List<OppgittPeriodeEntitet> perioder) {
-        var sortertePerioder = sorterEtterFom(perioder);
-
-        if(sortertePerioder.size() > 0) {
-            return Optional.of(sortertePerioder.get(0).getFom());
-        }
-
-        return Optional.empty();
+        return perioder.stream().map(OppgittPeriodeEntitet::getFom).min(Comparator.naturalOrder());
     }
 
     static List<OppgittPeriodeEntitet> slåSammenLikePerioder(List<OppgittPeriodeEntitet> perioder) {

--- a/domenetjenester/uttak/src/test/java/no/nav/foreldrepenger/domene/uttak/uttaksgrunnlag/fp/VedtaksperioderHelperTest.java
+++ b/domenetjenester/uttak/src/test/java/no/nav/foreldrepenger/domene/uttak/uttaksgrunnlag/fp/VedtaksperioderHelperTest.java
@@ -42,8 +42,6 @@ public class VedtaksperioderHelperTest {
 
     private final LocalDate fødselsdato = LocalDate.of(2018, 1, 1);
 
-    private final VedtaksperioderHelper vedtaksperioderHelper = new VedtaksperioderHelper();
-
     @Test
     public void skal_lage_en_klippet_vedtaksperiode_av_tidligere_uttak_fra_endringsdato() {
         var uttakResultatPerioderEntitet = new UttakResultatPerioderEntitet();
@@ -60,7 +58,7 @@ public class VedtaksperioderHelperTest {
         var uttakResultatEntitet = new UttakResultatEntitet.Builder(
             mock(Behandlingsresultat.class)).medOpprinneligPerioder(uttakResultatPerioderEntitet).build();
 
-        var perioder = vedtaksperioderHelper.opprettOppgittePerioder(uttakResultatEntitet, List.of(),
+        var perioder = VedtaksperioderHelper.opprettOppgittePerioder(uttakResultatEntitet, List.of(),
             fødselsdato.plusWeeks(10));
 
         assertThat(perioder).hasSize(1);
@@ -85,7 +83,7 @@ public class VedtaksperioderHelperTest {
         var uttakResultatEntitet = new UttakResultatEntitet.Builder(
             mock(Behandlingsresultat.class)).medOpprinneligPerioder(uttakResultatPerioderEntitet).build();
 
-        var perioder = vedtaksperioderHelper.opprettOppgittePerioder(uttakResultatEntitet, List.of(),
+        var perioder = VedtaksperioderHelper.opprettOppgittePerioder(uttakResultatEntitet, List.of(),
             fødselsdato.minusWeeks(3));
 
         assertThat(perioder).hasSize(3);
@@ -118,7 +116,7 @@ public class VedtaksperioderHelperTest {
         var uttakResultatEntitet = new UttakResultatEntitet.Builder(
             mock(Behandlingsresultat.class)).medOpprinneligPerioder(uttakResultatPerioderEntitet).build();
 
-        var perioder = vedtaksperioderHelper.opprettOppgittePerioder(uttakResultatEntitet, List.of(),
+        var perioder = VedtaksperioderHelper.opprettOppgittePerioder(uttakResultatEntitet, List.of(),
             fødselsdato.minusWeeks(3));
 
         assertThat(perioder).hasSize(3);
@@ -166,7 +164,7 @@ public class VedtaksperioderHelperTest {
             .build();
 
         //Kjør tjeneste for å opprette søknadsperioder for revurdering.
-        var perioder = vedtaksperioderHelper.opprettOppgittePerioder(uttakResultatEntitet, List.of(utsettelseAvFp, fp),
+        var perioder = VedtaksperioderHelper.opprettOppgittePerioder(uttakResultatEntitet, List.of(utsettelseAvFp, fp),
             fødselsdato.minusWeeks(3));
 
         //Verifiser resultat
@@ -220,7 +218,7 @@ public class VedtaksperioderHelperTest {
             .build();
 
         //Kjør tjeneste for å opprette søknadsperioder for revurdering.
-        var perioder = vedtaksperioderHelper.opprettOppgittePerioder(uttakResultatEntitet, List.of(fp),
+        var perioder = VedtaksperioderHelper.opprettOppgittePerioder(uttakResultatEntitet, List.of(fp),
             fødselsdato.plusWeeks(10));
 
         //Verifiser resultat
@@ -259,7 +257,7 @@ public class VedtaksperioderHelperTest {
             .build();
 
         //Kjør tjeneste for å opprette søknadsperioder for revurdering.
-        var perioder = vedtaksperioderHelper.opprettOppgittePerioder(uttakResultatEntitet, List.of(mk),
+        var perioder = VedtaksperioderHelper.opprettOppgittePerioder(uttakResultatEntitet, List.of(mk),
             fødselsdato.plusWeeks(10));
 
         //Verifiser resultat
@@ -299,7 +297,7 @@ public class VedtaksperioderHelperTest {
             .build();
 
         //Kjør tjeneste for å opprette søknadsperioder for revurdering.
-        var perioder = vedtaksperioderHelper.opprettOppgittePerioder(uttakResultatEntitet, List.of(mk), fødselsdato);
+        var perioder = VedtaksperioderHelper.opprettOppgittePerioder(uttakResultatEntitet, List.of(mk), fødselsdato);
 
         //Verifiser resultat
         assertThat(perioder).hasSize(2);
@@ -352,7 +350,7 @@ public class VedtaksperioderHelperTest {
 
 
         //Kjør tjeneste for å opprette søknadsperioder for revurdering.
-        var perioder = vedtaksperioderHelper.opprettOppgittePerioder(uttakResultatEntitet, List.of(),
+        var perioder = VedtaksperioderHelper.opprettOppgittePerioder(uttakResultatEntitet, List.of(),
             fødselsdato.minusWeeks(3));
 
         //Verifiser resultat
@@ -400,7 +398,7 @@ public class VedtaksperioderHelperTest {
 
 
         //Kjør tjeneste for å opprette søknadsperioder for revurdering.
-        var perioder = vedtaksperioderHelper.opprettOppgittePerioder(uttakResultatEntitet, List.of(),
+        var perioder = VedtaksperioderHelper.opprettOppgittePerioder(uttakResultatEntitet, List.of(),
             fødselsdato.minusWeeks(3));
 
         //Verifiser resultat
@@ -432,7 +430,7 @@ public class VedtaksperioderHelperTest {
                 .medArbeidsprosent(BigDecimal.ZERO)
                 .build());
 
-        var konvertetPeriode = vedtaksperioderHelper.konverter(periodeEntitet);
+        var konvertetPeriode = VedtaksperioderHelper.konverter(periodeEntitet);
         assertThat(konvertetPeriode.getPeriodeType()).isEqualTo(UttakPeriodeType.FELLESPERIODE);
         assertThat(konvertetPeriode.getÅrsak()).isEqualTo(Årsak.UKJENT);
     }
@@ -457,7 +455,7 @@ public class VedtaksperioderHelperTest {
                 .medArbeidsprosent(BigDecimal.ZERO)
                 .build());
 
-        var konvertetPeriode = vedtaksperioderHelper.konverter(periodeEntitet);
+        var konvertetPeriode = VedtaksperioderHelper.konverter(periodeEntitet);
         assertThat(konvertetPeriode.getPeriodeType()).isEqualTo(UttakPeriodeType.MØDREKVOTE);
         assertThat(konvertetPeriode.getÅrsak()).isEqualTo(UtsettelseÅrsak.FERIE);
     }
@@ -494,7 +492,7 @@ public class VedtaksperioderHelperTest {
                 .medArbeidsprosent(BigDecimal.ZERO)
                 .build());
 
-        var konvertetPeriode = vedtaksperioderHelper.konverter(periodeEntitet);
+        var konvertetPeriode = VedtaksperioderHelper.konverter(periodeEntitet);
         assertThat(konvertetPeriode.getPeriodeType()).isEqualTo(UttakPeriodeType.FEDREKVOTE);
         assertThat(konvertetPeriode.getÅrsak()).isEqualTo(Årsak.UKJENT);
         assertThat(konvertetPeriode.getArbeidsprosent()).isEqualTo(arbeidstidsprosent);
@@ -534,7 +532,7 @@ public class VedtaksperioderHelperTest {
                 .medArbeidsprosent(BigDecimal.ZERO)
                 .build());
 
-        var konvertetPeriode = vedtaksperioderHelper.konverter(periodeEntitet);
+        var konvertetPeriode = VedtaksperioderHelper.konverter(periodeEntitet);
         assertThat(konvertetPeriode.getPeriodeType()).isEqualTo(UttakPeriodeType.FEDREKVOTE);
         assertThat(konvertetPeriode.getÅrsak()).isEqualTo(Årsak.UKJENT);
         assertThat(konvertetPeriode.getArbeidsprosent()).isEqualTo(arbeidstidsprosent);
@@ -574,7 +572,7 @@ public class VedtaksperioderHelperTest {
                 .medArbeidsprosent(BigDecimal.ZERO)
                 .build());
 
-        var konvertetPeriode = vedtaksperioderHelper.konverter(periodeEntitet);
+        var konvertetPeriode = VedtaksperioderHelper.konverter(periodeEntitet);
         assertThat(konvertetPeriode.getPeriodeType()).isEqualTo(UttakPeriodeType.FEDREKVOTE);
         assertThat(konvertetPeriode.getÅrsak()).isEqualTo(Årsak.UKJENT);
         assertThat(konvertetPeriode.getArbeidsprosent()).isEqualTo(arbeidstidsprosent);
@@ -609,7 +607,7 @@ public class VedtaksperioderHelperTest {
                 .medArbeidsprosent(BigDecimal.ZERO)
                 .build());
 
-        var konvertertPeriode = vedtaksperioderHelper.konverter(periodeEntitet);
+        var konvertertPeriode = VedtaksperioderHelper.konverter(periodeEntitet);
         assertThat(konvertertPeriode.getPeriodeType()).isEqualTo(UttakPeriodeType.FEDREKVOTE);
         assertThat(konvertertPeriode.getÅrsak()).isEqualTo(Årsak.UKJENT);
         assertThat(konvertertPeriode.isSamtidigUttak()).isTrue();
@@ -647,7 +645,7 @@ public class VedtaksperioderHelperTest {
                 .medArbeidsprosent(BigDecimal.ZERO)
                 .build());
 
-        var konvertetPeriode = vedtaksperioderHelper.konverter(periodeEntitet);
+        var konvertetPeriode = VedtaksperioderHelper.konverter(periodeEntitet);
         assertThat(konvertetPeriode.getPeriodeType()).isEqualTo(UttakPeriodeType.FORELDREPENGER);
         assertThat(konvertetPeriode.getÅrsak()).isEqualTo(Årsak.UKJENT);
         assertThat(konvertetPeriode.getArbeidsprosent()).isEqualTo(BigDecimal.valueOf(50));
@@ -668,7 +666,7 @@ public class VedtaksperioderHelperTest {
         var uttakResultatEntitet = new UttakResultatEntitet.Builder(
             mock(Behandlingsresultat.class)).medOpprinneligPerioder(uttakResultatPerioderEntitet).build();
 
-        var perioder = vedtaksperioderHelper.opprettOppgittePerioder(uttakResultatEntitet, List.of(),
+        var perioder = VedtaksperioderHelper.opprettOppgittePerioder(uttakResultatEntitet, List.of(),
             fødselsdato.minusWeeks(3));
 
         assertThat(perioder).hasSize(1);
@@ -688,7 +686,7 @@ public class VedtaksperioderHelperTest {
         var uttakResultatEntitet = new UttakResultatEntitet.Builder(
             mock(Behandlingsresultat.class)).medOpprinneligPerioder(uttakResultatPerioderEntitet).build();
 
-        var perioder = vedtaksperioderHelper.opprettOppgittePerioder(uttakResultatEntitet, List.of(), fødselsdato);
+        var perioder = VedtaksperioderHelper.opprettOppgittePerioder(uttakResultatEntitet, List.of(), fødselsdato);
 
         assertThat(perioder).hasSize(1);
         assertThat(perioder.get(0).getFom()).isEqualTo(uttakResultatPeriode.getFom());
@@ -708,7 +706,7 @@ public class VedtaksperioderHelperTest {
             .medPeriodeType(UttakPeriodeType.MØDREKVOTE)
             .build();
 
-        var perioder = vedtaksperioderHelper.opprettOppgittePerioder(uttakResultatEntitet, List.of(mk), null);
+        var perioder = VedtaksperioderHelper.opprettOppgittePerioder(uttakResultatEntitet, List.of(mk), null);
 
         assertThat(perioder).hasSize(1);
         assertThat(perioder.get(0).getFom()).isEqualTo(mk.getFom());
@@ -737,7 +735,7 @@ public class VedtaksperioderHelperTest {
                 .medArbeidsprosent(BigDecimal.TEN)
                 .build());
 
-        var konvertetPeriode = vedtaksperioderHelper.konverter(periodeEntitet);
+        var konvertetPeriode = VedtaksperioderHelper.konverter(periodeEntitet);
         assertThat(konvertetPeriode.isSamtidigUttak()).isEqualTo(periodeEntitet.isSamtidigUttak());
         assertThat(konvertetPeriode.getSamtidigUttaksprosent()).isEqualTo(periodeSøknad.getSamtidigUttaksprosent());
     }
@@ -759,7 +757,7 @@ public class VedtaksperioderHelperTest {
                 .medArbeidsprosent(BigDecimal.TEN)
                 .build());
 
-        var konvertetPeriode = vedtaksperioderHelper.konverter(periodeEntitet);
+        var konvertetPeriode = VedtaksperioderHelper.konverter(periodeEntitet);
         assertThat(konvertetPeriode.isSamtidigUttak()).isEqualTo(periodeEntitet.isSamtidigUttak());
         assertThat(konvertetPeriode.getSamtidigUttaksprosent()).isEqualTo(periodeSøknad.getSamtidigUttaksprosent());
     }
@@ -781,7 +779,7 @@ public class VedtaksperioderHelperTest {
                 .medArbeidsprosent(BigDecimal.TEN)
                 .build());
 
-        var konvertetPeriode = vedtaksperioderHelper.konverter(uttaksperiode);
+        var konvertetPeriode = VedtaksperioderHelper.konverter(uttaksperiode);
         assertThat(konvertetPeriode.getÅrsak()).isEqualTo(uttaksperiode.getOverføringÅrsak());
     }
 
@@ -803,7 +801,7 @@ public class VedtaksperioderHelperTest {
                 .medArbeidsprosent(BigDecimal.TEN)
                 .build());
 
-        var konvertetPeriode = vedtaksperioderHelper.konverter(uttaksperiode);
+        var konvertetPeriode = VedtaksperioderHelper.konverter(uttaksperiode);
         assertThat(konvertetPeriode.getMottattDato()).isEqualTo(
             uttaksperiode.getPeriodeSøknad().orElseThrow().getMottattDato());
     }

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
         <fp-jms.version>2.2.0</fp-jms.version>
 
         <fp-kontrakter.version>6.1.27</fp-kontrakter.version>
-        <fp-tidsserie.version>2.6.4</fp-tidsserie.version>
+        <fp-tidsserie.version>2.6.5</fp-tidsserie.version>
         <fp-nare.version>2.4.0</fp-nare.version>
         <abakus-kontrakt.version>1.3.35</abakus-kontrakt.version>
         <kalkulus.version>1.5.61</kalkulus.version>

--- a/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/registrering/fp/EndringssøknadSøknadMapperTest.java
+++ b/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/registrering/fp/EndringssøknadSøknadMapperTest.java
@@ -65,7 +65,7 @@ public class EndringssøknadSøknadMapperTest {
         var soeknad = ytelseSøknadMapper.mapSøknad(manuellRegistreringEndringsøknadDto, navBruker);
 
         var oppgittPeriodeMottattDatoTjeneste = new OppgittPeriodeTidligstMottattDatoTjeneste(
-            new YtelseFordelingTjeneste(repositoryProvider.getYtelsesFordelingRepository()));
+            new YtelseFordelingTjeneste(repositoryProvider.getYtelsesFordelingRepository()), null);
         var oversetter = new SøknadOversetter(repositoryProvider, grunnlagRepositoryProvider,
             virksomhetTjeneste, iayTjeneste, personinfoAdapter, datavarehusTjeneste, oppgittPeriodeMottattDatoTjeneste,
             new AnnenPartOversetter(personinfoAdapter));

--- a/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/registrering/fp/SøknadMapperTest.java
+++ b/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/registrering/fp/SøknadMapperTest.java
@@ -100,7 +100,7 @@ public class SøknadMapperTest {
         repositoryProvider = new BehandlingRepositoryProvider(entityManager);
         grunnlagRepositoryProvider = new BehandlingGrunnlagRepositoryProvider(entityManager);
         oppgittPeriodeMottattDato = new OppgittPeriodeTidligstMottattDatoTjeneste(
-            new YtelseFordelingTjeneste(repositoryProvider.getYtelsesFordelingRepository()));
+            new YtelseFordelingTjeneste(repositoryProvider.getYtelsesFordelingRepository()), null);
 
         kvinne = new PersoninfoKjønn.Builder().medAktørId(STD_KVINNE_AKTØR_ID)
             .medNavBrukerKjønn(NavBrukerKjønn.KVINNE)


### PR DESCRIPTION
Initiell logging på veien mot å dele opp perioder som skal ha ulik mottattdato

Litt usikker på om det er best å sammenligne med forrige behandling sin getGjeldendeSøknadsperioder eller getOppgittePerioder - eller sjekke begge