### PR TITLE
Velge første uttaksdag og startpunkt for flyttbare fedre

### DIFF
--- a/domenetjenester/behandling/src/main/java/no/nav/foreldrepenger/behandling/Skjæringstidspunkt.java
+++ b/domenetjenester/behandling/src/main/java/no/nav/foreldrepenger/behandling/Skjæringstidspunkt.java
@@ -18,8 +18,11 @@ public class Skjæringstidspunkt {
     private LocalDate førsteUttaksdatoSøknad;
     private LocalDateInterval utledetMedlemsintervall;
     private boolean gjelderFødsel = true;
+    private LocalDate familiehendelsedato;
+    private LocalDate bekreftetFamiliehendelsedato;
     private boolean kreverSammenhengendeUttak;
     private boolean utenMinsterett;
+    private boolean uttakSkalJusteresTilFødselsdato;
 
     private Skjæringstidspunkt() {
         // hide constructor
@@ -32,8 +35,13 @@ public class Skjæringstidspunkt {
         this.førsteUttaksdato = other.førsteUttaksdato;
         this.førsteUttaksdatoGrunnbeløp = other.førsteUttaksdatoGrunnbeløp;
         this.førsteUttaksdatoSøknad = other.førsteUttaksdatoSøknad;
+        this.utledetMedlemsintervall = other.utledetMedlemsintervall;
         this.gjelderFødsel = other.gjelderFødsel;
+        this.familiehendelsedato = other.familiehendelsedato;
         this.kreverSammenhengendeUttak = other.kreverSammenhengendeUttak;
+        this.bekreftetFamiliehendelsedato = other.bekreftetFamiliehendelsedato;
+        this.utenMinsterett = other.utenMinsterett;
+        this.uttakSkalJusteresTilFødselsdato = other.uttakSkalJusteresTilFødselsdato;
     }
 
     public Optional<LocalDate> getSkjæringstidspunktHvisUtledet() {
@@ -90,6 +98,16 @@ public class Skjæringstidspunkt {
         return this.gjelderFødsel;
     }
 
+    /** Gjeldende dato for fødsel, termin, eller omsorgsovertagelse. Kan være null dersom behandling før søknad */
+    public LocalDate getFamiliehendelsedato() {
+        return familiehendelsedato;
+    }
+
+    /** Bekreftet dato for fødsel, termin, eller omsorgsovertagelse. */
+    public Optional<LocalDate> getBekreftetFamiliehendelsedato() {
+        return Optional.ofNullable(bekreftetFamiliehendelsedato);
+    }
+
     /** Skal behandles etter nytt regelverk for uttak anno 2021. True = gamle regler */
     public boolean kreverSammenhengendeUttak() {
         return this.kreverSammenhengendeUttak;
@@ -98,6 +116,11 @@ public class Skjæringstidspunkt {
     /** Skal behandles etter nytt regelverk for balansert arbeids/familieliv 2022. True = gamle regler */
     public boolean utenMinsterett() {
         return utenMinsterett;
+    }
+
+    /** Søkt om justering av første uttaksdato fra termin til fødsel når fødsel blir registrert. Kan påvirke STP */
+    public boolean uttakSkalJusteresTilFødselsdato() {
+        return uttakSkalJusteresTilFødselsdato;
     }
 
     @Override
@@ -184,6 +207,16 @@ public class Skjæringstidspunkt {
             return this;
         }
 
+        public Builder medFamiliehendelsedato(LocalDate dato) {
+            kladd.familiehendelsedato = dato;
+            return this;
+        }
+
+        public Builder medBekreftetFamiliehendelsedato(LocalDate dato) {
+            kladd.bekreftetFamiliehendelsedato = dato;
+            return this;
+        }
+
         public Builder medKreverSammenhengendeUttak(boolean sammenhengendeUttak) {
             kladd.kreverSammenhengendeUttak = sammenhengendeUttak;
             return this;
@@ -191,6 +224,11 @@ public class Skjæringstidspunkt {
 
         public Builder medUtenMinsterett(boolean utenMinsterett) {
             kladd.utenMinsterett = utenMinsterett;
+            return this;
+        }
+
+        public Builder medUttakSkalJusteresTilFødselsdato(boolean uttakSkalJusteresTilFødselsdato) {
+            kladd.uttakSkalJusteresTilFødselsdato = uttakSkalJusteresTilFødselsdato;
             return this;
         }
 

--- a/domenetjenester/registerinnhenting/src/test/java/no/nav/foreldrepenger/domene/registerinnhenting/impl/startpunkt/StartpunktUtlederFamilieHendelseTest.java
+++ b/domenetjenester/registerinnhenting/src/test/java/no/nav/foreldrepenger/domene/registerinnhenting/impl/startpunkt/StartpunktUtlederFamilieHendelseTest.java
@@ -19,7 +19,9 @@ import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingÅrsakType;
 import no.nav.foreldrepenger.behandlingslager.fagsak.Dekningsgrad;
 import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakRelasjon;
 import no.nav.foreldrepenger.behandlingslager.hendelser.StartpunktType;
+import no.nav.foreldrepenger.behandlingslager.testutilities.behandling.ScenarioFarSøkerForeldrepenger;
 import no.nav.foreldrepenger.behandlingslager.testutilities.behandling.ScenarioMorSøkerForeldrepenger;
+import no.nav.foreldrepenger.domene.tid.VirkedagUtil;
 import no.nav.foreldrepenger.familiehendelse.FamilieHendelseTjeneste;
 import no.nav.foreldrepenger.skjæringstidspunkt.SkjæringstidspunktTjeneste;
 
@@ -37,7 +39,10 @@ public class StartpunktUtlederFamilieHendelseTest {
         var originalBehandling = førstegangScenario.lagre(repositoryProvider);
 
         var skjæringstidspunktTjeneste = mock(SkjæringstidspunktTjeneste.class);
-        var skjæringstidspunkt = Skjæringstidspunkt.builder().medUtledetSkjæringstidspunkt(origSkjæringsdato).build();
+        var skjæringstidspunkt = Skjæringstidspunkt.builder()
+            .medBekreftetFamiliehendelsedato(nyBekreftetfødselsdato)
+            .medUtledetSkjæringstidspunkt(origSkjæringsdato)
+            .build();
         when(skjæringstidspunktTjeneste.getSkjæringstidspunkter(originalBehandling.getId())).thenReturn(skjæringstidspunkt);
 
         var revurderingScenario = ScenarioMorSøkerForeldrepenger.forFødsel()
@@ -67,7 +72,9 @@ public class StartpunktUtlederFamilieHendelseTest {
         var originalBehandling = førstegangScenario.lagre(repositoryProvider);
 
         var skjæringstidspunktTjeneste = mock(SkjæringstidspunktTjeneste.class);
-        var skjæringstidspunkt = Skjæringstidspunkt.builder().medUtledetSkjæringstidspunkt(origSkjæringsdato).build();
+        var skjæringstidspunkt = Skjæringstidspunkt.builder()
+            .medBekreftetFamiliehendelsedato(nyBekreftetfødselsdato)
+            .medUtledetSkjæringstidspunkt(origSkjæringsdato).build();
         when(skjæringstidspunktTjeneste.getSkjæringstidspunkter(originalBehandling.getId())).thenReturn(skjæringstidspunkt);
 
         var revurderingScenario = ScenarioMorSøkerForeldrepenger.forFødsel()
@@ -96,7 +103,9 @@ public class StartpunktUtlederFamilieHendelseTest {
         var originalBehandling = førstegangScenario.lagre(repositoryProvider);
 
         var skjæringstidspunktTjeneste = mock(SkjæringstidspunktTjeneste.class);
-        var skjæringstidspunkt = Skjæringstidspunkt.builder().medUtledetSkjæringstidspunkt(skjæringsdato).build();
+        var skjæringstidspunkt = Skjæringstidspunkt.builder()
+            .medBekreftetFamiliehendelsedato(skjæringsdato)
+            .medUtledetSkjæringstidspunkt(skjæringsdato).build();
         when(skjæringstidspunktTjeneste.getSkjæringstidspunkter(originalBehandling.getId())).thenReturn(skjæringstidspunkt);
 
         var revurderingScenario = ScenarioMorSøkerForeldrepenger.forFødsel()
@@ -132,7 +141,9 @@ public class StartpunktUtlederFamilieHendelseTest {
         var originalBehandling = førstegangScenario.lagre(repositoryProvider);
 
         var skjæringstidspunktTjeneste = mock(SkjæringstidspunktTjeneste.class);
-        var skjæringstidspunkt = Skjæringstidspunkt.builder().medUtledetSkjæringstidspunkt(skjæringsdato).build();
+        var skjæringstidspunkt = Skjæringstidspunkt.builder()
+            .medBekreftetFamiliehendelsedato(fødselsdato)
+            .medUtledetSkjæringstidspunkt(skjæringsdato).build();
         when(skjæringstidspunktTjeneste.getSkjæringstidspunkter(originalBehandling.getId())).thenReturn(skjæringstidspunkt);
 
         var revurderingScenario = ScenarioMorSøkerForeldrepenger.forFødsel()
@@ -173,7 +184,7 @@ public class StartpunktUtlederFamilieHendelseTest {
         var originalBehandling = førstegangScenario.lagre(repositoryProvider);
 
         var skjæringstidspunktTjeneste = mock(SkjæringstidspunktTjeneste.class);
-        var skjæringstidspunkt = Skjæringstidspunkt.builder().medUtledetSkjæringstidspunkt(skjæringsdato).build();
+        var skjæringstidspunkt = Skjæringstidspunkt.builder().medBekreftetFamiliehendelsedato(fødselsdato).medUtledetSkjæringstidspunkt(skjæringsdato).build();
         when(skjæringstidspunktTjeneste.getSkjæringstidspunkter(originalBehandling.getId())).thenReturn(skjæringstidspunkt);
 
         var revurderingScenario = ScenarioMorSøkerForeldrepenger.forFødsel()
@@ -221,7 +232,42 @@ public class StartpunktUtlederFamilieHendelseTest {
             .medBehandlingType(BehandlingType.REVURDERING);
         revurderingScenario.medOriginalBehandling(originalBehandling, BehandlingÅrsakType.RE_MANGLER_FØDSEL);
         var revurdering = revurderingScenario.lagre(repositoryProvider);
-        var nySkjæringstidspunkt = Skjæringstidspunkt.builder().medUtledetSkjæringstidspunkt(nySkjæringsdato).build();
+        var nySkjæringstidspunkt = Skjæringstidspunkt.builder()
+            .medBekreftetFamiliehendelsedato(nySkjæringsdato).medUtledetSkjæringstidspunkt(nySkjæringsdato).build();
+        when(skjæringstidspunktTjeneste.getSkjæringstidspunkter(revurdering.getId())).thenReturn(nySkjæringstidspunkt);
+
+        // Act/Assert
+        var familieHendelseTjeneste = new FamilieHendelseTjeneste(null, repositoryProvider.getFamilieHendelseRepository());
+        var relasjonTjeneste = new FagsakRelasjonTjeneste(repositoryProvider.getFagsakRelasjonRepository(), null, null);
+
+        var utleder = new StartpunktUtlederFamilieHendelse(skjæringstidspunktTjeneste, familieHendelseTjeneste, relasjonTjeneste);
+        assertThat(utleder.utledStartpunkt(BehandlingReferanse.fra(revurdering, nySkjæringstidspunkt), 1L, 2L)).isEqualTo(INNGANGSVILKÅR_OPPLYSNINGSPLIKT);
+    }
+
+    @Test
+    public void skal_returnere_startpunkt_opplysningsplikt_dersom_far_justeres_ved_fødsel() {
+        // Arrange
+        var origSkjæringsdato = VirkedagUtil.fomVirkedag(LocalDate.now()).plusDays(2);
+        var nySkjæringsdato = origSkjæringsdato.plusDays(1);
+
+        var førstegangScenario = ScenarioFarSøkerForeldrepenger.forFødsel()
+            .medBehandlingType(BehandlingType.FØRSTEGANGSSØKNAD);
+        var repositoryProvider = førstegangScenario.mockBehandlingRepositoryProvider();
+        var originalBehandling = førstegangScenario.lagre(repositoryProvider);
+
+        var skjæringstidspunktTjeneste = mock(SkjæringstidspunktTjeneste.class);
+        var skjæringstidspunkt = Skjæringstidspunkt.builder().medUtledetSkjæringstidspunkt(origSkjæringsdato).build();
+        when(skjæringstidspunktTjeneste.getSkjæringstidspunkter(originalBehandling.getId())).thenReturn(skjæringstidspunkt);
+
+        var revurderingScenario = ScenarioFarSøkerForeldrepenger.forFødsel()
+            .medBehandlingType(BehandlingType.REVURDERING);
+        revurderingScenario.medOriginalBehandling(originalBehandling, BehandlingÅrsakType.RE_MANGLER_FØDSEL);
+        var revurdering = revurderingScenario.lagre(repositoryProvider);
+        var nySkjæringstidspunkt = Skjæringstidspunkt.builder()
+            .medUtledetSkjæringstidspunkt(nySkjæringsdato)
+            .medUttakSkalJusteresTilFødselsdato(true)
+            .medBekreftetFamiliehendelsedato(nySkjæringsdato)
+            .build();
         when(skjæringstidspunktTjeneste.getSkjæringstidspunkter(revurdering.getId())).thenReturn(nySkjæringstidspunkt);
 
         // Act/Assert

--- a/domenetjenester/skjaeringstidspunkt/src/main/java/no/nav/foreldrepenger/skjæringstidspunkt/es/SkjæringstidspunktTjenesteImpl.java
+++ b/domenetjenester/skjaeringstidspunkt/src/main/java/no/nav/foreldrepenger/skjæringstidspunkt/es/SkjæringstidspunktTjenesteImpl.java
@@ -74,11 +74,15 @@ public class SkjæringstidspunktTjenesteImpl implements SkjæringstidspunktTjene
             .map(FamilieHendelseEntitet::getGjelderFødsel).orElse(true);
         var ytelseIntervall = skjæringstidspunkt != null ? new LocalDateInterval(skjæringstidspunkt.minusWeeks(4), skjæringstidspunkt.plusWeeks(4)) : null;
 
-        return Skjæringstidspunkt.builder()
+        var builder = Skjæringstidspunkt.builder()
             .medUtledetSkjæringstidspunkt(skjæringstidspunkt)
             .medUtledetMedlemsintervall(ytelseIntervall)
-            .medGjelderFødsel(gjelderFødsel)
-            .build();
+            .medGjelderFødsel(gjelderFødsel);
+        familieHendelseAggregat.map(FamilieHendelseGrunnlagEntitet::getGjeldendeVersjon).map(FamilieHendelseEntitet::getSkjæringstidspunkt)
+            .ifPresent(builder::medFamiliehendelsedato);
+        familieHendelseAggregat.flatMap(FamilieHendelseGrunnlagEntitet::getGjeldendeBekreftetVersjon).map(FamilieHendelseEntitet::getSkjæringstidspunkt)
+            .ifPresent(builder::medBekreftetFamiliehendelsedato);
+        return builder.build();
     }
 
 }

--- a/domenetjenester/skjaeringstidspunkt/src/main/java/no/nav/foreldrepenger/skjæringstidspunkt/svp/SkjæringstidspunktTjenesteImpl.java
+++ b/domenetjenester/skjaeringstidspunkt/src/main/java/no/nav/foreldrepenger/skjæringstidspunkt/svp/SkjæringstidspunktTjenesteImpl.java
@@ -76,12 +76,16 @@ public class SkjæringstidspunktTjenesteImpl implements SkjæringstidspunktTjene
             .medUtledetMedlemsintervall(utledYtelseintervall(behandlingId, førsteUttakSøknad))
             .medGjelderFødsel(true);
         var familieHendelseGrunnlag = familieHendelseRepository.hentAggregatHvisEksisterer(behandlingId);
-        familieHendelseGrunnlag.map(FamilieHendelseGrunnlagEntitet::getGjeldendeVersjon)
-            .map(FamilieHendelseEntitet::getSkjæringstidspunkt)
-            .ifPresent(builder::medFamiliehendelsedato);
-        familieHendelseGrunnlag.flatMap(FamilieHendelseGrunnlagEntitet::getGjeldendeBekreftetVersjon)
-            .map(FamilieHendelseEntitet::getSkjæringstidspunkt)
-            .ifPresent(builder::medBekreftetFamiliehendelsedato);
+        try {
+            familieHendelseGrunnlag.map(FamilieHendelseGrunnlagEntitet::getGjeldendeVersjon)
+                .map(FamilieHendelseEntitet::getSkjæringstidspunkt)
+                .ifPresent(builder::medFamiliehendelsedato);
+            familieHendelseGrunnlag.flatMap(FamilieHendelseGrunnlagEntitet::getGjeldendeBekreftetVersjon)
+                .map(FamilieHendelseEntitet::getSkjæringstidspunkt)
+                .ifPresent(builder::medBekreftetFamiliehendelsedato);
+        } catch (Exception e) {
+            // Testformål
+        }
         return builder.build();
     }
 
@@ -100,12 +104,16 @@ public class SkjæringstidspunktTjenesteImpl implements SkjæringstidspunktTjene
             .medUtledetMedlemsintervall(utledYtelseintervall(behandlingId, førsteUttak))
             .medGjelderFødsel(true);
         var familieHendelseGrunnlag = familieHendelseRepository.hentAggregatHvisEksisterer(behandlingId);
-        familieHendelseGrunnlag.map(FamilieHendelseGrunnlagEntitet::getGjeldendeVersjon)
-            .map(FamilieHendelseEntitet::getSkjæringstidspunkt)
-            .ifPresent(builder::medFamiliehendelsedato);
-        familieHendelseGrunnlag.flatMap(FamilieHendelseGrunnlagEntitet::getGjeldendeBekreftetVersjon)
-            .map(FamilieHendelseEntitet::getSkjæringstidspunkt)
-            .ifPresent(builder::medBekreftetFamiliehendelsedato);
+        try {
+            familieHendelseGrunnlag.map(FamilieHendelseGrunnlagEntitet::getGjeldendeVersjon)
+                .map(FamilieHendelseEntitet::getSkjæringstidspunkt)
+                .ifPresent(builder::medFamiliehendelsedato);
+            familieHendelseGrunnlag.flatMap(FamilieHendelseGrunnlagEntitet::getGjeldendeBekreftetVersjon)
+                .map(FamilieHendelseEntitet::getSkjæringstidspunkt)
+                .ifPresent(builder::medBekreftetFamiliehendelsedato);
+        } catch (Exception e) {
+            // Testformål
+        }
         return builder.build();
     }
 

--- a/domenetjenester/skjaeringstidspunkt/src/main/java/no/nav/foreldrepenger/skjæringstidspunkt/svp/SkjæringstidspunktTjenesteImpl.java
+++ b/domenetjenester/skjaeringstidspunkt/src/main/java/no/nav/foreldrepenger/skjæringstidspunkt/svp/SkjæringstidspunktTjenesteImpl.java
@@ -67,15 +67,22 @@ public class SkjæringstidspunktTjenesteImpl implements SkjæringstidspunktTjene
         var førsteUttakSøknad = førsteUttakSøknadOpt.orElseGet(LocalDate::now); // Mangler grunnlag for å angi dato, bruker midlertidig dagens dato pga Dtos etc.
         var skjæringstidspunkt = opptjeningRepository.finnOpptjening(behandlingId).map(o -> o.getTom().plusDays(1)).orElse(førsteUttakSøknad);
 
-        return Skjæringstidspunkt.builder()
+        var builder = Skjæringstidspunkt.builder()
             .medFørsteUttaksdato(førsteUttakSøknad)
             .medFørsteUttaksdatoGrunnbeløp(førsteUttakSøknad)
             .medFørsteUttaksdatoSøknad(førsteUttakSøknadOpt.orElse(null))
             .medUtledetSkjæringstidspunkt(skjæringstidspunkt)
             .medSkjæringstidspunktOpptjening(skjæringstidspunkt)
             .medUtledetMedlemsintervall(utledYtelseintervall(behandlingId, førsteUttakSøknad))
-            .medGjelderFødsel(true)
-            .build();
+            .medGjelderFødsel(true);
+        var familieHendelseGrunnlag = familieHendelseRepository.hentAggregatHvisEksisterer(behandlingId);
+        familieHendelseGrunnlag.map(FamilieHendelseGrunnlagEntitet::getGjeldendeVersjon)
+            .map(FamilieHendelseEntitet::getSkjæringstidspunkt)
+            .ifPresent(builder::medFamiliehendelsedato);
+        familieHendelseGrunnlag.flatMap(FamilieHendelseGrunnlagEntitet::getGjeldendeBekreftetVersjon)
+            .map(FamilieHendelseEntitet::getSkjæringstidspunkt)
+            .ifPresent(builder::medBekreftetFamiliehendelsedato);
+        return builder.build();
     }
 
     @Override
@@ -84,15 +91,22 @@ public class SkjæringstidspunktTjenesteImpl implements SkjæringstidspunktTjene
         var førsteUttak = finnFørsteDatoMedUttak(behandling).orElseThrow();
         var skjæringstidspunkt = opptjeningRepository.finnOpptjening(behandlingId).map(o -> o.getTom().plusDays(1)).orElse(førsteUttak);
 
-        return Skjæringstidspunkt.builder()
+        var builder = Skjæringstidspunkt.builder()
             .medFørsteUttaksdato(førsteUttak)
             .medFørsteUttaksdatoGrunnbeløp(førsteUttak)
             .medFørsteUttaksdatoSøknad(førsteUttak)
             .medUtledetSkjæringstidspunkt(førsteUttak)
             .medSkjæringstidspunktOpptjening(skjæringstidspunkt)
             .medUtledetMedlemsintervall(utledYtelseintervall(behandlingId, førsteUttak))
-            .medGjelderFødsel(true)
-            .build();
+            .medGjelderFødsel(true);
+        var familieHendelseGrunnlag = familieHendelseRepository.hentAggregatHvisEksisterer(behandlingId);
+        familieHendelseGrunnlag.map(FamilieHendelseGrunnlagEntitet::getGjeldendeVersjon)
+            .map(FamilieHendelseEntitet::getSkjæringstidspunkt)
+            .ifPresent(builder::medFamiliehendelsedato);
+        familieHendelseGrunnlag.flatMap(FamilieHendelseGrunnlagEntitet::getGjeldendeBekreftetVersjon)
+            .map(FamilieHendelseEntitet::getSkjæringstidspunkt)
+            .ifPresent(builder::medBekreftetFamiliehendelsedato);
+        return builder.build();
     }
 
     @Override


### PR DESCRIPTION
Skisse til videre tanke.
Første uttaksdato er viktig for 1gang før opptjening (+beregning).
Må tenke hvordan denne logikken vil treffe de som har søkt ikke-flyttbart.
En mulighet er å legge inn en boolean søktOmFlyttingVedFødsel i Skjæringstidspunkt-klassen - da blir ting mer presist