### PR TITLE
Mer presis logging av perioder som kan kastes

### DIFF
--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/ytelsefordeling/periode/GraderingAktivitetType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/ytelsefordeling/periode/GraderingAktivitetType.java
@@ -4,5 +4,4 @@ public enum GraderingAktivitetType {
     ARBEID,
     SELVSTENDIG_NÆRINGSDRIVENDE,
     FRILANS,
-    ANNET;
 }

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/ytelsefordeling/periode/GraderingAktivitetType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/ytelsefordeling/periode/GraderingAktivitetType.java
@@ -1,0 +1,8 @@
+package no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.periode;
+
+public enum GraderingAktivitetType {
+    ARBEID,
+    SELVSTENDIG_NÆRINGSDRIVENDE,
+    FRILANS,
+    ANNET;
+}

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/ytelsefordeling/periode/OppgittPeriodeEntitet.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/ytelsefordeling/periode/OppgittPeriodeEntitet.java
@@ -312,7 +312,7 @@ public class OppgittPeriodeEntitet extends BaseEntitet implements IndexKey {
         } else if (erFrilanser) {
             return GraderingAktivitetType.FRILANS;
         } else {
-            return GraderingAktivitetType.ANNET;
+            return null;
         }
     }
 

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/ytelsefordeling/periode/OppgittPeriodeEntitet.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/ytelsefordeling/periode/OppgittPeriodeEntitet.java
@@ -304,6 +304,18 @@ public class OppgittPeriodeEntitet extends BaseEntitet implements IndexKey {
         return getÅrsak() instanceof UtsettelseÅrsak;
     }
 
+    public GraderingAktivitetType utledGraderingAktivitetType() {
+        if (erArbeidstaker) {
+            return GraderingAktivitetType.ARBEID;
+        } else if (erSelvstendig) {
+            return GraderingAktivitetType.SELVSTENDIG_NÆRINGSDRIVENDE;
+        } else if (erFrilanser) {
+            return GraderingAktivitetType.FRILANS;
+        } else {
+            return GraderingAktivitetType.ANNET;
+        }
+    }
+
     public LocalDate getMottattDato() {
         return mottattDato;
     }

--- a/behandlingslager/domene/src/test/java/no/nav/foreldrepenger/behandlingslager/geografisk/LandkoderTest.java
+++ b/behandlingslager/domene/src/test/java/no/nav/foreldrepenger/behandlingslager/geografisk/LandkoderTest.java
@@ -2,14 +2,29 @@ package no.nav.foreldrepenger.behandlingslager.geografisk;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 import org.junit.jupiter.api.Test;
+
+import no.nav.fpsak.tidsserie.LocalDateSegment;
+import no.nav.fpsak.tidsserie.LocalDateTimeline;
 
 public class LandkoderTest {
 
     @Test
     public void skal_sjekke_for_norge() {
+        LocalDate ref = LocalDate.now();
+        List<LocalDateSegment<Integer>> tliste = new ArrayList<>();
+        var tomListe = new LocalDateTimeline<>(tliste);
+        var innholdListe = new LocalDateTimeline<>(List.of(new LocalDateSegment<>(ref.minusDays(10), ref.minusDays(5), 1),
+            new LocalDateSegment<>(ref.plusDays(5), ref.plusDays(10), 1)));
+        var innholdListe2 = new LocalDateTimeline<>(List.of(new LocalDateSegment<>(ref.minusDays(15), ref.minusDays(7), 1),
+            new LocalDateSegment<>(ref.plusDays(8), ref.plusDays(15), 2)));
+        var diff = innholdListe2.combine(innholdListe, (i, lhs, rhs) -> new LocalDateSegment<>(i, !Objects.equals(lhs, rhs)), LocalDateTimeline.JoinStyle.CROSS_JOIN);
+        System.out.println(diff.filterValue(v -> v));
         assertThat(Landkoder.erNorge("SWE")).isFalse();
         assertThat(Landkoder.erNorge("NOR")).isTrue();
     }

--- a/behandlingslager/domene/src/test/java/no/nav/foreldrepenger/behandlingslager/geografisk/LandkoderTest.java
+++ b/behandlingslager/domene/src/test/java/no/nav/foreldrepenger/behandlingslager/geografisk/LandkoderTest.java
@@ -2,29 +2,14 @@ package no.nav.foreldrepenger.behandlingslager.geografisk;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.time.LocalDate;
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 
 import org.junit.jupiter.api.Test;
-
-import no.nav.fpsak.tidsserie.LocalDateSegment;
-import no.nav.fpsak.tidsserie.LocalDateTimeline;
 
 public class LandkoderTest {
 
     @Test
     public void skal_sjekke_for_norge() {
-        LocalDate ref = LocalDate.now();
-        List<LocalDateSegment<Integer>> tliste = new ArrayList<>();
-        var tomListe = new LocalDateTimeline<>(tliste);
-        var innholdListe = new LocalDateTimeline<>(List.of(new LocalDateSegment<>(ref.minusDays(10), ref.minusDays(5), 1),
-            new LocalDateSegment<>(ref.plusDays(5), ref.plusDays(10), 1)));
-        var innholdListe2 = new LocalDateTimeline<>(List.of(new LocalDateSegment<>(ref.minusDays(15), ref.minusDays(7), 1),
-            new LocalDateSegment<>(ref.plusDays(8), ref.plusDays(15), 2)));
-        var diff = innholdListe2.combine(innholdListe, (i, lhs, rhs) -> new LocalDateSegment<>(i, !Objects.equals(lhs, rhs)), LocalDateTimeline.JoinStyle.CROSS_JOIN);
-        System.out.println(diff.filterValue(v -> v));
         assertThat(Landkoder.erNorge("SWE")).isFalse();
         assertThat(Landkoder.erNorge("NOR")).isTrue();
     }

--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/dokumentmottak/impl/OppgittPeriodeTidligstMottattDatoTjeneste.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/dokumentmottak/impl/OppgittPeriodeTidligstMottattDatoTjeneste.java
@@ -113,7 +113,7 @@ public class OppgittPeriodeTidligstMottattDatoTjeneste {
             .flatMap(uttakRepository::hentUttakResultatHvisEksisterer).orElse(null);
         var tidligstedato = nysøknad.stream().map(OppgittPeriodeEntitet::getFom).min(Comparator.naturalOrder()).orElse(null);
         List<OppgittPeriodeEntitet> perioderURBekreft = forrigeUttak != null && tidligstedato != null ? VedtaksperioderHelper.opprettOppgittePerioder(forrigeUttak, List.of(), tidligstedato) : List.of();
-        List<OppgittPeriodeEntitet> perioderURSøknad = forrigeUttak != null && tidligstedato != null ?  VedtaksperioderHelper.opprettOppgittePerioderSøknadverdier(forrigeUttak, List.of(), tidligstedato) : List.of();
+        List<OppgittPeriodeEntitet> perioderURSøknad = forrigeUttak != null && tidligstedato != null ?  VedtaksperioderHelper.opprettOppgittePerioderSøknadverdier(forrigeUttak, tidligstedato) : List.of();
 
         // Bygg tidslinjer for uttaksperioder
         var tidslinjeSammenlignNy =  new LocalDateTimeline<>(nysøknad.stream().map(p -> new LocalDateSegment<>(p.getFom(), p.getTom(), new SammenligningPeriodeForMottat(p))).toList());
@@ -188,18 +188,23 @@ public class OppgittPeriodeTidligstMottattDatoTjeneste {
     }
 
     public void sjekkOmPerioderKanForkastesSomLike(Behandling behandling, List<OppgittPeriodeEntitet> nysøknad) {
+        // Tidslinje og tidligste dato fra ny søknad
+        var tidligstedato = nysøknad.stream().map(OppgittPeriodeEntitet::getFom).min(Comparator.naturalOrder()).orElse(null);
         var tidslinjeSammenlignNy =  new LocalDateTimeline<>(nysøknad.stream().map(p -> new LocalDateSegment<>(p.getFom(), p.getTom(), new SammenligningPeriodeForOppgitt(p))).toList());
 
+        // Tidslinje for innvilgete peridoder fra forrige uttaksresultat - kun fom tidligstedato
         var forrigeUttak = behandling.getOriginalBehandlingId()
             .flatMap(uttakRepository::hentUttakResultatHvisEksisterer).orElse(null);
-        var tidligstedato = nysøknad.stream().map(OppgittPeriodeEntitet::getFom).min(Comparator.naturalOrder()).orElse(null);
+        List<OppgittPeriodeEntitet> perioderURBekreft = forrigeUttak != null && tidligstedato != null ? VedtaksperioderHelper.opprettOppgittePerioderKunInnvilget(forrigeUttak, tidligstedato) : List.of();
+        var segmenter = perioderURBekreft.stream().map(p -> new LocalDateSegment<>(p.getFom(), p.getTom(), new SammenligningPeriodeForOppgitt(p))).toList();
+        var tidslinjeSammenlignURB =  tidligstedato == null ? new LocalDateTimeline<>(segmenter) : new LocalDateTimeline<>(segmenter).intersection(new LocalDateInterval(tidligstedato, LocalDateInterval.TIDENES_ENDE));
 
-        List<OppgittPeriodeEntitet> perioderURBekreft = forrigeUttak != null && tidligstedato != null ? VedtaksperioderHelper.opprettOppgittePerioder(forrigeUttak, List.of(), tidligstedato) : List.of();
-        var tidslinjeSammenlignURB =  new LocalDateTimeline<>(perioderURBekreft.stream().map(p -> new LocalDateSegment<>(p.getFom(), p.getTom(), new SammenligningPeriodeForOppgitt(p))).toList());
+        // Finner segmenter der de to tidslinjene (søknad vs vedtakFomTidligsteDatoSøknad) er ulike
+        var ulike = tidslinjeSammenlignNy.combine(tidslinjeSammenlignURB, (i, l, r) -> new LocalDateSegment<>(i, !Objects.equals(l ,r)), LocalDateTimeline.JoinStyle.CROSS_JOIN)
+            .filterValue(v -> v);
 
-        var sammenfall = tidslinjeSammenlignNy.combine(tidslinjeSammenlignURB, this::leftIfEqualsRight, LocalDateTimeline.JoinStyle.INNER_JOIN);
-        var nyheter = tidslinjeSammenlignNy.disjoint(sammenfall);
-        var førsteNyhet = nyheter.getLocalDateIntervals().stream().map(LocalDateInterval::getFomDato).min(Comparator.naturalOrder());
+        // Første segment med ulikhet
+        var førsteNyhet = ulike.getLocalDateIntervals().stream().map(LocalDateInterval::getFomDato).min(Comparator.naturalOrder());
         if (førsteNyhet.isPresent() &&!førsteNyhet.get().equals(tidligstedato)) {
             LOG.info("SØKNAD KAST PERIODER: behandling {} kan kaste perioder mellom {} og {}", behandling.getId(), tidligstedato, førsteNyhet.get());
         }

--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/dokumentmottak/impl/OppgittPeriodeTidligstMottattDatoTjeneste.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/dokumentmottak/impl/OppgittPeriodeTidligstMottattDatoTjeneste.java
@@ -228,7 +228,7 @@ public class OppgittPeriodeTidligstMottattDatoTjeneste {
             this(periode.getÅrsak(), periode.getPeriodeType(), periode.getSamtidigUttaksprosent(), periode.isGradert() ? new SammenligningGraderingForOppgitt(periode) : null, periode.isFlerbarnsdager(), periode.getMorsAktivitet());
         }
     }
-    
+
     private record SammenligningGraderingForOppgitt(GraderingAktivitetType gradertAktivitet, Stillingsprosent arbeidsprosent, Arbeidsgiver arbeidsgiver) {
         SammenligningGraderingForOppgitt(OppgittPeriodeEntitet periode) {
             this(periode.utledGraderingAktivitetType(), periode.getArbeidsprosentSomStillingsprosent(), periode.getArbeidsgiver());

--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/dokumentmottak/impl/OppgittPeriodeTidligstMottattDatoTjeneste.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/dokumentmottak/impl/OppgittPeriodeTidligstMottattDatoTjeneste.java
@@ -17,6 +17,7 @@ import org.slf4j.LoggerFactory;
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
 import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.MorsAktivitet;
 import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.YtelseFordelingAggregat;
+import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.periode.GraderingAktivitetType;
 import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.periode.OppgittFordelingEntitet;
 import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.periode.OppgittPeriodeEntitet;
 import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.periode.UttakPeriodeType;
@@ -227,10 +228,10 @@ public class OppgittPeriodeTidligstMottattDatoTjeneste {
             this(periode.getÅrsak(), periode.getPeriodeType(), periode.getSamtidigUttaksprosent(), periode.isGradert() ? new SammenligningGraderingForOppgitt(periode) : null, periode.isFlerbarnsdager(), periode.getMorsAktivitet());
         }
     }
-
-    private record SammenligningGraderingForOppgitt(boolean erArbeidstaker, Stillingsprosent arbeidsprosent, Arbeidsgiver arbeidsgiver) {
+    
+    private record SammenligningGraderingForOppgitt(GraderingAktivitetType gradertAktivitet, Stillingsprosent arbeidsprosent, Arbeidsgiver arbeidsgiver) {
         SammenligningGraderingForOppgitt(OppgittPeriodeEntitet periode) {
-            this(periode.isArbeidstaker(), periode.getArbeidsprosentSomStillingsprosent(), periode.getArbeidsgiver());
+            this(periode.utledGraderingAktivitetType(), periode.getArbeidsprosentSomStillingsprosent(), periode.getArbeidsgiver());
         }
     }
 

--- a/domenetjenester/produksjonsstyring/src/main/java/no/nav/foreldrepenger/produksjonsstyring/behandlingenhet/nom/SkjermetPersonKlient.java
+++ b/domenetjenester/produksjonsstyring/src/main/java/no/nav/foreldrepenger/produksjonsstyring/behandlingenhet/nom/SkjermetPersonKlient.java
@@ -1,10 +1,20 @@
 package no.nav.foreldrepenger.produksjonsstyring.behandlingenhet.nom;
 
+import java.time.Duration;
+
 import javax.enterprise.context.Dependent;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import no.nav.foreldrepenger.konfig.Environment;
+import no.nav.vedtak.felles.integrasjon.rest.RestClient;
 import no.nav.vedtak.felles.integrasjon.rest.RestClientConfig;
+import no.nav.vedtak.felles.integrasjon.rest.RestConfig;
+import no.nav.vedtak.felles.integrasjon.rest.RestRequest;
 import no.nav.vedtak.felles.integrasjon.rest.TokenFlow;
 import no.nav.vedtak.felles.integrasjon.skjerming.AbstractSkjermetPersonKlient;
+import no.nav.vedtak.felles.integrasjon.skjerming.Skjerming;
 
 /*
  * Klient for å sjekke om person er skjermet.
@@ -13,9 +23,43 @@ import no.nav.vedtak.felles.integrasjon.skjerming.AbstractSkjermetPersonKlient;
 @Dependent
 @RestClientConfig(tokenConfig = TokenFlow.AZUREAD_CC, endpointProperty = "skjermet.person.rs.url", endpointDefault = "https://skjermede-personer-pip.intern.nav.no/skjermet",
     scopesProperty = "skjermet.person.rs.azure.scope", scopesDefault = "api://prod-gcp.nom.skjermede-personer-pip/.default")
-public class SkjermetPersonKlient extends AbstractSkjermetPersonKlient {
+public class SkjermetPersonKlient implements Skjerming {
 
-    public SkjermetPersonKlient() {
-        super();
+    private static final Logger LOG = LoggerFactory.getLogger(AbstractSkjermetPersonKlient.class);
+    private static final boolean TESTENV = Environment.current().isLocal();
+
+    private final RestClient client;
+    private final RestConfig restConfig;
+
+    protected SkjermetPersonKlient() {
+        this.client = RestClient.client();
+        this.restConfig = RestConfig.forClient(this.getClass());
+        if (!restConfig.tokenConfig().isAzureAD()) {
+            throw new IllegalArgumentException("Utviklerfeil: klient må annoteres med Azure CC");
+        }
     }
+
+
+    @Override
+    public boolean erSkjermet(String fnr) {
+        if (TESTENV || fnr == null) return false;
+
+        var request = RestRequest.newPOSTJson(new SkjermetRequestDto(fnr), restConfig.endpoint(), restConfig)
+            .timeout(Duration.ofSeconds(60));
+
+        try {
+            return kallMedSjekk(request);
+        } catch (Exception e) {
+            LOG.info("SkjermetPerson fikk feil", e);
+        }
+        return kallMedSjekk(request);
+    }
+
+    private boolean kallMedSjekk(RestRequest request) {
+        var skjermet = client.send(request, String.class);
+        return "true".equalsIgnoreCase(skjermet);
+    }
+
+    private record SkjermetRequestDto(String personident) {}
+
 }


### PR DESCRIPTION
Utleder overflødige perioder slik: 
* Søknad -> søknadfom + tidslinje
* UR/forrige -> tidslinje av innvilgete perioder fom søknadfom 

Finner segmenter der ene eller andre har verdi og verdiene er ulike. Utelukker segmenter der begge er like eller begge mangler
Periode fra søknadfom - førsteUlikeFom-1 kan forkastes