### PR TITLE
TFP-5145 justerer også perioder med foreldrepenger for bfhr rundt fødsel

### DIFF
--- a/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/uttaksgrunnlag/fp/FarsJustering.java
+++ b/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/uttaksgrunnlag/fp/FarsJustering.java
@@ -102,7 +102,7 @@ class FarsJustering implements ForelderFødselJustering {
     }
 
     private boolean erFedrekvoteRundtTermin(OppgittPeriodeEntitet op) {
-        return op.isSamtidigUttak() && erFedrekvote(op) && liggerIIntervalletRundtTermin(op) && !op.isFlerbarnsdager();
+        return op.isSamtidigUttak() && (erFedrekvote(op) || erForeldrepenger(op)) && liggerIIntervalletRundtTermin(op) && !op.isFlerbarnsdager();
     }
 
     private Boolean liggerIIntervalletRundtTermin(OppgittPeriodeEntitet op) {
@@ -112,6 +112,10 @@ class FarsJustering implements ForelderFødselJustering {
 
     private Optional<LocalDateInterval> intervallRundt(LocalDate dato) {
         return TidsperiodeFarRundtFødsel.intervallFarRundtFødsel(false, true, dato, dato);
+    }
+
+    private boolean erForeldrepenger(OppgittPeriodeEntitet op) {
+        return UttakPeriodeType.FORELDREPENGER.equals(op.getPeriodeType());
     }
 
     private boolean erFedrekvote(OppgittPeriodeEntitet op) {

--- a/domenetjenester/uttak/src/test/java/no/nav/foreldrepenger/domene/uttak/uttaksgrunnlag/fp/FarsJusteringTest.java
+++ b/domenetjenester/uttak/src/test/java/no/nav/foreldrepenger/domene/uttak/uttaksgrunnlag/fp/FarsJusteringTest.java
@@ -4,9 +4,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.time.LocalDate;
+import java.util.EnumSet;
 import java.util.List;
+import java.util.Set;
 
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.periode.FordelingPeriodeKilde;
 import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.periode.OppgittPeriodeBuilder;
@@ -16,27 +19,33 @@ import no.nav.foreldrepenger.behandlingslager.uttak.fp.SamtidigUttaksprosent;
 
 class FarsJusteringTest {
 
-    @Test
-    void fødselEtterTermin() {
+    static Set<UttakPeriodeType> typerStønadskonto() {
+        return EnumSet.of(UttakPeriodeType.FEDREKVOTE, UttakPeriodeType.FORELDREPENGER);
+    }
+
+    @ParameterizedTest
+    @MethodSource(value = "typerStønadskonto")
+    void fødselEtterTermin(UttakPeriodeType uttakPeriodeType) {
         var termindato = LocalDate.of(2022, 8, 12);
         var fødselsdato = termindato.plusWeeks(1);
         var farsJustering = new FarsJustering(termindato, fødselsdato, true);
 
-        var søktPeriode = periodeForFarRundtFødsel(termindato, termindato.plusWeeks(2).minusDays(1));
+        var søktPeriode = periodeForFarRundtFødsel(termindato, termindato.plusWeeks(2).minusDays(1), uttakPeriodeType);
         var justert = farsJustering.justerVedFødselEtterTermin(List.of(søktPeriode));
 
         assertThat(justert).hasSize(1);
         assertThat(justert.get(0).getFom()).isEqualTo(fødselsdato);
         assertThat(justert.get(0).getTom()).isEqualTo(fødselsdato.plusWeeks(2).minusDays(1));
-        assertThat(justert.get(0).getPeriodeType()).isEqualTo(UttakPeriodeType.FEDREKVOTE);
+        assertThat(justert.get(0).getPeriodeType()).isEqualTo(uttakPeriodeType);
     }
 
-    @Test
-    void fødselLikTermin() {
+    @ParameterizedTest
+    @MethodSource(value = "typerStønadskonto")
+    void fødselLikTermin(UttakPeriodeType uttakPeriodeType) {
         var termindato = LocalDate.of(2022, 8, 12);
         var farsJustering = new FarsJustering(termindato, termindato, true);
 
-        var søktPeriode = periodeForFarRundtFødsel(termindato, termindato.plusWeeks(2).minusDays(1));
+        var søktPeriode = periodeForFarRundtFødsel(termindato, termindato.plusWeeks(2).minusDays(1), uttakPeriodeType);
         var justert = farsJustering.justerVedFødselEtterTermin(List.of(søktPeriode));
 
         assertThat(justert).hasSize(1);
@@ -44,66 +53,71 @@ class FarsJusteringTest {
         assertThat(justert.get(0).getTom()).isEqualTo(søktPeriode.getTom());
     }
 
-    @Test
-    void søktFørTerminSkalIkkeJustereVedFødselEtterTermin() {
+    @ParameterizedTest
+    @MethodSource(value = "typerStønadskonto")
+    void søktFørTerminSkalIkkeJustereVedFødselEtterTermin(UttakPeriodeType uttakPeriodeType) {
         var termindato = LocalDate.of(2022, 8, 12);
         var fødselsdato = termindato.plusWeeks(1);
         var farsJustering = new FarsJustering(termindato, fødselsdato, true);
 
-        var søktPeriode = periodeForFarRundtFødsel(termindato.minusDays(2), termindato.plusWeeks(2).minusDays(3));
+        var søktPeriode = periodeForFarRundtFødsel(termindato.minusDays(2), termindato.plusWeeks(2).minusDays(3), uttakPeriodeType);
         assertThatThrownBy(() -> farsJustering.justerVedFødselEtterTermin(List.of(søktPeriode))).isInstanceOf(IllegalStateException.class);
     }
 
-    @Test
-    void fødselEtterTerminFlerePerioderSkalIkkeJusteres1() {
+    @ParameterizedTest
+    @MethodSource(value = "typerStønadskonto")
+    void fødselEtterTerminFlerePerioderSkalIkkeJusteres1(UttakPeriodeType uttakPeriodeType) {
         var termindato = LocalDate.of(2022, 8, 12);
         var fødselsdato = termindato.plusWeeks(1);
         var farsJustering = new FarsJustering(termindato, fødselsdato, true);
 
-        var søktPeriode1 = periodeForFarRundtFødsel(termindato, termindato.plusWeeks(2).minusDays(1));
-        var søktPeriode2 = periodeForFarRundtFødsel(termindato.plusWeeks(4), termindato.plusWeeks(6).minusDays(1));
-        var fedrekvoteEtterUke6 = OppgittPeriodeBuilder.ny().medPeriode(termindato.plusWeeks(6), termindato.plusWeeks(10).minusDays(1))
-            .medPeriodeType(UttakPeriodeType.FEDREKVOTE)
+        var søktPeriode1 = periodeForFarRundtFødsel(termindato, termindato.plusWeeks(2).minusDays(1), uttakPeriodeType);
+        var søktPeriode2 = periodeForFarRundtFødsel(termindato.plusWeeks(4), termindato.plusWeeks(6).minusDays(1), uttakPeriodeType);
+        var periodeEtterUke6 = OppgittPeriodeBuilder.ny().medPeriode(termindato.plusWeeks(6), termindato.plusWeeks(10).minusDays(1))
+            .medPeriodeType(uttakPeriodeType)
             .medPeriodeKilde(FordelingPeriodeKilde.SØKNAD)
             .build();
 
-        assertThatThrownBy(() -> farsJustering.justerVedFødselEtterTermin(List.of(søktPeriode1, søktPeriode2, fedrekvoteEtterUke6)))
+        assertThatThrownBy(() -> farsJustering.justerVedFødselEtterTermin(List.of(søktPeriode1, søktPeriode2, periodeEtterUke6)))
             .isInstanceOf(IllegalStateException.class);
 
     }
 
-    @Test
-    void fødselEtterTerminFlerePerioderSkalIkkeJusteres2() {
+    @ParameterizedTest
+    @MethodSource(value = "typerStønadskonto")
+    void fødselEtterTerminFlerePerioderSkalIkkeJusteres2(UttakPeriodeType uttakPeriodeType) {
         var termindato = LocalDate.of(2022, 8, 12);
         var fødselsdato = termindato.plusWeeks(1);
         var farsJustering = new FarsJustering(termindato, fødselsdato, true);
 
-        var søktPeriode1 = periodeForFarRundtFødsel(termindato, termindato.plusWeeks(2).minusDays(1));
-        var søktPeriode2 = periodeForFarRundtFødsel(termindato.plusWeeks(4), termindato.plusWeeks(6).minusDays(1));
+        var søktPeriode1 = periodeForFarRundtFødsel(termindato, termindato.plusWeeks(2).minusDays(1), uttakPeriodeType);
+        var søktPeriode2 = periodeForFarRundtFødsel(termindato.plusWeeks(4), termindato.plusWeeks(6).minusDays(1), uttakPeriodeType);
 
         assertThatThrownBy(() -> farsJustering.justerVedFødselEtterTermin(List.of(søktPeriode1, søktPeriode2))).isInstanceOf(IllegalStateException.class);
     }
 
-    @Test
-    void fødselEtterTerminFlerbarnsdagerSkalIkkeJusteres() {
+    @ParameterizedTest
+    @MethodSource(value = "typerStønadskonto")
+    void fødselEtterTerminFlerbarnsdagerSkalIkkeJusteres(UttakPeriodeType uttakPeriodeType) {
         var termindato = LocalDate.of(2022, 8, 12);
         var fødselsdato = termindato.plusWeeks(1);
         var farsJustering = new FarsJustering(termindato, fødselsdato, true);
 
-        var søktPeriode = periodeForFarRundtFødselBuilder(termindato, termindato.plusWeeks(2).minusDays(1))
+        var søktPeriode = periodeForFarRundtFødselBuilder(termindato, termindato.plusWeeks(2).minusDays(1), uttakPeriodeType)
             .medFlerbarnsdager(true)
             .build();
 
         assertThatThrownBy(() -> farsJustering.justerVedFødselEtterTermin(List.of(søktPeriode))).isInstanceOf(IllegalStateException.class);
     }
 
-    @Test
-    void fødselLengeEtterTerminJusteresHvisIngenOverlappMedSenerePeriode() {
+    @ParameterizedTest
+    @MethodSource(value = "typerStønadskonto")
+    void fødselLengeEtterTerminJusteresHvisIngenOverlappMedSenerePeriode(UttakPeriodeType uttakPeriodeType) {
         var termindato = LocalDate.of(2022, 8, 12);
         var fødselsdato = termindato.plusWeeks(5);
         var farsJustering = new FarsJustering(termindato, fødselsdato, true);
 
-        var søktPeriode = periodeForFarRundtFødsel(termindato, termindato.plusWeeks(2).minusDays(1));
+        var søktPeriode = periodeForFarRundtFødsel(termindato, termindato.plusWeeks(2).minusDays(1), uttakPeriodeType);
         var justert = farsJustering.justerVedFødselEtterTermin(List.of(søktPeriode));
 
         assertThat(justert).hasSize(1);
@@ -111,30 +125,32 @@ class FarsJusteringTest {
         assertThat(justert.get(0).getTom()).isEqualTo(fødselsdato.plusWeeks(2).minusDays(1));
     }
 
-    @Test
-    void fødselLengeEtterTerminSkalForkortesAvSenerePeriode() {
+    @ParameterizedTest
+    @MethodSource(value = "typerStønadskonto")
+    void fødselLengeEtterTerminSkalForkortesAvSenerePeriode(UttakPeriodeType uttakPeriodeType) {
         var termindato = LocalDate.of(2022, 8, 12);
         var fødselsdato = termindato.plusWeeks(5);
         var farsJustering = new FarsJustering(termindato, fødselsdato, true);
 
-        var fedrekvoteEtterUke6 = OppgittPeriodeBuilder.ny().medPeriode(termindato.plusWeeks(6), termindato.plusWeeks(10).minusDays(1))
-            .medPeriodeType(UttakPeriodeType.FEDREKVOTE)
+        var periodeEtterUke6 = OppgittPeriodeBuilder.ny().medPeriode(termindato.plusWeeks(6), termindato.plusWeeks(10).minusDays(1))
+            .medPeriodeType(uttakPeriodeType)
             .medPeriodeKilde(FordelingPeriodeKilde.SØKNAD)
             .build();
 
-        var søktPeriode1 = periodeForFarRundtFødsel(termindato, termindato.plusWeeks(2).minusDays(1));
-        var justert = farsJustering.justerVedFødselEtterTermin(List.of(søktPeriode1, fedrekvoteEtterUke6));
+        var søktPeriode1 = periodeForFarRundtFødsel(termindato, termindato.plusWeeks(2).minusDays(1), uttakPeriodeType);
+        var justert = farsJustering.justerVedFødselEtterTermin(List.of(søktPeriode1, periodeEtterUke6));
 
         assertThat(justert).hasSize(2);
         assertThat(justert.get(0).getFom()).isEqualTo(fødselsdato);
-        assertThat(justert.get(0).getTom()).isEqualTo(fedrekvoteEtterUke6.getFom().minusDays(1));
+        assertThat(justert.get(0).getTom()).isEqualTo(periodeEtterUke6.getFom().minusDays(1));
 
-        assertThat(justert.get(1).getFom()).isEqualTo(fedrekvoteEtterUke6.getFom());
-        assertThat(justert.get(1).getTom()).isEqualTo(fedrekvoteEtterUke6.getTom());
+        assertThat(justert.get(1).getFom()).isEqualTo(periodeEtterUke6.getFom());
+        assertThat(justert.get(1).getTom()).isEqualTo(periodeEtterUke6.getTom());
     }
 
-    @Test
-    void fødselEtterTerminFødtIHelg() {
+    @ParameterizedTest
+    @MethodSource(value = "typerStønadskonto")
+    void fødselEtterTerminFødtIHelg(UttakPeriodeType uttakPeriodeType) {
         //torsdag
         var termindato = LocalDate.of(2022, 8, 10);
 
@@ -142,17 +158,18 @@ class FarsJusteringTest {
         var fødselsdato = LocalDate.of(2022, 8, 14);
         var farsJustering = new FarsJustering(termindato, fødselsdato, true);
 
-        var søktPeriode = periodeForFarRundtFødsel(termindato, termindato.plusWeeks(2).minusDays(1));
+        var søktPeriode = periodeForFarRundtFødsel(termindato, termindato.plusWeeks(2).minusDays(1), uttakPeriodeType);
         var justert = farsJustering.justerVedFødselEtterTermin(List.of(søktPeriode));
 
         assertThat(justert).hasSize(1);
         assertThat(justert.get(0).getFom()).isEqualTo(LocalDate.of(2022, 8, 15));
         assertThat(justert.get(0).getTom()).isEqualTo(LocalDate.of(2022, 8, 26));
-        assertThat(justert.get(0).getPeriodeType()).isEqualTo(UttakPeriodeType.FEDREKVOTE);
+        assertThat(justert.get(0).getPeriodeType()).isEqualTo(uttakPeriodeType);
     }
 
-    @Test
-    void fødselEtterTerminTermindatoIHelg() {
+    @ParameterizedTest
+    @MethodSource(value = "typerStønadskonto")
+    void fødselEtterTerminTermindatoIHelg(UttakPeriodeType uttakPeriodeType) {
         //lørdag
         var termindato = LocalDate.of(2022, 8, 13);
 
@@ -160,147 +177,155 @@ class FarsJusteringTest {
         var fødselsdato = LocalDate.of(2022, 8, 16);
         var farsJustering = new FarsJustering(termindato, fødselsdato, true);
 
-        var søktPeriode = periodeForFarRundtFødsel(termindato, termindato.plusWeeks(2).minusDays(1));
+        var søktPeriode = periodeForFarRundtFødsel(termindato, termindato.plusWeeks(2).minusDays(1), uttakPeriodeType);
         var justert = farsJustering.justerVedFødselEtterTermin(List.of(søktPeriode));
 
         assertThat(justert).hasSize(1);
         assertThat(justert.get(0).getFom()).isEqualTo(fødselsdato);
         assertThat(justert.get(0).getTom()).isEqualTo(fødselsdato.plusWeeks(2).minusDays(1));
-        assertThat(justert.get(0).getPeriodeType()).isEqualTo(UttakPeriodeType.FEDREKVOTE);
+        assertThat(justert.get(0).getPeriodeType()).isEqualTo(uttakPeriodeType);
     }
 
-    @Test
-    void fødselEtterTerminBådeTermindatoOgFødselISammeHelg() {
+    @ParameterizedTest
+    @MethodSource(value = "typerStønadskonto")
+    void fødselEtterTerminBådeTermindatoOgFødselISammeHelg(UttakPeriodeType uttakPeriodeType) {
         var termindato = LocalDate.of(2022, 8, 27);
         var fødselsdato = LocalDate.of(2022, 8, 28);
         var farsJustering = new FarsJustering(termindato, fødselsdato, true);
 
-        var søktPeriode = periodeForFarRundtFødsel(LocalDate.of(2022, 8, 29), LocalDate.of(2022, 9, 6));
+        var søktPeriode = periodeForFarRundtFødsel(LocalDate.of(2022, 8, 29), LocalDate.of(2022, 9, 6), uttakPeriodeType);
         var justert = farsJustering.justerVedFødselEtterTermin(List.of(søktPeriode));
 
         assertThat(justert).hasSize(1);
         assertThat(justert.get(0).getFom()).isEqualTo(søktPeriode.getFom());
         assertThat(justert.get(0).getTom()).isEqualTo(søktPeriode.getTom());
-        assertThat(justert.get(0).getPeriodeType()).isEqualTo(UttakPeriodeType.FEDREKVOTE);
+        assertThat(justert.get(0).getPeriodeType()).isEqualTo(uttakPeriodeType);
     }
 
-    @Test
-    void fødselFørTermin() {
+    @ParameterizedTest
+    @MethodSource(value = "typerStønadskonto")
+    void fødselFørTermin(UttakPeriodeType uttakPeriodeType) {
         var termindato = LocalDate.of(2022, 8, 10);
         var fødselsdato = termindato.minusWeeks(1);
         var farsJustering = new FarsJustering(termindato, fødselsdato, true);
 
-        var søktPeriode = periodeForFarRundtFødsel(termindato, termindato.plusWeeks(2).minusDays(1));
+        var søktPeriode = periodeForFarRundtFødsel(termindato, termindato.plusWeeks(2).minusDays(1), uttakPeriodeType);
         var justert = farsJustering.justerVedFødselFørTermin(List.of(søktPeriode));
 
         assertThat(justert).hasSize(1);
         assertThat(justert.get(0).getFom()).isEqualTo(fødselsdato);
         assertThat(justert.get(0).getTom()).isEqualTo(fødselsdato.plusWeeks(2).minusDays(1));
-        assertThat(justert.get(0).getPeriodeType()).isEqualTo(UttakPeriodeType.FEDREKVOTE);
+        assertThat(justert.get(0).getPeriodeType()).isEqualTo(uttakPeriodeType);
     }
 
-    @Test
-    void fødselFørTerminPeriodeEtterUke6() {
+    @ParameterizedTest
+    @MethodSource(value = "typerStønadskonto")
+    void fødselFørTerminPeriodeEtterUke6(UttakPeriodeType uttakPeriodeType) {
         var termindato = LocalDate.of(2022, 8, 12);
         var fødselsdato = termindato.minusDays(3);
         var farsJustering = new FarsJustering(termindato, fødselsdato, true);
 
-        var søktPeriode1 = periodeForFarRundtFødsel(termindato, termindato.plusWeeks(2).minusDays(1));
-        var søktPeriode2 = periodeForFarRundtFødsel(termindato.plusWeeks(6), termindato.plusWeeks(10).minusDays(1));
+        var søktPeriode1 = periodeForFarRundtFødsel(termindato, termindato.plusWeeks(2).minusDays(1), uttakPeriodeType);
+        var søktPeriode2 = periodeForFarRundtFødsel(termindato.plusWeeks(6), termindato.plusWeeks(10).minusDays(1), uttakPeriodeType);
         var justert = farsJustering.justerVedFødselFørTermin(List.of(søktPeriode1, søktPeriode2));
 
         assertThat(justert).hasSize(2);
         assertThat(justert.get(0).getFom()).isEqualTo(fødselsdato);
         assertThat(justert.get(0).getTom()).isEqualTo(fødselsdato.plusWeeks(2).minusDays(1));
-        assertThat(justert.get(0).getPeriodeType()).isEqualTo(UttakPeriodeType.FEDREKVOTE);
+        assertThat(justert.get(0).getPeriodeType()).isEqualTo(uttakPeriodeType);
 
         assertThat(justert.get(1).getFom()).isEqualTo(søktPeriode2.getFom());
         assertThat(justert.get(1).getTom()).isEqualTo(søktPeriode2.getTom());
-        assertThat(justert.get(1).getPeriodeType()).isEqualTo(UttakPeriodeType.FEDREKVOTE);
+        assertThat(justert.get(1).getPeriodeType()).isEqualTo(uttakPeriodeType);
     }
 
-    @Test
-    void fødselFørTerminFlereUkerRundtFødsel() {
+    @ParameterizedTest
+    @MethodSource(value = "typerStønadskonto")
+    void fødselFørTerminFlereUkerRundtFødsel(UttakPeriodeType uttakPeriodeType) {
         var termindato = LocalDate.of(2022, 8, 12);
         var fødselsdato = termindato.minusDays(4);
         var farsJustering = new FarsJustering(termindato, fødselsdato, true);
 
-        var søktPeriode1 = periodeForFarRundtFødsel(termindato, termindato.plusWeeks(1).minusDays(1));
-        var søktPeriode2 = periodeForFarRundtFødsel(termindato.plusWeeks(4), termindato.plusWeeks(5).minusDays(1));
+        var søktPeriode1 = periodeForFarRundtFødsel(termindato, termindato.plusWeeks(1).minusDays(1), uttakPeriodeType);
+        var søktPeriode2 = periodeForFarRundtFødsel(termindato.plusWeeks(4), termindato.plusWeeks(5).minusDays(1), uttakPeriodeType);
 
         assertThatThrownBy(() -> farsJustering.justerVedFødselEtterTermin(List.of(søktPeriode1, søktPeriode2))).isInstanceOf(IllegalStateException.class);
     }
 
-    @Test
-    void fødselFørTerminTermindatoIHelg() {
+    @ParameterizedTest
+    @MethodSource(value = "typerStønadskonto")
+    void fødselFørTerminTermindatoIHelg(UttakPeriodeType uttakPeriodeType) {
         var termindato = LocalDate.of(2022, 8, 20);
         var fødselsdato = termindato.minusDays(4);
         var farsJustering = new FarsJustering(termindato, fødselsdato, true);
 
-        var søktPeriode = periodeForFarRundtFødsel(termindato, termindato.plusWeeks(2).minusDays(1));
+        var søktPeriode = periodeForFarRundtFødsel(termindato, termindato.plusWeeks(2).minusDays(1), uttakPeriodeType);
         var justert = farsJustering.justerVedFødselFørTermin(List.of(søktPeriode));
 
         assertThat(justert).hasSize(1);
         assertThat(justert.get(0).getFom()).isEqualTo(fødselsdato);
         assertThat(justert.get(0).getTom()).isEqualTo(fødselsdato.plusWeeks(2).minusDays(1));
-        assertThat(justert.get(0).getPeriodeType()).isEqualTo(UttakPeriodeType.FEDREKVOTE);
+        assertThat(justert.get(0).getPeriodeType()).isEqualTo(uttakPeriodeType);
     }
 
-    @Test
-    void fødselFørTerminFødselIHelg() {
+    @ParameterizedTest
+    @MethodSource(value = "typerStønadskonto")
+    void fødselFørTerminFødselIHelg(UttakPeriodeType uttakPeriodeType) {
         var termindato = LocalDate.of(2022, 8, 16);
         var fødselsdato = LocalDate.of(2022, 8, 7);
         var farsJustering = new FarsJustering(termindato, fødselsdato, true);
 
-        var søktPeriode = periodeForFarRundtFødsel(termindato, termindato.plusWeeks(1).minusDays(1));
+        var søktPeriode = periodeForFarRundtFødsel(termindato, termindato.plusWeeks(1).minusDays(1), uttakPeriodeType);
         var justert = farsJustering.justerVedFødselFørTermin(List.of(søktPeriode));
 
         assertThat(justert).hasSize(1);
         assertThat(justert.get(0).getFom()).isEqualTo(LocalDate.of(2022, 8, 8));
         assertThat(justert.get(0).getTom()).isEqualTo(LocalDate.of(2022, 8, 12));
-        assertThat(justert.get(0).getPeriodeType()).isEqualTo(UttakPeriodeType.FEDREKVOTE);
+        assertThat(justert.get(0).getPeriodeType()).isEqualTo(uttakPeriodeType);
     }
 
-    @Test
-    void fødselFørTerminBådeTermindatoOgFødselIHelg() {
+    @ParameterizedTest
+    @MethodSource(value = "typerStønadskonto")
+    void fødselFørTerminBådeTermindatoOgFødselIHelg(UttakPeriodeType uttakPeriodeType) {
         var termindato = LocalDate.of(2022, 8, 27);
         var fødselsdato = LocalDate.of(2022, 8, 21);
         var farsJustering = new FarsJustering(termindato, fødselsdato, true);
 
-        var søktPeriode = periodeForFarRundtFødsel(LocalDate.of(2022, 8, 29), LocalDate.of(2022, 8, 31));
+        var søktPeriode = periodeForFarRundtFødsel(LocalDate.of(2022, 8, 29), LocalDate.of(2022, 8, 31), uttakPeriodeType);
         var justert = farsJustering.justerVedFødselFørTermin(List.of(søktPeriode));
 
         assertThat(justert).hasSize(1);
         assertThat(justert.get(0).getFom()).isEqualTo(LocalDate.of(2022, 8, 22));
         assertThat(justert.get(0).getTom()).isEqualTo(LocalDate.of(2022, 8, 24));
-        assertThat(justert.get(0).getPeriodeType()).isEqualTo(UttakPeriodeType.FEDREKVOTE);
+        assertThat(justert.get(0).getPeriodeType()).isEqualTo(uttakPeriodeType);
     }
 
-    @Test
-    void fødselFørTerminBådeTermindatoOgFødselISammeHelg() {
+    @ParameterizedTest
+    @MethodSource(value = "typerStønadskonto")
+    void fødselFørTerminBådeTermindatoOgFødselISammeHelg(UttakPeriodeType uttakPeriodeType) {
         var termindato = LocalDate.of(2022, 8, 28);
         var fødselsdato = LocalDate.of(2022, 8, 27);
         var farsJustering = new FarsJustering(termindato, fødselsdato, true);
 
-        var søktPeriode = periodeForFarRundtFødsel(LocalDate.of(2022, 8, 29), LocalDate.of(2022, 9, 6));
+        var søktPeriode = periodeForFarRundtFødsel(LocalDate.of(2022, 8, 29), LocalDate.of(2022, 9, 6), uttakPeriodeType);
         var justert = farsJustering.justerVedFødselFørTermin(List.of(søktPeriode));
 
         assertThat(justert).hasSize(1);
         assertThat(justert.get(0).getFom()).isEqualTo(søktPeriode.getFom());
         assertThat(justert.get(0).getTom()).isEqualTo(søktPeriode.getTom());
-        assertThat(justert.get(0).getPeriodeType()).isEqualTo(UttakPeriodeType.FEDREKVOTE);
+        assertThat(justert.get(0).getPeriodeType()).isEqualTo(uttakPeriodeType);
     }
 
-    private OppgittPeriodeEntitet periodeForFarRundtFødsel(LocalDate fom, LocalDate tom) {
-        return periodeForFarRundtFødselBuilder(fom, tom).build();
+    private OppgittPeriodeEntitet periodeForFarRundtFødsel(LocalDate fom, LocalDate tom, UttakPeriodeType uttakPeriodeType) {
+        return periodeForFarRundtFødselBuilder(fom, tom, uttakPeriodeType).build();
     }
 
-    private OppgittPeriodeBuilder periodeForFarRundtFødselBuilder(LocalDate fom, LocalDate tom) {
+    private OppgittPeriodeBuilder periodeForFarRundtFødselBuilder(LocalDate fom, LocalDate tom, UttakPeriodeType uttakPeriodeType) {
         return OppgittPeriodeBuilder.ny()
             .medPeriode(fom, tom)
             .medSamtidigUttak(true)
             .medSamtidigUttaksprosent(new SamtidigUttaksprosent(100))
-            .medPeriodeType(UttakPeriodeType.FEDREKVOTE)
+            .medPeriodeType(uttakPeriodeType)
             .medPeriodeKilde(FordelingPeriodeKilde.SØKNAD)
             .medFlerbarnsdager(false);
     }


### PR DESCRIPTION
Støtter caset der vi også flytter fars periode hvis det avklares av saksbehandler at mor ikke har rett. Fedrekvoten omgjøres til foreldrepenger