### PR TITLE
Hent mer fagsakinfo med ett kall

### DIFF
--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/BehandlingRestTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/BehandlingRestTjeneste.java
@@ -163,6 +163,8 @@ public class BehandlingRestTjeneste {
         @NotNull @Valid BehandlingIdDto behandlingIdDto) throws URISyntaxException {
         var behandling = getBehandling(behandlingIdDto);
 
+        LOG.info("REST DEPRECATED {} POST {}", this.getClass().getSimpleName(), BASE_PATH);
+
         var gruppeOpt = behandlingsprosessTjeneste.sjekkOgForberedAsynkInnhentingAvRegisteropplysningerOgKjørProsess(behandling);
 
         // sender alltid til poll status slik at vi får sjekket på utestående prosess
@@ -185,6 +187,7 @@ public class BehandlingRestTjeneste {
             @TilpassetAbacAttributt(supplierClass = BehandlingAbacSuppliers.TaskgruppeAbacDataSupplier.class) @QueryParam("gruppe") @Valid ProsessTaskGruppeIdDto gruppeDto)
         throws URISyntaxException {
         var behandling = getBehandling(behandlingIdDto);
+        LOG.info("REST DEPRECATED {} GET {}", this.getClass().getSimpleName(), BEHANDLINGER_STATUS_PART_PATH);
         var gruppe = gruppeDto == null ? null : gruppeDto.getGruppe();
         var prosessTaskGruppePågår = behandlingsprosessTjeneste.sjekkProsessTaskPågårForBehandling(behandling, gruppe);
         return Redirect.tilBehandlingEllerPollStatus(request, behandling.getUuid(), prosessTaskGruppePågår.orElse(null));
@@ -204,6 +207,7 @@ public class BehandlingRestTjeneste {
     public Response hentBehandlingResultat(@TilpassetAbacAttributt(supplierClass = BehandlingAbacSuppliers.BehandlingIdAbacDataSupplier.class)
         @NotNull @QueryParam("behandlingId") @Valid BehandlingIdDto behandlingIdDto) {
         var behandling = getBehandling(behandlingIdDto);
+        LOG.info("REST DEPRECATED {} GET {}", this.getClass().getSimpleName(), BASE_PATH);
         var taskStatus = behandlingsprosessTjeneste.sjekkProsessTaskPågårForBehandling(behandling, null).orElse(null);
         var dto = behandlingDtoTjeneste.lagUtvidetBehandlingDto(behandling, taskStatus);
         var responseBuilder = Response.ok().entity(dto);

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/BehandlingRestTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/BehandlingRestTjeneste.java
@@ -186,8 +186,14 @@ public class BehandlingRestTjeneste {
         @NotNull @QueryParam("behandlingId") @Valid BehandlingIdDto behandlingIdDto,
             @TilpassetAbacAttributt(supplierClass = BehandlingAbacSuppliers.TaskgruppeAbacDataSupplier.class) @QueryParam("gruppe") @Valid ProsessTaskGruppeIdDto gruppeDto)
         throws URISyntaxException {
-        var behandling = getBehandling(behandlingIdDto);
         LOG.info("REST DEPRECATED {} GET {}", this.getClass().getSimpleName(), BEHANDLINGER_STATUS_PART_PATH);
+        return getMidlertidigStatusResponse(request, behandlingIdDto, gruppeDto);
+    }
+
+    Response getMidlertidigStatusResponse(HttpServletRequest request,
+                                 BehandlingIdDto behandlingIdDto,
+                                 ProsessTaskGruppeIdDto gruppeDto) throws URISyntaxException {
+        var behandling = getBehandling(behandlingIdDto);
         var gruppe = gruppeDto == null ? null : gruppeDto.getGruppe();
         var prosessTaskGruppePågår = behandlingsprosessTjeneste.sjekkProsessTaskPågårForBehandling(behandling, gruppe);
         return Redirect.tilBehandlingEllerPollStatus(request, behandling.getUuid(), prosessTaskGruppePågår.orElse(null));
@@ -206,8 +212,13 @@ public class BehandlingRestTjeneste {
     @BeskyttetRessurs(actionType = ActionType.READ, resourceType = ResourceType.FAGSAK)
     public Response hentBehandlingResultat(@TilpassetAbacAttributt(supplierClass = BehandlingAbacSuppliers.BehandlingIdAbacDataSupplier.class)
         @NotNull @QueryParam("behandlingId") @Valid BehandlingIdDto behandlingIdDto) {
-        var behandling = getBehandling(behandlingIdDto);
         LOG.info("REST DEPRECATED {} GET {}", this.getClass().getSimpleName(), BASE_PATH);
+        return getAsynkResultatResponse(behandlingIdDto);
+    }
+
+    Response getAsynkResultatResponse(BehandlingIdDto behandlingIdDto) {
+        var behandling = getBehandling(behandlingIdDto);
+
         var taskStatus = behandlingsprosessTjeneste.sjekkProsessTaskPågårForBehandling(behandling, null).orElse(null);
         var dto = behandlingDtoTjeneste.lagUtvidetBehandlingDto(behandling, taskStatus);
         var responseBuilder = Response.ok().entity(dto);

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/BehandlingRestTjenestePathHack1.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/BehandlingRestTjenestePathHack1.java
@@ -17,6 +17,9 @@ import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.headers.Header;
@@ -49,6 +52,8 @@ import no.nav.vedtak.sikkerhet.abac.beskyttet.ResourceType;
 @Produces(MediaType.APPLICATION_JSON)
 public class BehandlingRestTjenestePathHack1 {
 
+    private static final Logger LOG = LoggerFactory.getLogger(BehandlingRestTjenestePathHack1.class);
+
     static final String BASE_PATH = "/behandling";
     private static final String BEHANDLING_PART_PATH = "";
     public static final String BEHANDLING_PATH = BASE_PATH + BEHANDLING_PART_PATH;
@@ -78,6 +83,7 @@ public class BehandlingRestTjenestePathHack1 {
                                                     @TilpassetAbacAttributt(supplierClass = BehandlingAbacSuppliers.UuidAbacDataSupplier.class) @NotNull @QueryParam(UuidDto.NAME) @Parameter(description = UuidDto.DESC) @Valid UuidDto uuidDto,
                                                     @TilpassetAbacAttributt(supplierClass = BehandlingAbacSuppliers.TaskgruppeAbacDataSupplier.class) @QueryParam("gruppe") @Valid ProsessTaskGruppeIdDto gruppeDto)
         throws URISyntaxException {
+        LOG.info("REST DEPRECATED {} GET {}", this.getClass().getSimpleName(), STATUS_PATH);
         return behandlingRestTjeneste.hentBehandlingMidlertidigStatus(request, new BehandlingIdDto(uuidDto), gruppeDto);
     }
 
@@ -89,6 +95,7 @@ public class BehandlingRestTjenestePathHack1 {
     @BeskyttetRessurs(actionType = ActionType.READ, resourceType = ResourceType.FAGSAK)
     public Response hentBehandlingResultat(@TilpassetAbacAttributt(supplierClass = BehandlingAbacSuppliers.UuidAbacDataSupplier.class)
         @NotNull @QueryParam(UuidDto.NAME) @Parameter(description = UuidDto.DESC) @Valid UuidDto uuidDto) {
+        LOG.info("REST DEPRECATED {} GET {}", this.getClass().getSimpleName(), BASE_PATH);
         return behandlingRestTjeneste.hentBehandlingResultat(new BehandlingIdDto(uuidDto));
     }
 }

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/BehandlingRestTjenestePathHack1.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/BehandlingRestTjenestePathHack1.java
@@ -84,7 +84,7 @@ public class BehandlingRestTjenestePathHack1 {
                                                     @TilpassetAbacAttributt(supplierClass = BehandlingAbacSuppliers.TaskgruppeAbacDataSupplier.class) @QueryParam("gruppe") @Valid ProsessTaskGruppeIdDto gruppeDto)
         throws URISyntaxException {
         LOG.info("REST DEPRECATED {} GET {}", this.getClass().getSimpleName(), STATUS_PATH);
-        return behandlingRestTjeneste.hentBehandlingMidlertidigStatus(request, new BehandlingIdDto(uuidDto), gruppeDto);
+        return behandlingRestTjeneste.getMidlertidigStatusResponse(request, new BehandlingIdDto(uuidDto), gruppeDto);
     }
 
     @GET
@@ -96,6 +96,6 @@ public class BehandlingRestTjenestePathHack1 {
     public Response hentBehandlingResultat(@TilpassetAbacAttributt(supplierClass = BehandlingAbacSuppliers.UuidAbacDataSupplier.class)
         @NotNull @QueryParam(UuidDto.NAME) @Parameter(description = UuidDto.DESC) @Valid UuidDto uuidDto) {
         LOG.info("REST DEPRECATED {} GET {}", this.getClass().getSimpleName(), BASE_PATH);
-        return behandlingRestTjeneste.hentBehandlingResultat(new BehandlingIdDto(uuidDto));
+        return behandlingRestTjeneste.getAsynkResultatResponse(new BehandlingIdDto(uuidDto));
     }
 }

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/BehandlingRestTjenestePathHack2.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/BehandlingRestTjenestePathHack2.java
@@ -13,6 +13,9 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import no.nav.foreldrepenger.domene.typer.Saksnummer;
@@ -34,6 +37,8 @@ import no.nav.vedtak.sikkerhet.abac.beskyttet.ResourceType;
 @Path(BehandlingRestTjenestePathHack2.BASE_PATH)
 @Produces(MediaType.APPLICATION_JSON)
 public class BehandlingRestTjenestePathHack2 {
+
+    private static final Logger LOG = LoggerFactory.getLogger(BehandlingRestTjenestePathHack2.class);
 
     static final String BASE_PATH = "/fagsak";
     private static final String FAGSAK_BEHANDLING_PART_PATH = "/behandling";
@@ -61,6 +66,7 @@ public class BehandlingRestTjenestePathHack2 {
     public List<BehandlingDto> hentAlleBehandlinger(@TilpassetAbacAttributt(supplierClass = SaksnummerAbacSupplier.Supplier.class)
             @NotNull @QueryParam("saksnummer") @Parameter(description = "Saksnummer må være et eksisterende saksnummer") @Valid SaksnummerDto s) {
         var saksnummer = new Saksnummer(s.getVerdi());
+        LOG.info("REST DEPRECATED {} GET {}", this.getClass().getSimpleName(), FAGSAK_BEHANDLING_PATH);
         var behandlinger = behandlingsutredningTjeneste.hentBehandlingerForSaksnummer(saksnummer);
         return behandlingDtoTjeneste.lagBehandlingDtoer(behandlinger);
     }

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/dto/behandling/BehandlingDtoTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/dto/behandling/BehandlingDtoTjeneste.java
@@ -6,7 +6,6 @@ import static no.nav.foreldrepenger.web.app.rest.ResourceLinks.post;
 import java.time.LocalDate;
 import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -229,10 +228,7 @@ public class BehandlingDtoTjeneste {
     }
 
     private boolean erBehandlingMedGjeldendeVedtak(Behandling behandling, Optional<Behandling> behandlingMedGjeldendeVedtak) {
-        if (behandlingMedGjeldendeVedtak.isEmpty()) {
-            return false;
-        }
-        return Objects.equals(behandlingMedGjeldendeVedtak.get().getId(), behandling.getId());
+        return behandlingMedGjeldendeVedtak.filter(b -> b.getId().equals(behandling.getId())).isPresent();
     }
 
     public UtvidetBehandlingDto lagUtvidetBehandlingDto(Behandling behandling, AsyncPollingStatus asyncStatus) {

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/fagsak/app/FagsakFullTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/fagsak/app/FagsakFullTjeneste.java
@@ -1,0 +1,148 @@
+package no.nav.foreldrepenger.web.app.tjenester.fagsak.app;
+
+import java.time.LocalDate;
+import java.util.Collection;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import no.nav.foreldrepenger.behandling.FagsakRelasjonTjeneste;
+import no.nav.foreldrepenger.behandlingslager.aktør.NavBruker;
+import no.nav.foreldrepenger.behandlingslager.aktør.PersoninfoBasis;
+import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingType;
+import no.nav.foreldrepenger.behandlingslager.behandling.familiehendelse.FamilieHendelseEntitet;
+import no.nav.foreldrepenger.behandlingslager.behandling.familiehendelse.FamilieHendelseGrunnlagEntitet;
+import no.nav.foreldrepenger.behandlingslager.behandling.familiehendelse.TerminbekreftelseEntitet;
+import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepository;
+import no.nav.foreldrepenger.behandlingslager.fagsak.Dekningsgrad;
+import no.nav.foreldrepenger.behandlingslager.fagsak.Fagsak;
+import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakRelasjon;
+import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakRepository;
+import no.nav.foreldrepenger.behandlingslager.geografisk.Landkoder;
+import no.nav.foreldrepenger.behandlingslager.geografisk.Språkkode;
+import no.nav.foreldrepenger.domene.person.PersoninfoAdapter;
+import no.nav.foreldrepenger.domene.personopplysning.PersonopplysningTjeneste;
+import no.nav.foreldrepenger.domene.typer.Saksnummer;
+import no.nav.foreldrepenger.familiehendelse.FamilieHendelseTjeneste;
+import no.nav.foreldrepenger.web.app.tjenester.behandling.aksjonspunkt.BehandlingsoppretterTjeneste;
+import no.nav.foreldrepenger.web.app.tjenester.behandling.dto.BehandlingOpprettingDto;
+import no.nav.foreldrepenger.web.app.tjenester.behandling.dto.behandling.AnnenPartBehandlingDto;
+import no.nav.foreldrepenger.web.app.tjenester.behandling.dto.behandling.BehandlingDtoTjeneste;
+import no.nav.foreldrepenger.web.app.tjenester.fagsak.dto.FagsakFullDto;
+import no.nav.foreldrepenger.web.app.tjenester.fagsak.dto.PersonDto;
+import no.nav.foreldrepenger.web.app.tjenester.fagsak.dto.SakHendelseDto;
+import no.nav.foreldrepenger.web.app.util.StringUtils;
+
+@ApplicationScoped
+public class FagsakFullTjeneste {
+
+    private FagsakRepository fagsakRepository;
+
+    private PersoninfoAdapter personinfoAdapter;
+    private BehandlingRepository behandlingRepository;
+
+    private FagsakRelasjonTjeneste fagsakRelasjonTjeneste;
+    private FamilieHendelseTjeneste familieHendelseTjeneste;
+    private PersonopplysningTjeneste personopplysningTjeneste;
+
+    private BehandlingsoppretterTjeneste behandlingsoppretterTjeneste;
+    private BehandlingDtoTjeneste behandlingDtoTjeneste;
+
+    protected FagsakFullTjeneste() {
+        // CDI runner
+    }
+
+    @Inject
+    public FagsakFullTjeneste(FagsakRepository fagsakRepository,
+                              BehandlingRepository behandlingRepository,
+                              PersoninfoAdapter personinfoAdapter,
+                              FagsakRelasjonTjeneste fagsakRelasjonTjeneste,
+                              FamilieHendelseTjeneste familieHendelseTjeneste,
+                              PersonopplysningTjeneste personopplysningTjeneste,
+                              BehandlingsoppretterTjeneste behandlingsoppretterTjeneste,
+                              BehandlingDtoTjeneste behandlingDtoTjeneste) {
+        this.fagsakRepository = fagsakRepository;
+        this.personinfoAdapter = personinfoAdapter;
+        this.behandlingRepository = behandlingRepository;
+        this.fagsakRelasjonTjeneste = fagsakRelasjonTjeneste;
+        this.familieHendelseTjeneste = familieHendelseTjeneste;
+        this.personopplysningTjeneste = personopplysningTjeneste;
+        this.behandlingsoppretterTjeneste = behandlingsoppretterTjeneste;
+        this.behandlingDtoTjeneste = behandlingDtoTjeneste;
+    }
+
+    public Optional<FagsakFullDto> hentFullFagsakDtoForSaksnummer(Saksnummer saksnummer) {
+        var fagsak = fagsakRepository.hentSakGittSaksnummer(saksnummer).orElse(null);
+        if (fagsak == null) {
+            return Optional.empty();
+        }
+        var familiehendelse = hentFamilieHendelse(fagsak).orElse(null);
+        var dekningsgrad = finnDekningsgrad(fagsak);
+        var annenpartSak = hentAnnenPartsGjeldendeYtelsesBehandling(fagsak).orElse(null);
+        var bruker = lagBrukerPersonDto(fagsak).orElse(null);
+        var manglerAdresse = personinfoAdapter.sjekkOmBrukerManglerAdresse(fagsak.getAktørId());
+        var annenpart = lagAnnenpartPersonDto(fagsak).orElse(null);
+        var oppretting = Stream.of(BehandlingType.getYtelseBehandlingTyper(), BehandlingType.getAndreBehandlingTyper()).flatMap(Collection::stream)
+            .map(bt -> new BehandlingOpprettingDto(bt, behandlingsoppretterTjeneste.kanOppretteNyBehandlingAvType(fagsak.getId(), bt)))
+            .toList();
+        var behandlinger = behandlingDtoTjeneste.lagBehandlingDtoer(behandlingRepository.hentAbsoluttAlleBehandlingerForFagsak(fagsak.getId()));
+        var dto = new FagsakFullDto(fagsak, dekningsgrad, bruker, manglerAdresse, annenpart, annenpartSak, familiehendelse, oppretting, behandlinger);
+        return Optional.of(dto);
+    }
+
+    private Optional<PersonDto> lagBrukerPersonDto(Fagsak fagsak) {
+        return personinfoAdapter.hentBrukerBasisForAktør(fagsak.getAktørId())
+            .map(pi -> mapFraPersoninfoBasisTilPersonDto(pi, Optional.ofNullable(fagsak.getNavBruker()).map(NavBruker::getSpråkkode).orElse(Språkkode.NB)));
+    }
+
+    private Optional<PersonDto> lagAnnenpartPersonDto(Fagsak fagsak) {
+        return fagsakRelasjonTjeneste.finnRelasjonForHvisEksisterer(fagsak)
+            .flatMap(fr -> fr.getRelatertFagsak(fagsak))
+            .map(Fagsak::getAktørId)
+            .or(() -> behandlingRepository.hentSisteYtelsesBehandlingForFagsakId(fagsak.getId())
+                .flatMap(b -> personopplysningTjeneste.hentOppgittAnnenPartAktørId(b.getId())))
+            .flatMap(personinfoAdapter::hentBrukerBasisForAktør)
+            .map(FagsakFullTjeneste::mapFraPersoninfoBasisTilPersonDto)
+            .or(() -> behandlingRepository.hentSisteYtelsesBehandlingForFagsakId(fagsak.getId())
+                .flatMap(b -> personopplysningTjeneste.hentOppgittAnnenPart(b.getId()))
+                .filter(ap -> ap.getAktørId() == null && ap.getUtenlandskFnrLand() != null && !Landkoder.UDEFINERT.equals(ap.getUtenlandskFnrLand()))
+                .map(ap -> new PersonDto(null, null, null, null, null, null, null, null, null)));
+    }
+
+    private Integer finnDekningsgrad(Fagsak fagsak) {
+        return fagsakRelasjonTjeneste.finnRelasjonForHvisEksisterer(fagsak)
+            .map(FagsakRelasjon::getGjeldendeDekningsgrad)
+            .map(Dekningsgrad::getVerdi).orElse(null);
+    }
+
+    private static PersonDto mapFraPersoninfoBasisTilPersonDto(PersoninfoBasis pi) {
+        return mapFraPersoninfoBasisTilPersonDto(pi, Språkkode.NB);
+    }
+
+    private static PersonDto mapFraPersoninfoBasisTilPersonDto(PersoninfoBasis pi, Språkkode språkkode) {
+        return new PersonDto(pi.aktørId().getId(), StringUtils.formaterMedStoreOgSmåBokstaver(pi.navn()), pi.personIdent().getIdent(), pi.kjønn(),
+            pi.diskresjonskode(), pi.fødselsdato(), pi.dødsdato(), pi.dødsdato(), språkkode);
+    }
+
+    private Optional<SakHendelseDto> hentFamilieHendelse(Fagsak fagsak) {
+        return behandlingRepository.hentSisteYtelsesBehandlingForFagsakId(fagsak.getId())
+            .flatMap(b -> familieHendelseTjeneste.finnAggregat(b.getId()))
+            .map(FamilieHendelseGrunnlagEntitet::getGjeldendeVersjon)
+            .map(h -> new SakHendelseDto(h.getType(), hendelseDato(h), h.getAntallBarn(),
+                !h.getBarna().isEmpty() && h.getBarna().stream().allMatch(b -> b.getDødsdato().isPresent())));
+    }
+
+    private LocalDate hendelseDato(FamilieHendelseEntitet fh) {
+        return Optional.ofNullable(fh.getSkjæringstidspunkt())
+            .orElseGet(() -> fh.getTerminbekreftelse().map(TerminbekreftelseEntitet::getTermindato).orElse(null));
+    }
+
+    private Optional<AnnenPartBehandlingDto> hentAnnenPartsGjeldendeYtelsesBehandling(Fagsak fagsak) {
+        return fagsakRelasjonTjeneste.finnRelasjonForHvisEksisterer(fagsak)
+            .flatMap(r -> r.getRelatertFagsakFraId(fagsak.getId()))
+            .map(Fagsak::getId).flatMap(behandlingRepository::hentSisteYtelsesBehandlingForFagsakId)
+            .map(behandling -> new AnnenPartBehandlingDto(behandling.getFagsak().getSaksnummer().getVerdi(), behandling.getUuid()));
+    }
+}

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/fagsak/app/FagsakTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/fagsak/app/FagsakTjeneste.java
@@ -1,9 +1,6 @@
 package no.nav.foreldrepenger.web.app.tjenester.fagsak.app;
 
-import static no.nav.foreldrepenger.web.app.rest.ResourceLinks.get;
-
 import java.time.LocalDate;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -11,7 +8,6 @@ import java.util.stream.Collectors;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
-import no.nav.foreldrepenger.behandling.DekningsgradTjeneste;
 import no.nav.foreldrepenger.behandling.FagsakRelasjonTjeneste;
 import no.nav.foreldrepenger.behandlingslager.aktør.NavBruker;
 import no.nav.foreldrepenger.behandlingslager.aktør.PersoninfoBasis;
@@ -21,6 +17,7 @@ import no.nav.foreldrepenger.behandlingslager.behandling.familiehendelse.Terminb
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepository;
 import no.nav.foreldrepenger.behandlingslager.fagsak.Dekningsgrad;
 import no.nav.foreldrepenger.behandlingslager.fagsak.Fagsak;
+import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakRelasjon;
 import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakRepository;
 import no.nav.foreldrepenger.behandlingslager.geografisk.Landkoder;
 import no.nav.foreldrepenger.behandlingslager.geografisk.Språkkode;
@@ -31,19 +28,14 @@ import no.nav.foreldrepenger.domene.typer.AktørId;
 import no.nav.foreldrepenger.domene.typer.PersonIdent;
 import no.nav.foreldrepenger.domene.typer.Saksnummer;
 import no.nav.foreldrepenger.familiehendelse.FamilieHendelseTjeneste;
-import no.nav.foreldrepenger.web.app.rest.ResourceLink;
 import no.nav.foreldrepenger.web.app.tjenester.VurderProsessTaskStatusForPollingApi;
-import no.nav.foreldrepenger.web.app.tjenester.behandling.BehandlingRestTjeneste;
 import no.nav.foreldrepenger.web.app.tjenester.behandling.dto.AsyncPollingStatus;
-import no.nav.foreldrepenger.web.app.tjenester.behandling.historikk.HistorikkRestTjeneste;
-import no.nav.foreldrepenger.web.app.tjenester.dokument.DokumentRestTjeneste;
-import no.nav.foreldrepenger.web.app.tjenester.fagsak.FagsakRestTjeneste;
 import no.nav.foreldrepenger.web.app.tjenester.fagsak.dto.AktoerInfoDto;
 import no.nav.foreldrepenger.web.app.tjenester.fagsak.dto.FagsakDto;
+import no.nav.foreldrepenger.web.app.tjenester.fagsak.dto.FagsakSøkDto;
 import no.nav.foreldrepenger.web.app.tjenester.fagsak.dto.PersonDto;
 import no.nav.foreldrepenger.web.app.tjenester.fagsak.dto.SakHendelseDto;
 import no.nav.foreldrepenger.web.app.tjenester.fagsak.dto.SakPersonerDto;
-import no.nav.foreldrepenger.web.app.tjenester.fagsak.dto.SaksnummerDto;
 import no.nav.foreldrepenger.web.app.util.StringUtils;
 
 @ApplicationScoped
@@ -58,7 +50,6 @@ public class FagsakTjeneste {
     private FagsakRelasjonTjeneste fagsakRelasjonTjeneste;
     private FamilieHendelseTjeneste familieHendelseTjeneste;
     private PersonopplysningTjeneste personopplysningTjeneste;
-    private DekningsgradTjeneste dekningsgradTjeneste;
 
     protected FagsakTjeneste() {
         // CDI runner
@@ -71,8 +62,7 @@ public class FagsakTjeneste {
                           PersoninfoAdapter personinfoAdapter,
                           FagsakRelasjonTjeneste fagsakRelasjonTjeneste,
                           FamilieHendelseTjeneste familieHendelseTjeneste,
-                          PersonopplysningTjeneste personopplysningTjeneste,
-                          DekningsgradTjeneste dekningsgradTjeneste) {
+                          PersonopplysningTjeneste personopplysningTjeneste) {
         this.fagsakRepository = fagsakRepository;
         this.personinfoAdapter = personinfoAdapter;
         this.behandlingRepository = behandlingRepository;
@@ -80,12 +70,11 @@ public class FagsakTjeneste {
         this.familieHendelseTjeneste = familieHendelseTjeneste;
         this.personopplysningTjeneste = personopplysningTjeneste;
         this.prosesseringAsynkTjeneste = prosesseringAsynkTjeneste;
-        this.dekningsgradTjeneste = dekningsgradTjeneste;
     }
 
     public Optional<AsyncPollingStatus> sjekkProsessTaskPågår(Saksnummer saksnummer, String gruppe) {
 
-        var fagsak = fagsakRepository.hentSakGittSaksnummer(saksnummer);
+        var fagsak = hentFagsakForSaksnummer(saksnummer);
         if (fagsak.isPresent()) {
             var fagsakId = fagsak.get().getId();
             var nesteTask = prosesseringAsynkTjeneste.sjekkProsessTaskPågår(fagsakId, null, gruppe);
@@ -98,31 +87,32 @@ public class FagsakTjeneste {
         return fagsakRepository.hentSakGittSaksnummer(saksnummer);
     }
 
-    public List<FagsakDto> søkFagsakDto(String søkestreng) {
+    public List<FagsakSøkDto> søkFagsakDto(String søkestreng) {
         if (PersonIdent.erGyldigFnr(søkestreng)) {
-            return hentFagsakDtoForFnr(new PersonIdent(søkestreng));
+            return hentFagsakSøkDtoForFnr(new PersonIdent(søkestreng));
         }
         if (AktørId.erGyldigAktørId(søkestreng)) {
-            return hentFagsakDtoForAktørId(new AktørId(søkestreng));
+            return hentFagsakSøkDtoForAktørId(new AktørId(søkestreng));
         }
 
         try {
-            return lagFagsakDtoForSaksnummer(new Saksnummer(søkestreng)).stream().collect(Collectors.toList());
+            return hentFagsakForSaksnummer(new Saksnummer(søkestreng))
+                .map(this::mapFraFagsakTilFagsakSøkDto).stream().collect(Collectors.toList());
         } catch (Exception e) { // Ugyldig saksnummer
             return List.of();
         }
     }
 
-    private List<FagsakDto> hentFagsakDtoForFnr(PersonIdent fnr) {
-        return personinfoAdapter.hentAktørForFnr(fnr).map(this::hentFagsakDtoForAktørId).orElse(List.of());
+    private List<FagsakSøkDto> hentFagsakSøkDtoForFnr(PersonIdent fnr) {
+        return personinfoAdapter.hentAktørForFnr(fnr).map(this::hentFagsakSøkDtoForAktørId).orElse(List.of());
     }
 
-    private List<FagsakDto> hentFagsakDtoForAktørId(AktørId aktørId) {
-        return fagsakRepository.hentForBruker(aktørId).stream().map(this::mapFraFagsakTilFagsakDto).collect(Collectors.toList());
+    private List<FagsakSøkDto> hentFagsakSøkDtoForAktørId(AktørId aktørId) {
+        return fagsakRepository.hentForBruker(aktørId).stream().map(this::mapFraFagsakTilFagsakSøkDto).collect(Collectors.toList());
     }
 
     public Optional<FagsakDto> hentFagsakDtoForSaksnummer(Saksnummer saksnummer) {
-        return lagFagsakDtoForSaksnummer(saksnummer);
+        return hentFagsakForSaksnummer(saksnummer).map(this::mapFraFagsakTilFagsakDto);
     }
 
     public Optional<SakPersonerDto> lagSakPersonerDto(Saksnummer saksnummer) {
@@ -143,7 +133,7 @@ public class FagsakTjeneste {
             .orElseGet(() -> behandlingRepository.hentSisteYtelsesBehandlingForFagsakId(fagsak.getId())
                 .flatMap(b -> personopplysningTjeneste.hentOppgittAnnenPart(b.getId()))
                 .filter(ap -> ap.getAktørId() == null && ap.getUtenlandskFnrLand() != null && !Landkoder.UDEFINERT.equals(ap.getUtenlandskFnrLand()))
-                .map(ap -> new PersonDto(null, null, null, null, null, null, null, null))
+                .map(ap -> new PersonDto(null, null, null, null, null, null, null, null, null))
                 .orElse(null));
         var fh = hentFamilieHendelse(fagsak);
         return Optional.of(new SakPersonerDto(bruker, annenPart, fh.orElse(null)));
@@ -157,9 +147,9 @@ public class FagsakTjeneste {
         var personDto = mapFraPersoninfoBasisTilPersonDto(personinfo);
         var fagsakDtoer = fagsakRepository.hentForBruker(aktørId)
             .stream()
-            .map(fagsak -> mapFraFagsakTilFagsakDto(fagsak))
+            .map(this::mapFraFagsakTilFagsakSøkDto)
             .collect(Collectors.toList());
-        var aktoerInfoDto = new AktoerInfoDto(personinfo.aktørId().getId(), personDto, fagsakDtoer);
+        var aktoerInfoDto = new AktoerInfoDto(personinfo.aktørId().getId(), personinfo.aktørId().getId(), personDto, fagsakDtoer);
         return Optional.of(aktoerInfoDto);
     }
 
@@ -168,7 +158,9 @@ public class FagsakTjeneste {
     }
 
     private Integer finnDekningsgrad(Saksnummer saksnummer) {
-        return dekningsgradTjeneste.finnDekningsgrad(saksnummer).map(Dekningsgrad::getVerdi).orElse(null);
+        return fagsakRelasjonTjeneste.finnRelasjonHvisEksisterer(saksnummer)
+            .map(FagsakRelasjon::getGjeldendeDekningsgrad)
+            .map(Dekningsgrad::getVerdi).orElse(null);
     }
 
     private static PersonDto mapFraPersoninfoBasisTilPersonDto(PersoninfoBasis pi) {
@@ -177,17 +169,17 @@ public class FagsakTjeneste {
 
     private static PersonDto mapFraPersoninfoBasisTilPersonDto(PersoninfoBasis pi, Språkkode språkkode) {
         return new PersonDto(pi.aktørId().getId(), StringUtils.formaterMedStoreOgSmåBokstaver(pi.navn()), pi.personIdent().getIdent(), pi.kjønn(),
-            pi.diskresjonskode(), pi.fødselsdato(), pi.dødsdato(), språkkode);
-    }
-
-    private Optional<FagsakDto> lagFagsakDtoForSaksnummer(Saksnummer saksnummer) {
-        return fagsakRepository.hentSakGittSaksnummer(saksnummer).map(this::mapFraFagsakTilFagsakDto);
+            pi.diskresjonskode(), pi.fødselsdato(), pi.dødsdato(), pi.dødsdato(), språkkode);
     }
 
     private FagsakDto mapFraFagsakTilFagsakDto(Fagsak fagsak) {
         var fh = hentFamilieHendelse(fagsak);
-        return new FagsakDto(fagsak, fh.map(SakHendelseDto::getHendelseDato).orElse(null), fagsak.getRelasjonsRolleType(),
-            finnDekningsgrad(fagsak.getSaksnummer()), lagLenker(fagsak), lagLenkerEngangshent(fagsak));
+        return new FagsakDto(fagsak, fh.map(SakHendelseDto::getHendelseDato).orElse(null), finnDekningsgrad(fagsak.getSaksnummer()));
+    }
+
+    private FagsakSøkDto mapFraFagsakTilFagsakSøkDto(Fagsak fagsak) {
+        var fh = hentFamilieHendelse(fagsak);
+        return new FagsakSøkDto(fagsak, fh.map(SakHendelseDto::getHendelseDato).orElse(null));
     }
 
     private Optional<SakHendelseDto> hentFamilieHendelse(Fagsak fagsak) {
@@ -203,21 +195,4 @@ public class FagsakTjeneste {
             .orElseGet(() -> fh.getTerminbekreftelse().map(TerminbekreftelseEntitet::getTermindato).orElse(null));
     }
 
-    private static List<ResourceLink> lagLenker(Fagsak fagsak) {
-        List<ResourceLink> lenkene = new ArrayList<>();
-        var saksnummer = new SaksnummerDto(fagsak.getSaksnummer());
-        lenkene.add(get(FagsakRestTjeneste.RETTIGHETER_PATH, "sak-rettigheter", saksnummer));
-        lenkene.add(get(HistorikkRestTjeneste.HISTORIKK_PATH, "sak-historikk", saksnummer));
-        lenkene.add(get(DokumentRestTjeneste.DOKUMENTER_PATH, "sak-dokumentliste", saksnummer));
-        lenkene.add(get(BehandlingRestTjeneste.BEHANDLINGER_ALLE_PATH, "sak-alle-behandlinger", saksnummer));
-        lenkene.add(get(BehandlingRestTjeneste.ANNEN_PART_BEHANDLING_PATH, "sak-annen-part-behandling", saksnummer));
-        return lenkene;
-    }
-
-    private static List<ResourceLink> lagLenkerEngangshent(Fagsak fagsak) {
-        List<ResourceLink> lenkene = new ArrayList<>();
-        var saksnummer = new SaksnummerDto(fagsak.getSaksnummer());
-        lenkene.add(get(FagsakRestTjeneste.PERSONER_PATH, "sak-personer", saksnummer));
-        return lenkene;
-    }
 }

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/fagsak/dto/AktoerInfoDto.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/fagsak/dto/AktoerInfoDto.java
@@ -2,41 +2,5 @@ package no.nav.foreldrepenger.web.app.tjenester.fagsak.dto;
 
 import java.util.List;
 
-public class AktoerInfoDto {
-
-    private String aktoerId;
-    private PersonDto person;
-    private List<FagsakDto> fagsaker;
-
-    public AktoerInfoDto(String aktoerId, PersonDto person, List<FagsakDto> fagsaker) {
-        this.aktoerId = aktoerId;
-        this.person = person;
-        this.fagsaker = fagsaker;
-    }
-
-    public String getAktoerId() {
-        return aktoerId;
-    }
-
-    public void setAktoerId(String aktoerId) {
-        this.aktoerId = aktoerId;
-    }
-
-    public void setFagsaker(List<FagsakDto> fagsaker) {
-        this.fagsaker = fagsaker;
-    }
-
-    public PersonDto getPerson() {
-        return person;
-    }
-
-    public List<FagsakDto> getFagsaker() {
-        return fagsaker;
-    }
-
-    public void setPerson(PersonDto person) {
-        this.person = person;
-    }
-
-
+public record AktoerInfoDto(@Deprecated(forRemoval = true) String aktoerId, String aktørId, PersonDto person, List<FagsakSøkDto> fagsaker) {
 }

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/fagsak/dto/FagsakDto.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/fagsak/dto/FagsakDto.java
@@ -1,124 +1,35 @@
 package no.nav.foreldrepenger.web.app.tjenester.fagsak.dto;
 
 import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
 
 import no.nav.foreldrepenger.behandlingslager.behandling.personopplysning.RelasjonsRolleType;
 import no.nav.foreldrepenger.behandlingslager.fagsak.Fagsak;
 import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakStatus;
 import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakYtelseType;
-import no.nav.foreldrepenger.web.app.rest.ResourceLink;
 
-public class FagsakDto {  // SøkDto saksnummer + fagsakYtelseType + status + NavRestTjeneste
-    private String saksnummer;
-    private String saksnummerString;
-    private FagsakYtelseType sakstype;
-    private FagsakYtelseType fagsakYtelseType;
-    private RelasjonsRolleType relasjonsRolleType;
-    private FagsakStatus status;
-    private LocalDate barnFodt;
-    private Integer dekningsgrad;
-    private String aktoerId;
+/**
+ * Brukes for backend oppslag av fagsak. Fødselsdato saneres herfra
+ */
+public record FagsakDto(String saksnummer, @Deprecated(forRemoval = true) String saksnummerString,
+                        FagsakYtelseType fagsakYtelseType, @Deprecated(forRemoval = true) FagsakYtelseType sakstype,
+                        FagsakStatus status, RelasjonsRolleType relasjonsRolleType, Integer dekningsgrad,
+                        String aktørId, @Deprecated(forRemoval = true) String aktoerId,
+                        @Deprecated(forRemoval = true) LocalDate barnFødt, @Deprecated(forRemoval = true) LocalDate barnFodt) {
 
-    private List<ResourceLink> links = new ArrayList<>();
-    private List<ResourceLink> onceLinks = new ArrayList<>();
 
-    public FagsakDto() {
-        // Injiseres i test
-    }
-
-    public FagsakDto(Fagsak fagsak,
-                     LocalDate barnFodt,
-                     RelasjonsRolleType relasjonsRolleType,
-                     Integer dekningsgrad,
-                     List<ResourceLink> links,
-                     List<ResourceLink> linksOnce) {
-        this.saksnummer = fagsak.getSaksnummer().getVerdi();
-        this.saksnummerString = fagsak.getSaksnummer().getVerdi();
-        this.aktoerId = fagsak.getAktørId().getId();
-        this.sakstype = fagsak.getYtelseType();
-        this.fagsakYtelseType = fagsak.getYtelseType();
-        this.status = fagsak.getStatus();
-        this.barnFodt = barnFodt;
-        this.relasjonsRolleType = relasjonsRolleType;
-        this.dekningsgrad = dekningsgrad;
-        this.links = links;
-        this.onceLinks = linksOnce;
-    }
-
-    public String getSaksnummer() {
-        return saksnummer;
-    }
-
-    public FagsakYtelseType getSakstype() {
-        return sakstype;
-    }
-
-    public FagsakStatus getStatus() {
-        return status;
-    }
-
-    public String getSaksnummerString() {
-        return saksnummerString;
-    }
-
-    public LocalDate getBarnFodt() {
-        return barnFodt;
-    }
-
-    public FagsakYtelseType getFagsakYtelseType() {
-        return fagsakYtelseType;
-    }
-
-    public RelasjonsRolleType getRelasjonsRolleType() {
-        return relasjonsRolleType;
-    }
-
-    public Integer getDekningsgrad() {
-        return dekningsgrad;
-    }
-
-    public String getAktoerId() {
-        return aktoerId;
-    }
-
-    public List<ResourceLink> getLinks() {
-        return links;
-    }
-
-    public List<ResourceLink> getOnceLinks() {
-        return onceLinks;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        var fagsakDto = (FagsakDto) o;
-        return Objects.equals(saksnummer, fagsakDto.saksnummer)
-            && Objects.equals(saksnummerString, fagsakDto.saksnummerString)
-            && sakstype == fagsakDto.sakstype && relasjonsRolleType == fagsakDto.relasjonsRolleType && status == fagsakDto.status
-            && Objects.equals(barnFodt, fagsakDto.barnFodt)
-            && Objects.equals(dekningsgrad, fagsakDto.dekningsgrad)
-            && Objects.equals(aktoerId, fagsakDto.aktoerId);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(saksnummer, saksnummerString, sakstype, relasjonsRolleType, status,
-            barnFodt, dekningsgrad, aktoerId);
+        public FagsakDto(Fagsak fagsak, LocalDate barnFødt, Integer dekningsgrad) {
+            this(fagsak.getSaksnummer().getVerdi(), fagsak.getSaksnummer().getVerdi(), fagsak.getYtelseType(), fagsak.getYtelseType(),
+                fagsak.getStatus(), fagsak.getRelasjonsRolleType(), dekningsgrad, fagsak.getAktørId().getId(), fagsak.getAktørId().getId(), barnFødt, barnFødt);
     }
 
     @Override
     public String toString() {
         return "FagsakDto{" +
             "saksnummer=" + saksnummer +
-            ", sakstype=" + sakstype +
+            ", fagsakYtelseType=" + fagsakYtelseType +
             ", relasjonsRolleType=" + relasjonsRolleType +
             ", status=" + status +
-            ", barnFodt=" + barnFodt +
+            ", barnFødt=" + barnFødt +
             ", dekningsgrad=" + dekningsgrad +
             '}';
     }

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/fagsak/dto/FagsakFullDto.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/fagsak/dto/FagsakFullDto.java
@@ -1,0 +1,39 @@
+package no.nav.foreldrepenger.web.app.tjenester.fagsak.dto;
+
+import java.util.List;
+
+import no.nav.foreldrepenger.behandlingslager.behandling.personopplysning.RelasjonsRolleType;
+import no.nav.foreldrepenger.behandlingslager.fagsak.Fagsak;
+import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakStatus;
+import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakYtelseType;
+import no.nav.foreldrepenger.web.app.tjenester.behandling.dto.BehandlingOpprettingDto;
+import no.nav.foreldrepenger.web.app.tjenester.behandling.dto.behandling.AnnenPartBehandlingDto;
+import no.nav.foreldrepenger.web.app.tjenester.behandling.dto.behandling.BehandlingDto;
+
+public record FagsakFullDto(String saksnummer,
+                            FagsakYtelseType fagsakYtelseType,
+                            RelasjonsRolleType relasjonsRolleType,
+                            FagsakStatus status,
+                            String aktørId,
+                            boolean sakSkalTilInfotrygd,
+                            Integer dekningsgrad,
+                            PersonDto bruker,
+                            boolean brukerManglerAdresse,
+                            PersonDto annenPart,
+                            AnnenPartBehandlingDto annenpartBehandling,
+                            SakHendelseDto familiehendelse,
+                            List<BehandlingOpprettingDto> behandlingTypeKanOpprettes,
+                            List<BehandlingDto> behandlinger) {
+
+    public FagsakFullDto(Fagsak fagsak, Integer dekningsgrad, PersonDto bruker,
+                         boolean brukerManglerAdresse,
+                         PersonDto annenPart,
+                         AnnenPartBehandlingDto annenpartBehandling,
+                         SakHendelseDto familiehendelse,
+                         List<BehandlingOpprettingDto> behandlingTypeKanOpprettes,
+                         List<BehandlingDto> behandlinger) {
+        this(fagsak.getSaksnummer().getVerdi(), fagsak.getYtelseType(), fagsak.getRelasjonsRolleType(), fagsak.getStatus(), fagsak.getAktørId().getId(),
+            fagsak.erStengt(), dekningsgrad, bruker, brukerManglerAdresse, annenPart, annenpartBehandling,
+            familiehendelse, behandlingTypeKanOpprettes, behandlinger);
+    }
+}

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/fagsak/dto/FagsakSøkDto.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/fagsak/dto/FagsakSøkDto.java
@@ -1,0 +1,31 @@
+package no.nav.foreldrepenger.web.app.tjenester.fagsak.dto;
+
+import java.time.LocalDate;
+
+import no.nav.foreldrepenger.behandlingslager.fagsak.Fagsak;
+import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakStatus;
+import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakYtelseType;
+
+/**
+ * Brukes for oppslag på aktørId eller søk etter saksnummer/fnr. Med fødselsdato for visnings/sorteringsformål
+ */
+public record FagsakSøkDto(String saksnummer,
+                           FagsakYtelseType fagsakYtelseType,
+                           FagsakStatus status,
+                           @Deprecated(forRemoval = true) String aktoerId,
+                           String aktørId,
+                           @Deprecated(forRemoval = true) LocalDate barnFodt,
+                           LocalDate barnFødt) {
+
+    public FagsakSøkDto(Fagsak fagsak, LocalDate barnFødt) {
+        this(fagsak.getSaksnummer().getVerdi(), fagsak.getYtelseType(), fagsak.getStatus(),
+            fagsak.getAktørId().getId(), fagsak.getAktørId().getId(), barnFødt, barnFødt);
+    }
+
+
+    @Override
+    public String toString() {
+        return "FagsakSøkDto{" + "saksnummer='" + saksnummer + "', fagsakYtelseType=" + fagsakYtelseType + ", status=" + status
+            + ", barnFødt=" + barnFødt + '}';
+    }
+}

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/fagsak/dto/PersonDto.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/fagsak/dto/PersonDto.java
@@ -6,78 +6,18 @@ import java.util.Objects;
 import no.nav.foreldrepenger.behandlingslager.aktør.NavBrukerKjønn;
 import no.nav.foreldrepenger.behandlingslager.geografisk.Språkkode;
 
-public class PersonDto {
-
-    private String navn;
-    private String fødselsnummer;
-    private NavBrukerKjønn kjønn;
-    private String diskresjonskode;
-    private LocalDate fødselsdato;
-    private LocalDate dodsdato;
-    private Språkkode språkkode;
-    private String aktørId;
-
-    public PersonDto() {
-        // Injiseres i test
-    }
-
-    public PersonDto(String aktørid, String navn, String fødselsnummer, NavBrukerKjønn navBrukerKjønn, String diskresjonskode,
-                     LocalDate fødselsdato, LocalDate dodsdato, Språkkode språkkode) {
-        this.navn = navn;
-        this.fødselsnummer = fødselsnummer;
-        this.kjønn = navBrukerKjønn;
-        this.diskresjonskode = diskresjonskode;
-        this.fødselsdato = fødselsdato;
-        this.dodsdato = dodsdato;
-        this.språkkode = språkkode;
-        this.aktørId = aktørid;
-    }
-
-    public String getNavn() {
-        return navn;
-    }
-
-    public NavBrukerKjønn getKjønn() {
-        return kjønn;
-    }
-
-    public String getDiskresjonskode() {
-        return diskresjonskode;
-    }
-
-    public LocalDate getFødselsdato() {
-        return fødselsdato;
-    }
-
-    public LocalDate getDodsdato() {
-        return dodsdato;
-    }
-
-    public Språkkode getSpråkkode() {
-        return språkkode;
-    }
-
-    public String getAktørId() {
-        return aktørId;
-    }
-
-    public String getFødselsnummer() {
-        return fødselsnummer;
-    }
+public record PersonDto(String aktørId, String navn, String fødselsnummer, NavBrukerKjønn kjønn, String diskresjonskode,
+                        LocalDate fødselsdato, LocalDate dødsdato, @Deprecated(forRemoval = true) LocalDate dodsdato, Språkkode språkkode) {
 
     @Override
     public String toString() {
-        return "PersonDto{" +
-            "aktørId='" + aktørId + '\'' +
-            '}';
+        return "PersonDto{fødselsdato=" + fødselsdato + "}";
     }
 
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        var personDto = (PersonDto) o;
-        return Objects.equals(aktørId, personDto.aktørId);
+        return o instanceof PersonDto other && Objects.equals(aktørId, other.aktørId);
     }
 
     @Override

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/saksbehandler/InitielleLinksRestTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/saksbehandler/InitielleLinksRestTjeneste.java
@@ -46,6 +46,7 @@ public class InitielleLinksRestTjeneste {
         lenkene.add(get(KodeverkRestTjeneste.KODERVERK_PATH, "kodeverk"));
         lenkene.add(get(KodeverkRestTjeneste.ENHETER_PATH, "behandlende-enheter"));
         List<ResourceLink> saklenker = new ArrayList<>();
+        saklenker.add(get(FagsakRestTjeneste.FAGSAK_FULL_PATH, "fagsak-full"));
         saklenker.add(get(FagsakRestTjeneste.FAGSAK_PATH, "fagsak"));
         saklenker.add(get(FagsakRestTjeneste.PERSONER_PATH, "sak-personer"));
         saklenker.add(get(FagsakRestTjeneste.RETTIGHETER_PATH, "sak-rettigheter"));


### PR DESCRIPTION
Prøver rydde i Dtos
* FagsakSøkDto: til bruk for "søk" i fp-frontend søk + /fpsak/aktoer/<aktørid> og fplos søk
* FagsakDto: backendbruk i formidling og tilbake
* FagsakFullDto til fpfrontend gjennom "fagsak-full" - henter opp  lenkene "fagsak", "sak-personer", "sak-rettigheter", "sak-alle-behandlinger", "sak-annen-part-behandling", "har-ikke-adresse" i ett kall. 
* Historikk + Dokumentliste må hentes separat (samtidig med fagsak-full)

Gjør om barnFodt->barnFødt og aktoerId->aktørId i konsumenter
Tilsvarende øvelser for BehandlingDtos er neste steg +  fjernin av ting som deprekeres her