### PR TITLE
Redusere mulighet for berørt vranglås

### DIFF
--- a/domenetjenester/behandling-revurdering/src/test/java/no/nav/foreldrepenger/behandling/revurdering/flytkontroll/BehandlingFlytkontrollTest.java
+++ b/domenetjenester/behandling-revurdering/src/test/java/no/nav/foreldrepenger/behandling/revurdering/flytkontroll/BehandlingFlytkontrollTest.java
@@ -1,6 +1,8 @@
 package no.nav.foreldrepenger.behandling.revurdering.flytkontroll;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -141,7 +143,7 @@ public class BehandlingFlytkontrollTest {
         when(behandlingBerørt.harÅpentAksjonspunktMedType(AksjonspunktDefinisjon.AUTO_KØET_BEHANDLING)).thenReturn(true);
         when(behandlingBerørt.getAktivtBehandlingSteg()).thenReturn(StartpunktType.UTTAKSVILKÅR.getBehandlingSteg());
         assertThat(flytkontroll.uttaksProsessenSkalVente(EGEN_BERØRT_ID)).isTrue();
-        verify(behandlingProsesseringTjeneste, times(1));
+        verify(behandlingProsesseringTjeneste, times(1)).opprettTasksForFortsettBehandlingSettUtført(any(), eq(Optional.of(AksjonspunktDefinisjon.AUTO_KØET_BEHANDLING)));
     }
 
 

--- a/domenetjenester/behandling-revurdering/src/test/java/no/nav/foreldrepenger/behandling/revurdering/flytkontroll/BehandlingFlytkontrollTest.java
+++ b/domenetjenester/behandling-revurdering/src/test/java/no/nav/foreldrepenger/behandling/revurdering/flytkontroll/BehandlingFlytkontrollTest.java
@@ -1,8 +1,9 @@
 package no.nav.foreldrepenger.behandling.revurdering.flytkontroll;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.anySet;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
@@ -16,10 +17,12 @@ import org.junit.jupiter.api.Test;
 import no.nav.foreldrepenger.behandlingskontroll.BehandlingskontrollTjeneste;
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingÅrsakType;
+import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.AksjonspunktDefinisjon;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRevurderingRepository;
 import no.nav.foreldrepenger.behandlingslager.fagsak.Fagsak;
 import no.nav.foreldrepenger.behandlingslager.hendelser.StartpunktType;
+import no.nav.foreldrepenger.behandlingsprosess.prosessering.BehandlingProsesseringTjeneste;
 
 public class BehandlingFlytkontrollTest {
 
@@ -27,16 +30,19 @@ public class BehandlingFlytkontrollTest {
     private static Long FAGSAK_AP_ID = 2L;
     private static Long BEHANDLING_ID = 99L;
     private static Long BERØRT_ID = 98L;
+    private static Long EGEN_BERØRT_ID = 97L;
 
     private BehandlingRepository behandlingRepository = mock(BehandlingRepository.class);
     private BehandlingRevurderingRepository behandlingRevurderingRepository = mock(
-            BehandlingRevurderingRepository.class);
+        BehandlingRevurderingRepository.class);
     private BehandlingskontrollTjeneste behandlingskontrollTjeneste = mock(BehandlingskontrollTjeneste.class);
+    private BehandlingProsesseringTjeneste behandlingProsesseringTjeneste = mock(BehandlingProsesseringTjeneste.class);
     private BehandlingFlytkontroll flytkontroll;
     private Behandling behandling = mock(Behandling.class);
     private Behandling behandlingAnnenPart = mock(Behandling.class);
     private Behandling behandlingBerørt = mock(Behandling.class);
     private Behandling behandlingSammeSak = mock(Behandling.class);
+    private Behandling behandlingSammeSakBerørt = mock(Behandling.class);
     private Fagsak fagsak = mock(Fagsak.class);
     private Fagsak fagsakAnnenPart = mock(Fagsak.class);
 
@@ -46,13 +52,19 @@ public class BehandlingFlytkontrollTest {
         when(behandling.getId()).thenReturn(BEHANDLING_ID);
         when(behandlingBerørt.getId()).thenReturn(BERØRT_ID);
         when(behandlingBerørt.erRevurdering()).thenReturn(true);
+        when(behandlingBerørt.harBehandlingÅrsak(BehandlingÅrsakType.BERØRT_BEHANDLING)).thenReturn(true);
+        when(behandlingBerørt.harNoenBehandlingÅrsaker(BehandlingÅrsakType.alleTekniskeÅrsaker())).thenReturn(true);
+        when(behandlingSammeSakBerørt.getFagsak()).thenReturn(fagsak);
+        when(behandlingSammeSakBerørt.getId()).thenReturn(EGEN_BERØRT_ID);
+        when(behandlingSammeSakBerørt.erRevurdering()).thenReturn(true);
+        when(behandlingSammeSakBerørt.harBehandlingÅrsak(BehandlingÅrsakType.BERØRT_BEHANDLING)).thenReturn(true);
+        when(behandlingSammeSakBerørt.harNoenBehandlingÅrsaker(BehandlingÅrsakType.alleTekniskeÅrsaker())).thenReturn(true);
         when(fagsak.getId()).thenReturn(FAGSAK_ID);
         when(fagsakAnnenPart.getId()).thenReturn(FAGSAK_AP_ID);
         when(behandlingRepository.hentBehandling(BEHANDLING_ID)).thenReturn(behandling);
-        when(behandlingBerørt.harBehandlingÅrsak(BehandlingÅrsakType.BERØRT_BEHANDLING)).thenReturn(true);
-        when(behandlingBerørt.harNoenBehandlingÅrsaker(BehandlingÅrsakType.alleTekniskeÅrsaker())).thenReturn(true);
+        when(behandlingRepository.hentBehandling(EGEN_BERØRT_ID)).thenReturn(behandlingSammeSakBerørt);
         flytkontroll = new BehandlingFlytkontroll(behandlingRevurderingRepository, behandlingskontrollTjeneste,
-                behandlingRepository);
+                behandlingProsesseringTjeneste, behandlingRepository);
     }
 
     @Test
@@ -98,6 +110,40 @@ public class BehandlingFlytkontrollTest {
                 StartpunktType.UTTAKSVILKÅR.getBehandlingSteg())).thenReturn(false);
         assertThat(flytkontroll.uttaksProsessenSkalVente(BEHANDLING_ID)).isTrue();
     }
+
+    @Test
+    public void berørtSkalVenteNårKobletHarBerørtFørSynk() {
+        when(behandlingRevurderingRepository.finnFagsakPåMedforelder(fagsak)).thenReturn(Optional.of(fagsakAnnenPart));
+        when(behandlingRepository.hentÅpneYtelseBehandlingerForFagsakId(FAGSAK_AP_ID)).thenReturn(
+            List.of(behandlingBerørt));
+        when(behandlingskontrollTjeneste.erStegPassert(behandlingBerørt,
+            StartpunktType.UTTAKSVILKÅR.getBehandlingSteg())).thenReturn(false);
+        assertThat(flytkontroll.uttaksProsessenSkalVente(EGEN_BERØRT_ID)).isFalse();
+    }
+
+    @Test
+    public void berørtSkalVenteNårKobletHarBerørtIUttak() {
+        when(behandlingRevurderingRepository.finnFagsakPåMedforelder(fagsak)).thenReturn(Optional.of(fagsakAnnenPart));
+        when(behandlingRepository.hentÅpneYtelseBehandlingerForFagsakId(FAGSAK_AP_ID)).thenReturn(
+            List.of(behandlingBerørt));
+        when(behandlingskontrollTjeneste.erStegPassert(behandlingBerørt,
+            StartpunktType.UTTAKSVILKÅR.getBehandlingSteg())).thenReturn(true);
+        assertThat(flytkontroll.uttaksProsessenSkalVente(EGEN_BERØRT_ID)).isTrue();
+    }
+
+    @Test
+    public void berørtSkalVenteNårKobletHarBerørtPåVentVedSynk() {
+        when(behandlingRevurderingRepository.finnFagsakPåMedforelder(fagsak)).thenReturn(Optional.of(fagsakAnnenPart));
+        when(behandlingRepository.hentÅpneYtelseBehandlingerForFagsakId(FAGSAK_AP_ID)).thenReturn(
+            List.of(behandlingBerørt));
+        when(behandlingskontrollTjeneste.erStegPassert(behandlingBerørt,
+            StartpunktType.UTTAKSVILKÅR.getBehandlingSteg())).thenReturn(false);
+        when(behandlingBerørt.harÅpentAksjonspunktMedType(AksjonspunktDefinisjon.AUTO_KØET_BEHANDLING)).thenReturn(true);
+        when(behandlingBerørt.getAktivtBehandlingSteg()).thenReturn(StartpunktType.UTTAKSVILKÅR.getBehandlingSteg());
+        assertThat(flytkontroll.uttaksProsessenSkalVente(EGEN_BERØRT_ID)).isTrue();
+        verify(behandlingProsesseringTjeneste, times(1));
+    }
+
 
     @Test
     public void revurderingSkalVenteNårSammeSakHarBerørt() {


### PR DESCRIPTION
Et par tiltak for å unngå "vranglås" dersom begge parter søker ending samtidig og begge vedtakene gir berørt på annenpart ca samtidig- da kan begge de berørte bli satt på vent rett før uttakssteget
1. Køkontroller sørger for at berørte på vent blir kjørt før køet endringssøknad eller hendelse
2. Synkpunkt før uttak vil ikke sette berørte på vent med mindre annenpart har en berørt i uttak (eller i kø ved synkpunkt)

Får se tidlig 2023 om dette har hatt effekt. Vil antagelig også fikse noen særtilfelle med rar rekkefølge på berørt og endring.