### PR TITLE
TFP-5140 Fletter inn eksisterende tilrettelegginger ved ny svp søknad…

### DIFF
--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/tilrettelegging/SvpTilretteleggingEntitet.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/tilrettelegging/SvpTilretteleggingEntitet.java
@@ -184,6 +184,22 @@ public class SvpTilretteleggingEntitet extends BaseEntitet implements IndexKey {
             this(new SvpTilretteleggingEntitet());
         }
 
+        public static Builder fraEksisterende(SvpTilretteleggingEntitet tilrettelegging) {
+            return new Builder()
+                .medArbeidsgiver(tilrettelegging.getArbeidsgiver().orElse(null))
+                .medArbeidType(tilrettelegging.getArbeidType())
+                .medBehovForTilretteleggingFom(tilrettelegging.behovForTilretteleggingFom)
+                .medBegrunnelse(tilrettelegging.getBegrunnelse().orElse(null))
+                .medArbeidType(tilrettelegging.getArbeidType())
+                .medArbeidsgiver(tilrettelegging.getArbeidsgiver().orElse(null))
+                .medInternArbeidsforholdRef(tilrettelegging.getInternArbeidsforholdRef().orElse(null))
+                .medKopiertFraTidligereBehandling(true)
+                .medOpplysningerOmRisikofaktorer(tilrettelegging.getOpplysningerOmRisikofaktorer().orElse(null))
+                .medOpplysningerOmTilretteleggingstiltak(tilrettelegging.getOpplysningerOmTilretteleggingstiltak().orElse(null))
+                .medSkalBrukes(tilrettelegging.getSkalBrukes())
+                .medMottattTidspunkt(tilrettelegging.getMottattTidspunkt())
+                .medTilretteleggingFraDatoer(tilrettelegging.getTilretteleggingFOMListe());
+        }
         public Builder(SvpTilretteleggingEntitet tilretteleggingEntitet) {
             mal = new SvpTilretteleggingEntitet(tilretteleggingEntitet, null);
             if (mal.tilretteleggingFOMListe == null) {
@@ -196,31 +212,39 @@ public class SvpTilretteleggingEntitet extends BaseEntitet implements IndexKey {
             return this;
         }
 
-        public Builder medHelTilrettelegging(LocalDate helTilretteleggingFom) {
+        public Builder medHelTilrettelegging(LocalDate helTilretteleggingFom, LocalDate tidligstMottatt) {
             var tilretteleggingFOM = new TilretteleggingFOM.Builder()
                 .medTilretteleggingType(TilretteleggingType.HEL_TILRETTELEGGING)
                 .medFomDato(helTilretteleggingFom)
+                .medTidligstMottattDato(tidligstMottatt)
                 .build();
             mal.tilretteleggingFOMListe.add(tilretteleggingFOM);
             return this;
         }
 
-        public Builder medDelvisTilrettelegging(LocalDate delvisTilretteleggingFom, BigDecimal stillingsprosent) {
+        public Builder medDelvisTilrettelegging(LocalDate delvisTilretteleggingFom, BigDecimal stillingsprosent, LocalDate tidligstMottatt) {
             var tilretteleggingFOM = new TilretteleggingFOM.Builder()
                 .medTilretteleggingType(TilretteleggingType.DELVIS_TILRETTELEGGING)
                 .medFomDato(delvisTilretteleggingFom)
                 .medStillingsprosent(stillingsprosent)
+                .medTidligstMottattDato(tidligstMottatt)
                 .build();
             mal.tilretteleggingFOMListe.add(tilretteleggingFOM);
             return this;
         }
 
-        public Builder medIngenTilrettelegging(LocalDate slutteArbeidFom) {
+        public Builder medIngenTilrettelegging(LocalDate slutteArbeidFom, LocalDate tidligstMottatt) {
             var tilretteleggingFOM = new TilretteleggingFOM.Builder()
                 .medTilretteleggingType(TilretteleggingType.INGEN_TILRETTELEGGING)
                 .medFomDato(slutteArbeidFom)
+                .medTidligstMottattDato(tidligstMottatt)
                 .build();
             mal.tilretteleggingFOMListe.add(tilretteleggingFOM);
+            return this;
+        }
+
+        public Builder medTilretteleggingFraDatoer(List<TilretteleggingFOM> tilretteleggingFraDatoer) {
+            mal.tilretteleggingFOMListe = tilretteleggingFraDatoer;
             return this;
         }
 

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/tilrettelegging/TilretteleggingFOM.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/tilrettelegging/TilretteleggingFOM.java
@@ -36,6 +36,9 @@ public class TilretteleggingFOM extends BaseEntitet implements IndexKey {
     @Column(name = "OVERSTYRT_UTBETALINGSGRAD")
     private BigDecimal overstyrtUtbetalingsgrad;
 
+    @Column(name = "TIDLIGST_MOTATT_DATO")
+    private LocalDate tidligstMotattDato;
+
     public Long getId() {
         return id;
     }
@@ -56,6 +59,9 @@ public class TilretteleggingFOM extends BaseEntitet implements IndexKey {
         return overstyrtUtbetalingsgrad;
     }
 
+    public LocalDate getTidligstMotattDato() {
+        return tidligstMotattDato;
+    }
     @Override
     public String getIndexKey() {
         return IndexKey.createKey(id);
@@ -71,10 +77,20 @@ public class TilretteleggingFOM extends BaseEntitet implements IndexKey {
             mal.fomDato = tilretteleggingFOM.getFomDato();
             mal.stillingsprosent = tilretteleggingFOM.getStillingsprosent();
             mal.overstyrtUtbetalingsgrad = tilretteleggingFOM.getOverstyrtUtbetalingsgrad();
+            mal.tidligstMotattDato = tilretteleggingFOM.getTidligstMotattDato()
+            ;
         }
 
         public Builder() {
             mal = new TilretteleggingFOM();
+        }
+
+        public Builder fraEksisterende(TilretteleggingFOM tilretteleggingFOM) {
+            return new Builder().medFomDato(tilretteleggingFOM.getFomDato())
+                .medTilretteleggingType(tilretteleggingFOM.getType())
+                .medStillingsprosent(tilretteleggingFOM.getStillingsprosent())
+                .medOverstyrtUtbetalingsgrad(tilretteleggingFOM.getOverstyrtUtbetalingsgrad())
+                .medTidligstMottattDato(tilretteleggingFOM.getTidligstMotattDato());
         }
 
         public Builder medTilretteleggingType(TilretteleggingType type) {
@@ -94,6 +110,11 @@ public class TilretteleggingFOM extends BaseEntitet implements IndexKey {
 
         public Builder medOverstyrtUtbetalingsgrad(BigDecimal overstyrtUtbetalingsgrad) {
             mal.overstyrtUtbetalingsgrad = overstyrtUtbetalingsgrad;
+            return this;
+        }
+
+        public Builder medTidligstMottattDato(LocalDate tidligstMotattDato) {
+            mal.tidligstMotattDato = tidligstMotattDato;
             return this;
         }
 

--- a/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/avklarfakta/svp/KontrollerFaktaStegImplTest.java
+++ b/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/avklarfakta/svp/KontrollerFaktaStegImplTest.java
@@ -131,7 +131,7 @@ public class KontrollerFaktaStegImplTest {
     private void lagreSvp(Behandling behandling, LocalDate jordmorsdato) {
         var tilrettelegging = new SvpTilretteleggingEntitet.Builder()
                 .medBehovForTilretteleggingFom(jordmorsdato)
-                .medIngenTilrettelegging(jordmorsdato)
+                .medIngenTilrettelegging(jordmorsdato, jordmorsdato)
                 .medArbeidType(ArbeidType.ORDINÆRT_ARBEIDSFORHOLD)
                 .medArbeidsgiver(Arbeidsgiver.person(AktørId.dummy()))
                 .medMottattTidspunkt(LocalDateTime.now())

--- a/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/inngangsvilkår/opptjening/svp/FastsettOpptjeningsperiodeStegTest.java
+++ b/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/inngangsvilkår/opptjening/svp/FastsettOpptjeningsperiodeStegTest.java
@@ -295,7 +295,7 @@ public class FastsettOpptjeningsperiodeStegTest {
     private void lagreSvp(Behandling behandling, LocalDate jordmorsdato) {
         var tilrettelegging = new SvpTilretteleggingEntitet.Builder()
                 .medBehovForTilretteleggingFom(jordmorsdato)
-                .medIngenTilrettelegging(jordmorsdato)
+                .medIngenTilrettelegging(jordmorsdato, jordmorsdato)
                 .medArbeidType(ArbeidType.ORDINÆRT_ARBEIDSFORHOLD)
                 .medArbeidsgiver(Arbeidsgiver.person(AktørId.dummy()))
                 .medMottattTidspunkt(LocalDateTime.now())

--- a/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/uttak/svp/SvpHelper.java
+++ b/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/uttak/svp/SvpHelper.java
@@ -49,7 +49,7 @@ class SvpHelper {
     void lagreIngenTilrettelegging(Behandling behandling, LocalDate jordmorsdato) {
         var tilrettelegging = new SvpTilretteleggingEntitet.Builder()
                 .medBehovForTilretteleggingFom(jordmorsdato)
-                .medIngenTilrettelegging(jordmorsdato)
+                .medIngenTilrettelegging(jordmorsdato, jordmorsdato  )
                 .medArbeidType(ArbeidType.ORDINÆRT_ARBEIDSFORHOLD)
                 .medArbeidsgiver(Arbeidsgiver.person(AktørId.dummy()))
                 .medMottattTidspunkt(LocalDateTime.now())
@@ -65,7 +65,7 @@ class SvpHelper {
     void lagreDelvisTilrettelegging(Behandling behandling, LocalDate jordmorsdato, LocalDate tilretteleggingFom, BigDecimal arbeidsprosent) {
         var tilrettelegging = new SvpTilretteleggingEntitet.Builder()
             .medBehovForTilretteleggingFom(jordmorsdato)
-            .medDelvisTilrettelegging(tilretteleggingFom, arbeidsprosent)
+            .medDelvisTilrettelegging(tilretteleggingFom, arbeidsprosent, jordmorsdato)
             .medArbeidType(ArbeidType.ORDINÆRT_ARBEIDSFORHOLD)
             .medArbeidsgiver(Arbeidsgiver.person(AktørId.dummy()))
             .medMottattTidspunkt(LocalDateTime.now())

--- a/domenetjenester/arbeidsforhold/src/test/java/no/nav/foreldrepenger/domene/arbeidsforhold/svp/InntektsmeldingTjenesteTest.java
+++ b/domenetjenester/arbeidsforhold/src/test/java/no/nav/foreldrepenger/domene/arbeidsforhold/svp/InntektsmeldingTjenesteTest.java
@@ -144,7 +144,7 @@ public class InntektsmeldingTjenesteTest {
     private SvpGrunnlagEntitet byggSvpGrunnlag(Behandling behandling, String arbeidsgiverOrgnr) {
         var tilrettelegging = new SvpTilretteleggingEntitet.Builder()
                 .medBehovForTilretteleggingFom(LocalDate.now())
-                .medIngenTilrettelegging(LocalDate.now())
+                .medIngenTilrettelegging(LocalDate.now(), LocalDate.now())
                 .medArbeidType(ArbeidType.ORDINÆRT_ARBEIDSFORHOLD)
                 .medArbeidsgiver(Arbeidsgiver.virksomhet(arbeidsgiverOrgnr))
                 .medMottattTidspunkt(LocalDateTime.now())

--- a/domenetjenester/datavarehus/src/test/java/no/nav/foreldrepenger/datavarehus/xml/svp/VedtakXmlTest.java
+++ b/domenetjenester/datavarehus/src/test/java/no/nav/foreldrepenger/datavarehus/xml/svp/VedtakXmlTest.java
@@ -64,10 +64,10 @@ import no.nav.foreldrepenger.domene.entiteter.BGAndelArbeidsforhold;
 import no.nav.foreldrepenger.domene.entiteter.BeregningsgrunnlagAktivitetStatus;
 import no.nav.foreldrepenger.domene.entiteter.BeregningsgrunnlagEntitet;
 import no.nav.foreldrepenger.domene.entiteter.BeregningsgrunnlagPeriode;
-import no.nav.foreldrepenger.domene.modell.kodeverk.BeregningsgrunnlagPeriodeRegelType;
 import no.nav.foreldrepenger.domene.entiteter.BeregningsgrunnlagPrStatusOgAndel;
-import no.nav.foreldrepenger.domene.modell.kodeverk.PeriodeÅrsak;
 import no.nav.foreldrepenger.domene.entiteter.Sammenligningsgrunnlag;
+import no.nav.foreldrepenger.domene.modell.kodeverk.BeregningsgrunnlagPeriodeRegelType;
+import no.nav.foreldrepenger.domene.modell.kodeverk.PeriodeÅrsak;
 import no.nav.foreldrepenger.domene.person.PersoninfoAdapter;
 import no.nav.foreldrepenger.domene.personopplysning.PersonopplysningTjeneste;
 import no.nav.foreldrepenger.domene.typer.AktørId;
@@ -172,7 +172,7 @@ public class VedtakXmlTest {
         var jordmorsDato = LocalDate.of(2019, Month.APRIL, 1);
         var tilrettelegging = new SvpTilretteleggingEntitet.Builder()
                 .medBehovForTilretteleggingFom(jordmorsDato)
-                .medIngenTilrettelegging(jordmorsDato)
+                .medIngenTilrettelegging(jordmorsDato, jordmorsDato)
                 .medArbeidType(ArbeidType.ORDINÆRT_ARBEIDSFORHOLD)
                 .medArbeidsgiver(Arbeidsgiver.person(AktørId.dummy()))
                 .medKopiertFraTidligereBehandling(false)
@@ -270,7 +270,7 @@ public class VedtakXmlTest {
     private void lagreSvp(Behandling behandling, LocalDate jordmorsdato) {
         var tilrettelegging = new SvpTilretteleggingEntitet.Builder()
                 .medBehovForTilretteleggingFom(jordmorsdato)
-                .medIngenTilrettelegging(jordmorsdato)
+                .medIngenTilrettelegging(jordmorsdato, jordmorsdato)
                 .medArbeidType(ArbeidType.ORDINÆRT_ARBEIDSFORHOLD)
                 .medArbeidsgiver(Arbeidsgiver.person(AktørId.dummy()))
                 .medMottattTidspunkt(LocalDateTime.now())

--- a/domenetjenester/skjaeringstidspunkt/src/test/java/no/nav/foreldrepenger/skjæringstidspunkt/svp/SkjæringstidspunktTjenesteImplTest.java
+++ b/domenetjenester/skjaeringstidspunkt/src/test/java/no/nav/foreldrepenger/skjæringstidspunkt/svp/SkjæringstidspunktTjenesteImplTest.java
@@ -16,15 +16,15 @@ public class SkjæringstidspunktTjenesteImplTest {
 
     @Test
     public void skal_utlede_skjæringstidspunktet() {
-        var forventetResultat = LocalDate.of(2019, 7, 10);
+        var forventetSkjæringstidspunkt = LocalDate.of(2019, 7, 10);
 
         var svpGrunnlagEntitet = new SvpGrunnlagEntitet.Builder();
         var svp = new SvpTilretteleggingEntitet.Builder();
-        svp.medBehovForTilretteleggingFom(forventetResultat);
-        svp.medDelvisTilrettelegging(forventetResultat, BigDecimal.valueOf(50));
-        svp.medDelvisTilrettelegging(LocalDate.of(2019, 9, 17), BigDecimal.valueOf(30));
-        svp.medHelTilrettelegging(LocalDate.of(2019, 11, 1));
-        svp.medIngenTilrettelegging(LocalDate.of(2019, 11, 25));
+        svp.medBehovForTilretteleggingFom(forventetSkjæringstidspunkt);
+        svp.medDelvisTilrettelegging(forventetSkjæringstidspunkt, BigDecimal.valueOf(50), forventetSkjæringstidspunkt);
+        svp.medDelvisTilrettelegging(LocalDate.of(2019, 9, 17), BigDecimal.valueOf(30), forventetSkjæringstidspunkt);
+        svp.medHelTilrettelegging(LocalDate.of(2019, 11, 1), forventetSkjæringstidspunkt);
+        svp.medIngenTilrettelegging(LocalDate.of(2019, 11, 25), forventetSkjæringstidspunkt);
 
         var tilretteleggingEntitet = svp.build();
         svpGrunnlagEntitet.medOpprinneligeTilrettelegginger(List.of(tilretteleggingEntitet));
@@ -32,6 +32,6 @@ public class SkjæringstidspunktTjenesteImplTest {
 
         var dag = SkjæringstidspunktTjenesteImpl.utledBasertPåGrunnlag(svpGrunnlagEntitet.build());
 
-        assertThat(dag).isEqualTo(forventetResultat);
+        assertThat(dag).isEqualTo(forventetSkjæringstidspunkt);
     }
 }

--- a/domenetjenester/skjaeringstidspunkt/src/test/java/no/nav/foreldrepenger/skjæringstidspunkt/svp/SøknadsperiodeFristTjenesteImplTest.java
+++ b/domenetjenester/skjaeringstidspunkt/src/test/java/no/nav/foreldrepenger/skjæringstidspunkt/svp/SøknadsperiodeFristTjenesteImplTest.java
@@ -16,16 +16,16 @@ public class SøknadsperiodeFristTjenesteImplTest {
 
     @Test
     public void skal_utlede_skjæringstidspunktet() {
-        var forventetResultat = LocalDate.of(2019, 7, 10);
+        var forventetSkjæringstidspunkt = LocalDate.of(2019, 7, 10);
 
         var jordmorsDato = LocalDate.of(2019, Month.APRIL, 1);
 
         var svp = new SvpTilretteleggingEntitet.Builder()
-            .medBehovForTilretteleggingFom(forventetResultat)
-            .medDelvisTilrettelegging(forventetResultat, BigDecimal.valueOf(50))
-            .medDelvisTilrettelegging(LocalDate.of(2019, 9, 17), BigDecimal.valueOf(30))
-            .medHelTilrettelegging(LocalDate.of(2019, 11, 1))
-            .medIngenTilrettelegging(LocalDate.of(2019, 11, 25));
+            .medBehovForTilretteleggingFom(forventetSkjæringstidspunkt)
+            .medDelvisTilrettelegging(forventetSkjæringstidspunkt, BigDecimal.valueOf(50), forventetSkjæringstidspunkt)
+            .medDelvisTilrettelegging(LocalDate.of(2019, 9, 17), BigDecimal.valueOf(30), forventetSkjæringstidspunkt)
+            .medHelTilrettelegging(LocalDate.of(2019, 11, 1), forventetSkjæringstidspunkt)
+            .medIngenTilrettelegging(LocalDate.of(2019, 11, 25), forventetSkjæringstidspunkt);
 
         var svpGrunnlag = new SvpGrunnlagEntitet.Builder()
             .medOpprinneligeTilrettelegginger(List.of(svp.build()))
@@ -33,7 +33,7 @@ public class SøknadsperiodeFristTjenesteImplTest {
 
         var dag = SøknadsperiodeFristTjenesteImpl.utledNettoSøknadsperiodeFomFraGrunnlag(svpGrunnlag.build());
 
-        assertThat(dag).hasValueSatisfying(ldi -> assertThat(ldi).isEqualTo(forventetResultat));
+        assertThat(dag).hasValueSatisfying(ldi -> assertThat(ldi).isEqualTo(forventetSkjæringstidspunkt));
     }
 
 

--- a/domenetjenester/uttak/src/test/java/no/nav/foreldrepenger/domene/uttak/svp/GrunnlagOppretter.java
+++ b/domenetjenester/uttak/src/test/java/no/nav/foreldrepenger/domene/uttak/svp/GrunnlagOppretter.java
@@ -33,7 +33,7 @@ class GrunnlagOppretter {
         var jordmorsDato = LocalDate.of(2019, Month.APRIL, 1);
         var tilrettelegging = new SvpTilretteleggingEntitet.Builder()
             .medBehovForTilretteleggingFom(jordmorsDato)
-            .medIngenTilrettelegging(jordmorsDato)
+            .medIngenTilrettelegging(jordmorsDato, jordmorsDato)
             .medArbeidType(ArbeidType.ORDINÆRT_ARBEIDSFORHOLD)
             .medArbeidsgiver(Arbeidsgiver.person(AktørId.dummy()))
             .medKopiertFraTidligereBehandling(false)

--- a/migreringer/src/main/resources/db/migration/defaultDS/4.1/V4.1_07__TFP-5140_tilretteleggingFom.sql
+++ b/migreringer/src/main/resources/db/migration/defaultDS/4.1/V4.1_07__TFP-5140_tilretteleggingFom.sql
@@ -1,0 +1,3 @@
+ALTER TABLE TILRETTELEGGING_FOM ADD TIDLIGST_MOTATT_DATO DATE;
+COMMENT ON COLUMN TILRETTELEGGING_FOM.TIDLIGST_MOTATT_DATO IS 'Har verdi dersom fra dato er flettet inn fra eksisteredende grunnlag ved ny søknad'
+

--- a/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/svp/BekreftSvangerskapspengerOppdatererTest.java
+++ b/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/svp/BekreftSvangerskapspengerOppdatererTest.java
@@ -296,7 +296,7 @@ public class BekreftSvangerskapspengerOppdatererTest {
     private SvpGrunnlagEntitet byggSøknadsgrunnlag(Behandling behandling) {
         var tilrettelegging = new SvpTilretteleggingEntitet.Builder().medBehovForTilretteleggingFom(
             BEHOV_DATO)
-            .medIngenTilrettelegging(BEHOV_DATO)
+            .medIngenTilrettelegging(BEHOV_DATO, LocalDate.now())
             .medArbeidType(ArbeidType.ORDINÆRT_ARBEIDSFORHOLD)
             .medArbeidsgiver(Arbeidsgiver.person(AktørId.dummy()))
             .medMottattTidspunkt(LocalDateTime.now())


### PR DESCRIPTION
… hvis fra dato er før tidligste nye fra dato slik at saksbehandler slipper å manuelt legge de inn. Utvidet TILRETTELEGGING_FOM med tidligst mottatt dato for å håndtere søknadsfrist senere.