### PR TITLE
Utvider behandlingdto med vilkår og aksjonspunkt

### DIFF
--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/dto/behandling/BehandlingDto.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/dto/behandling/BehandlingDto.java
@@ -14,6 +14,7 @@ import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingStatus;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingType;
 import no.nav.foreldrepenger.behandlingslager.geografisk.Språkkode;
 import no.nav.foreldrepenger.web.app.rest.ResourceLink;
+import no.nav.foreldrepenger.web.app.tjenester.behandling.vilkår.VilkårDto;
 
 @JsonAutoDetect(getterVisibility = JsonAutoDetect.Visibility.NONE, setterVisibility = JsonAutoDetect.Visibility.NONE, fieldVisibility = JsonAutoDetect.Visibility.ANY)
 public class BehandlingDto {
@@ -75,6 +76,8 @@ public class BehandlingDto {
     private BehandlingsresultatDto behandlingsresultat;
     @JsonProperty("behandlingÅrsaker")
     private List<BehandlingÅrsakDto> behandlingÅrsaker;
+    @JsonProperty("vilkår")
+    private List<VilkårDto> vilkår;
 
     /**
      * REST HATEOAS - pekere på data innhold som hentes fra andre url'er, eller handlinger som er tilgjengelig på behandling.
@@ -138,6 +141,10 @@ public class BehandlingDto {
 
     public BehandlingÅrsakDto getFørsteÅrsak() {
         return førsteÅrsak;
+    }
+
+    public List<VilkårDto> getVilkår() {
+        return vilkår;
     }
 
     public boolean isErAktivPapirsoknad() {
@@ -320,5 +327,9 @@ public class BehandlingDto {
 
     void setToTrinnsBehandling(boolean toTrinnsBehandling) {
         this.toTrinnsBehandling = toTrinnsBehandling;
+    }
+
+    public void setVilkår(List<VilkårDto> vilkår) {
+        this.vilkår = vilkår;
     }
 }

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/dto/behandling/BehandlingDtoForBackendTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/dto/behandling/BehandlingDtoForBackendTjeneste.java
@@ -9,8 +9,6 @@ import javax.inject.Inject;
 
 import no.nav.foreldrepenger.behandlingslager.aktør.OrganisasjonsEnhet;
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
-import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingResultatType;
-import no.nav.foreldrepenger.behandlingslager.behandling.Behandlingsresultat;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingsresultatRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepositoryProvider;
@@ -67,8 +65,7 @@ public class BehandlingDtoForBackendTjeneste {
                                                   Optional<OrganisasjonsEnhet> endretEnhet) {
         var dto = new UtvidetBehandlingDto();
         var vedtaksDato = behandlingVedtak.map(BehandlingVedtak::getVedtaksdato).orElse(null);
-        var behandlingsresultat = behandlingsresultatRepository.hentHvisEksisterer(behandling.getId())
-            .map(Behandlingsresultat::getBehandlingResultatType).orElse(BehandlingResultatType.IKKE_FASTSATT);
+        var behandlingsresultat = behandlingsresultatRepository.hentHvisEksisterer(behandling.getId()).orElse(null);
         BehandlingDtoUtil.settStandardfelterUtvidet(behandling, behandlingsresultat, dto, erBehandlingGjeldendeVedtak(behandling), vedtaksDato);
         if (asyncStatus != null && !asyncStatus.isPending()) {
             dto.setAsyncStatus(asyncStatus);

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/dto/behandling/BehandlingDtoTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/dto/behandling/BehandlingDtoTjeneste.java
@@ -16,13 +16,13 @@ import no.nav.foreldrepenger.behandling.RelatertBehandlingTjeneste;
 import no.nav.foreldrepenger.behandling.revurdering.RevurderingTjeneste;
 import no.nav.foreldrepenger.behandlingskontroll.FagsakYtelseTypeRef;
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
-import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingResultatType;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingStatus;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingType;
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandlingsresultat;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingsresultatRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.Aksjonspunkt;
 import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.AksjonspunktDefinisjon;
+import no.nav.foreldrepenger.behandlingslager.behandling.beregning.LegacyESBeregningsresultat;
 import no.nav.foreldrepenger.behandlingslager.behandling.dokument.BehandlingDokumentRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepositoryProvider;
@@ -31,6 +31,9 @@ import no.nav.foreldrepenger.behandlingslager.behandling.søknad.SøknadReposito
 import no.nav.foreldrepenger.behandlingslager.behandling.tilbakekreving.TilbakekrevingRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.vedtak.BehandlingVedtak;
 import no.nav.foreldrepenger.behandlingslager.behandling.vedtak.BehandlingVedtakRepository;
+import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.AvklarteUttakDatoerEntitet;
+import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.YtelseFordelingAggregat;
+import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.YtelsesFordelingRepository;
 import no.nav.foreldrepenger.behandlingslager.fagsak.Fagsak;
 import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakRelasjon;
 import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakRelasjonRepository;
@@ -47,10 +50,12 @@ import no.nav.foreldrepenger.domene.typer.Saksnummer;
 import no.nav.foreldrepenger.domene.uttak.ForeldrepengerUttak;
 import no.nav.foreldrepenger.domene.uttak.ForeldrepengerUttakTjeneste;
 import no.nav.foreldrepenger.konfig.KonfigVerdi;
+import no.nav.foreldrepenger.produksjonsstyring.totrinn.TotrinnTjeneste;
 import no.nav.foreldrepenger.skjæringstidspunkt.SkjæringstidspunktTjeneste;
 import no.nav.foreldrepenger.web.app.rest.ResourceLink;
 import no.nav.foreldrepenger.web.app.tjenester.behandling.BehandlingRestTjeneste;
 import no.nav.foreldrepenger.web.app.tjenester.behandling.BehandlingRestTjenestePathHack1;
+import no.nav.foreldrepenger.web.app.tjenester.behandling.aksjonspunkt.AksjonspunktDtoMapper;
 import no.nav.foreldrepenger.web.app.tjenester.behandling.aksjonspunkt.AksjonspunktRestTjeneste;
 import no.nav.foreldrepenger.web.app.tjenester.behandling.aksjonspunkt.BekreftedeAksjonspunkterDto;
 import no.nav.foreldrepenger.web.app.tjenester.behandling.anke.AnkeRestTjeneste;
@@ -110,6 +115,8 @@ public class BehandlingDtoTjeneste {
     private RelatertBehandlingTjeneste relatertBehandlingTjeneste;
     private String fpoppdragOverrideProxyUrl;
     private KontrollerAktivitetskravDtoTjeneste kontrollerAktivitetskravDtoTjeneste;
+    private TotrinnTjeneste totrinnTjeneste;
+    private YtelsesFordelingRepository ytelsesFordelingRepository;
 
     @Inject
     public BehandlingDtoTjeneste(BehandlingRepositoryProvider repositoryProvider,
@@ -121,7 +128,8 @@ public class BehandlingDtoTjeneste {
                                  RelatertBehandlingTjeneste relatertBehandlingTjeneste,
                                  ForeldrepengerUttakTjeneste foreldrepengerUttakTjeneste,
                                  @KonfigVerdi(value = "fpoppdrag.override.proxy.url", required = false) String fpoppdragOverrideProxyUrl,
-                                 KontrollerAktivitetskravDtoTjeneste kontrollerAktivitetskravDtoTjeneste) {
+                                 KontrollerAktivitetskravDtoTjeneste kontrollerAktivitetskravDtoTjeneste,
+                                 TotrinnTjeneste totrinnTjeneste) {
 
         this.beregningTjeneste = beregningTjeneste;
         this.foreldrepengerUttakTjeneste = foreldrepengerUttakTjeneste;
@@ -138,6 +146,8 @@ public class BehandlingDtoTjeneste {
         this.relatertBehandlingTjeneste = relatertBehandlingTjeneste;
         this.fpoppdragOverrideProxyUrl = fpoppdragOverrideProxyUrl;
         this.kontrollerAktivitetskravDtoTjeneste = kontrollerAktivitetskravDtoTjeneste;
+        this.totrinnTjeneste = totrinnTjeneste;
+        this.ytelsesFordelingRepository = repositoryProvider.getYtelsesFordelingRepository();
     }
 
     BehandlingDtoTjeneste() {
@@ -161,9 +171,7 @@ public class BehandlingDtoTjeneste {
                                            BehandlingRepository behandlingRepository) {
         var dto = new BehandlingDto();
         var uuidDto = new UuidDto(behandling.getUuid());
-        var behandlingsresultat = Optional.ofNullable(getBehandlingsresultat(behandling.getId()))
-            .map(Behandlingsresultat::getBehandlingResultatType).orElse(BehandlingResultatType.IKKE_FASTSATT);
-        BehandlingDtoUtil.setStandardfelterMedGjeldendeVedtak(behandling, behandlingsresultat, dto, erBehandlingMedGjeldendeVedtak, vedtaksdato);
+        BehandlingDtoUtil.setStandardfelterMedGjeldendeVedtak(behandling, getBehandlingsresultat(behandling.getId()), dto, erBehandlingMedGjeldendeVedtak, vedtaksdato);
         dto.setSpråkkode(getSpråkkode(behandling, søknadRepository, behandlingRepository));
         dto.setBehandlingsresultat(behandlingsresultatDto.orElse(null));
 
@@ -233,9 +241,7 @@ public class BehandlingDtoTjeneste {
         var vedtaksDato = behandlingVedtakRepository.hentForBehandlingHvisEksisterer(behandling.getId())
             .map(BehandlingVedtak::getVedtaksdato)
             .orElse(null);
-        var behandlingsresultat = Optional.ofNullable(getBehandlingsresultat(behandling.getId()))
-            .map(Behandlingsresultat::getBehandlingResultatType).orElse(BehandlingResultatType.IKKE_FASTSATT);
-        BehandlingDtoUtil.settStandardfelterUtvidet(behandling, behandlingsresultat, dto, erBehandlingMedGjeldendeVedtak, vedtaksDato);
+        BehandlingDtoUtil.settStandardfelterUtvidet(behandling, getBehandlingsresultat(behandling.getId()), dto, erBehandlingMedGjeldendeVedtak, vedtaksDato);
         dto.setSpråkkode(getSpråkkode(behandling, søknadRepository, behandlingRepository));
         var behandlingsresultatDto = lagBehandlingsresultatDto(behandling);
         dto.setBehandlingsresultat(behandlingsresultatDto.orElse(null));
@@ -277,6 +283,7 @@ public class BehandlingDtoTjeneste {
 
         var uuidDto = new UuidDto(behandling.getUuid());
         dto.leggTil(get(AksjonspunktRestTjeneste.AKSJONSPUNKT_V2_PATH, "aksjonspunkter", uuidDto));
+        dto.setAksjonspunkter(AksjonspunktDtoMapper.lagAksjonspunktDto(behandling, totrinnTjeneste.hentTotrinnaksjonspunktvurderinger(behandling)));
         if (!dto.isErAktivPapirsoknad()) {
             dto.leggTil(get(VilkårRestTjeneste.VILKÅR_V2_PATH, "vilkar", uuidDto));
         }
@@ -328,6 +335,7 @@ public class BehandlingDtoTjeneste {
     private UtvidetBehandlingDto utvideBehandlingDto(Behandling behandling, UtvidetBehandlingDto dto) {
         var uuidDto = new UuidDto(behandling.getUuid());
         // mapping ved hjelp av tjenester
+        dto.setHarSøknad(søknadRepository.hentSøknadHvisEksisterer(behandling.getId()).isPresent());
         dto.leggTil(get(SøknadRestTjeneste.SOKNAD_PATH, "soknad", uuidDto));
         dto.leggTil(get(SøknadRestTjeneste.SOKNAD_BACKEND_PATH, "soknad-backend", uuidDto));
         dto.leggTil(get(DokumentRestTjeneste.MOTTATT_DOKUMENTER_PATH, "mottattdokument", uuidDto));
@@ -353,9 +361,16 @@ public class BehandlingDtoTjeneste {
             dto.leggTil(get(OpptjeningRestTjeneste.UTLAND_DOK_STATUS_PATH, "utland-dok-status", uuidDto));
         }
 
+        var harSimuleringAksjonspunkt = behandling.getAksjonspunktMedDefinisjonOptional(AksjonspunktDefinisjon.VURDER_FEILUTBETALING).isPresent();
         if (FagsakYtelseType.ENGANGSTØNAD.equals(behandling.getFagsakYtelseType())) {
+            var beregning =  Optional.ofNullable(getBehandlingsresultat(behandling.getId()))
+                .map(Behandlingsresultat::getBeregningResultat)
+                .flatMap(LegacyESBeregningsresultat::getSisteBeregning)
+                .isPresent();
+            dto.setSjekkSimuleringResultat(beregning || harSimuleringAksjonspunkt);
             dto.leggTil(get(BeregningsresultatRestTjeneste.ENGANGSTONAD_PATH, "beregningsresultat-engangsstonad", uuidDto));
         } else {
+            dto.setSjekkSimuleringResultat(behandlingsresultatRepository.hentHvisEksisterer(behandling.getId()).isPresent() || harSimuleringAksjonspunkt);
             dto.leggTil(get(YtelsefordelingRestTjeneste.YTELSESFORDELING_PATH, "ytelsefordeling", uuidDto));
             dto.leggTil(get(OpptjeningRestTjeneste.OPPTJENING_PATH, "opptjening", uuidDto));
             dto.leggTil(get(FeriepengegrunnlagRestTjeneste.FERIEPENGER_PATH, "feriepengegrunnlag", uuidDto));
@@ -393,6 +408,9 @@ public class BehandlingDtoTjeneste {
                     dto.leggTil(get(BeregningsresultatRestTjeneste.FORELDREPENGER_PATH, "beregningsresultat-foreldrepenger", uuidDto));
                 }
             } else {
+                var harSattEndringsdato = ytelsesFordelingRepository.hentAggregatHvisEksisterer(behandling.getId())
+                    .flatMap(YtelseFordelingAggregat::getAvklarteDatoer).map(AvklarteUttakDatoerEntitet::getGjeldendeEndringsdato).isPresent();
+                dto.setHarSattEndringsdato(harSattEndringsdato);
                 dto.leggTil(get(UttakRestTjeneste.SAMMENHENGENDE_UTTAK_PATH, "krever-sammenhengende-uttak", uuidDto));
                 dto.leggTil(get(UttakRestTjeneste.UTEN_MINSTERETT_PATH, "uten-minsterett", uuidDto));
                 if (!kontrollerAktivitetskravDtoTjeneste.lagDtos(uuidDto).isEmpty()) {
@@ -487,11 +505,7 @@ public class BehandlingDtoTjeneste {
         if (!behandling.erYtelseBehandling() || behandlingsresultat.isBehandlingHenlagt()) {
             return Optional.empty();
         }
-        var skjæringstidspunktHvisUtledet = skjæringstidspunktTjeneste.getSkjæringstidspunkter(behandling.getId()).getSkjæringstidspunktHvisUtledet();
-        if (skjæringstidspunktHvisUtledet.isEmpty()) {
-            return Optional.empty();
-        }
-        return Optional.of(new SkjæringstidspunktDto(skjæringstidspunktHvisUtledet.get()));
+        return SkjæringstidspunktDto.fraSkjæringstidspunkt(skjæringstidspunktTjeneste.getSkjæringstidspunkter(behandling.getId()));
     }
 
     private Optional<ResourceLink> lagSimuleringResultatLink(Behandling behandling) {

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/dto/behandling/BehandlingDtoTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/dto/behandling/BehandlingDtoTjeneste.java
@@ -283,7 +283,7 @@ public class BehandlingDtoTjeneste {
 
         var uuidDto = new UuidDto(behandling.getUuid());
         dto.leggTil(get(AksjonspunktRestTjeneste.AKSJONSPUNKT_V2_PATH, "aksjonspunkter", uuidDto));
-        dto.setAksjonspunkter(AksjonspunktDtoMapper.lagAksjonspunktDto(behandling, totrinnTjeneste.hentTotrinnaksjonspunktvurderinger(behandling)));
+        dto.setAksjonspunktene(AksjonspunktDtoMapper.lagAksjonspunktDto(behandling, totrinnTjeneste.hentTotrinnaksjonspunktvurderinger(behandling)));
         if (!dto.isErAktivPapirsoknad()) {
             dto.leggTil(get(VilkårRestTjeneste.VILKÅR_V2_PATH, "vilkar", uuidDto));
         }

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/dto/behandling/BehandlingDtoTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/dto/behandling/BehandlingDtoTjeneste.java
@@ -335,6 +335,7 @@ public class BehandlingDtoTjeneste {
     private UtvidetBehandlingDto utvideBehandlingDto(Behandling behandling, UtvidetBehandlingDto dto) {
         var uuidDto = new UuidDto(behandling.getUuid());
         // mapping ved hjelp av tjenester
+        dto.setHarRegisterdata(behandlingRepository.hentSistOppdatertTidspunkt(behandling.getId()).isPresent());
         dto.setHarSøknad(søknadRepository.hentSøknadHvisEksisterer(behandling.getId()).isPresent());
         dto.leggTil(get(SøknadRestTjeneste.SOKNAD_PATH, "soknad", uuidDto));
         dto.leggTil(get(SøknadRestTjeneste.SOKNAD_BACKEND_PATH, "soknad-backend", uuidDto));

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/dto/behandling/BehandlingFormidlingDto.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/dto/behandling/BehandlingFormidlingDto.java
@@ -1,10 +1,11 @@
 package no.nav.foreldrepenger.web.app.tjenester.behandling.dto.behandling;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-import no.nav.foreldrepenger.web.app.rest.ResourceLink;
-
 import java.util.ArrayList;
 import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import no.nav.foreldrepenger.web.app.rest.ResourceLink;
 
 /**
  * Dataobjekt som skal brukes som respons ut mot fp-formidling.
@@ -21,6 +22,9 @@ public class BehandlingFormidlingDto extends BehandlingDto {
     @JsonProperty("formidlingRessurser")
     private List<ResourceLink> formidlingRessurser = new ArrayList<>();
 
+    @JsonProperty("harAvklartAnnenForelderRett")
+    private Boolean harAvklartAnnenForelderRett;
+
     public List<ResourceLink> getFormidlingRessurser() {
         return formidlingRessurser;
     }
@@ -31,5 +35,13 @@ public class BehandlingFormidlingDto extends BehandlingDto {
 
     public void setFormidlingRessurser(List<ResourceLink> formidlingRessurser) {
         this.formidlingRessurser = formidlingRessurser;
+    }
+
+    public Boolean getHarAvklartAnnenForelderRett() {
+        return harAvklartAnnenForelderRett;
+    }
+
+    public void setHarAvklartAnnenForelderRett(Boolean harAvklartAnnenForelderRett) {
+        this.harAvklartAnnenForelderRett = harAvklartAnnenForelderRett;
     }
 }

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/dto/behandling/FagsakBehandlingDtoTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/dto/behandling/FagsakBehandlingDtoTjeneste.java
@@ -16,7 +16,6 @@ import no.nav.foreldrepenger.behandling.BehandlingReferanse;
 import no.nav.foreldrepenger.behandling.revurdering.RevurderingTjeneste;
 import no.nav.foreldrepenger.behandlingskontroll.FagsakYtelseTypeRef;
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
-import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingResultatType;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingStatus;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingType;
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandlingsresultat;
@@ -121,9 +120,7 @@ public class FagsakBehandlingDtoTjeneste {
                                            BehandlingRepository behandlingRepository) {
         var dto = new FagsakBehandlingDto();
         var uuidDto = new UuidDto(behandling.getUuid());
-        var behandlingsresultat = Optional.ofNullable(getBehandlingsresultat(behandling.getId()))
-            .map(Behandlingsresultat::getBehandlingResultatType).orElse(BehandlingResultatType.IKKE_FASTSATT);
-        BehandlingDtoUtil.setStandardfelterMedGjeldendeVedtak(behandling, behandlingsresultat, dto, erBehandlingMedGjeldendeVedtak, vedtaksdato);
+        BehandlingDtoUtil.setStandardfelterMedGjeldendeVedtak(behandling, getBehandlingsresultat(behandling.getId()), dto, erBehandlingMedGjeldendeVedtak, vedtaksdato);
         dto.setSpråkkode(getSpråkkode(behandling, søknadRepository, behandlingRepository));
         dto.setBehandlingsresultat(behandlingsresultatDto.orElse(null));
 
@@ -215,11 +212,7 @@ public class FagsakBehandlingDtoTjeneste {
         if (!behandling.erYtelseBehandling() || behandlingsresultat.isBehandlingHenlagt()) {
             return Optional.empty();
         }
-        var skjæringstidspunktHvisUtledet = skjæringstidspunktTjeneste.getSkjæringstidspunkter(behandling.getId()).getSkjæringstidspunktHvisUtledet();
-        if (skjæringstidspunktHvisUtledet.isEmpty()) {
-            return Optional.empty();
-        }
-        return Optional.of(new SkjæringstidspunktDto(skjæringstidspunktHvisUtledet.get()));
+        return SkjæringstidspunktDto.fraSkjæringstidspunkt(skjæringstidspunktTjeneste.getSkjæringstidspunkter(behandling.getId()));
     }
 
     private Behandlingsresultat getBehandlingsresultat(Long behandlingId) {

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/dto/behandling/SkjæringstidspunktDto.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/dto/behandling/SkjæringstidspunktDto.java
@@ -1,21 +1,17 @@
 package no.nav.foreldrepenger.web.app.tjenester.behandling.dto.behandling;
 
 import java.time.LocalDate;
+import java.util.Optional;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
-import com.fasterxml.jackson.annotation.JsonProperty;
+
+import no.nav.foreldrepenger.behandling.Skjæringstidspunkt;
 
 @JsonAutoDetect(getterVisibility = JsonAutoDetect.Visibility.NONE, setterVisibility = JsonAutoDetect.Visibility.NONE, fieldVisibility = JsonAutoDetect.Visibility.ANY)
-public class SkjæringstidspunktDto {
+public record SkjæringstidspunktDto(LocalDate dato, boolean kreverSammenhengendeUttak, boolean utenMinsterett) {
 
-    @JsonProperty("dato")
-    private final LocalDate dato;
-
-    public SkjæringstidspunktDto(LocalDate dato) {
-        this.dato = dato;
-    }
-
-    public LocalDate getDato() {
-        return dato;
+    public static Optional<SkjæringstidspunktDto> fraSkjæringstidspunkt(Skjæringstidspunkt skjæringstidspunkt) {
+        var dato = Optional.ofNullable(skjæringstidspunkt).flatMap(Skjæringstidspunkt::getSkjæringstidspunktHvisUtledet);
+        return dato.map(d -> new SkjæringstidspunktDto(d, skjæringstidspunkt.kreverSammenhengendeUttak(), skjæringstidspunkt.utenMinsterett()));
     }
 }

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/dto/behandling/UtvidetBehandlingDto.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/dto/behandling/UtvidetBehandlingDto.java
@@ -21,6 +21,9 @@ public class UtvidetBehandlingDto extends BehandlingDto {
     @JsonProperty("harSøknad")
     private boolean harSøknad;
 
+    @JsonProperty("harRegisterdata")
+    private boolean harRegisterdata;
+
     @JsonProperty("harSattEndringsdato")
     private boolean harSattEndringsdato;
 
@@ -47,6 +50,10 @@ public class UtvidetBehandlingDto extends BehandlingDto {
         return harSøknad;
     }
 
+    public boolean getHarRegisterdata() {
+        return harRegisterdata;
+    }
+
     public boolean getHarSattEndringsdato() {
         return harSattEndringsdato;
     }
@@ -69,6 +76,10 @@ public class UtvidetBehandlingDto extends BehandlingDto {
 
     public void setHarSøknad(boolean harSøknad) {
         this.harSøknad = harSøknad;
+    }
+
+    public void setHarRegisterdata(boolean harRegisterdata) {
+        this.harRegisterdata = harRegisterdata;
     }
 
     public void setHarSattEndringsdato(boolean harSattEndringsdato) {

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/dto/behandling/UtvidetBehandlingDto.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/dto/behandling/UtvidetBehandlingDto.java
@@ -15,8 +15,8 @@ public class UtvidetBehandlingDto extends BehandlingDto {
     @JsonProperty("ansvarligBeslutter")
     private String ansvarligBeslutter;
 
-    @JsonProperty("aksjonspunkter")
-    private Set<AksjonspunktDto> aksjonspunkter;
+    @JsonProperty("aksjonspunktene")
+    private Set<AksjonspunktDto> aksjonspunktene;
 
     @JsonProperty("harSøknad")
     private boolean harSøknad;
@@ -42,8 +42,8 @@ public class UtvidetBehandlingDto extends BehandlingDto {
         return taskStatus;
     }
 
-    public Set<AksjonspunktDto> getAksjonspunkter() {
-        return aksjonspunkter;
+    public Set<AksjonspunktDto> getAksjonspunktene() {
+        return aksjonspunktene;
     }
 
     public boolean getHarSøknad() {
@@ -70,8 +70,8 @@ public class UtvidetBehandlingDto extends BehandlingDto {
         this.taskStatus = asyncStatus;
     }
 
-    public void setAksjonspunkter(Set<AksjonspunktDto> aksjonspunkter) {
-        this.aksjonspunkter = aksjonspunkter;
+    public void setAksjonspunktene(Set<AksjonspunktDto> aksjonspunktene) {
+        this.aksjonspunktene = aksjonspunktene;
     }
 
     public void setHarSøknad(boolean harSøknad) {

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/dto/behandling/UtvidetBehandlingDto.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/dto/behandling/UtvidetBehandlingDto.java
@@ -1,9 +1,12 @@
 package no.nav.foreldrepenger.web.app.tjenester.behandling.dto.behandling;
 
+import java.util.Set;
+
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import no.nav.foreldrepenger.web.app.tjenester.behandling.aksjonspunkt.AksjonspunktDto;
 import no.nav.foreldrepenger.web.app.tjenester.behandling.dto.AsyncPollingStatus;
 
 @JsonAutoDetect(getterVisibility = Visibility.NONE, setterVisibility = Visibility.NONE, fieldVisibility = Visibility.ANY)
@@ -11,6 +14,18 @@ public class UtvidetBehandlingDto extends BehandlingDto {
 
     @JsonProperty("ansvarligBeslutter")
     private String ansvarligBeslutter;
+
+    @JsonProperty("aksjonspunkter")
+    private Set<AksjonspunktDto> aksjonspunkter;
+
+    @JsonProperty("harSøknad")
+    private boolean harSøknad;
+
+    @JsonProperty("harSattEndringsdato")
+    private boolean harSattEndringsdato;
+
+    @JsonProperty("sjekkSimuleringResultat")
+    private boolean sjekkSimuleringResultat;
 
     /** Eventuelt async status på tasks. */
     @JsonProperty("taskStatus")
@@ -24,11 +39,43 @@ public class UtvidetBehandlingDto extends BehandlingDto {
         return taskStatus;
     }
 
+    public Set<AksjonspunktDto> getAksjonspunkter() {
+        return aksjonspunkter;
+    }
+
+    public boolean getHarSøknad() {
+        return harSøknad;
+    }
+
+    public boolean getHarSattEndringsdato() {
+        return harSattEndringsdato;
+    }
+
+    public boolean getSjekkSimuleringResultat() {
+        return sjekkSimuleringResultat;
+    }
+
     public void setAnsvarligBeslutter(String ansvarligBeslutter) {
         this.ansvarligBeslutter = ansvarligBeslutter;
     }
 
     public void setAsyncStatus(AsyncPollingStatus asyncStatus) {
         this.taskStatus = asyncStatus;
+    }
+
+    public void setAksjonspunkter(Set<AksjonspunktDto> aksjonspunkter) {
+        this.aksjonspunkter = aksjonspunkter;
+    }
+
+    public void setHarSøknad(boolean harSøknad) {
+        this.harSøknad = harSøknad;
+    }
+
+    public void setHarSattEndringsdato(boolean harSattEndringsdato) {
+        this.harSattEndringsdato = harSattEndringsdato;
+    }
+
+    public void setSjekkSimuleringResultat(boolean sjekkSimuleringResultat) {
+        this.sjekkSimuleringResultat = sjekkSimuleringResultat;
     }
 }

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/vilkår/VilkårDtoMapper.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/vilkår/VilkårDtoMapper.java
@@ -12,13 +12,13 @@ import no.nav.foreldrepenger.behandlingslager.behandling.vilkår.VilkårResultat
 import no.nav.foreldrepenger.behandlingslager.hendelser.StartpunktType;
 
 
-class VilkårDtoMapper {
+public final class VilkårDtoMapper {
 
     private VilkårDtoMapper() {
         // SONAR - Utility classes should not have public constructors
     }
 
-    static List<VilkårDto> lagVilkarDto(Behandling behandling, Behandlingsresultat behandlingsresultat) {
+    public static List<VilkårDto> lagVilkarDto(Behandling behandling, Behandlingsresultat behandlingsresultat) {
         return Optional.ofNullable(behandlingsresultat)
             .map(Behandlingsresultat::getVilkårResultat)
             .map(VilkårResultat::getVilkårene).orElse(List.of()).stream()

--- a/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/BehandlingDtoTjenesteTest.java
+++ b/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/BehandlingDtoTjenesteTest.java
@@ -1,6 +1,7 @@
 package no.nav.foreldrepenger.web.app.tjenester.behandling;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 
 import java.lang.reflect.InvocationTargetException;
 import java.net.URI;
@@ -42,6 +43,7 @@ import no.nav.foreldrepenger.domene.opptjening.aksjonspunkt.OpptjeningIUtlandDok
 import no.nav.foreldrepenger.domene.prosess.BeregningTjeneste;
 import no.nav.foreldrepenger.domene.uttak.ForeldrepengerUttakTjeneste;
 import no.nav.foreldrepenger.konfig.Environment;
+import no.nav.foreldrepenger.produksjonsstyring.totrinn.TotrinnTjeneste;
 import no.nav.foreldrepenger.skjæringstidspunkt.SkjæringstidspunktTjeneste;
 import no.nav.foreldrepenger.web.app.ApplicationConfig;
 import no.nav.foreldrepenger.web.app.rest.ResourceLink;
@@ -92,7 +94,7 @@ public class BehandlingDtoTjenesteTest {
     public void setUp() {
         tjeneste = new BehandlingDtoTjeneste(repositoryProvider, beregningTjeneste, tilbakekrevingRepository, skjæringstidspunktTjeneste,
                 opptjeningIUtlandDokStatusTjeneste, behandlingDokumentRepository, relatertBehandlingTjeneste, foreldrepengerUttakTjeneste, null,
-                kontrollerAktivitetskravDtoTjeneste);
+                kontrollerAktivitetskravDtoTjeneste, mock(TotrinnTjeneste.class));
     }
 
     @Test

--- a/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/BehandlingRestTjenesteESTest.java
+++ b/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/BehandlingRestTjenesteESTest.java
@@ -32,6 +32,7 @@ import no.nav.foreldrepenger.domene.opptjening.aksjonspunkt.OpptjeningIUtlandDok
 import no.nav.foreldrepenger.domene.prosess.BeregningTjeneste;
 import no.nav.foreldrepenger.domene.typer.AktørId;
 import no.nav.foreldrepenger.domene.uttak.ForeldrepengerUttakTjeneste;
+import no.nav.foreldrepenger.produksjonsstyring.totrinn.TotrinnTjeneste;
 import no.nav.foreldrepenger.skjæringstidspunkt.es.RegisterInnhentingIntervall;
 import no.nav.foreldrepenger.skjæringstidspunkt.es.SkjæringstidspunktTjenesteImpl;
 import no.nav.foreldrepenger.web.app.tjenester.behandling.aksjonspunkt.BehandlingsoppretterTjeneste;
@@ -78,7 +79,7 @@ public class BehandlingRestTjenesteESTest {
         var behandlingDtoTjeneste = new BehandlingDtoTjeneste(repositoryProvider, beregningTjeneste,
             tilbakekrevingRepository, skjæringstidspunktTjeneste, opptjeningIUtlandDokStatusTjeneste,
             behandlingDokumentRepository, relatertBehandlingTjeneste,
-            new ForeldrepengerUttakTjeneste(repositoryProvider.getFpUttakRepository()), null, null);
+            new ForeldrepengerUttakTjeneste(repositoryProvider.getFpUttakRepository()), null, null, mock(TotrinnTjeneste.class));
 
         henleggBehandlingTjeneste = mock(HenleggBehandlingTjeneste.class);
         behandlingRestTjeneste = new BehandlingRestTjeneste(behandlingsutredningTjeneste, behandlingsoppretterTjeneste,

--- a/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/BehandlingÅrsakDtoTest.java
+++ b/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/BehandlingÅrsakDtoTest.java
@@ -28,6 +28,7 @@ import no.nav.foreldrepenger.domene.prosess.BeregningTjeneste;
 import no.nav.foreldrepenger.domene.prosess.HentOgLagreBeregningsgrunnlagTjeneste;
 import no.nav.foreldrepenger.domene.uttak.ForeldrepengerUttakTjeneste;
 import no.nav.foreldrepenger.domene.ytelsefordeling.YtelseFordelingTjeneste;
+import no.nav.foreldrepenger.produksjonsstyring.totrinn.TotrinnTjeneste;
 import no.nav.foreldrepenger.skjæringstidspunkt.fp.SkjæringstidspunktTjenesteImpl;
 import no.nav.foreldrepenger.skjæringstidspunkt.fp.SkjæringstidspunktUtils;
 import no.nav.foreldrepenger.skjæringstidspunkt.overganger.MinsterettBehandling2022;
@@ -65,7 +66,7 @@ public class BehandlingÅrsakDtoTest extends EntityManagerAwareTest {
             behandlingDokumentRepository, relatertBehandlingTjeneste,
             foreldrepengerUttakTjeneste, null,
             new KontrollerAktivitetskravDtoTjeneste(repositoryProvider.getBehandlingRepository(),
-                ytelseFordelingTjeneste, uttakInputTjeneste, foreldrepengerUttakTjeneste));
+                ytelseFordelingTjeneste, uttakInputTjeneste, foreldrepengerUttakTjeneste), mock(TotrinnTjeneste.class));
     }
 
     @Test


### PR DESCRIPTION
Legger til vilkår i BehandlingDto og diverse i utvidetBehandlingDto
* private Set<AksjonspunktDto> aksjonspunkter;
* private boolean harSøknad;
* private boolean harSattEndringsdato;
* private boolean sjekkSimuleringResultat; - indikerer om man bør sjekke lenken til oppdrag (det finnes beregning)

Lenkene "krever-sammenhengende-uttak" og "uten-minsterett" finnes nå under behandlingsresultat . skjæringstidspunkt