### PR TITLE
Gjort en rekke lenker betinget

### DIFF
--- a/behandlingsprosess/src/main/java/no/nav/foreldrepenger/behandling/steg/varselrevurdering/es/VarselRevurderingStegImpl.java
+++ b/behandlingsprosess/src/main/java/no/nav/foreldrepenger/behandling/steg/varselrevurdering/es/VarselRevurderingStegImpl.java
@@ -78,6 +78,6 @@ public class VarselRevurderingStegImpl implements VarselRevurderingSteg {
     }
 
     private boolean harUtførtVentRevurdering(Behandling behandling) {
-        return behandling.getAksjonspunktMedDefinisjonOptional(AUTO_SATT_PÅ_VENT_REVURDERING).map(Aksjonspunkt::erUtført).orElse(Boolean.FALSE);
+        return behandling.getAksjonspunktMedDefinisjonOptional(AUTO_SATT_PÅ_VENT_REVURDERING).filter(Aksjonspunkt::erUtført).isPresent();
     }
 }

--- a/behandlingsprosess/src/main/java/no/nav/foreldrepenger/behandling/steg/varselrevurdering/fp/VarselRevurderingStegImpl.java
+++ b/behandlingsprosess/src/main/java/no/nav/foreldrepenger/behandling/steg/varselrevurdering/fp/VarselRevurderingStegImpl.java
@@ -79,6 +79,6 @@ public class VarselRevurderingStegImpl implements VarselRevurderingSteg {
     }
 
     private boolean harUtførtVentRevurdering(Behandling behandling) {
-        return behandling.getAksjonspunktMedDefinisjonOptional(AUTO_SATT_PÅ_VENT_REVURDERING).map(Aksjonspunkt::erUtført).orElse(Boolean.FALSE);
+        return behandling.getAksjonspunktMedDefinisjonOptional(AUTO_SATT_PÅ_VENT_REVURDERING).filter(Aksjonspunkt::erUtført).isPresent();
     }
 }

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/dto/behandling/UtvidetBehandlingDto.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/dto/behandling/UtvidetBehandlingDto.java
@@ -30,6 +30,10 @@ public class UtvidetBehandlingDto extends BehandlingDto {
     @JsonProperty("harSattEndringsdato")
     private boolean harSattEndringsdato;
 
+    @JsonProperty("alleUttaksperioderAvslått")
+    private boolean alleUttaksperioderAvslått;
+
+    @Deprecated(forRemoval = true) // Sjekk heller om lenken "simuleringResultat" er inkludert i dto
     @JsonProperty("sjekkSimuleringResultat")
     private boolean sjekkSimuleringResultat;
 
@@ -65,6 +69,10 @@ public class UtvidetBehandlingDto extends BehandlingDto {
         return harSattEndringsdato;
     }
 
+    public boolean getAlleUttaksperioderAvslått() {
+        return alleUttaksperioderAvslått;
+    }
+
     public boolean getSjekkSimuleringResultat() {
         return sjekkSimuleringResultat;
     }
@@ -95,6 +103,10 @@ public class UtvidetBehandlingDto extends BehandlingDto {
 
     public void setHarSattEndringsdato(boolean harSattEndringsdato) {
         this.harSattEndringsdato = harSattEndringsdato;
+    }
+
+    public void setAlleUttaksperioderAvslått(boolean alleUttaksperioderAvslått) {
+        this.alleUttaksperioderAvslått = alleUttaksperioderAvslått;
     }
 
     public void setSjekkSimuleringResultat(boolean sjekkSimuleringResultat) {

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/medlem/MedlemDtoTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/medlem/MedlemDtoTjeneste.java
@@ -101,7 +101,7 @@ public class MedlemDtoTjeneste {
             dto.setOpphold(mapOppholdstillatelser(behandlingId));
             dto.setFom(mapMedlemV2Fom(behandling, ref, personopplysningerAggregat, medlemskapOpt).orElse(null));
 
-            if (behandling.getAksjonspunktMedDefinisjonOptional(AksjonspunktDefinisjon.AVKLAR_FORTSATT_MEDLEMSKAP).isPresent()) {
+            if (behandling.harAksjonspunktMedType(AksjonspunktDefinisjon.AVKLAR_FORTSATT_MEDLEMSKAP)) {
                 mapAndrePerioder(dto, medlemskapOpt.flatMap(MedlemskapAggregat::getVurderingLøpendeMedlemskap)
                     .map(VurdertMedlemskapPeriodeEntitet::getPerioder).orElse(Collections.emptySet()), ref);
             }

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/uttak/overstyring/FaktaUttakSaksbehandlerOverstyringshåndterer.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/uttak/overstyring/FaktaUttakSaksbehandlerOverstyringshåndterer.java
@@ -59,7 +59,7 @@ public class FaktaUttakSaksbehandlerOverstyringshåndterer extends AbstractOvers
     }
 
     private boolean aksjonspunktFinnesFraFør(Behandling behandling) {
-        return behandling.getAksjonspunktMedDefinisjonOptional(AksjonspunktDefinisjon.AVKLAR_FAKTA_UTTAK_SAKSBEHANDLER_OVERSTYRING).isPresent();
+        return behandling.harAksjonspunktMedType(AksjonspunktDefinisjon.AVKLAR_FAKTA_UTTAK_SAKSBEHANDLER_OVERSTYRING);
     }
 
     private boolean kanIkkeFinnesAksjonspunktFaktaUttak(Behandling behandling) {

--- a/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/BehandlingDtoTjenesteTest.java
+++ b/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/BehandlingDtoTjenesteTest.java
@@ -94,16 +94,6 @@ public class BehandlingDtoTjenesteTest {
     }
 
     @Test
-    public void skal_ha_med_simuleringsresultatURL() {
-        var behandling = lagBehandling();
-
-        var dto = tjeneste.lagUtvidetBehandlingDto(behandling, null);
-
-        assertThat(getLinkRel(dto)).contains("simuleringResultat");
-        assertThat(getLinkHref(dto)).contains(URI.create("/fpoppdrag/api/simulering/resultat-uten-inntrekk"));
-    }
-
-    @Test
     public void skal_ha_med_tilbakekrevings_link_når_det_finnes_et_resultat() {
         var behandling = lagBehandling();
 

--- a/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/BehandlingDtoTjenesteTest.java
+++ b/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/BehandlingDtoTjenesteTest.java
@@ -23,7 +23,6 @@ import javax.ws.rs.Path;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import no.nav.foreldrepenger.behandling.RelatertBehandlingTjeneste;
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingType;
 import no.nav.foreldrepenger.behandlingslager.behandling.dokument.BehandlingDokumentRepository;
@@ -78,9 +77,6 @@ public class BehandlingDtoTjenesteTest {
     private BehandlingDokumentRepository behandlingDokumentRepository;
 
     @Inject
-    private RelatertBehandlingTjeneste relatertBehandlingTjeneste;
-
-    @Inject
     private ForeldrepengerUttakTjeneste foreldrepengerUttakTjeneste;
 
     @Inject
@@ -93,7 +89,7 @@ public class BehandlingDtoTjenesteTest {
     @BeforeEach
     public void setUp() {
         tjeneste = new BehandlingDtoTjeneste(repositoryProvider, beregningTjeneste, tilbakekrevingRepository, skjæringstidspunktTjeneste,
-                opptjeningIUtlandDokStatusTjeneste, behandlingDokumentRepository, relatertBehandlingTjeneste, foreldrepengerUttakTjeneste, null,
+                opptjeningIUtlandDokStatusTjeneste, behandlingDokumentRepository, foreldrepengerUttakTjeneste, null,
                 kontrollerAktivitetskravDtoTjeneste, mock(TotrinnTjeneste.class));
     }
 

--- a/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/BehandlingRestTjenesteESTest.java
+++ b/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/BehandlingRestTjenesteESTest.java
@@ -17,7 +17,6 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import no.nav.foreldrepenger.behandling.FagsakTjeneste;
-import no.nav.foreldrepenger.behandling.RelatertBehandlingTjeneste;
 import no.nav.foreldrepenger.behandling.steg.iverksettevedtak.HenleggBehandlingTjeneste;
 import no.nav.foreldrepenger.behandlingslager.aktør.NavBrukerKjønn;
 import no.nav.foreldrepenger.behandlingslager.behandling.dokument.BehandlingDokumentRepository;
@@ -73,12 +72,10 @@ public class BehandlingRestTjenesteESTest {
         repositoryProvider = new BehandlingRepositoryProvider(entityManager);
         var fagsakTjeneste = new FagsakTjeneste(repositoryProvider.getFagsakRepository(),
             repositoryProvider.getSøknadRepository(), null);
-        var relatertBehandlingTjeneste = new RelatertBehandlingTjeneste(repositoryProvider);
         var skjæringstidspunktTjeneste = new SkjæringstidspunktTjenesteImpl(repositoryProvider,
             new RegisterInnhentingIntervall(Period.of(1, 0, 0), Period.of(0, 6, 0)));
         var behandlingDtoTjeneste = new BehandlingDtoTjeneste(repositoryProvider, beregningTjeneste,
-            tilbakekrevingRepository, skjæringstidspunktTjeneste, opptjeningIUtlandDokStatusTjeneste,
-            behandlingDokumentRepository, relatertBehandlingTjeneste,
+            tilbakekrevingRepository, skjæringstidspunktTjeneste, opptjeningIUtlandDokStatusTjeneste, behandlingDokumentRepository,
             new ForeldrepengerUttakTjeneste(repositoryProvider.getFpUttakRepository()), null, null, mock(TotrinnTjeneste.class));
 
         henleggBehandlingTjeneste = mock(HenleggBehandlingTjeneste.class);

--- a/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/BehandlingÅrsakDtoTest.java
+++ b/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/BehandlingÅrsakDtoTest.java
@@ -55,7 +55,6 @@ public class BehandlingÅrsakDtoTest extends EntityManagerAwareTest {
             new OpptjeningIUtlandDokStatusRepository(entityManager));
         var tilbakekrevingRepository = new TilbakekrevingRepository(entityManager);
         var behandlingDokumentRepository = new BehandlingDokumentRepository(entityManager);
-        var relatertBehandlingTjeneste = new RelatertBehandlingTjeneste(repositoryProvider);
         var ytelseFordelingTjeneste = new YtelseFordelingTjeneste(repositoryProvider.getYtelsesFordelingRepository());
         var foreldrepengerUttakTjeneste = new ForeldrepengerUttakTjeneste(repositoryProvider.getFpUttakRepository());
         var uttakInputTjeneste = new UttakInputTjeneste(repositoryProvider, mock(HentOgLagreBeregningsgrunnlagTjeneste.class),
@@ -63,8 +62,7 @@ public class BehandlingÅrsakDtoTest extends EntityManagerAwareTest {
             new BeregningUttakTjeneste(foreldrepengerUttakTjeneste, repositoryProvider.getYtelsesFordelingRepository()));
         behandlingDtoTjeneste = new BehandlingDtoTjeneste(repositoryProvider, beregningtjeneste,
             tilbakekrevingRepository, skjæringstidspunktTjeneste, opptjeningIUtlandDokStatusTjeneste,
-            behandlingDokumentRepository, relatertBehandlingTjeneste,
-            foreldrepengerUttakTjeneste, null,
+            behandlingDokumentRepository, foreldrepengerUttakTjeneste, null,
             new KontrollerAktivitetskravDtoTjeneste(repositoryProvider.getBehandlingRepository(),
                 ytelseFordelingTjeneste, uttakInputTjeneste, foreldrepengerUttakTjeneste), mock(TotrinnTjeneste.class));
     }


### PR DESCRIPTION
Har gjort en del lenker betinget .
* BEREGNINGRESULTAT_ENGANGSSTONAD er bare med om det foreligger - bruk i BeregningEsProsessStegInitPanel
* BEREGNINGRESULTAT_FORELDREPENGER er bare med om det foreligger + TilkjentYtelseFpProsessStegInitPanel.ts trenger ikke sjekke på uttak - gjør slik som TilkjentYtelseProsessStegInitPanel (eller slå sammen)
* UTTAK_KONTROLLER_AKTIVITETSKRAV var betinget fra før - AktivitetskravFaktaInitPanel 
* BEREGNINGSGRUNNLAG var betinget fra før BeregningFaktaInitPanel
* Lagt til betinget lenke "beregningsgrunnlagharbesteberegning" (=beregningsgrunnlag) til bruk i BesteberegningFaktaInitPanel
* ARBEID_OG_INNTEKT er gjort betinget av registerdata -> ArbeidOgInntektFaktaInitPanel
* Lagt til boolsk allePerioderAvslått for å vurdere om uttak-prosess-steg skal merkes om IKKE_OPPFYLT i UttakProsessStegInitPanel
* Gjort sjekkSimuleringResultat deprekert -> sjekk om lenke simuleringResultat er med i Dto.

Har ikke gjort noe med Klage, Anke, Innsyn, TBK - det er så få tilfelle at det gir liten gevinst.
Klage kan antagelig erstatte logikk rundt om klageVurderingResultatNK finnes med sjekk på om 5083 (formkrav) eller 5036 (klage) har status UTFØRT. Ditto for NFP er 5082 og 5035. 
For anke gjelder om 5093 er utført og trygderett om 5094 eller 7033 er utført.