### PR TITLE
TFP-4749 nullstill svp-vilkår ved tilbakehopp også i revurdering

### DIFF
--- a/behandlingsprosess/src/main/java/no/nav/foreldrepenger/behandling/steg/inngangsvilkår/svp/VurderSvangerskapspengervilkårSteg.java
+++ b/behandlingsprosess/src/main/java/no/nav/foreldrepenger/behandling/steg/inngangsvilkår/svp/VurderSvangerskapspengervilkårSteg.java
@@ -9,8 +9,10 @@ import javax.inject.Inject;
 
 import no.nav.foreldrepenger.behandling.steg.inngangsvilkår.InngangsvilkårFellesTjeneste;
 import no.nav.foreldrepenger.behandling.steg.inngangsvilkår.InngangsvilkårStegImpl;
+import no.nav.foreldrepenger.behandlingskontroll.BehandlingStegModell;
 import no.nav.foreldrepenger.behandlingskontroll.BehandlingStegRef;
 import no.nav.foreldrepenger.behandlingskontroll.BehandlingTypeRef;
+import no.nav.foreldrepenger.behandlingskontroll.BehandlingskontrollKontekst;
 import no.nav.foreldrepenger.behandlingskontroll.FagsakYtelseTypeRef;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingStegType;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepositoryProvider;
@@ -23,8 +25,7 @@ import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakYtelseType;
 @ApplicationScoped
 public class VurderSvangerskapspengervilkårSteg extends InngangsvilkårStegImpl {
 
-    private static List<VilkårType> STØTTEDE_VILKÅR = singletonList(
-            VilkårType.SVANGERSKAPSPENGERVILKÅR);
+    private static List<VilkårType> STØTTEDE_VILKÅR = singletonList(VilkårType.SVANGERSKAPSPENGERVILKÅR);
 
     @Inject
     public VurderSvangerskapspengervilkårSteg(BehandlingRepositoryProvider repositoryProvider,
@@ -35,5 +36,11 @@ public class VurderSvangerskapspengervilkårSteg extends InngangsvilkårStegImpl
     @Override
     public List<VilkårType> vilkårHåndtertAvSteg() {
         return STØTTEDE_VILKÅR;
+    }
+
+    @Override
+    public void vedHoppOverBakover(BehandlingskontrollKontekst kontekst, BehandlingStegModell modell, BehandlingStegType hoppesTilSteg,
+                                   BehandlingStegType hoppesFraSteg) {
+        ryddVilkårTilbakeHopp(kontekst, b -> true);
     }
 }


### PR DESCRIPTION
Før ble SVP-vilkår nullstilt kun ved tilbakehopp i førstegang, men ikke i revurdering.
Alle feilene rundt 5092 er knyttet til tilbakehopp i revurderinger