### PR TITLE
TFP-5193: Steg 1 (prodsetting) - kjør simulering via gammelt endepunkt uten sammenli…

### DIFF
--- a/domenetjenester/okonomistotte/src/main/java/no/nav/foreldrepenger/økonomistøtte/simulering/tjeneste/SimuleringIntegrasjonTjeneste.java
+++ b/domenetjenester/okonomistotte/src/main/java/no/nav/foreldrepenger/økonomistøtte/simulering/tjeneste/SimuleringIntegrasjonTjeneste.java
@@ -1,6 +1,5 @@
 package no.nav.foreldrepenger.økonomistøtte.simulering.tjeneste;
 
-import static no.nav.foreldrepenger.økonomistøtte.SimulerOppdragTjeneste.tilOppdragKontrollDto;
 import static no.nav.foreldrepenger.økonomistøtte.SimulerOppdragTjeneste.tilOppdragXml;
 import static no.nav.foreldrepenger.økonomistøtte.simulering.tjeneste.SimulerOppdragIntegrasjonTjenesteFeil.startSimuleringFeiletMedFeilmelding;
 
@@ -43,11 +42,11 @@ public class SimuleringIntegrasjonTjeneste {
             startSimuleringOLD(oppdragskontroll.getBehandlingId(), tilOppdragXml(oppdragskontroll));
 
             // Kjører simulering av samme oppdragskontroll, men uten persistering i databasen, logger avvik og er failsafe
-            try {
-                startSimuleringViaFpWsProxy(tilOppdragKontrollDto(oppdragskontroll));
-            } catch (Exception e) {
-                LOG.info("Simulering via fp-ws-proxy feilet. Sjekk secure logg til fpoppdrag/fp-ws-proxy");
-            }
+//            try {
+//                startSimuleringViaFpWsProxy(tilOppdragKontrollDto(oppdragskontroll));
+//            } catch (Exception e) {
+//                LOG.info("Simulering via fp-ws-proxy feilet. Sjekk secure logg til fpoppdrag/fp-ws-proxy");
+//            }
 
         } else {
             if (oppdragskontrollOpt.isPresent()) {


### PR DESCRIPTION
Prodsetting av fpwsproxy endringene:
1. FPSAK: Kommenter ut kall til nytt simuleringsendepunkt i fpoppdrag (simulere via det gamle endepunktet)
2. FPOPPDRAG: Slå på lagring av simuleringsgrunnlag i DB for nytt endepunkt (via fp-ws-proxy). Da vil begge endepunktene /simulering/start og /simulering/start/v2 lagre til databasen.
3. FPSAK: Bytt kall til nytt simuleringsendepunkt (/start/v2).


Etter at det er verifisert at ting fungere som forventet, rydd opp i gammel kode:
1. FPOPPDRAG: Lag et endepunkt /start som gjør det samme som /start/v2.
2. FPSAK: Bytt til å kalle ‘/start’ endepunktet og sanner gammel kode
3. FPOPPDRAG: Sanner gammelt endepunkt (/start/v2) og tilhørende kode