### PR TITLE
TFP-4873 overstyrings AP for ny fakta om uttak

### DIFF
--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/aksjonspunkt/AksjonspunktDefinisjon.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/aksjonspunkt/AksjonspunktDefinisjon.java
@@ -333,6 +333,9 @@ public enum AksjonspunktDefinisjon implements Kodeverdi {
     OVERSTYRING_AV_FAKTA_UTTAK(AksjonspunktKodeDefinisjon.OVERSTYRING_AV_FAKTA_UTTAK_KODE, AksjonspunktType.OVERSTYRING,
             "Overstyr søknadsperioder", BehandlingStegType.KONTROLLER_AKTIVITETSKRAV, VurderingspunktType.INN,
             UTEN_VILKÅR, SkjermlenkeType.FAKTA_OM_UTTAK, TOTRINN, EnumSet.of(FP, SVP)),
+    OVERSTYRING_FAKTA_UTTAK(AksjonspunktKodeDefinisjon.OVERSTYRING_FAKTA_UTTAK_KODE, AksjonspunktType.OVERSTYRING,
+        "Overstyr fakta om uttak", BehandlingStegType.FAKTA_UTTAK, VurderingspunktType.UT,
+        UTEN_VILKÅR, SkjermlenkeType.FAKTA_UTTAK, TOTRINN, EnumSet.of(FP)),
     OVERSTYRING_AV_BEREGNINGSAKTIVITETER(AksjonspunktKodeDefinisjon.OVERSTYRING_AV_BEREGNINGSAKTIVITETER_KODE, AksjonspunktType.OVERSTYRING,
             "Overstyring av beregningsaktiviteter", BehandlingStegType.FASTSETT_SKJÆRINGSTIDSPUNKT_BEREGNING, VurderingspunktType.UT,
             UTEN_VILKÅR, SkjermlenkeType.FAKTA_OM_BEREGNING, TOTRINN, EnumSet.of(FP, SVP)),
@@ -346,8 +349,6 @@ public enum AksjonspunktDefinisjon implements Kodeverdi {
     AVKLAR_FAKTA_UTTAK_SAKSBEHANDLER_OVERSTYRING(AksjonspunktKodeDefinisjon.AVKLAR_FAKTA_UTTAK_SAKSBEHANDLER_OVERSTYRING_KODE, AksjonspunktType.SAKSBEHANDLEROVERSTYRING,
             "Saksbehandler endret søknadsperioder uten aksjonspunkt", BehandlingStegType.KONTROLLER_AKTIVITETSKRAV, VurderingspunktType.INN, UTEN_VILKÅR,
             SkjermlenkeType.FAKTA_OM_UTTAK, TOTRINN, EnumSet.of(FP, SVP)),
-
-    //TODO TFP-4873 overstyring av nye fakta uttak AP
 
     // Gruppe : 700
 

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/aksjonspunkt/AksjonspunktKodeDefinisjon.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/aksjonspunkt/AksjonspunktKodeDefinisjon.java
@@ -115,15 +115,15 @@ public class AksjonspunktKodeDefinisjon {
     public static final String AVKLAR_FAKTA_UTTAK_GRADERING_AKTIVITET_UTEN_BEREGNINGSGRUNNLAG_KODE = "5098";
     public static final String AVKLAR_FAKTA_UTTAK_SAKSBEHANDLER_OVERSTYRING_KODE = "6070";
     public static final String OVERSTYRING_AV_FAKTA_UTTAK_KODE = "6013";
-    public static final String OVERSTYRING_FAKTA_UTTAK_KODE = "6063";
+    public static final String OVERSTYRING_FAKTA_UTTAK_KODE = "6065";
     public static final String FASTSETT_UTTAKPERIODER_KODE = "5071";
     public static final String AVKLAR_FØRSTE_UTTAKSDATO_KODE = "5081";
     public static final String OVERSTYRING_AV_UTTAKPERIODER_KODE = "6008";
     public static final String AVKLAR_FAKTA_ANNEN_FORELDER_HAR_RETT_KODE = "5086";
     public static final String VURDER_UTTAK_DOKUMENTASJON_KODE = "5074";
-    public static final String FAKTA_UTTAK_MANUELT_SATT_STARTDATO_ULIK_SØKNAD_STARTDATO_KODE = "5063";
+    public static final String FAKTA_UTTAK_GRADERING_UKJENT_AKTIVITET_KODE = "5063";
     public static final String FAKTA_UTTAK_INGEN_PERIODER_KODE = "5064";
-    public static final String FAKTA_UTTAK_GRADERING_UKJENT_AKTIVITET_KODE = "5065";
+    public static final String FAKTA_UTTAK_MANUELT_SATT_STARTDATO_ULIK_SØKNAD_STARTDATO_KODE = "5065";
     public static final String FAKTA_UTTAK_GRADERING_AKTIVITET_UTEN_BEREGNINGSGRUNNLAG_KODE = "5066";
 
     public static final String KONTROLLER_ANNENPART_EØS_KODE = "5069";

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/aksjonspunkt/AksjonspunktKodeDefinisjon.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/aksjonspunkt/AksjonspunktKodeDefinisjon.java
@@ -115,6 +115,7 @@ public class AksjonspunktKodeDefinisjon {
     public static final String AVKLAR_FAKTA_UTTAK_GRADERING_AKTIVITET_UTEN_BEREGNINGSGRUNNLAG_KODE = "5098";
     public static final String AVKLAR_FAKTA_UTTAK_SAKSBEHANDLER_OVERSTYRING_KODE = "6070";
     public static final String OVERSTYRING_AV_FAKTA_UTTAK_KODE = "6013";
+    public static final String OVERSTYRING_FAKTA_UTTAK_KODE = "6063";
     public static final String FASTSETT_UTTAKPERIODER_KODE = "5071";
     public static final String AVKLAR_FØRSTE_UTTAKSDATO_KODE = "5081";
     public static final String OVERSTYRING_AV_UTTAKPERIODER_KODE = "6008";

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/uttak/fakta/FaktaUttakFellesTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/uttak/fakta/FaktaUttakFellesTjeneste.java
@@ -92,7 +92,9 @@ class FaktaUttakFellesTjeneste {
             .medDokumentasjonVurdering(null)
             .medMorsAktivitet(dto.morsAktivitet())
             .medFlerbarnsdager(dto.flerbarnsdager())
-            .medPeriodeType(dto.uttakPeriodeType());
+            .medPeriodeType(dto.uttakPeriodeType())
+            .medSamtidigUttaksprosent(dto.samtidigUttaksprosent())
+            .medSamtidigUttak(dto.samtidigUttaksprosent() != null);
 
         if (dto.utsettelseÅrsak() != null) {
             builder = builder.medÅrsak(dto.utsettelseÅrsak())
@@ -101,9 +103,6 @@ class FaktaUttakFellesTjeneste {
             builder = builder.medÅrsak(dto.overføringÅrsak());
         } else if (dto.oppholdÅrsak() != null) {
             builder = builder.medÅrsak(dto.oppholdÅrsak());
-        } else if (dto.samtidigUttaksprosent() != null) {
-            builder = builder.medSamtidigUttaksprosent(dto.samtidigUttaksprosent())
-                .medSamtidigUttak(true);
         } else if (dto.arbeidstidsprosent() != null && dto.arbeidstidsprosent().compareTo(BigDecimal.ZERO) > 0) {
             builder = builder.medArbeidsgiver(mapArbeidsgiver(dto.arbeidsforhold()))
                 .medGraderingAktivitetType(mapAktivitetType(dto.arbeidsforhold()))

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/uttak/fakta/FaktaUttakFellesTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/uttak/fakta/FaktaUttakFellesTjeneste.java
@@ -1,0 +1,126 @@
+package no.nav.foreldrepenger.web.app.tjenester.behandling.uttak.fakta;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.Comparator;
+import java.util.List;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import no.nav.foreldrepenger.behandling.aksjonspunkt.OppdateringResultat;
+import no.nav.foreldrepenger.behandling.revurdering.ytelse.UttakInputTjeneste;
+import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.AksjonspunktStatus;
+import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.AvklarteUttakDatoerEntitet;
+import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.YtelsesFordelingRepository;
+import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.periode.GraderingAktivitetType;
+import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.periode.OppgittPeriodeBuilder;
+import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.periode.OppgittPeriodeEntitet;
+import no.nav.foreldrepenger.behandlingslager.virksomhet.Arbeidsgiver;
+import no.nav.foreldrepenger.behandlingslager.virksomhet.OrgNummer;
+import no.nav.foreldrepenger.domene.typer.AktørId;
+import no.nav.foreldrepenger.domene.uttak.fakta.v2.FaktaUttakAksjonspunktUtleder;
+import no.nav.foreldrepenger.domene.ytelsefordeling.YtelseFordelingTjeneste;
+import no.nav.foreldrepenger.web.app.tjenester.behandling.uttak.dto.ArbeidsforholdDto;
+
+@ApplicationScoped
+class FaktaUttakFellesTjeneste {
+
+    private UttakInputTjeneste uttakInputtjeneste;
+    private FaktaUttakAksjonspunktUtleder utleder;
+    private YtelseFordelingTjeneste ytelseFordelingTjeneste;
+    private YtelsesFordelingRepository ytelsesFordelingRepository;
+
+    @Inject
+    public FaktaUttakFellesTjeneste(UttakInputTjeneste uttakInputtjeneste,
+                                    FaktaUttakAksjonspunktUtleder utleder,
+                                    YtelseFordelingTjeneste ytelseFordelingTjeneste,
+                                    YtelsesFordelingRepository ytelsesFordelingRepository) {
+        this.uttakInputtjeneste = uttakInputtjeneste;
+        this.utleder = utleder;
+        this.ytelseFordelingTjeneste = ytelseFordelingTjeneste;
+        this.ytelsesFordelingRepository = ytelsesFordelingRepository;
+    }
+
+    FaktaUttakFellesTjeneste() {
+        //CDI
+    }
+
+    public OppdateringResultat oppdater(List<FaktaUttakPeriodeDto> perioder, Long behandlingId) {
+        var overstyrtePerioder = perioder.stream().map(FaktaUttakFellesTjeneste::map).toList();
+        ytelseFordelingTjeneste.overstyrSøknadsperioder(behandlingId, overstyrtePerioder, List.of());
+        oppdaterEndringsdato(overstyrtePerioder, behandlingId);
+        //TODO TFP-4873 historikk, totrinn
+        //TODO TFP-4873 periode mottatt dato?
+        var input = uttakInputtjeneste.lagInput(behandlingId);
+        var reutlededAp = utleder.utledAksjonspunkterFor(input);
+        var builder = OppdateringResultat.utenTransisjon();
+        reutlededAp.forEach(ap -> builder.medEkstraAksjonspunktResultat(ap, AksjonspunktStatus.OPPRETTET));
+        return builder.build();
+    }
+
+    private static OppgittPeriodeEntitet map(FaktaUttakPeriodeDto dto) {
+        var builder = OppgittPeriodeBuilder.ny().medPeriode(dto.fom(), dto.tom()).medPeriodeKilde(dto.periodeKilde())
+            //TODO TFP-4873 smartere enn å bare sett null
+            .medDokumentasjonVurdering(null)
+            .medMorsAktivitet(dto.morsAktivitet())
+            .medFlerbarnsdager(dto.flerbarnsdager())
+            .medPeriodeType(dto.uttakPeriodeType());
+
+        if (dto.utsettelseÅrsak() != null) {
+            builder = builder.medÅrsak(dto.utsettelseÅrsak())
+                .medPeriodeType(null);
+        } else if (dto.overføringÅrsak() != null) {
+            builder = builder.medÅrsak(dto.overføringÅrsak());
+        } else if (dto.oppholdÅrsak() != null) {
+            builder = builder.medÅrsak(dto.oppholdÅrsak());
+        } else if (dto.samtidigUttaksprosent() != null) {
+            builder = builder.medSamtidigUttaksprosent(dto.samtidigUttaksprosent())
+                .medSamtidigUttak(true);
+        } else if (dto.arbeidstidsprosent() != null && dto.arbeidstidsprosent().compareTo(BigDecimal.ZERO) > 0) {
+            builder = builder.medArbeidsgiver(mapArbeidsgiver(dto.arbeidsforhold()))
+                .medGraderingAktivitetType(mapAktivitetType(dto.arbeidsforhold()))
+                .medArbeidsprosent(dto.arbeidstidsprosent());
+        }
+        return builder.build();
+    }
+
+    private static GraderingAktivitetType mapAktivitetType(ArbeidsforholdDto arbeidsforhold) {
+        if (arbeidsforhold == null) {
+            return null;
+        }
+        return switch (arbeidsforhold.arbeidType()) {
+            case ORDINÆRT_ARBEID -> GraderingAktivitetType.ARBEID;
+            case SELVSTENDIG_NÆRINGSDRIVENDE -> GraderingAktivitetType.SELVSTENDIG_NÆRINGSDRIVENDE;
+            case FRILANS -> GraderingAktivitetType.FRILANS;
+            case ANNET -> null;
+        };
+    }
+
+    private static Arbeidsgiver mapArbeidsgiver(ArbeidsforholdDto arbeidsforhold) {
+        if (arbeidsforhold == null || arbeidsforhold.arbeidsgiverReferanse() == null) {
+            return null;
+        }
+        if (OrgNummer.erGyldigOrgnr(arbeidsforhold.arbeidsgiverReferanse())) {
+            return Arbeidsgiver.virksomhet(arbeidsforhold.arbeidsgiverReferanse());
+        }
+        return Arbeidsgiver.person(new AktørId(arbeidsforhold.arbeidsgiverReferanse()));
+    }
+
+    private void oppdaterEndringsdato(List<OppgittPeriodeEntitet> perioder, Long behandlingId) {
+        var avklarteDatoer = ytelseFordelingTjeneste.hentAggregat(behandlingId).getAvklarteDatoer();
+        if (avklarteDatoer.isPresent()) {
+            var førsteDag = fomDato(perioder);
+            if (førsteDag.isBefore(avklarteDatoer.get().getGjeldendeEndringsdato())) {
+                var nyeAvklarteDatoer = new AvklarteUttakDatoerEntitet.Builder(avklarteDatoer).medJustertEndringsdato(førsteDag).build();
+                var ytelseFordelingAggregat = ytelsesFordelingRepository.opprettBuilder(behandlingId)
+                    .medAvklarteDatoer(nyeAvklarteDatoer).build();
+                ytelsesFordelingRepository.lagre(behandlingId, ytelseFordelingAggregat);
+            }
+        }
+    }
+
+    private LocalDate fomDato(List<OppgittPeriodeEntitet> perioder) {
+        return perioder.stream().map(p -> p.getFom()).min(Comparator.naturalOrder()).orElseThrow();
+    }
+}

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/uttak/fakta/FaktaUttakFellesTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/uttak/fakta/FaktaUttakFellesTjeneste.java
@@ -1,7 +1,6 @@
 package no.nav.foreldrepenger.web.app.tjenester.behandling.uttak.fakta;
 
 import java.math.BigDecimal;
-import java.time.LocalDate;
 import java.util.Comparator;
 import java.util.List;
 
@@ -10,7 +9,8 @@ import javax.inject.Inject;
 
 import no.nav.foreldrepenger.behandling.aksjonspunkt.OppdateringResultat;
 import no.nav.foreldrepenger.behandling.revurdering.ytelse.UttakInputTjeneste;
-import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.AksjonspunktStatus;
+import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
+import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.AvklarteUttakDatoerEntitet;
 import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.YtelsesFordelingRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.periode.GraderingAktivitetType;
@@ -22,6 +22,7 @@ import no.nav.foreldrepenger.domene.typer.AktørId;
 import no.nav.foreldrepenger.domene.uttak.fakta.v2.FaktaUttakAksjonspunktUtleder;
 import no.nav.foreldrepenger.domene.ytelsefordeling.YtelseFordelingTjeneste;
 import no.nav.foreldrepenger.web.app.tjenester.behandling.uttak.dto.ArbeidsforholdDto;
+import no.nav.foreldrepenger.web.app.tjenester.behandling.ytelsefordeling.FørsteUttaksdatoTjeneste;
 
 @ApplicationScoped
 class FaktaUttakFellesTjeneste {
@@ -30,16 +31,22 @@ class FaktaUttakFellesTjeneste {
     private FaktaUttakAksjonspunktUtleder utleder;
     private YtelseFordelingTjeneste ytelseFordelingTjeneste;
     private YtelsesFordelingRepository ytelsesFordelingRepository;
+    private FørsteUttaksdatoTjeneste førsteUttaksdatoTjeneste;
+    private BehandlingRepository behandlingRepository;
 
     @Inject
     public FaktaUttakFellesTjeneste(UttakInputTjeneste uttakInputtjeneste,
                                     FaktaUttakAksjonspunktUtleder utleder,
                                     YtelseFordelingTjeneste ytelseFordelingTjeneste,
-                                    YtelsesFordelingRepository ytelsesFordelingRepository) {
+                                    YtelsesFordelingRepository ytelsesFordelingRepository,
+                                    FørsteUttaksdatoTjeneste førsteUttaksdatoTjeneste,
+                                    BehandlingRepository behandlingRepository) {
         this.uttakInputtjeneste = uttakInputtjeneste;
         this.utleder = utleder;
         this.ytelseFordelingTjeneste = ytelseFordelingTjeneste;
         this.ytelsesFordelingRepository = ytelsesFordelingRepository;
+        this.førsteUttaksdatoTjeneste = førsteUttaksdatoTjeneste;
+        this.behandlingRepository = behandlingRepository;
     }
 
     FaktaUttakFellesTjeneste() {
@@ -48,15 +55,35 @@ class FaktaUttakFellesTjeneste {
 
     public OppdateringResultat oppdater(List<FaktaUttakPeriodeDto> perioder, Long behandlingId) {
         var overstyrtePerioder = perioder.stream().map(FaktaUttakFellesTjeneste::map).toList();
+        var behandling = behandlingRepository.hentBehandling(behandlingId);
+        validerFørsteUttaksdag(overstyrtePerioder, behandling);
         ytelseFordelingTjeneste.overstyrSøknadsperioder(behandlingId, overstyrtePerioder, List.of());
         oppdaterEndringsdato(overstyrtePerioder, behandlingId);
         //TODO TFP-4873 historikk, totrinn
         //TODO TFP-4873 periode mottatt dato?
+        validerReutledetAksjonspunkt(behandlingId);
+        return OppdateringResultat.utenTransisjon().build();
+    }
+
+    private void validerReutledetAksjonspunkt(Long behandlingId) {
+        //Burde ikke kunne lagre et uttak som fører til AP
         var input = uttakInputtjeneste.lagInput(behandlingId);
         var reutlededAp = utleder.utledAksjonspunkterFor(input);
-        var builder = OppdateringResultat.utenTransisjon();
-        reutlededAp.forEach(ap -> builder.medEkstraAksjonspunktResultat(ap, AksjonspunktStatus.OPPRETTET));
-        return builder.build();
+        if (!reutlededAp.isEmpty()) {
+            throw new IllegalStateException("Lagrede perioder fører til at aksjonspunkt reutledes");
+        }
+    }
+
+    private void validerFørsteUttaksdag(List<OppgittPeriodeEntitet> overstyrtePerioder, Behandling behandling) {
+        //Burde overstyre første uttaksdag i Fakta om saken
+        var førsteOverstyrt = overstyrtePerioder.stream().filter(p -> !p.isUtsettelse()).map(p -> p.getFom()).min(Comparator.naturalOrder());
+        if (førsteOverstyrt.isPresent()) {
+            var førsteUttaksdato = førsteUttaksdatoTjeneste.finnFørsteUttaksdato(behandling).orElseThrow();
+            if (førsteOverstyrt.get().isBefore(førsteUttaksdato)) {
+                throw new IllegalArgumentException(
+                    "første dag i overstyrte perioder kan ikke ligge før gyldig første uttaksdato " + førsteOverstyrt + " - " + førsteUttaksdato);
+            }
+        }
     }
 
     private static OppgittPeriodeEntitet map(FaktaUttakPeriodeDto dto) {
@@ -110,7 +137,7 @@ class FaktaUttakFellesTjeneste {
     private void oppdaterEndringsdato(List<OppgittPeriodeEntitet> perioder, Long behandlingId) {
         var avklarteDatoer = ytelseFordelingTjeneste.hentAggregat(behandlingId).getAvklarteDatoer();
         if (avklarteDatoer.isPresent()) {
-            var førsteDag = fomDato(perioder);
+            var førsteDag = perioder.stream().map(p -> p.getFom()).min(Comparator.naturalOrder()).orElseThrow();
             if (førsteDag.isBefore(avklarteDatoer.get().getGjeldendeEndringsdato())) {
                 var nyeAvklarteDatoer = new AvklarteUttakDatoerEntitet.Builder(avklarteDatoer).medJustertEndringsdato(førsteDag).build();
                 var ytelseFordelingAggregat = ytelsesFordelingRepository.opprettBuilder(behandlingId)
@@ -120,7 +147,4 @@ class FaktaUttakFellesTjeneste {
         }
     }
 
-    private LocalDate fomDato(List<OppgittPeriodeEntitet> perioder) {
-        return perioder.stream().map(p -> p.getFom()).min(Comparator.naturalOrder()).orElseThrow();
-    }
 }

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/uttak/fakta/FaktaUttakOppdaterer.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/uttak/fakta/FaktaUttakOppdaterer.java
@@ -1,10 +1,5 @@
 package no.nav.foreldrepenger.web.app.tjenester.behandling.uttak.fakta;
 
-import java.math.BigDecimal;
-import java.time.LocalDate;
-import java.util.Comparator;
-import java.util.List;
-
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
@@ -12,119 +7,24 @@ import no.nav.foreldrepenger.behandling.aksjonspunkt.AksjonspunktOppdaterParamet
 import no.nav.foreldrepenger.behandling.aksjonspunkt.AksjonspunktOppdaterer;
 import no.nav.foreldrepenger.behandling.aksjonspunkt.DtoTilServiceAdapter;
 import no.nav.foreldrepenger.behandling.aksjonspunkt.OppdateringResultat;
-import no.nav.foreldrepenger.behandling.revurdering.ytelse.UttakInputTjeneste;
-import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.AvklarteUttakDatoerEntitet;
-import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.YtelsesFordelingRepository;
-import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.periode.GraderingAktivitetType;
-import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.periode.OppgittPeriodeBuilder;
-import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.periode.OppgittPeriodeEntitet;
-import no.nav.foreldrepenger.behandlingslager.virksomhet.Arbeidsgiver;
-import no.nav.foreldrepenger.behandlingslager.virksomhet.OrgNummer;
-import no.nav.foreldrepenger.domene.typer.AktørId;
-import no.nav.foreldrepenger.domene.uttak.fakta.v2.FaktaUttakAksjonspunktUtleder;
-import no.nav.foreldrepenger.domene.ytelsefordeling.YtelseFordelingTjeneste;
-import no.nav.foreldrepenger.web.app.tjenester.behandling.uttak.dto.ArbeidsforholdDto;
 
 @ApplicationScoped
 @DtoTilServiceAdapter(dto = FaktaUttakDto.class, adapter = AksjonspunktOppdaterer.class)
 public class FaktaUttakOppdaterer implements AksjonspunktOppdaterer<FaktaUttakDto> {
 
-    private UttakInputTjeneste uttakInputtjeneste;
-    private FaktaUttakAksjonspunktUtleder utleder;
-    private YtelseFordelingTjeneste ytelseFordelingTjeneste;
-    private YtelsesFordelingRepository ytelsesFordelingRepository;
+    private FaktaUttakFellesTjeneste fellesTjeneste;
 
     @Inject
-    public FaktaUttakOppdaterer(UttakInputTjeneste uttakInputTjeneste,
-                                FaktaUttakAksjonspunktUtleder utleder,
-                                YtelseFordelingTjeneste ytelseFordelingTjeneste,
-                                YtelsesFordelingRepository ytelsesFordelingRepository) {
-        this.uttakInputtjeneste = uttakInputTjeneste;
-        this.utleder = utleder;
-        this.ytelseFordelingTjeneste = ytelseFordelingTjeneste;
-        this.ytelsesFordelingRepository = ytelsesFordelingRepository;
+    public FaktaUttakOppdaterer(FaktaUttakFellesTjeneste fellesTjeneste) {
+        this.fellesTjeneste = fellesTjeneste;
     }
 
     FaktaUttakOppdaterer() {
-        // for CDI proxy
+        //CDI
     }
 
     @Override
     public OppdateringResultat oppdater(FaktaUttakDto dto, AksjonspunktOppdaterParameter param) {
-        var overstyrtePerioder = dto.getPerioder().stream().map(FaktaUttakOppdaterer::map).toList();
-        ytelseFordelingTjeneste.overstyrSøknadsperioder(param.getBehandlingId(), overstyrtePerioder, List.of());
-        oppdaterEndringsdato(overstyrtePerioder, param.getBehandlingId());
-        //TODO TFP-4873 historikk, totrinn
-        //TODO TFP-4873 periode mottatt dato?
-        var input = uttakInputtjeneste.lagInput(param.getBehandlingId());
-        var reutlededAp = utleder.utledAksjonspunkterFor(input);
-        var apSomLøses = param.getAksjonspunkt().orElseThrow();
-        var holdÅpent = reutlededAp.contains(apSomLøses.getAksjonspunktDefinisjon());
-        return OppdateringResultat.utenTransisjon().medBeholdAksjonspunktÅpent(holdÅpent).build();
+        return fellesTjeneste.oppdater(dto.getPerioder(), param.getBehandlingId());
     }
-
-    private static OppgittPeriodeEntitet map(FaktaUttakPeriodeDto dto) {
-        var builder = OppgittPeriodeBuilder.ny().medPeriode(dto.fom(), dto.tom()).medPeriodeKilde(dto.periodeKilde())
-            //TODO TFP-4873 smartere enn å bare sett null
-            .medDokumentasjonVurdering(null)
-            .medMorsAktivitet(dto.morsAktivitet())
-            .medFlerbarnsdager(dto.flerbarnsdager())
-            .medPeriodeType(dto.uttakPeriodeType());
-
-        if (dto.utsettelseÅrsak() != null) {
-            builder = builder.medÅrsak(dto.utsettelseÅrsak())
-                .medPeriodeType(null);
-        } else if (dto.overføringÅrsak() != null) {
-            builder = builder.medÅrsak(dto.overføringÅrsak());
-        } else if (dto.oppholdÅrsak() != null) {
-            builder = builder.medÅrsak(dto.oppholdÅrsak());
-        } else if (dto.samtidigUttaksprosent() != null) {
-            builder = builder.medSamtidigUttaksprosent(dto.samtidigUttaksprosent())
-                .medSamtidigUttak(true);
-        } else if (dto.arbeidstidsprosent() != null && dto.arbeidstidsprosent().compareTo(BigDecimal.ZERO) > 0) {
-            builder = builder.medArbeidsgiver(mapArbeidsgiver(dto.arbeidsforhold()))
-                .medGraderingAktivitetType(mapAktivitetType(dto.arbeidsforhold()))
-                .medArbeidsprosent(dto.arbeidstidsprosent());
-        }
-        return builder.build();
-    }
-
-    private static GraderingAktivitetType mapAktivitetType(ArbeidsforholdDto arbeidsforhold) {
-        if (arbeidsforhold == null) {
-            return null;
-        }
-        return switch (arbeidsforhold.arbeidType()) {
-            case ORDINÆRT_ARBEID -> GraderingAktivitetType.ARBEID;
-            case SELVSTENDIG_NÆRINGSDRIVENDE -> GraderingAktivitetType.SELVSTENDIG_NÆRINGSDRIVENDE;
-            case FRILANS -> GraderingAktivitetType.FRILANS;
-            case ANNET -> null;
-        };
-    }
-
-    private static Arbeidsgiver mapArbeidsgiver(ArbeidsforholdDto arbeidsforhold) {
-        if (arbeidsforhold == null || arbeidsforhold.arbeidsgiverReferanse() == null) {
-            return null;
-        }
-        if (OrgNummer.erGyldigOrgnr(arbeidsforhold.arbeidsgiverReferanse())) {
-            return Arbeidsgiver.virksomhet(arbeidsforhold.arbeidsgiverReferanse());
-        }
-        return Arbeidsgiver.person(new AktørId(arbeidsforhold.arbeidsgiverReferanse()));
-    }
-
-    private void oppdaterEndringsdato(List<OppgittPeriodeEntitet> perioder, Long behandlingId) {
-        var avklarteDatoer = ytelseFordelingTjeneste.hentAggregat(behandlingId).getAvklarteDatoer();
-        if (avklarteDatoer.isPresent()) {
-            var førsteDag = fomDato(perioder);
-            if (førsteDag.isBefore(avklarteDatoer.get().getGjeldendeEndringsdato())) {
-                var nyeAvklarteDatoer = new AvklarteUttakDatoerEntitet.Builder(avklarteDatoer).medJustertEndringsdato(førsteDag).build();
-                var ytelseFordelingAggregat = ytelsesFordelingRepository.opprettBuilder(behandlingId).medAvklarteDatoer(nyeAvklarteDatoer).build();
-                ytelsesFordelingRepository.lagre(behandlingId, ytelseFordelingAggregat);
-            }
-        }
-    }
-
-    private LocalDate fomDato(List<OppgittPeriodeEntitet> perioder) {
-        return perioder.stream().map(p -> p.getFom()).min(Comparator.naturalOrder()).orElseThrow();
-    }
-
 }

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/uttak/fakta/FaktaUttakOverstyringshåndterer.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/uttak/fakta/FaktaUttakOverstyringshåndterer.java
@@ -1,0 +1,41 @@
+package no.nav.foreldrepenger.web.app.tjenester.behandling.uttak.fakta;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import no.nav.foreldrepenger.behandling.aksjonspunkt.AbstractOverstyringshåndterer;
+import no.nav.foreldrepenger.behandling.aksjonspunkt.DtoTilServiceAdapter;
+import no.nav.foreldrepenger.behandling.aksjonspunkt.OppdateringResultat;
+import no.nav.foreldrepenger.behandling.aksjonspunkt.Overstyringshåndterer;
+import no.nav.foreldrepenger.behandlingskontroll.BehandlingskontrollKontekst;
+import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
+import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.AksjonspunktDefinisjon;
+import no.nav.foreldrepenger.historikk.HistorikkTjenesteAdapter;
+
+@ApplicationScoped
+@DtoTilServiceAdapter(dto = OverstyringFaktaUttakDto.class, adapter = Overstyringshåndterer.class)
+public class FaktaUttakOverstyringshåndterer extends AbstractOverstyringshåndterer<OverstyringFaktaUttakDto> {
+
+    private FaktaUttakFellesTjeneste fellesTjeneste;
+
+    @Inject
+    public FaktaUttakOverstyringshåndterer(HistorikkTjenesteAdapter historikkAdapter,
+                                           FaktaUttakFellesTjeneste fellesTjeneste) {
+        super(historikkAdapter, AksjonspunktDefinisjon.OVERSTYRING_FAKTA_UTTAK);
+        this.fellesTjeneste = fellesTjeneste;
+    }
+
+    FaktaUttakOverstyringshåndterer() {
+        //CDI
+    }
+
+    @Override
+    public OppdateringResultat håndterOverstyring(OverstyringFaktaUttakDto dto, Behandling behandling, BehandlingskontrollKontekst kontekst) {
+        return fellesTjeneste.oppdater(dto.getPerioder(), behandling.getId());
+    }
+
+    @Override
+    protected void lagHistorikkInnslag(Behandling behandling, OverstyringFaktaUttakDto dto) {
+
+    }
+}

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/uttak/fakta/OverstyringFaktaUttakDto.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/uttak/fakta/OverstyringFaktaUttakDto.java
@@ -1,0 +1,46 @@
+package no.nav.foreldrepenger.web.app.tjenester.behandling.uttak.fakta;
+
+import java.util.List;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+import no.nav.foreldrepenger.behandling.aksjonspunkt.OverstyringAksjonspunktDto;
+import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.AksjonspunktKodeDefinisjon;
+
+@JsonTypeName(AksjonspunktKodeDefinisjon.OVERSTYRING_FAKTA_UTTAK_KODE)
+public class OverstyringFaktaUttakDto extends OverstyringAksjonspunktDto {
+
+    @Valid
+    @NotNull
+    @Size(min = 1, max = 200)
+    private List<FaktaUttakPeriodeDto> perioder;
+
+    OverstyringFaktaUttakDto() {
+        // jackson
+    }
+
+    public List<FaktaUttakPeriodeDto> getPerioder() {
+        return perioder;
+    }
+
+    public void setPerioder(List<FaktaUttakPeriodeDto> perioder) {
+        this.perioder = perioder;
+    }
+
+    @JsonIgnore
+    @Override
+    public String getAvslagskode() {
+        return null;
+    }
+
+    @JsonIgnore
+    @Override
+    public boolean getErVilkarOk() {
+        return false;
+    }
+}

--- a/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/uttak/fakta/FaktaUttakFellesTjenesteTest.java
+++ b/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/uttak/fakta/FaktaUttakFellesTjenesteTest.java
@@ -1,8 +1,14 @@
 package no.nav.foreldrepenger.web.app.tjenester.behandling.uttak.fakta;
 
+import static no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.periode.FordelingPeriodeKilde.ANDRE_NAV_VEDTAK;
+import static no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.periode.FordelingPeriodeKilde.SØKNAD;
+import static no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.periode.UttakPeriodeType.FEDREKVOTE;
+import static no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.periode.UttakPeriodeType.FELLESPERIODE;
+import static no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.periode.UttakPeriodeType.MØDREKVOTE;
+import static no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.periode.UttakPeriodeType.UDEFINERT;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
@@ -15,33 +21,29 @@ import no.nav.foreldrepenger.behandling.aksjonspunkt.OppdateringResultat;
 import no.nav.foreldrepenger.behandling.revurdering.ytelse.UttakInputTjeneste;
 import no.nav.foreldrepenger.behandling.revurdering.ytelse.fp.BeregningUttakTjeneste;
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
-import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingStegType;
-import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.AksjonspunktDefinisjon;
 import no.nav.foreldrepenger.behandlingslager.behandling.familiehendelse.FamilieHendelseBuilder;
 import no.nav.foreldrepenger.behandlingslager.behandling.familiehendelse.HendelseVersjonType;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepositoryProvider;
 import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.AvklarteUttakDatoerEntitet;
 import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.MorsAktivitet;
 import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.YtelsesFordelingRepository;
-import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.periode.FordelingPeriodeKilde;
-import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.periode.GraderingAktivitetType;
 import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.periode.OppgittFordelingEntitet;
-import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.periode.UttakPeriodeType;
+import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.periode.OppgittPeriodeBuilder;
 import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.årsak.OppholdÅrsak;
 import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.årsak.OverføringÅrsak;
 import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.årsak.UtsettelseÅrsak;
 import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.årsak.Årsak;
 import no.nav.foreldrepenger.behandlingslager.testutilities.behandling.ScenarioMorSøkerForeldrepenger;
-import no.nav.foreldrepenger.behandlingslager.uttak.UttakArbeidType;
 import no.nav.foreldrepenger.behandlingslager.uttak.fp.SamtidigUttaksprosent;
 import no.nav.foreldrepenger.dbstoette.CdiDbAwareTest;
 import no.nav.foreldrepenger.domene.abakus.AbakusInMemoryInntektArbeidYtelseTjeneste;
 import no.nav.foreldrepenger.domene.medlem.MedlemTjeneste;
 import no.nav.foreldrepenger.domene.prosess.HentOgLagreBeregningsgrunnlagTjeneste;
+import no.nav.foreldrepenger.domene.uttak.ForeldrepengerUttakTjeneste;
 import no.nav.foreldrepenger.domene.uttak.fakta.v2.FaktaUttakAksjonspunktUtleder;
 import no.nav.foreldrepenger.domene.ytelsefordeling.YtelseFordelingTjeneste;
 import no.nav.foreldrepenger.skjæringstidspunkt.SkjæringstidspunktTjeneste;
-import no.nav.foreldrepenger.web.app.tjenester.behandling.uttak.dto.ArbeidsforholdDto;
+import no.nav.foreldrepenger.web.app.tjenester.behandling.ytelsefordeling.FørsteUttaksdatoTjenesteImpl;
 
 @CdiDbAwareTest
 class FaktaUttakFellesTjenesteTest {
@@ -65,22 +67,23 @@ class FaktaUttakFellesTjenesteTest {
     void skal_lagre_perioder() {
         var opprinneligFom = LocalDate.now();
         var behandling = ScenarioMorSøkerForeldrepenger.forFødsel()
-            .medFordeling(new OppgittFordelingEntitet(List.of(), true))
-            .leggTilAksjonspunkt(AksjonspunktDefinisjon.FAKTA_UTTAK_MANUELT_SATT_STARTDATO_ULIK_SØKNAD_STARTDATO, BehandlingStegType.FAKTA_UTTAK)
-            .medBekreftetHendelse(FamilieHendelseBuilder.oppdatere(Optional.empty(), HendelseVersjonType.BEKREFTET).medFødselsDato(opprinneligFom))
-            .medAvklarteUttakDatoer(new AvklarteUttakDatoerEntitet.Builder().medJustertEndringsdato(opprinneligFom).build())
+            .medFordeling(new OppgittFordelingEntitet(List.of(OppgittPeriodeBuilder.ny()
+                    .medPeriodeType(MØDREKVOTE)
+                    .medPeriodeKilde(SØKNAD)
+                    .medPeriode(opprinneligFom, opprinneligFom.plusWeeks(5))
+                .build()), true))
+            .medBekreftetHendelse(familiehendelse(opprinneligFom))
+            .medAvklarteUttakDatoer(avklarteUttakDatoer(opprinneligFom))
             .lagre(repositoryProvider);
-        var dto = new FaktaUttakDto.ManueltSattStartdatoDto();
-        var mødrekvoteDto = new FaktaUttakPeriodeDto(opprinneligFom.minusWeeks(1), opprinneligFom.plusWeeks(2).minusDays(1), UttakPeriodeType.MØDREKVOTE, null, null, null,
-            BigDecimal.TEN, new ArbeidsforholdDto("000000000", UttakArbeidType.ORDINÆRT_ARBEID), null, false, null, FordelingPeriodeKilde.TIDLIGERE_VEDTAK);
+        var mødrekvoteDto = mødrekvote(opprinneligFom, opprinneligFom.plusWeeks(2));
         var utsettelseDto = new FaktaUttakPeriodeDto(mødrekvoteDto.tom().plusDays(1), mødrekvoteDto.tom().plusWeeks(1), null, UtsettelseÅrsak.SYKDOM,
-            null, null, null, null, null, false, MorsAktivitet.ARBEID, FordelingPeriodeKilde.SØKNAD);
+            null, null, null, null, null, false, MorsAktivitet.ARBEID, SØKNAD);
         var oppholdDto = new FaktaUttakPeriodeDto(utsettelseDto.tom().plusDays(1), utsettelseDto.tom().plusWeeks(1), null, null,
-            null, OppholdÅrsak.FEDREKVOTE_ANNEN_FORELDER, null, null, null, false, null, FordelingPeriodeKilde.SØKNAD);
-        var overføringDto = new FaktaUttakPeriodeDto(oppholdDto.tom().plusDays(1), oppholdDto.tom().plusWeeks(1), UttakPeriodeType.FEDREKVOTE,
-            null, OverføringÅrsak.SYKDOM_ANNEN_FORELDER, null, null, null, null, false, null, FordelingPeriodeKilde.ANDRE_NAV_VEDTAK);
-        var samtidigUttak = new FaktaUttakPeriodeDto(overføringDto.tom().plusDays(1), overføringDto.tom().plusWeeks(1), UttakPeriodeType.FELLESPERIODE,
-            null, null, null, null, null, SamtidigUttaksprosent.TEN, true, null, FordelingPeriodeKilde.SØKNAD);
+            null, OppholdÅrsak.FEDREKVOTE_ANNEN_FORELDER, null, null, null, false, null, SØKNAD);
+        var overføringDto = new FaktaUttakPeriodeDto(oppholdDto.tom().plusDays(1), oppholdDto.tom().plusWeeks(1), FEDREKVOTE,
+            null, OverføringÅrsak.SYKDOM_ANNEN_FORELDER, null, null, null, null, false, null, ANDRE_NAV_VEDTAK);
+        var samtidigUttak = new FaktaUttakPeriodeDto(overføringDto.tom().plusDays(1), overføringDto.tom().plusWeeks(1), FELLESPERIODE,
+            null, null, null, null, null, SamtidigUttaksprosent.TEN, true, null, SØKNAD);
         var resultat = kjørOppdaterer(behandling, List.of(mødrekvoteDto, utsettelseDto, oppholdDto, overføringDto, samtidigUttak));
         var yfa = ytelseFordelingTjeneste.hentAggregat(behandling.getId());
         var lagretPerioder = yfa.getGjeldendeFordeling().getPerioder();
@@ -92,10 +95,10 @@ class FaktaUttakFellesTjenesteTest {
 
         assertThat(lagretPerioder.get(0).getFom()).isEqualTo(mødrekvoteDto.fom());
         assertThat(lagretPerioder.get(0).getTom()).isEqualTo(mødrekvoteDto.tom());
-        assertThat(lagretPerioder.get(0).getGraderingAktivitetType()).isEqualTo(GraderingAktivitetType.ARBEID);
+        assertThat(lagretPerioder.get(0).getGraderingAktivitetType()).isNull();
         assertThat(lagretPerioder.get(0).getArbeidsprosent()).isEqualTo(mødrekvoteDto.arbeidstidsprosent());
         assertThat(lagretPerioder.get(0).getDokumentasjonVurdering()).isNull();
-        assertThat(lagretPerioder.get(0).getArbeidsgiver().getIdentifikator()).isEqualTo(mødrekvoteDto.arbeidsforhold().arbeidsgiverReferanse());
+        assertThat(lagretPerioder.get(0).getArbeidsgiver()).isNull();
         assertThat(lagretPerioder.get(0).getPeriodeKilde()).isEqualTo(mødrekvoteDto.periodeKilde());
         assertThat(lagretPerioder.get(0).getSamtidigUttaksprosent()).isEqualTo(mødrekvoteDto.samtidigUttaksprosent());
         assertThat(lagretPerioder.get(0).getPeriodeType()).isEqualTo(mødrekvoteDto.uttakPeriodeType());
@@ -110,7 +113,7 @@ class FaktaUttakFellesTjenesteTest {
         assertThat(lagretPerioder.get(1).getArbeidsgiver()).isNull();
         assertThat(lagretPerioder.get(1).getPeriodeKilde()).isEqualTo(utsettelseDto.periodeKilde());
         assertThat(lagretPerioder.get(1).getSamtidigUttaksprosent()).isNull();
-        assertThat(lagretPerioder.get(1).getPeriodeType()).isEqualTo(UttakPeriodeType.UDEFINERT);
+        assertThat(lagretPerioder.get(1).getPeriodeType()).isEqualTo(UDEFINERT);
         assertThat(lagretPerioder.get(1).isFlerbarnsdager()).isEqualTo(utsettelseDto.flerbarnsdager());
         assertThat(lagretPerioder.get(1).getÅrsak()).isEqualTo(utsettelseDto.utsettelseÅrsak());
 
@@ -122,7 +125,7 @@ class FaktaUttakFellesTjenesteTest {
         assertThat(lagretPerioder.get(2).getArbeidsgiver()).isNull();
         assertThat(lagretPerioder.get(2).getPeriodeKilde()).isEqualTo(oppholdDto.periodeKilde());
         assertThat(lagretPerioder.get(2).getSamtidigUttaksprosent()).isNull();
-        assertThat(lagretPerioder.get(2).getPeriodeType()).isEqualTo(UttakPeriodeType.UDEFINERT);
+        assertThat(lagretPerioder.get(2).getPeriodeType()).isEqualTo(UDEFINERT);
         assertThat(lagretPerioder.get(2).isFlerbarnsdager()).isEqualTo(oppholdDto.flerbarnsdager());
         assertThat(lagretPerioder.get(2).getÅrsak()).isEqualTo(oppholdDto.oppholdÅrsak());
 
@@ -151,6 +154,54 @@ class FaktaUttakFellesTjenesteTest {
         assertThat(lagretPerioder.get(4).getÅrsak()).isEqualTo(Årsak.UKJENT);
     }
 
+    @Test
+    void gir_exception_hvis_det_lagres_uttak_som_starter_før_gyldig_første_uttaksdag() {
+        var opprinneligFom = LocalDate.now();
+        var behandling = ScenarioMorSøkerForeldrepenger.forFødsel()
+            .medFordeling(new OppgittFordelingEntitet(List.of(OppgittPeriodeBuilder.ny()
+                .medPeriodeType(MØDREKVOTE)
+                .medPeriodeKilde(SØKNAD)
+                .medPeriode(opprinneligFom, opprinneligFom.plusWeeks(5))
+                .build()), true))
+            .medBekreftetHendelse(familiehendelse(opprinneligFom))
+            .lagre(repositoryProvider);
+        var mødrekvoteDto = mødrekvote(opprinneligFom.minusWeeks(1), opprinneligFom.plusWeeks(2));
+        assertThatThrownBy(() -> kjørOppdaterer(behandling, List.of(mødrekvoteDto))).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void gir_ikke_exception_hvis_det_lagres_utsettelse_som_starter_før_gyldig_første_uttaksdag() {
+        var opprinneligFom = LocalDate.now();
+        var behandling = ScenarioMorSøkerForeldrepenger.forFødsel()
+            .medFordeling(new OppgittFordelingEntitet(List.of(OppgittPeriodeBuilder.ny()
+                .medPeriodeType(MØDREKVOTE)
+                .medPeriodeKilde(SØKNAD)
+                .medPeriode(opprinneligFom, opprinneligFom.plusWeeks(5))
+                .build()), true))
+            .medBekreftetHendelse(familiehendelse(opprinneligFom))
+            .lagre(repositoryProvider);
+        var mødrekvoteDto = mødrekvote(opprinneligFom, opprinneligFom.plusWeeks(2));
+        var utsettelseDto = new FaktaUttakPeriodeDto(opprinneligFom.minusWeeks(2), mødrekvoteDto.fom().minusDays(1),
+            null, UtsettelseÅrsak.SYKDOM, null, null, null, null, null, false, null, SØKNAD);
+        kjørOppdaterer(behandling, List.of(mødrekvoteDto, utsettelseDto));
+
+        var lagretPerioder = ytelseFordelingTjeneste.hentAggregat(behandling.getId()).getGjeldendeFordeling().getPerioder();
+        assertThat(lagretPerioder).hasSize(2);
+    }
+
+    private static FaktaUttakPeriodeDto mødrekvote(LocalDate fom, LocalDate tom) {
+        return new FaktaUttakPeriodeDto(fom, tom, MØDREKVOTE, null, null, null, null,
+            null, null, false, null, SØKNAD);
+    }
+
+    private static AvklarteUttakDatoerEntitet avklarteUttakDatoer(LocalDate endringsdato) {
+        return new AvklarteUttakDatoerEntitet.Builder().medJustertEndringsdato(endringsdato.plusWeeks(2)).build();
+    }
+
+    private static FamilieHendelseBuilder familiehendelse(LocalDate fødselsdato) {
+        return FamilieHendelseBuilder.oppdatere(Optional.empty(), HendelseVersjonType.BEKREFTET).medFødselsDato(fødselsdato);
+    }
+
     private OppdateringResultat kjørOppdaterer(Behandling behandling, List<FaktaUttakPeriodeDto> perioder) {
         var uttakInputTjeneste = new UttakInputTjeneste(repositoryProvider,
             new HentOgLagreBeregningsgrunnlagTjeneste(repositoryProvider.getEntityManager()), new AbakusInMemoryInntektArbeidYtelseTjeneste(),
@@ -158,7 +209,8 @@ class FaktaUttakFellesTjenesteTest {
             new YtelseFordelingTjeneste(repositoryProvider.getYtelsesFordelingRepository()), true);
 
         var tjeneste = new FaktaUttakFellesTjeneste(uttakInputTjeneste, faktaUttakAksjonspunktUtleder, ytelseFordelingTjeneste,
-            ytelsesFordelingRepository);
+            ytelsesFordelingRepository, new FørsteUttaksdatoTjenesteImpl(ytelseFordelingTjeneste,
+            new ForeldrepengerUttakTjeneste(repositoryProvider.getFpUttakRepository())), repositoryProvider.getBehandlingRepository());
         return tjeneste.oppdater(perioder, behandling.getId());
     }
 }


### PR DESCRIPTION
6065
Bruker fellestjeneste med vanlig AP oppdaterer. Fungerer så lenge vi ikke trenger forskjellig historikkinnslag på vanlig og overstyring.