### PR TITLE
TFP-5306 startpunkt uttak ved endring i pleiepenger/nestesak

### DIFF
--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/nestesak/NesteSakGrunnlagEntitet.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/nestesak/NesteSakGrunnlagEntitet.java
@@ -23,9 +23,11 @@ import no.nav.vedtak.felles.jpa.converters.BooleanToStringConverter;
 /*
  * Grunnlag med livssyklus gitt av saker som innvilger ny stønadsperiode som påvirker aktuell saks stønadsperiode
  */
-@Entity(name = "NestesakGrunnlag")
+@Entity(name = NesteSakGrunnlagEntitet.GRUNNLAG_NAME)
 @Table(name = "GR_NESTESAK")
 public class NesteSakGrunnlagEntitet extends BaseEntitet {
+
+    public static final String GRUNNLAG_NAME = "NestesakGrunnlag";
 
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "SEQ_GR_NESTESAK")
@@ -59,7 +61,7 @@ public class NesteSakGrunnlagEntitet extends BaseEntitet {
         this.hendelsedato = grunnlag.hendelsedato;
     }
 
-    Long getId() {
+    public Long getId() {
         return id;
     }
 

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/nestesak/NesteSakRepository.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/nestesak/NesteSakRepository.java
@@ -65,6 +65,14 @@ public class NesteSakRepository {
         return HibernateVerktøy.hentUniktResultat(query);
     }
 
+    public NesteSakGrunnlagEntitet hentGrunnlagPåId(Long grunnlagId) {
+        final var query = entityManager
+            .createQuery("FROM NestesakGrunnlag n WHERE n.id = :grunnlagId", NesteSakGrunnlagEntitet.class)
+            .setParameter("grunnlagId", grunnlagId);
+
+        return query.getResultStream().findFirst().orElse(null);
+    }
+
     public void kopierGrunnlagFraEksisterendeBehandling(Long orginalBehandlingId, Long nyBehandlingId) {
         var eksisterendeGrunnlag = hentGrunnlag(orginalBehandlingId);
         eksisterendeGrunnlag.ifPresent(g -> {

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/personopplysning/PersonopplysningRepository.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/personopplysning/PersonopplysningRepository.java
@@ -80,9 +80,7 @@ public class PersonopplysningRepository {
 
     public Optional<PersonopplysningGrunnlagEntitet> hentPersonopplysningerHvisEksisterer(Long behandlingId) {
         Objects.requireNonNull(behandlingId, "behandlingId"); // NOSONAR //$NON-NLS-1$
-        var pbg = getAktivtGrunnlag(behandlingId);
-        var entitet = pbg.orElse(null);
-        return Optional.ofNullable(entitet);
+        return getAktivtGrunnlag(behandlingId);
     }
 
     public Optional<OppgittAnnenPartEntitet> hentOppgittAnnenPartHvisEksisterer(Long behandlingId) {

--- a/domenetjenester/registerinnhenting/src/main/java/no/nav/foreldrepenger/domene/registerinnhenting/StønadsperioderInnhenter.java
+++ b/domenetjenester/registerinnhenting/src/main/java/no/nav/foreldrepenger/domene/registerinnhenting/StønadsperioderInnhenter.java
@@ -7,7 +7,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
@@ -16,11 +15,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
-import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingResultatType;
-import no.nav.foreldrepenger.behandlingslager.behandling.Behandlingsresultat;
-import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingsresultatRepository;
+import no.nav.foreldrepenger.behandlingslager.behandling.EndringsresultatSnapshot;
 import no.nav.foreldrepenger.behandlingslager.behandling.familiehendelse.FamilieHendelseEntitet;
 import no.nav.foreldrepenger.behandlingslager.behandling.familiehendelse.FamilieHendelseGrunnlagEntitet;
+import no.nav.foreldrepenger.behandlingslager.behandling.nestesak.NesteSakGrunnlagEntitet;
 import no.nav.foreldrepenger.behandlingslager.behandling.nestesak.NesteSakRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.personopplysning.PersonopplysningRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.personopplysning.RelasjonsRolleType;
@@ -104,6 +102,17 @@ public class StønadsperioderInnhenter {
         } else {
             nesteSakRepository.fjernEventuellNesteSak(behandling.getId());
         }
+    }
+
+    public EndringsresultatSnapshot finnAktivGrunnlagId(Long behandlingId) {
+        var funnetId = nesteSakRepository.hentGrunnlag(behandlingId).map(NesteSakGrunnlagEntitet::getId);
+        return funnetId
+            .map(id -> EndringsresultatSnapshot.medSnapshot(NesteSakGrunnlagEntitet.class, id))
+            .orElse(EndringsresultatSnapshot.utenSnapshot(NesteSakGrunnlagEntitet.class));
+    }
+
+    public NesteSakGrunnlagEntitet hentGrunnlagPåId(Long grunnlagId) {
+        return nesteSakRepository.hentGrunnlagPåId(grunnlagId);
     }
 
     Optional<MuligSak> finnSenereStønadsperiode(Behandling behandling) {

--- a/domenetjenester/registerinnhenting/src/main/java/no/nav/foreldrepenger/domene/registerinnhenting/impl/startpunkt/StartpunktUtlederInntektArbeidYtelse.java
+++ b/domenetjenester/registerinnhenting/src/main/java/no/nav/foreldrepenger/domene/registerinnhenting/impl/startpunkt/StartpunktUtlederInntektArbeidYtelse.java
@@ -94,7 +94,12 @@ class StartpunktUtlederInntektArbeidYtelse implements StartpunktUtleder {
         var erInntektsmeldingEndret = iayGrunnlagDiff.erEndringPåInntektsmelding();
 
         var saksnummer = ref.saksnummer();
+
+        // Endringer før STP, eller rundt STP der man har søkt både ES og FP
         var aktørYtelseEndringForSøker = iayGrunnlagDiff.endringPåAktørYtelseForAktør(saksnummer, skjæringstidspunkt, ref.aktørId());
+
+        // Endringer etter STP for ytelser der vi normalt skal vike (innvilge utsettelse)
+        var erEndringPleiepengerEtterStp = iayGrunnlagDiff.erEndringPleiepengerEtterStp(skjæringstidspunkt, ref.aktørId());
 
         if (vurderArbeidsforhold) {
             var iayGrunnlag = iayTjeneste.hentGrunnlag(ref.behandlingId()); // TODO burde ikke være nødvendig (bør velge grunnlagId1, grunnlagId2)
@@ -122,6 +127,9 @@ class StartpunktUtlederInntektArbeidYtelse implements StartpunktUtleder {
         }
         if (aktørYtelseEndringForSøker.erAndreYtelserEndret()) {
             leggTilStartpunkt(startpunkter, grunnlagId1, grunnlagId2, defaultStartpunktForRegisterEndringer, "aktør ytelse andre tema");
+        }
+        if (erEndringPleiepengerEtterStp) {
+            leggTilStartpunkt(startpunkter, grunnlagId1, grunnlagId2, StartpunktType.UTTAKSVILKÅR, "pleiepenger under uttaket");
         }
         if (erAktørInntektEndretForSøker) {
             leggTilStartpunkt(startpunkter, grunnlagId1, grunnlagId2, defaultStartpunktForRegisterEndringer, "aktør inntekt");

--- a/domenetjenester/registerinnhenting/src/main/java/no/nav/foreldrepenger/domene/registerinnhenting/impl/startpunkt/StartpunktUtlederNesteSak.java
+++ b/domenetjenester/registerinnhenting/src/main/java/no/nav/foreldrepenger/domene/registerinnhenting/impl/startpunkt/StartpunktUtlederNesteSak.java
@@ -1,0 +1,42 @@
+package no.nav.foreldrepenger.domene.registerinnhenting.impl.startpunkt;
+
+import java.util.Objects;
+import java.util.Optional;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import no.nav.foreldrepenger.behandling.BehandlingReferanse;
+import no.nav.foreldrepenger.behandlingslager.behandling.GrunnlagRef;
+import no.nav.foreldrepenger.behandlingslager.behandling.nestesak.NesteSakGrunnlagEntitet;
+import no.nav.foreldrepenger.behandlingslager.behandling.nestesak.NesteSakRepository;
+import no.nav.foreldrepenger.behandlingslager.hendelser.StartpunktType;
+import no.nav.foreldrepenger.domene.registerinnhenting.StartpunktUtleder;
+
+@ApplicationScoped
+@GrunnlagRef(NesteSakGrunnlagEntitet.GRUNNLAG_NAME)
+class StartpunktUtlederNesteSak implements StartpunktUtleder {
+
+    private NesteSakRepository nesteSakRepository;
+
+    StartpunktUtlederNesteSak() {
+        // For CDI
+    }
+
+    @Inject
+    StartpunktUtlederNesteSak(NesteSakRepository nesteSakRepository) {
+        this.nesteSakRepository = nesteSakRepository;
+    }
+
+    @Override
+    public StartpunktType utledStartpunkt(BehandlingReferanse ref, Object grunnlagId1, Object grunnlagId2) {
+        var startdato1 = Optional.ofNullable(nesteSakRepository.hentGrunnlagPåId((Long)grunnlagId1))
+            .map(NesteSakGrunnlagEntitet::getStartdato).orElse(null);
+        var startdato2 =Optional.ofNullable(nesteSakRepository.hentGrunnlagPåId((Long)grunnlagId2))
+            .map(NesteSakGrunnlagEntitet::getStartdato).orElse(null);
+
+        // Ser kun på endring av startdato for neste stønadsperiode
+        return Objects.equals(startdato1, startdato2) ? StartpunktType.UDEFINERT : StartpunktType.UTTAKSVILKÅR;
+    }
+
+}

--- a/domenetjenester/registerinnhenting/src/test/java/no/nav/foreldrepenger/domene/registerinnhenting/impl/startpunkt/StartpunktUtlederNesteSakTest.java
+++ b/domenetjenester/registerinnhenting/src/test/java/no/nav/foreldrepenger/domene/registerinnhenting/impl/startpunkt/StartpunktUtlederNesteSakTest.java
@@ -58,7 +58,7 @@ public class StartpunktUtlederNesteSakTest {
     }
 
     @Test
-    public void skal_returnere_startpunkt_udefinert_dersom_oppstått_neste_sak() {
+    public void skal_returnere_startpunkt_uttak_dersom_oppstått_neste_sak() {
         // Arrange
         var behandling = ScenarioMorSøkerForeldrepenger.forFødsel()
             .medBehandlingType(BehandlingType.FØRSTEGANGSSØKNAD)
@@ -76,7 +76,7 @@ public class StartpunktUtlederNesteSakTest {
     }
 
     @Test
-    public void skal_returnere_startpunkt_udefinert_dersom_ulik_startdato_neste_sak() {
+    public void skal_returnere_startpunkt_uttak_dersom_ulik_startdato_neste_sak() {
         // Arrange
         var behandling = ScenarioMorSøkerForeldrepenger.forFødsel()
             .medBehandlingType(BehandlingType.FØRSTEGANGSSØKNAD)

--- a/domenetjenester/registerinnhenting/src/test/java/no/nav/foreldrepenger/domene/registerinnhenting/impl/startpunkt/StartpunktUtlederNesteSakTest.java
+++ b/domenetjenester/registerinnhenting/src/test/java/no/nav/foreldrepenger/domene/registerinnhenting/impl/startpunkt/StartpunktUtlederNesteSakTest.java
@@ -1,0 +1,101 @@
+package no.nav.foreldrepenger.domene.registerinnhenting.impl.startpunkt;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import no.nav.foreldrepenger.behandling.BehandlingReferanse;
+import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingType;
+import no.nav.foreldrepenger.behandlingslager.behandling.nestesak.NesteSakGrunnlagEntitet;
+import no.nav.foreldrepenger.behandlingslager.behandling.nestesak.NesteSakRepository;
+import no.nav.foreldrepenger.behandlingslager.hendelser.StartpunktType;
+import no.nav.foreldrepenger.behandlingslager.testutilities.behandling.ScenarioMorSøkerForeldrepenger;
+import no.nav.foreldrepenger.domene.typer.Saksnummer;
+
+@ExtendWith(MockitoExtension.class)
+public class StartpunktUtlederNesteSakTest {
+
+    @Mock
+    private NesteSakRepository nesteSakRepository;
+
+    @Test
+    public void skal_returnere_startpunkt_udefinert_dersom_ingen_neste_sak() {
+        // Arrange
+        var behandling = ScenarioMorSøkerForeldrepenger.forFødsel()
+            .medBehandlingType(BehandlingType.FØRSTEGANGSSØKNAD)
+            .lagMocked();
+        when(nesteSakRepository.hentGrunnlagPåId(anyLong())).thenReturn(null);
+        // Act/Assert
+        var utleder = new StartpunktUtlederNesteSak(nesteSakRepository);
+        assertThat(utleder.utledStartpunkt(BehandlingReferanse.fra(behandling, null), 1L, 2L)).isEqualTo(StartpunktType.UDEFINERT);
+    }
+
+    @Test
+    public void skal_returnere_startpunkt_udefinert_dersom_lik_startdato_neste_sak() {
+        // Arrange
+        var behandling = ScenarioMorSøkerForeldrepenger.forFødsel()
+            .medBehandlingType(BehandlingType.FØRSTEGANGSSØKNAD)
+            .lagMocked();
+        var nestesak = NesteSakGrunnlagEntitet.Builder.oppdatere(Optional.empty()).medBehandlingId(123L)
+            .medHendelsedato(LocalDate.now().plusWeeks(3))
+            .medStartdato(LocalDate.now().plusDays(2))
+            .medSaksnummer(new Saksnummer("987"))
+            .build();
+        var nestesak2 = NesteSakGrunnlagEntitet.Builder.oppdatere(Optional.of(nestesak)).medBehandlingId(234L).build();
+        when(nesteSakRepository.hentGrunnlagPåId(1L)).thenReturn(nestesak);
+        when(nesteSakRepository.hentGrunnlagPåId(2L)).thenReturn(nestesak2);
+        // Act/Assert
+        var utleder = new StartpunktUtlederNesteSak(nesteSakRepository);
+        assertThat(utleder.utledStartpunkt(BehandlingReferanse.fra(behandling, null), 1L, 2L)).isEqualTo(StartpunktType.UDEFINERT);
+    }
+
+    @Test
+    public void skal_returnere_startpunkt_udefinert_dersom_oppstått_neste_sak() {
+        // Arrange
+        var behandling = ScenarioMorSøkerForeldrepenger.forFødsel()
+            .medBehandlingType(BehandlingType.FØRSTEGANGSSØKNAD)
+            .lagMocked();
+        var nestesak = NesteSakGrunnlagEntitet.Builder.oppdatere(Optional.empty()).medBehandlingId(123L)
+            .medHendelsedato(LocalDate.now().plusWeeks(3))
+            .medStartdato(LocalDate.now().plusDays(2))
+            .medSaksnummer(new Saksnummer("987"))
+            .build();
+        when(nesteSakRepository.hentGrunnlagPåId(1L)).thenReturn(nestesak);
+        when(nesteSakRepository.hentGrunnlagPåId(2L)).thenReturn(null);
+        // Act/Assert
+        var utleder = new StartpunktUtlederNesteSak(nesteSakRepository);
+        assertThat(utleder.utledStartpunkt(BehandlingReferanse.fra(behandling, null), 1L, 2L)).isEqualTo(StartpunktType.UTTAKSVILKÅR);
+    }
+
+    @Test
+    public void skal_returnere_startpunkt_udefinert_dersom_ulik_startdato_neste_sak() {
+        // Arrange
+        var behandling = ScenarioMorSøkerForeldrepenger.forFødsel()
+            .medBehandlingType(BehandlingType.FØRSTEGANGSSØKNAD)
+            .lagMocked();
+        var nestesak = NesteSakGrunnlagEntitet.Builder.oppdatere(Optional.empty()).medBehandlingId(123L)
+            .medHendelsedato(LocalDate.now().plusWeeks(3))
+            .medStartdato(LocalDate.now().plusDays(2))
+            .medSaksnummer(new Saksnummer("987"))
+            .build();
+        var nestesak2 = NesteSakGrunnlagEntitet.Builder.oppdatere(Optional.of(nestesak))
+            .medBehandlingId(234L)
+            .medStartdato(LocalDate.now().plusDays(1))
+            .build();
+        when(nesteSakRepository.hentGrunnlagPåId(1L)).thenReturn(nestesak);
+        when(nesteSakRepository.hentGrunnlagPåId(2L)).thenReturn(nestesak2);
+        // Act/Assert
+        var utleder = new StartpunktUtlederNesteSak(nesteSakRepository);
+        assertThat(utleder.utledStartpunkt(BehandlingReferanse.fra(behandling, null), 1L, 2L)).isEqualTo(StartpunktType.UTTAKSVILKÅR);
+    }
+
+
+}


### PR DESCRIPTION
Overlapp pleiepenger og Opphør pga ny sak håndteres ved å opprette revurdering 
Dersom det finnes åpen behandling så får den en ekstra årsak og rykkes tilbake med tvungen registeroppdatering

Denne saken skal oppdager endringer i startdato neste sak og pleiepenger og sette startpunkt Uttak, slik at vi ikke blir stående i simulering eller vedtak pga startpunkt = udefinert.
