### PR TITLE
Unngå doble revurderinger ved to tette k9-vedtak

### DIFF
--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/vedtak/overlapp/HåndterOverlappPleiepengerTask.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/vedtak/overlapp/HåndterOverlappPleiepengerTask.java
@@ -1,12 +1,29 @@
 package no.nav.foreldrepenger.mottak.vedtak.overlapp;
 
+import java.util.Comparator;
+import java.util.List;
+
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
+import no.nav.abakus.vedtak.ytelse.Kildesystem;
+import no.nav.abakus.vedtak.ytelse.Ytelser;
+import no.nav.abakus.vedtak.ytelse.v1.YtelseV1;
+import no.nav.abakus.vedtak.ytelse.v1.anvisning.Anvisning;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingÅrsakType;
+import no.nav.foreldrepenger.behandlingslager.behandling.beregning.BeregningsresultatEntitet;
+import no.nav.foreldrepenger.behandlingslager.behandling.beregning.BeregningsresultatRepository;
+import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepository;
+import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepositoryProvider;
+import no.nav.foreldrepenger.behandlingslager.fagsak.Fagsak;
 import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakProsesstaskRekkefølge;
 import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakRepository;
 import no.nav.foreldrepenger.behandlingslager.task.GenerellProsessTask;
+import no.nav.foreldrepenger.domene.abakus.AbakusTjeneste;
+import no.nav.fpsak.tidsserie.LocalDateInterval;
+import no.nav.fpsak.tidsserie.LocalDateSegment;
+import no.nav.fpsak.tidsserie.LocalDateTimeline;
+import no.nav.fpsak.tidsserie.StandardCombinators;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTask;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTaskData;
 
@@ -16,13 +33,22 @@ import no.nav.vedtak.felles.prosesstask.api.ProsessTaskData;
 public class HåndterOverlappPleiepengerTask extends GenerellProsessTask {
 
     private HåndterOpphørAvYtelser tjeneste;
+    private AbakusTjeneste abakusTjeneste;
     private FagsakRepository fagsakRepository;
+    private BehandlingRepository behandlingRepository;
+    private BeregningsresultatRepository tilkjentYtelseRepository;
+
 
     @Inject
-    public HåndterOverlappPleiepengerTask(HåndterOpphørAvYtelser tjeneste, FagsakRepository fagsakRepository) {
+    public HåndterOverlappPleiepengerTask(HåndterOpphørAvYtelser tjeneste,
+                                          AbakusTjeneste abakusTjeneste,
+                                          BehandlingRepositoryProvider repositoryProvider) {
         super();
         this.tjeneste = tjeneste;
-        this.fagsakRepository = fagsakRepository;
+        this.abakusTjeneste = abakusTjeneste;
+        this.fagsakRepository = repositoryProvider.getFagsakRepository();
+        this.behandlingRepository = repositoryProvider.getBehandlingRepository();
+        this.tilkjentYtelseRepository = repositoryProvider.getBeregningsresultatRepository();
     }
 
     HåndterOverlappPleiepengerTask() {
@@ -32,6 +58,32 @@ public class HåndterOverlappPleiepengerTask extends GenerellProsessTask {
     @Override
     public void prosesser(ProsessTaskData prosessTaskData, Long fagsakId, Long behandlingId) {
         var fagsak = fagsakRepository.finnEksaktFagsak(fagsakId);
-        tjeneste.oppdaterEllerOpprettRevurdering(fagsak, null, BehandlingÅrsakType.RE_VEDTAK_PLEIEPENGER);
+        // Unngå doble revurderinger ved tette vedtak fra Pleiepenger
+        if (erFortsattOverlapp(fagsak)) {
+            tjeneste.oppdaterEllerOpprettRevurdering(fagsak, null, BehandlingÅrsakType.RE_VEDTAK_PLEIEPENGER);
+        }
+    }
+
+    private boolean erFortsattOverlapp(Fagsak fagsak) {
+        var tilkjentSegments = behandlingRepository.finnSisteAvsluttedeIkkeHenlagteBehandling(fagsak.getId())
+            .flatMap(b -> tilkjentYtelseRepository.hentUtbetBeregningsresultat(b.getId()))
+            .map(BeregningsresultatEntitet::getBeregningsresultatPerioder).orElse(List.of()).stream()
+            .filter(p -> p.getDagsats() > 0)
+            .map(p -> new LocalDateSegment<>(p.getBeregningsresultatPeriodeFom(), p.getBeregningsresultatPeriodeTom(), Boolean.TRUE))
+            .toList();
+        if (tilkjentSegments.isEmpty()) {
+            return false;
+        }
+        var tidligsteTilkjent = tilkjentSegments.stream().map(LocalDateSegment::getFom).min(Comparator.naturalOrder()).orElseThrow();
+        var tilkjentTidslinje = new LocalDateTimeline<>(tilkjentSegments, StandardCombinators::alwaysTrueForMatch).compress();
+
+        var request = AbakusTjeneste.lagRequestForHentVedtakFom(fagsak.getAktørId(), tidligsteTilkjent);
+        return abakusTjeneste.hentVedtakForAktørId(request).stream()
+            .map(y -> (YtelseV1)y)
+            .filter(y -> Kildesystem.K9SAK.equals(y.getKildesystem()))
+            .filter(y -> Ytelser.PLEIEPENGER_SYKT_BARN.equals(y.getYtelse()) || Ytelser.PLEIEPENGER_NÆRSTÅENDE.equals(y.getYtelse()))
+            .flatMap(y -> y.getAnvist().stream())
+            .map(Anvisning::getPeriode)
+            .anyMatch(p -> !tilkjentTidslinje.intersection(new LocalDateInterval(p.getFom(), p.getTom())).isEmpty());
     }
 }


### PR DESCRIPTION
Vi har et delay på kjøring av disse slik at vi er sikre på at abakus har persistert hendelsen.
Vi ser at det kan komme "to tette" vedtak fra K9sak som er like for oss (diff kun internt i k9sak i utsettelser u/utbetaling)

Denne sjekker om det fortsatt er overlapp når tasken starter opp.