### PR TITLE
TFP-5329 konsekvent bruke av grunnlag

### DIFF
--- a/behandlingslager/domene/src/test/java/no/nav/foreldrepenger/behandlingslager/behandling/tilrettelegging/SvangerskapspengerRepositoryTest.java
+++ b/behandlingslager/domene/src/test/java/no/nav/foreldrepenger/behandlingslager/behandling/tilrettelegging/SvangerskapspengerRepositoryTest.java
@@ -55,10 +55,8 @@ public class SvangerskapspengerRepositoryTest extends EntityManagerAwareTest {
         assertThat(kopiertGrunnlag.get().getOpprinneligeTilrettelegginger().getTilretteleggingListe()).hasSize(1);
         assertThat(kopiertGrunnlag.get().getOpprinneligeTilrettelegginger().getTilretteleggingListe().get(0).getKopiertFraTidligereBehandling()).isTrue();
         assertThat(kopiertGrunnlag.get().getOpprinneligeTilrettelegginger().getTilretteleggingListe().get(0).getMottattTidspunkt()).isEqualTo(I_GÅR);
-        assertThat(kopiertGrunnlag.get().getOpprinneligeTilrettelegginger().getTilretteleggingListe().get(0).getBehovForTilretteleggingFom()).isEqualTo(OM_TO_DAGER);
-        assertThat(kopiertGrunnlag.get().getOverstyrteTilrettelegginger().getTilretteleggingListe().get(0).getKopiertFraTidligereBehandling()).isTrue();
-        assertThat(kopiertGrunnlag.get().getOverstyrteTilrettelegginger().getTilretteleggingListe().get(0).getMottattTidspunkt()).isEqualTo(I_GÅR);
-        assertThat(kopiertGrunnlag.get().getOverstyrteTilrettelegginger().getTilretteleggingListe().get(0).getBehovForTilretteleggingFom()).isEqualTo(OM_TRE_DAGER);
+        assertThat(kopiertGrunnlag.get().getOpprinneligeTilrettelegginger().getTilretteleggingListe().get(0).getBehovForTilretteleggingFom()).isEqualTo(OM_TRE_DAGER);
+        assertThat(kopiertGrunnlag.get().getOverstyrteTilrettelegginger()).isNull();
     }
 
     private SvpTilretteleggingEntitet opprettTilrettelegging(LocalDate fom) {

--- a/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/avklarfakta/svp/LagreNyeTilretteleggingerTjenesteTest.java
+++ b/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/avklarfakta/svp/LagreNyeTilretteleggingerTjenesteTest.java
@@ -33,8 +33,7 @@ public class LagreNyeTilretteleggingerTjenesteTest extends EntityManagerAwareTes
     }
 
     @Test
-    public void skal_lagre_nye_tilrettelegginger_og_beholde_de_opprinnelige_unleash_enabled() {
-
+    public void skal_lagre_nye_tilrettelegginger_og_beholde_de_opprinnelige() {
         // Arrange
         var behandling = ScenarioMorSøkerSvangerskapspenger.forSvangerskapspenger().lagre(repositoryProvider);
 
@@ -65,5 +64,4 @@ public class LagreNyeTilretteleggingerTjenesteTest extends EntityManagerAwareTes
         assertThat(nyttGrunnlag.getOverstyrteTilrettelegginger().getTilretteleggingListe()).hasSize(1);
 
     }
-
 }

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/svp/BekreftSvangerskapspengerOppdaterer.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/svp/BekreftSvangerskapspengerOppdaterer.java
@@ -29,7 +29,6 @@ import no.nav.foreldrepenger.behandlingslager.behandling.skjermlenke.Skjermlenke
 import no.nav.foreldrepenger.behandlingslager.behandling.tilrettelegging.SvangerskapspengerRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.tilrettelegging.SvpTilretteleggingEntitet;
 import no.nav.foreldrepenger.behandlingslager.behandling.tilrettelegging.TilretteleggingFOM;
-import no.nav.foreldrepenger.behandlingslager.behandling.tilrettelegging.TilretteleggingFilter;
 import no.nav.foreldrepenger.behandlingslager.behandling.tilrettelegging.TilretteleggingType;
 import no.nav.foreldrepenger.domene.arbeidsforhold.InntektArbeidYtelseTjeneste;
 import no.nav.foreldrepenger.domene.iay.modell.InntektArbeidYtelseAggregat;
@@ -175,18 +174,18 @@ public class BekreftSvangerskapspengerOppdaterer implements AksjonspunktOppdater
         });
         var oppdatertTilrettelegging = new ArrayList<SvpTilretteleggingEntitet>();
         var bekreftedeArbeidsforholdDtoer = dto.getBekreftetSvpArbeidsforholdList();
-        var tilretteleggingerUfiltrert = new TilretteleggingFilter(svpGrunnlag).getAktuelleTilretteleggingerUfiltrert();
+        var gjeldendeTilrettelegginger = svpGrunnlag.getGjeldendeVersjon().getTilretteleggingListe();
 
-        var erMinsteBehovFraDatoEndret = endretMinsteBehovFra(bekreftedeArbeidsforholdDtoer, tilretteleggingerUfiltrert);
+        var erMinsteBehovFraDatoEndret = endretMinsteBehovFra(bekreftedeArbeidsforholdDtoer, gjeldendeTilrettelegginger);
 
         var erEndret = false;
         for (var arbeidsforholdDto : bekreftedeArbeidsforholdDtoer) {
-            if (mapTilretteleggingHvisEndret(arbeidsforholdDto, tilretteleggingerUfiltrert, oppdatertTilrettelegging)) {
+            if (mapTilretteleggingHvisEndret(arbeidsforholdDto, gjeldendeTilrettelegginger, oppdatertTilrettelegging)) {
                 erEndret = true;
             }
         }
 
-        if (oppdatertTilrettelegging.size() != tilretteleggingerUfiltrert.size()) {
+        if (oppdatertTilrettelegging.size() != gjeldendeTilrettelegginger.size()) {
             throw new TekniskException("FP-564312", "Antall overstyrte arbeidsforhold for svangerskapspenger stemmer "
                 + "ikke overens med arbeidsforhold fra søknaden: " + behandling.getId());
         }


### PR DESCRIPTION
Endret slik at vi lagrer fletting av eksisterende perioder ved ny søknad som overstyrt, og at vi alltid bruker gjeldende versjon når tilrettelegginger hentes.