### PR TITLE
TFP-5193: Steg 5, tar i bruk /simulering/start endepunktet

### DIFF
--- a/domenetjenester/okonomistotte/src/main/java/no/nav/foreldrepenger/økonomistøtte/simulering/klient/FpOppdragRestKlient.java
+++ b/domenetjenester/okonomistotte/src/main/java/no/nav/foreldrepenger/økonomistøtte/simulering/klient/FpOppdragRestKlient.java
@@ -30,7 +30,7 @@ import no.nav.vedtak.felles.integrasjon.rest.TokenFlow;
 public class FpOppdragRestKlient {
 
     private static final String FPOPPDRAG_HENT_RESULTAT = "/api/simulering/resultat";
-    private static final String FPOPPDRAG_START_SIMULERING = "/api/simulering/start/v2";
+    private static final String FPOPPDRAG_START_SIMULERING = "/api/simulering/start";
 
     private final RestClient restClient;
     private final RestConfig restConfig;


### PR DESCRIPTION
Prodsetting av fpwsproxy endringene:

1. FPSAK: Kommenter ut kall til nytt simuleringsendepunkt i fpoppdrag (simulere via det gamle endepunktet)
2. FPOPPDRAG: Slå på lagring av simuleringsgrunnlag i DB for nytt endepunkt (via fp-ws-proxy). Da vil begge endepunktene /simulering/start og /simulering/start/v2 lagre til databasen.
3. FPSAK: Bytt kall til nytt simuleringsendepunkt (/start/v2).
4. FPOPPDRAG: Lag et endepunkt /start som gjør det samme som /start/v2.
5. FPSAK: Bytt til å kalle ‘/start’ endepunktet og sanner gammel kode
6. FPOPPDRAG: Sanner gammelt endepunkt (/start/v2) og tilhørende kode