### PR TITLE
Forenkle flerbarnsfødselsmeldinger

### DIFF
--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/aktør/FødtBarnInfo.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/aktør/FødtBarnInfo.java
@@ -1,49 +1,14 @@
 package no.nav.foreldrepenger.behandlingslager.aktør;
 
 import java.time.LocalDate;
-import java.util.Objects;
 import java.util.Optional;
 
 import no.nav.foreldrepenger.domene.typer.PersonIdent;
 
-public class FødtBarnInfo {
-
-    private PersonIdent ident;
-    private LocalDate fødselsdato;
-    private LocalDate dødsdato;
-
-    private FødtBarnInfo(PersonIdent ident, LocalDate fødselsdato, LocalDate dødsdato) {
-        this.ident = ident;
-        this.fødselsdato = fødselsdato;
-        this.dødsdato = dødsdato;
-    }
-
-    // OBS: vil være null ved dødfødsel
-    public PersonIdent getIdent() {
-        return ident;
-    }
-
-    public LocalDate getFødselsdato() {
-        return fødselsdato;
-    }
+public record FødtBarnInfo(PersonIdent ident, LocalDate fødselsdato, LocalDate dødsdato) {
 
     public Optional<LocalDate> getDødsdato() {
         return Optional.ofNullable(dødsdato);
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        var that = (FødtBarnInfo) o;
-        return Objects.equals(ident, that.ident) &&
-            Objects.equals(fødselsdato, that.fødselsdato) &&
-            Objects.equals(dødsdato, that.dødsdato);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(ident, fødselsdato, dødsdato);
     }
 
     @Override
@@ -75,6 +40,7 @@ public class FødtBarnInfo {
         }
 
         public FødtBarnInfo build() {
+            // Vurder sjekking ident != null || dødsdato != null
             return new FødtBarnInfo(ident, fødselsdato, dødsdato);
         }
     }

--- a/domenetjenester/behandling-revurdering/src/main/java/no/nav/foreldrepenger/behandling/revurdering/RevurderingHistorikk.java
+++ b/domenetjenester/behandling-revurdering/src/main/java/no/nav/foreldrepenger/behandling/revurdering/RevurderingHistorikk.java
@@ -58,10 +58,10 @@ public class RevurderingHistorikk {
         String fødselsdatoVerdi;
         if (barnFødtIPeriode.size() > 1) {
             SortedSet<LocalDate> fødselsdatoer = new TreeSet<>(
-                    barnFødtIPeriode.stream().map(FødtBarnInfo::getFødselsdato).collect(Collectors.toSet()));
+                    barnFødtIPeriode.stream().map(FødtBarnInfo::fødselsdato).collect(Collectors.toSet()));
             fødselsdatoVerdi = fødselsdatoer.stream().map(dateFormat::format).collect(Collectors.joining(", "));
         } else {
-            fødselsdatoVerdi = dateFormat.format(barnFødtIPeriode.get(0).getFødselsdato());
+            fødselsdatoVerdi = dateFormat.format(barnFødtIPeriode.get(0).fødselsdato());
         }
         var historieBuilder = new HistorikkInnslagTekstBuilder()
                 .medHendelse(HistorikkinnslagType.NY_INFO_FRA_TPS)

--- a/domenetjenester/behandling-revurdering/src/main/java/no/nav/foreldrepenger/behandling/revurdering/etterkontroll/tjeneste/es/EtterkontrollTjenesteImpl.java
+++ b/domenetjenester/behandling-revurdering/src/main/java/no/nav/foreldrepenger/behandling/revurdering/etterkontroll/tjeneste/es/EtterkontrollTjenesteImpl.java
@@ -101,7 +101,7 @@ public class EtterkontrollTjenesteImpl implements EtterkontrollTjeneste {
     }
 
     private boolean skalReberegneES(Behandling behandling, List<FødtBarnInfo> fødteBarn) {
-        var fødselsdato = fødteBarn.stream().map(FødtBarnInfo::getFødselsdato).max(Comparator.naturalOrder()).orElse(null);
+        var fødselsdato = fødteBarn.stream().map(FødtBarnInfo::fødselsdato).max(Comparator.naturalOrder()).orElse(null);
         return (fødselsdato != null) && esBeregningRepository.skalReberegne(behandling.getId(), fødselsdato);
     }
 

--- a/domenetjenester/familie-hendelse/src/main/java/no/nav/foreldrepenger/familiehendelse/FamilieHendelseTjeneste.java
+++ b/domenetjenester/familie-hendelse/src/main/java/no/nav/foreldrepenger/familiehendelse/FamilieHendelseTjeneste.java
@@ -153,7 +153,7 @@ public class FamilieHendelseTjeneste {
         final var hendelseBuilder = familieGrunnlagRepository.opprettBuilderForregister(behandling)
             .tilbakestillBarn();
 
-        bekreftetTps.forEach(barn -> hendelseBuilder.leggTilBarn(barn.getFødselsdato(), barn.getDødsdato().orElse(null)));
+        bekreftetTps.forEach(barn -> hendelseBuilder.leggTilBarn(barn.fødselsdato(), barn.getDødsdato().orElse(null)));
         hendelseBuilder.medAntallBarn(bekreftetTps.size());
 
         familieGrunnlagRepository.lagreRegisterHendelse(behandling, hendelseBuilder);

--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/hendelser/es/FødselForretningshendelseHåndtererImpl.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/hendelser/es/FødselForretningshendelseHåndtererImpl.java
@@ -45,12 +45,14 @@ public class FødselForretningshendelseHåndtererImpl implements Forretningshend
 
     @Override
     public void håndterÅpenBehandling(Behandling åpenBehandling, BehandlingÅrsakType behandlingÅrsakType) {
-        forretningshendelseHåndtererFelles.håndterÅpenBehandling(åpenBehandling, behandlingÅrsakType);
+        if (!forretningshendelseHåndtererFelles.fødselAlleredeRegistrert(åpenBehandling)) {
+            forretningshendelseHåndtererFelles.håndterÅpenBehandling(åpenBehandling, behandlingÅrsakType);
+        }
     }
 
     @Override
     public void håndterAvsluttetBehandling(Behandling avsluttetBehandling, ForretningshendelseType forretningshendelseType, BehandlingÅrsakType behandlingÅrsakType) {
-        if (erRelevantForEngangsstønadSak(avsluttetBehandling)) {
+        if (!forretningshendelseHåndtererFelles.fødselAlleredeRegistrert(avsluttetBehandling) && erRelevantForEngangsstønadSak(avsluttetBehandling)) {
             forretningshendelseHåndtererFelles.opprettRevurderingLagStartTask(avsluttetBehandling.getFagsak(), behandlingÅrsakType);
         }
     }

--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/hendelser/fp/FødselForretningshendelseHåndtererImpl.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/hendelser/fp/FødselForretningshendelseHåndtererImpl.java
@@ -33,21 +33,27 @@ public class FødselForretningshendelseHåndtererImpl implements Forretningshend
 
     @Override
     public void håndterÅpenBehandling(Behandling åpenBehandling, BehandlingÅrsakType behandlingÅrsakType) {
-        forretningshendelseHåndtererFelles.håndterÅpenBehandling(åpenBehandling, behandlingÅrsakType);
+        if (!forretningshendelseHåndtererFelles.fødselAlleredeRegistrert(åpenBehandling)) {
+            forretningshendelseHåndtererFelles.håndterÅpenBehandling(åpenBehandling, behandlingÅrsakType);
+        }
     }
 
     @Override
     public void håndterAvsluttetBehandling(Behandling avsluttetBehandling,
                                            ForretningshendelseType forretningshendelseType,
                                            BehandlingÅrsakType behandlingÅrsakType) {
-        var fagsak = avsluttetBehandling.getFagsak();
-        forretningshendelseHåndtererFelles.opprettRevurderingLagStartTask(fagsak, behandlingÅrsakType);
+        if (!forretningshendelseHåndtererFelles.fødselAlleredeRegistrert(avsluttetBehandling)) {
+            forretningshendelseHåndtererFelles.opprettRevurderingLagStartTask(avsluttetBehandling.getFagsak(), behandlingÅrsakType);
+        }
 
     }
 
     @Override
     public void håndterKøetBehandling(Fagsak fagsak, BehandlingÅrsakType behandlingÅrsakType) {
         var køetBehandlingOpt = behandlingRevurderingRepository.finnKøetYtelsesbehandling(fagsak.getId());
+        if (køetBehandlingOpt.filter(forretningshendelseHåndtererFelles::fødselAlleredeRegistrert).isPresent()) {
+            return;
+        }
         forretningshendelseHåndtererFelles.håndterKøetBehandling(fagsak, behandlingÅrsakType, køetBehandlingOpt);
     }
 }

--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/hendelser/håndterer/ForretningshendelseHåndtererFelles.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/hendelser/håndterer/ForretningshendelseHåndtererFelles.java
@@ -1,16 +1,25 @@
 package no.nav.foreldrepenger.mottak.hendelser.håndterer;
 
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 
 import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
 
+import no.nav.foreldrepenger.behandling.BehandlingReferanse;
+import no.nav.foreldrepenger.behandlingslager.aktør.FødtBarnInfo;
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingÅrsakType;
 import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.Venteårsak;
+import no.nav.foreldrepenger.behandlingslager.behandling.familiehendelse.FamilieHendelseEntitet;
+import no.nav.foreldrepenger.behandlingslager.behandling.familiehendelse.UidentifisertBarn;
 import no.nav.foreldrepenger.behandlingslager.behandling.historikk.HistorikkinnslagType;
 import no.nav.foreldrepenger.behandlingslager.fagsak.Fagsak;
 import no.nav.foreldrepenger.behandlingsprosess.prosessering.BehandlingProsesseringTjeneste;
+import no.nav.foreldrepenger.domene.person.PersoninfoAdapter;
+import no.nav.foreldrepenger.familiehendelse.FamilieHendelseTjeneste;
 import no.nav.foreldrepenger.mottak.Behandlingsoppretter;
 import no.nav.foreldrepenger.mottak.dokumentmottak.HistorikkinnslagTjeneste;
 import no.nav.foreldrepenger.mottak.dokumentmottak.impl.Kompletthetskontroller;
@@ -23,6 +32,8 @@ public class ForretningshendelseHåndtererFelles {
     private HistorikkinnslagTjeneste historikkinnslagTjeneste;
     private Kompletthetskontroller kompletthetskontroller;
     private BehandlingProsesseringTjeneste behandlingProsesseringTjeneste;
+    private FamilieHendelseTjeneste familieHendelseTjeneste;
+    private PersoninfoAdapter personinfoAdapter;
     private KøKontroller køKontroller;
 
     @SuppressWarnings("unused")
@@ -35,11 +46,15 @@ public class ForretningshendelseHåndtererFelles {
                                               Kompletthetskontroller kompletthetskontroller,
                                               BehandlingProsesseringTjeneste behandlingProsesseringTjeneste,
                                               Behandlingsoppretter behandlingsoppretter,
+                                              FamilieHendelseTjeneste familieHendelseTjeneste,
+                                              PersoninfoAdapter personinfoAdapter,
                                               KøKontroller køKontroller) {
         this.historikkinnslagTjeneste = historikkinnslagTjeneste;
         this.kompletthetskontroller = kompletthetskontroller;
         this.behandlingsoppretter = behandlingsoppretter;
         this.behandlingProsesseringTjeneste = behandlingProsesseringTjeneste;
+        this.familieHendelseTjeneste = familieHendelseTjeneste;
+        this.personinfoAdapter = personinfoAdapter;
         this.køKontroller = køKontroller;
     }
 
@@ -63,5 +78,27 @@ public class ForretningshendelseHåndtererFelles {
         var køetBehandling = behandlingsoppretter.opprettRevurdering(fagsak, behandlingÅrsakType);
         historikkinnslagTjeneste.opprettHistorikkinnslagForVenteFristRelaterteInnslag(køetBehandling, HistorikkinnslagType.BEH_KØET, null, Venteårsak.VENT_ÅPEN_BEHANDLING);
         køKontroller.enkøBehandling(køetBehandling);
+    }
+
+    public boolean fødselAlleredeRegistrert(Behandling åpenEllerForrige) {
+        final var familieHendelseGrunnlag = familieHendelseTjeneste.finnAggregat(åpenEllerForrige.getId()).orElse(null);
+        if (familieHendelseGrunnlag == null) {
+            return false;
+        }
+        var intervaller = familieHendelseTjeneste.forventetFødselsIntervaller(BehandlingReferanse.fra(åpenEllerForrige));
+        var fødslerFraRegister = personinfoAdapter.innhentAlleFødteForBehandlingIntervaller(åpenEllerForrige.getAktørId(), intervaller);
+        var fødslerFraGrunnlag = familieHendelseGrunnlag.getGjeldendeBekreftetVersjon().map(FamilieHendelseEntitet::getBarna).orElse(List.of());
+        var grunnlagSammenlign = fødslerFraGrunnlag.stream().map(SammenlignBarn::new).toList();
+        return fødslerFraRegister.size() == fødslerFraGrunnlag.size() &&
+            fødslerFraRegister.stream().map(SammenlignBarn::new).allMatch(fbi -> grunnlagSammenlign.stream().anyMatch(ffg -> Objects.equals(fbi, ffg)));
+    }
+
+    private record SammenlignBarn(LocalDate fødselsdato, LocalDate dødsdato) {
+        public SammenlignBarn(UidentifisertBarn barn) {
+            this(barn.getFødselsdato(), barn.getDødsdato().orElse(null));
+        }
+        public SammenlignBarn(FødtBarnInfo barn) {
+            this(barn.fødselsdato(), barn.getDødsdato().orElse(null));
+        }
     }
 }

--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/hendelser/svp/FødselForretningshendelseHåndtererImpl.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/hendelser/svp/FødselForretningshendelseHåndtererImpl.java
@@ -26,11 +26,15 @@ public class FødselForretningshendelseHåndtererImpl implements Forretningshend
 
     @Override
     public void håndterÅpenBehandling(Behandling åpenBehandling, BehandlingÅrsakType behandlingÅrsakType) {
-        forretningshendelseHåndtererFelles.håndterÅpenBehandling(åpenBehandling, behandlingÅrsakType);
+        if (!forretningshendelseHåndtererFelles.fødselAlleredeRegistrert(åpenBehandling)) {
+            forretningshendelseHåndtererFelles.håndterÅpenBehandling(åpenBehandling, behandlingÅrsakType);
+        }
     }
 
     @Override
     public void håndterAvsluttetBehandling(Behandling avsluttetBehandling, ForretningshendelseType forretningshendelseType, BehandlingÅrsakType behandlingÅrsakType) {
-        forretningshendelseHåndtererFelles.opprettRevurderingLagStartTask(avsluttetBehandling.getFagsak(), behandlingÅrsakType);
+        if (!forretningshendelseHåndtererFelles.fødselAlleredeRegistrert(avsluttetBehandling)) {
+            forretningshendelseHåndtererFelles.opprettRevurderingLagStartTask(avsluttetBehandling.getFagsak(), behandlingÅrsakType);
+        }
     }
 }

--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/sakskompleks/KobleSakerTjeneste.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/sakskompleks/KobleSakerTjeneste.java
@@ -132,8 +132,8 @@ public class KobleSakerTjeneste {
     private Set<AktørId> finnAndreRegistrerteForeldreForBarnekull(AktørId aktørId, List<LocalDateInterval> intervaller) {
         // Hent fødsler i intervall og deretter kjerneinfo m/familierelasjoner for disse
         return personinfoAdapter.innhentAlleFødteForBehandlingIntervaller(aktørId, intervaller).stream()
-            .filter(b -> b.getIdent() != null) // Dødfødsel
-            .flatMap(b -> personinfoAdapter.finnAktørIdForForeldreTil(b.getIdent()).stream())
+            .filter(b -> b.ident() != null) // Dødfødsel
+            .flatMap(b -> personinfoAdapter.finnAktørIdForForeldreTil(b.ident()).stream())
             .filter(a -> !aktørId.equals(a))
             .collect(Collectors.toSet());
     }

--- a/domenetjenester/person/src/main/java/no/nav/foreldrepenger/domene/person/pdl/FødselTjeneste.java
+++ b/domenetjenester/person/src/main/java/no/nav/foreldrepenger/domene/person/pdl/FødselTjeneste.java
@@ -73,7 +73,7 @@ public class FødselTjeneste {
             .forEach(alleBarn::add);
 
         return alleBarn.stream()
-                .filter(fBI -> intervaller.stream().anyMatch(i -> i.encloses(fBI.getFødselsdato())))
+                .filter(fBI -> intervaller.stream().anyMatch(i -> i.encloses(fBI.fødselsdato())))
                 .collect(Collectors.toList());
     }
 

--- a/domenetjenester/person/src/main/java/no/nav/foreldrepenger/domene/personopplysning/PersonopplysningInnhenter.java
+++ b/domenetjenester/person/src/main/java/no/nav/foreldrepenger/domene/personopplysning/PersonopplysningInnhenter.java
@@ -252,7 +252,7 @@ public class PersonopplysningInnhenter {
 
     private Set<PersonIdent> finnBarnRelatertTil(List<FødtBarnInfo> filtrertFødselFREG) {
         return filtrertFødselFREG.stream()
-            .map(FødtBarnInfo::getIdent)
+            .map(FødtBarnInfo::ident)
             .filter(Objects::nonNull) // Dødfødsel
             .collect(Collectors.toSet());
     }

--- a/domenetjenester/registerinnhenting/src/main/java/no/nav/foreldrepenger/domene/registerinnhenting/RegisterdataInnhenter.java
+++ b/domenetjenester/registerinnhenting/src/main/java/no/nav/foreldrepenger/domene/registerinnhenting/RegisterdataInnhenter.java
@@ -152,10 +152,10 @@ public class RegisterdataInnhenter {
     }
 
     private void innhentPleiepenger(Behandling behandling, List<FødtBarnInfo> filtrertFødselFREG) {
-        var bekreftetFødt = filtrertFødselFREG.stream().map(FødtBarnInfo::getIdent).filter(Objects::nonNull).collect(Collectors.toSet());
+        var bekreftetFødt = filtrertFødselFREG.stream().map(FødtBarnInfo::ident).filter(Objects::nonNull).collect(Collectors.toSet());
 
         if (bekreftetFødt.isEmpty() || !FagsakYtelseType.FORELDREPENGER.equals(behandling.getFagsakYtelseType())) return;
-        var tidligstFødt = filtrertFødselFREG.stream().map(FødtBarnInfo::getFødselsdato).min(Comparator.naturalOrder()).orElseGet(LocalDate::now);
+        var tidligstFødt = filtrertFødselFREG.stream().map(FødtBarnInfo::fødselsdato).min(Comparator.naturalOrder()).orElseGet(LocalDate::now);
 
         var request = AbakusTjeneste.lagRequestForHentVedtakFom(behandling.getAktørId(), tidligstFødt.minusWeeks(25));
 

--- a/pom.xml
+++ b/pom.xml
@@ -35,8 +35,8 @@
 
         <fp-uttak.version>14.3.2</fp-uttak.version>
         <svp-uttak.version>2.3.4</svp-uttak.version>
-        <felles.version>4.2.13</felles.version>
-        <prosesstask.version>3.1.13</prosesstask.version>
+        <felles.version>4.2.15</felles.version>
+        <prosesstask.version>3.1.14</prosesstask.version>
         <fp-jms.version>2.2.0</fp-jms.version>
 
         <fp-kontrakter.version>6.1.31</fp-kontrakter.version>

--- a/web/src/main/java/no/nav/foreldrepenger/web/server/jetty/TimingFilter.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/server/jetty/TimingFilter.java
@@ -1,9 +1,8 @@
 package no.nav.foreldrepenger.web.server.jetty;
 
 import static io.micrometer.core.instrument.Metrics.timer;
-import static no.nav.vedtak.log.metrics.MetricsUtil.utvidMedHistogram;
+import static no.nav.vedtak.log.metrics.MetricsUtil.utvidMedMedian;
 
-import java.io.IOException;
 import java.time.Duration;
 
 import javax.annotation.Priority;
@@ -24,7 +23,7 @@ public class TimingFilter implements ContainerRequestFilter, ContainerResponseFi
     private static final ThreadLocalTimer TIMER = new ThreadLocalTimer();
 
     public TimingFilter() {
-        utvidMedHistogram(METRIC_NAME);
+        utvidMedMedian(METRIC_NAME);
     }
 
     @Override


### PR DESCRIPTION
Unngå flere revurderinger i tilfeller der alle barna allerede er innhentet i aktuelt grunnlag (åpen eller sist avsluttet behandling)
Flerbarnsfødsler gjør at fødslene kommer enkeltvis, men forsinkes i fpabonnent en time - slik at når første hendelsen behandles så er gjerne de andre barna allerede registrert i PDL -> trenger kun 1 revurdering.
Sjekker at antall og fødsels+dødsdatoer er like