### PR TITLE
Velg seneste aktivitetsavtale ved overlapp

### DIFF
--- a/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/iay/modell/Yrkesaktivitet.java
+++ b/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/iay/modell/Yrkesaktivitet.java
@@ -5,7 +5,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -18,7 +17,6 @@ import no.nav.foreldrepenger.behandlingslager.virksomhet.ArbeidType;
 import no.nav.foreldrepenger.behandlingslager.virksomhet.Arbeidsgiver;
 import no.nav.foreldrepenger.domene.tid.DatoIntervallEntitet;
 import no.nav.foreldrepenger.domene.typer.InternArbeidsforholdRef;
-import no.nav.foreldrepenger.domene.typer.Stillingsprosent;
 
 public class Yrkesaktivitet extends BaseEntitet implements IndexKey {
 
@@ -150,29 +148,6 @@ public class Yrkesaktivitet extends BaseEntitet implements IndexKey {
 
     public Collection<AktivitetsAvtale> getAlleAktivitetsAvtaler() {
         return Collections.unmodifiableSet(aktivitetsAvtale);
-    }
-
-    /**
-     * Gir stillingsprosent hvis det finnes for den gitte dagen Kaster feil hvis det
-     * blir gitt overlappene stillingsprosent
-     *
-     * @param dato {@link LocalDate}
-     * @return Stillingsprosent {@link Stillingsprosent}
-     */
-    public Optional<Stillingsprosent> getStillingsprosentFor(LocalDate dato) {
-        var avtaler = getAlleAktivitetsAvtaler()
-                .stream()
-                .filter(a -> !a.erAnsettelsesPeriode())
-                .filter(a -> a.getPeriode().inkluderer(dato))
-                .collect(Collectors.toList());
-
-        if (avtaler.isEmpty()) {
-            return Optional.empty();
-        }
-        if (avtaler.size() > 1) {
-            throw new IllegalStateException("Fant overlappende aktivitestavataler for " + this.toString());
-        }
-        return Optional.ofNullable(avtaler.get(0).getProsentsats());
     }
 
     void leggTilAktivitetsAvtale(AktivitetsAvtale aktivitetsAvtale) {

--- a/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/opptjening/OpptjeningsperioderTjeneste.java
+++ b/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/opptjening/OpptjeningsperioderTjeneste.java
@@ -188,11 +188,20 @@ public class OpptjeningsperioderTjeneste {
                 .medOpptjeningAktivitetType(type)
                 .medBegrunnelse(avtale.getBeskrivelse())
                 .medVurderingsStatus(vurderOpptjening.vurderStatus(type, behandlingReferanse, yr, grunnlag, grunnlag.harBlittSaksbehandlet()));
-        yr.getStillingsprosentFor(skjæringstidspunkt).ifPresent(builder::medStillingsandel);
+        getStillingsprosentVedDato(yr, skjæringstidspunkt).ifPresent(builder::medStillingsandel);
         MapYrkesaktivitetTilOpptjeningsperiodeTjeneste.settArbeidsgiverInformasjon(yr, builder);
         harSaksbehandlerVurdert(builder, type, behandlingReferanse, null, vurderOpptjening, grunnlag);
         builder.medErManueltRegistrert();
         perioder.add(builder.build());
+    }
+
+    private static Optional<Stillingsprosent> getStillingsprosentVedDato(Yrkesaktivitet yrkesaktivitet, LocalDate dato) {
+        return yrkesaktivitet.getAlleAktivitetsAvtaler()
+            .stream()
+            .filter(a -> !a.erAnsettelsesPeriode())
+            .filter(a -> a.getPeriode().inkluderer(dato))
+            .max(Comparator.comparing(a -> a.getPeriode().getFomDato()))
+            .map(AktivitetsAvtale::getProsentsats);
     }
 
     private OpptjeningsperiodeForSaksbehandling mapOppgittArbeidsforhold(OppgittArbeidsforhold oppgittArbeidsforhold,

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/dto/behandling/BehandlingDtoTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/dto/behandling/BehandlingDtoTjeneste.java
@@ -19,6 +19,7 @@ import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingStatus;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingType;
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandlingsresultat;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingsresultatRepository;
+import no.nav.foreldrepenger.behandlingslager.behandling.SpesialBehandling;
 import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.AksjonspunktDefinisjon;
 import no.nav.foreldrepenger.behandlingslager.behandling.beregning.BeregningsresultatEntitet;
 import no.nav.foreldrepenger.behandlingslager.behandling.beregning.BeregningsresultatRepository;
@@ -413,6 +414,8 @@ public class BehandlingDtoTjeneste {
                 dto.leggTil(post(ArbeidOgInntektsmeldingRestTjeneste.LAGRE_VURDERING_PATH, "arbeidsforhold-inntektsmelding-vurder", new ManglendeOpplysningerVurderingDto()));
                 dto.leggTil(
                     post(ArbeidOgInntektsmeldingRestTjeneste.ÅPNE_FOR_NY_VURDERING_PATH, "arbeidsforhold-inntektsmelding-apne-for-ny-vurdering", new BehandlingIdVersjonDto()));
+            } else if (SpesialBehandling.erSpesialBehandling(behandling)) {
+                dto.leggTil(get(ArbeidOgInntektsmeldingRestTjeneste.ARBEID_OG_INNTEKTSMELDING_PATH, "arbeidsforhold-inntektsmelding", uuidDto));
             }
 
             var tilkjentYtelse = beregningsresultatRepository.hentUtbetBeregningsresultat(behandling.getId())


### PR DESCRIPTION
Tilsvarende er gjort ifm arbeidsforhold/UtledStillingsprosent - klassene - men de ser på seneste fom som inkluderer stp eller første etter. 
Dette tilfellet gjelder nok primært de som har saksbehandlet-iay (når oppstår det?).

@pekern kunne du vært så snill og se på inntektArbeidYtelseTsType.ts mhp disse tre feltene nedenfor.
Gjerne sanere frontend og backend.
Jeg tror arbeidsforhold kun brukes i FaktaTilrettelegging og spm er om den kan bruke arbeidOgInntekt
Lenkene "arbeidsforhold-inntektsmelding" eller "inntektsmeldinger" eller er å foretrekke - slik at 'inntekt-arbeid-ytelse' kun brukes i fakta/ytelser

```
  inntektsmeldinger?: IAYInntektsmelding[];
  arbeidsforhold?: Arbeidsforhold[];
  skalKunneLeggeTilNyeArbeidsforhold: boolean;

```