### PR TITLE
Ignorer fordelinger med overlapp ved sjekk mottatt dato

### DIFF
--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/ytelsefordeling/periode/OppgittFordelingEntitet.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/ytelsefordeling/periode/OppgittFordelingEntitet.java
@@ -75,6 +75,10 @@ public class OppgittFordelingEntitet extends BaseEntitet {
         return ønskerJustertVedFødsel != null && ønskerJustertVedFødsel;
     }
 
+    public Long getId() {
+        return id;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {

--- a/behandlingsprosess/src/main/java/no/nav/foreldrepenger/behandling/steg/uttak/fp/KontrollerAktivitetskravSteg.java
+++ b/behandlingsprosess/src/main/java/no/nav/foreldrepenger/behandling/steg/uttak/fp/KontrollerAktivitetskravSteg.java
@@ -43,7 +43,7 @@ public class KontrollerAktivitetskravSteg implements UttakSteg {
     @Override
     public BehandleStegResultat utførSteg(BehandlingskontrollKontekst kontekst) {
         var uttakInput = uttakInputTjeneste.lagInput(kontekst.getBehandlingId());
-        return BehandleStegResultat.utførtMedAksjonspunkter(aksjonspunktUtleder.utledFor(uttakInput, true));
+        return BehandleStegResultat.utførtMedAksjonspunkter(aksjonspunktUtleder.utledFor(uttakInput));
     }
 
     @Override

--- a/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/uttak/fp/KontrollerAktivitetskravStegTest.java
+++ b/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/uttak/fp/KontrollerAktivitetskravStegTest.java
@@ -2,7 +2,6 @@ package no.nav.foreldrepenger.behandling.steg.uttak.fp;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -40,7 +39,7 @@ public class KontrollerAktivitetskravStegTest {
         var utleder = mock(KontrollerAktivitetskravAksjonspunktUtleder.class);
         var uttakInputTjeneste = mock(UttakInputTjeneste.class);
         List<AksjonspunktDefinisjon> forventetAksjonspunkter = forventet == null ? List.of() : List.of(forventet);
-        when(utleder.utledFor(any(), anyBoolean())).thenReturn(forventetAksjonspunkter);
+        when(utleder.utledFor(any())).thenReturn(forventetAksjonspunkter);
         var steg = new KontrollerAktivitetskravSteg(utleder, uttakInputTjeneste, null);
         return steg.utførSteg(new BehandlingskontrollKontekst(1L, AktørId.dummy(), mock(BehandlingLås.class)));
     }

--- a/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/uttaksgrunnlag/fp/TidligstMottattOppdaterer.java
+++ b/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/uttaksgrunnlag/fp/TidligstMottattOppdaterer.java
@@ -7,6 +7,9 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.periode.GraderingAktivitetType;
 import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.periode.OppgittFordelingEntitet;
 import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.periode.OppgittPeriodeBuilder;
@@ -24,6 +27,8 @@ import no.nav.fpsak.tidsserie.LocalDateTimeline;
 import no.nav.fpsak.tidsserie.StandardCombinators;
 
 public class TidligstMottattOppdaterer {
+
+    private static final Logger LOG = LoggerFactory.getLogger(TidligstMottattOppdaterer.class);
 
     private TidligstMottattOppdaterer() {
     }
@@ -47,7 +52,11 @@ public class TidligstMottattOppdaterer {
         for (var f : tidligereFordelinger) {
             var perioder = perioderForFordeling(f.getPerioder(), mottattDato, tidligstedato);
             if (!perioder.isEmpty()) {
-                nysøknadTidslinje = oppdaterTidligstMottattDato(nysøknadTidslinje, tidslinjeSammenlignNysøknad, perioder);
+                try {
+                    nysøknadTidslinje = oppdaterTidligstMottattDato(nysøknadTidslinje, tidslinjeSammenlignNysøknad, perioder);
+                } catch (Exception e) {
+                    LOG.warn("TidligstMottatt: Feil ved sjekk av tidligere fordeling {} - se bort fra enkelttilfelle, varsle dersom mange", f.getId());
+                }
             }
         }
 

--- a/domenetjenester/uttak/src/test/java/no/nav/foreldrepenger/domene/uttak/fakta/aktkrav/KontrollerAktivitetskravAksjonspunktUtlederTest.java
+++ b/domenetjenester/uttak/src/test/java/no/nav/foreldrepenger/domene/uttak/fakta/aktkrav/KontrollerAktivitetskravAksjonspunktUtlederTest.java
@@ -464,11 +464,11 @@ public class KontrollerAktivitetskravAksjonspunktUtlederTest {
         var familieHendelse = FamilieHendelse.forFødsel(fødselsdato, fødselsdato, List.of(), 1);
         var ref = BehandlingReferanse.fra(behandling);
         var fellesperiode1Resultat = skalKontrollereAktivitetskrav(ref, fellesperiode1,
-            ytelseFordelingTjeneste.hentAggregat(behandling.getId()), familieHendelse, true, List.of(), false);
+            ytelseFordelingTjeneste.hentAggregat(behandling.getId()), familieHendelse, true);
         var fellesperiode2Resultat = skalKontrollereAktivitetskrav(ref, fellesperiode2,
-            ytelseFordelingTjeneste.hentAggregat(behandling.getId()), familieHendelse, true, List.of(), false);
+            ytelseFordelingTjeneste.hentAggregat(behandling.getId()), familieHendelse, true);
         var fellesperiode3Resultat = skalKontrollereAktivitetskrav(ref, fellesperiode3,
-            ytelseFordelingTjeneste.hentAggregat(behandling.getId()), familieHendelse, true, List.of(), false);
+            ytelseFordelingTjeneste.hentAggregat(behandling.getId()), familieHendelse, true);
 
 
         assertThat(fellesperiode1Resultat.isAvklart()).isTrue();
@@ -506,7 +506,7 @@ public class KontrollerAktivitetskravAksjonspunktUtlederTest {
         var familieHendelse = FamilieHendelse.forFødsel(fødselsdato, fødselsdato, List.of(), 1);
         var ref = BehandlingReferanse.fra(behandling);
         var fellesperiode1Resultat = skalKontrollereAktivitetskrav(ref, fellesperiode,
-            ytelseFordelingTjeneste.hentAggregat(behandling.getId()), familieHendelse, true, List.of(), false);
+            ytelseFordelingTjeneste.hentAggregat(behandling.getId()), familieHendelse, true);
 
         assertThat(fellesperiode1Resultat.isAvklart()).isFalse();
         assertThat(fellesperiode1Resultat.kravTilAktivitet()).isTrue();
@@ -536,7 +536,7 @@ public class KontrollerAktivitetskravAksjonspunktUtlederTest {
         var familieHendelse = FamilieHendelse.forFødsel(fødselsdato, fødselsdato, List.of(), 1);
         var ref = BehandlingReferanse.fra(behandling);
         var fellesperiode1Resultat = skalKontrollereAktivitetskrav(ref, fellesperiode,
-            ytelseFordelingTjeneste.hentAggregat(behandling.getId()), familieHendelse, true, List.of(), false);
+            ytelseFordelingTjeneste.hentAggregat(behandling.getId()), familieHendelse, true);
 
         assertThat(fellesperiode1Resultat.isAvklart()).isTrue();
         assertThat(fellesperiode1Resultat.kravTilAktivitet()).isTrue();
@@ -563,7 +563,7 @@ public class KontrollerAktivitetskravAksjonspunktUtlederTest {
         var familieHendelse = FamilieHendelse.forFødsel(fødselsdato, fødselsdato, List.of(), 1);
         var ref = BehandlingReferanse.fra(behandling);
         var fellesperiode1Resultat = skalKontrollereAktivitetskrav(ref, fellesperiode,
-            ytelseFordelingTjeneste.hentAggregat(behandling.getId()), familieHendelse, true, List.of(), false);
+            ytelseFordelingTjeneste.hentAggregat(behandling.getId()), familieHendelse, true);
 
         assertThat(fellesperiode1Resultat.isAvklart()).isFalse();
         assertThat(fellesperiode1Resultat.kravTilAktivitet()).isFalse();
@@ -591,7 +591,7 @@ public class KontrollerAktivitetskravAksjonspunktUtlederTest {
         var familieHendelse = FamilieHendelse.forFødsel(fødselsdato, fødselsdato, List.of(), 1);
         var ref = BehandlingReferanse.fra(behandling);
         var fellesperiode1Resultat = skalKontrollereAktivitetskrav(ref, fellesperiode,
-            ytelseFordelingTjeneste.hentAggregat(behandling.getId()), familieHendelse, true, List.of(), false);
+            ytelseFordelingTjeneste.hentAggregat(behandling.getId()), familieHendelse, true);
 
         assertThat(fellesperiode1Resultat.isAvklart()).isFalse();
         assertThat(fellesperiode1Resultat.kravTilAktivitet()).isFalse();

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/uttak/app/KontrollerAktivitetskravDtoTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/uttak/app/KontrollerAktivitetskravDtoTjeneste.java
@@ -75,12 +75,11 @@ public class KontrollerAktivitetskravDtoTjeneste {
             .map(Annenpart::gjeldendeVedtakBehandlingId)
             .flatMap(foreldrepengerUttakTjeneste::hentUttakHvisEksisterer);
         var annenForelderHarRett = UttakOmsorgUtil.harAnnenForelderRett(ytelseFordelingAggregat, annenpartUttak);
-        var annenForelderFullMK = KontrollerAktivitetskravAksjonspunktUtleder.annenpartsHundreprosentMødrekvote(annenpartUttak);
 
         var result = new ArrayList<KontrollerAktivitetskravPeriodeDto>();
         for (var søknadsperiode : ytelseFordelingAggregat.getGjeldendeFordeling().getPerioder()) {
             var avklaringsresultat = KontrollerAktivitetskravAksjonspunktUtleder.skalKontrollereAktivitetskrav(
-                behandlingReferanse, søknadsperiode, ytelseFordelingAggregat, familieHendelse, annenForelderHarRett, annenForelderFullMK, false);
+                behandlingReferanse, søknadsperiode, ytelseFordelingAggregat, familieHendelse, annenForelderHarRett);
             if (avklaringsresultat.kravTilAktivitet()) {
                 if (avklaringsresultat.isAvklart()) {
                     var avklartePerioder = avklaringsresultat.avklartePerioder();


### PR DESCRIPTION
Her var det overlapp tom=fom=15/6 i en endringssøknad som var merget og henlagt. 
Det er en del overlapp fra vår 22 - ignorerer disse.

Fjerner logging av 150% - har bare vært 5 tilfelle av 4000 endringssøknader.