### PR TITLE
TFP-4873 viser også perioder fra forrige vedtak i fakta om uttak. Dis…

### DIFF
--- a/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/uttaksgrunnlag/fp/OppgittPeriodeUtil.java
+++ b/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/uttaksgrunnlag/fp/OppgittPeriodeUtil.java
@@ -14,7 +14,7 @@ import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.årsak.
 import no.nav.foreldrepenger.domene.tid.SimpleLocalDateInterval;
 import no.nav.foreldrepenger.regler.uttak.felles.Virkedager;
 
-class OppgittPeriodeUtil {
+public class OppgittPeriodeUtil {
 
     private OppgittPeriodeUtil() {
         //Forhindrer instanser
@@ -56,7 +56,7 @@ class OppgittPeriodeUtil {
         return perioder.stream().map(OppgittPeriodeEntitet::getFom).min(Comparator.naturalOrder());
     }
 
-    static List<OppgittPeriodeEntitet> slåSammenLikePerioder(List<OppgittPeriodeEntitet> perioder) {
+    public static List<OppgittPeriodeEntitet> slåSammenLikePerioder(List<OppgittPeriodeEntitet> perioder) {
         List<OppgittPeriodeEntitet> resultat = new ArrayList<>();
 
         var i = 0;
@@ -81,7 +81,7 @@ class OppgittPeriodeUtil {
         return resultat;
     }
 
-    private static boolean erLikBortsettFraTidsperiode(OppgittPeriodeEntitet periode1, OppgittPeriodeEntitet periode2) {
+    public static boolean erLikBortsettFraTidsperiode(OppgittPeriodeEntitet periode1, OppgittPeriodeEntitet periode2) {
         //begrunnelse ikke viktig å se på
         return Objects.equals(periode1.getGraderingAktivitetType(), periode2.getGraderingAktivitetType()) &&
             Objects.equals(periode1.isFlerbarnsdager(), periode2.isFlerbarnsdager()) &&

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/uttak/fakta/FaktaUttakHistorikkinnslagTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/uttak/fakta/FaktaUttakHistorikkinnslagTjeneste.java
@@ -202,7 +202,7 @@ public class FaktaUttakHistorikkinnslagTjeneste {
 
     private record Endring(String intro, String tekstFra, String tekstTil) {}
 
-    public static boolean erLikePerioder(OppgittPeriodeEntitet før, OppgittPeriodeEntitet etter) {
+    private static boolean erLikePerioder(OppgittPeriodeEntitet før, OppgittPeriodeEntitet etter) {
         return Objects.equals(før, etter) || (Objects.equals(før.getPeriodeType(), etter.getPeriodeType()) &&
             Objects.equals(før.getÅrsak(), etter.getÅrsak()) &&
             Objects.equals(arbeidsprosent(før), arbeidsprosent(etter)) &&

--- a/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/BehandlingÅrsakDtoTest.java
+++ b/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/BehandlingÅrsakDtoTest.java
@@ -69,7 +69,8 @@ public class BehandlingÅrsakDtoTest extends EntityManagerAwareTest {
             uttakInputTjeneste, new VurderUttakDokumentasjonAksjonspunktUtleder(ytelseFordelingTjeneste, new AktivitetskravDokumentasjonUtleder(foreldrepengerUttakTjeneste)));
         var kontrollerAktivitetskravDtoTjeneste = new KontrollerAktivitetskravDtoTjeneste(repositoryProvider.getBehandlingRepository(),
             ytelseFordelingTjeneste, uttakInputTjeneste, foreldrepengerUttakTjeneste);
-        var faktaUttakPeriodeDtoTjeneste = new FaktaUttakPeriodeDtoTjeneste(uttakInputTjeneste, ytelseFordelingTjeneste, repositoryProvider.getBehandlingRepository());
+        var faktaUttakPeriodeDtoTjeneste = new FaktaUttakPeriodeDtoTjeneste(uttakInputTjeneste, ytelseFordelingTjeneste, repositoryProvider.getBehandlingRepository(),
+            repositoryProvider.getFpUttakRepository());
 
         behandlingDtoTjeneste = new BehandlingDtoTjeneste(repositoryProvider, beregningtjeneste,
             tilbakekrevingRepository, skjæringstidspunktTjeneste, opptjeningIUtlandDokStatusTjeneste,

--- a/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/uttak/fakta/FaktaUttakPeriodeDtoTjenesteTest.java
+++ b/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/uttak/fakta/FaktaUttakPeriodeDtoTjenesteTest.java
@@ -12,7 +12,9 @@ import org.junit.jupiter.api.Test;
 
 import no.nav.foreldrepenger.behandling.revurdering.ytelse.UttakInputTjeneste;
 import no.nav.foreldrepenger.behandling.revurdering.ytelse.fp.BeregningUttakTjeneste;
+import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingÅrsakType;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepositoryProvider;
+import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.AvklarteUttakDatoerEntitet;
 import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.MorsAktivitet;
 import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.periode.DokumentasjonVurdering;
 import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.periode.FordelingPeriodeKilde;
@@ -22,7 +24,18 @@ import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.periode
 import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.periode.UttakPeriodeType;
 import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.årsak.UtsettelseÅrsak;
 import no.nav.foreldrepenger.behandlingslager.testutilities.behandling.ScenarioMorSøkerForeldrepenger;
+import no.nav.foreldrepenger.behandlingslager.uttak.PeriodeResultatType;
+import no.nav.foreldrepenger.behandlingslager.uttak.Utbetalingsgrad;
+import no.nav.foreldrepenger.behandlingslager.uttak.UttakArbeidType;
+import no.nav.foreldrepenger.behandlingslager.uttak.fp.PeriodeResultatÅrsak;
 import no.nav.foreldrepenger.behandlingslager.uttak.fp.SamtidigUttaksprosent;
+import no.nav.foreldrepenger.behandlingslager.uttak.fp.StønadskontoType;
+import no.nav.foreldrepenger.behandlingslager.uttak.fp.Trekkdager;
+import no.nav.foreldrepenger.behandlingslager.uttak.fp.UttakAktivitetEntitet;
+import no.nav.foreldrepenger.behandlingslager.uttak.fp.UttakResultatPeriodeAktivitetEntitet;
+import no.nav.foreldrepenger.behandlingslager.uttak.fp.UttakResultatPeriodeEntitet;
+import no.nav.foreldrepenger.behandlingslager.uttak.fp.UttakResultatPeriodeSøknadEntitet;
+import no.nav.foreldrepenger.behandlingslager.uttak.fp.UttakResultatPerioderEntitet;
 import no.nav.foreldrepenger.behandlingslager.virksomhet.Arbeidsgiver;
 import no.nav.foreldrepenger.dbstoette.CdiDbAwareTest;
 import no.nav.foreldrepenger.domene.abakus.AbakusInMemoryInntektArbeidYtelseTjeneste;
@@ -63,8 +76,38 @@ class FaktaUttakPeriodeDtoTjenesteTest {
 
         var dtoTjeneste = dtoTjeneste();
 
+        var fødselsdato = LocalDate.now();
+        var førstegangsbehandling = ScenarioMorSøkerForeldrepenger.forFødsel()
+            .medFødselAdopsjonsdato(fødselsdato)
+            .lagre(repositoryProvider);
+
+        var uttaksperiode = new UttakResultatPeriodeEntitet.Builder(fødselsdato, fødselsdato.plusWeeks(10))
+            .medResultatType(PeriodeResultatType.INNVILGET, PeriodeResultatÅrsak.KVOTE_ELLER_OVERFØRT_KVOTE)
+            .medSamtidigUttak(true)
+            .medSamtidigUttaksprosent(SamtidigUttaksprosent.TEN)
+            .medGraderingInnvilget(true)
+            .medFlerbarnsdager(true)
+            .medPeriodeSoknad(new UttakResultatPeriodeSøknadEntitet.Builder()
+                .medMorsAktivitet(MorsAktivitet.ARBEID)
+                .medGraderingArbeidsprosent(BigDecimal.TEN)
+                .medUttakPeriodeType(UttakPeriodeType.FELLESPERIODE)
+                .build())
+            .build();
+        new UttakResultatPeriodeAktivitetEntitet.Builder(uttaksperiode, new UttakAktivitetEntitet.Builder()
+            .medUttakArbeidType(UttakArbeidType.FRILANS)
+            .build())
+                .medArbeidsprosent(BigDecimal.ZERO)
+                .medUtbetalingsgrad(Utbetalingsgrad.FULL)
+                .medTrekkdager(new Trekkdager(10))
+                .medErSøktGradering(true)
+                .medTrekkonto(StønadskontoType.FELLESPERIODE)
+            .build();
+        var uttakperioder = new UttakResultatPerioderEntitet();
+        uttakperioder.leggTilPeriode(uttaksperiode);
+        repositoryProvider.getFpUttakRepository().lagreOpprinneligUttakResultatPerioder(førstegangsbehandling.getId(), uttakperioder);
+
         var op = OppgittPeriodeBuilder.ny()
-            .medPeriode(LocalDate.now(), LocalDate.now().plusWeeks(6))
+            .medPeriode(uttaksperiode.getTom().plusDays(1), uttaksperiode.getTom().plusDays(1).plusWeeks(6))
             .medPeriodeType(UttakPeriodeType.MØDREKVOTE)
             .medPeriodeKilde(FordelingPeriodeKilde.SØKNAD)
             .medArbeidsprosent(BigDecimal.TEN)
@@ -80,24 +123,40 @@ class FaktaUttakPeriodeDtoTjenesteTest {
 
         var behandling = ScenarioMorSøkerForeldrepenger.forFødsel()
             .medFordeling(new OppgittFordelingEntitet(List.of(op), true))
-            .medFødselAdopsjonsdato(LocalDate.now())
+            .medFødselAdopsjonsdato(fødselsdato)
+            .medOriginalBehandling(førstegangsbehandling, BehandlingÅrsakType.RE_ENDRING_FRA_BRUKER)
+            .medAvklarteUttakDatoer(new AvklarteUttakDatoerEntitet.Builder().medOpprinneligEndringsdato(op.getFom()).build())
             .lagre(repositoryProvider);
 
         var resultat = dtoTjeneste.lagDtos(new UuidDto(behandling.getUuid()));
 
-        assertThat(resultat).hasSize(1);
-        assertThat(resultat.get(0).fom()).isEqualTo(op.getFom());
-        assertThat(resultat.get(0).tom()).isEqualTo(op.getTom());
-        assertThat(resultat.get(0).uttakPeriodeType()).isEqualTo(op.getPeriodeType());
-        assertThat(resultat.get(0).periodeKilde()).isEqualTo(op.getPeriodeKilde());
-        assertThat(resultat.get(0).arbeidstidsprosent()).isEqualTo(op.getArbeidsprosent());
-        assertThat(resultat.get(0).arbeidsforhold().arbeidsgiverReferanse()).isEqualTo(op.getArbeidsgiver().getIdentifikator());
-        assertThat(resultat.get(0).morsAktivitet()).isEqualTo(op.getMorsAktivitet());
-        assertThat(resultat.get(0).samtidigUttaksprosent()).isEqualTo(op.getSamtidigUttaksprosent());
-        assertThat(resultat.get(0).utsettelseÅrsak()).isEqualTo(op.getÅrsak());
+        assertThat(resultat).hasSize(2);
+
+        assertThat(resultat.get(0).fom()).isEqualTo(uttaksperiode.getFom());
+        assertThat(resultat.get(0).tom()).isEqualTo(uttaksperiode.getTom());
+        assertThat(resultat.get(0).uttakPeriodeType()).isEqualTo(UttakPeriodeType.FELLESPERIODE);
+        assertThat(resultat.get(0).arbeidstidsprosent()).isEqualTo(uttaksperiode.getPeriodeSøknad().get().getGraderingArbeidsprosent());
+        assertThat(resultat.get(0).arbeidsforhold().arbeidsgiverReferanse()).isNull();
+        assertThat(resultat.get(0).morsAktivitet()).isEqualTo(uttaksperiode.getPeriodeSøknad().orElseThrow().getMorsAktivitet());
+        assertThat(resultat.get(0).samtidigUttaksprosent()).isEqualTo(uttaksperiode.getSamtidigUttaksprosent());
+        assertThat(resultat.get(0).utsettelseÅrsak()).isNull();
         assertThat(resultat.get(0).oppholdÅrsak()).isNull();
         assertThat(resultat.get(0).overføringÅrsak()).isNull();
-        assertThat(resultat.get(0).flerbarnsdager()).isEqualTo(op.isFlerbarnsdager());
+        assertThat(resultat.get(0).flerbarnsdager()).isEqualTo(uttaksperiode.isFlerbarnsdager());
+        assertThat(resultat.get(0).periodeKilde()).isEqualTo(FordelingPeriodeKilde.TIDLIGERE_VEDTAK);
+
+        assertThat(resultat.get(1).fom()).isEqualTo(op.getFom());
+        assertThat(resultat.get(1).tom()).isEqualTo(op.getTom());
+        assertThat(resultat.get(1).uttakPeriodeType()).isEqualTo(op.getPeriodeType());
+        assertThat(resultat.get(1).periodeKilde()).isEqualTo(op.getPeriodeKilde());
+        assertThat(resultat.get(1).arbeidstidsprosent()).isEqualTo(op.getArbeidsprosent());
+        assertThat(resultat.get(1).arbeidsforhold().arbeidsgiverReferanse()).isEqualTo(op.getArbeidsgiver().getIdentifikator());
+        assertThat(resultat.get(1).morsAktivitet()).isEqualTo(op.getMorsAktivitet());
+        assertThat(resultat.get(1).samtidigUttaksprosent()).isEqualTo(op.getSamtidigUttaksprosent());
+        assertThat(resultat.get(1).utsettelseÅrsak()).isEqualTo(op.getÅrsak());
+        assertThat(resultat.get(1).oppholdÅrsak()).isNull();
+        assertThat(resultat.get(1).overføringÅrsak()).isNull();
+        assertThat(resultat.get(1).flerbarnsdager()).isEqualTo(op.isFlerbarnsdager());
     }
 
     private FaktaUttakPeriodeDtoTjeneste dtoTjeneste() {
@@ -105,7 +164,8 @@ class FaktaUttakPeriodeDtoTjenesteTest {
             new HentOgLagreBeregningsgrunnlagTjeneste(repositoryProvider.getEntityManager()), new AbakusInMemoryInntektArbeidYtelseTjeneste(),
             skjæringstidspunktTjeneste, medlemTjeneste, beregningUttakTjeneste,
             new YtelseFordelingTjeneste(repositoryProvider.getYtelsesFordelingRepository()), true);
-        return new FaktaUttakPeriodeDtoTjeneste(uttakInputTjeneste, ytelseFordelingTjeneste, repositoryProvider.getBehandlingRepository());
+        return new FaktaUttakPeriodeDtoTjeneste(uttakInputTjeneste, ytelseFordelingTjeneste, repositoryProvider.getBehandlingRepository(),
+            repositoryProvider.getFpUttakRepository());
     }
 
 }


### PR DESCRIPTION
Henter perioder før endringsdato fram originalbehandling.
Disse vises på samme måte som behandlingens perioder (med kilde Vedtak).
Saksbehandler kan velge å endre disse, da vil endringsdato i behandling flyttes til første dag med endring (samme som skjer hvis man legger til en periode før endringsdato gamle fakta uttak).
Oppdaterer ser til at alle perioder etter endringsdato lagres i overstyrt + evt perioder med endring før endringsdato