### PR TITLE
TFP-5356 ikke opphør ved søknad på minsterett to tette

### DIFF
--- a/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/foreslåresultat/fp/ForeslåBehandlingsresultatTjenesteTest.java
+++ b/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/foreslåresultat/fp/ForeslåBehandlingsresultatTjenesteTest.java
@@ -18,8 +18,6 @@ import org.mockito.ArgumentMatchers;
 
 import no.nav.foreldrepenger.behandling.BehandlingReferanse;
 import no.nav.foreldrepenger.behandling.Skjæringstidspunkt;
-import no.nav.foreldrepenger.behandling.revurdering.ytelse.UttakInputTjeneste;
-import no.nav.foreldrepenger.behandling.revurdering.ytelse.fp.BeregningUttakTjeneste;
 import no.nav.foreldrepenger.behandling.revurdering.ytelse.fp.RevurderingBehandlingsresultatutleder;
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingResultatType;
@@ -28,6 +26,7 @@ import no.nav.foreldrepenger.behandlingslager.behandling.Behandlingsresultat;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingÅrsak;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingÅrsakType;
 import no.nav.foreldrepenger.behandlingslager.behandling.KonsekvensForYtelsen;
+import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingGrunnlagRepositoryProvider;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepositoryProvider;
 import no.nav.foreldrepenger.behandlingslager.behandling.vedtak.BehandlingVedtak;
@@ -48,19 +47,17 @@ import no.nav.foreldrepenger.behandlingslager.uttak.fp.UttakResultatPeriodeEntit
 import no.nav.foreldrepenger.behandlingslager.uttak.fp.UttakResultatPerioderEntitet;
 import no.nav.foreldrepenger.dbstoette.EntityManagerAwareTest;
 import no.nav.foreldrepenger.dokumentbestiller.DokumentBehandlingTjeneste;
-import no.nav.foreldrepenger.domene.abakus.AbakusInMemoryInntektArbeidYtelseTjeneste;
 import no.nav.foreldrepenger.domene.medlem.MedlemTjeneste;
 import no.nav.foreldrepenger.domene.prosess.BeregningTjeneste;
-import no.nav.foreldrepenger.domene.prosess.HentOgLagreBeregningsgrunnlagTjeneste;
 import no.nav.foreldrepenger.domene.uttak.ForeldrepengerUttakTjeneste;
 import no.nav.foreldrepenger.domene.uttak.OpphørUttakTjeneste;
-import no.nav.foreldrepenger.domene.uttak.UttakRepositoryProvider;
 import no.nav.foreldrepenger.skjæringstidspunkt.SkjæringstidspunktTjeneste;
 
 public class ForeslåBehandlingsresultatTjenesteTest extends EntityManagerAwareTest {
     private static final LocalDate SKJÆRINGSTIDSPUNKT = LocalDate.now();
 
     private BehandlingRepositoryProvider repositoryProvider;
+    private BehandlingGrunnlagRepositoryProvider grunnlagRepositoryProvider;
 
     private final DokumentBehandlingTjeneste dokumentBehandlingTjeneste = mock(DokumentBehandlingTjeneste.class);
     private final OpphørUttakTjeneste opphørUttakTjeneste = mock(OpphørUttakTjeneste.class);
@@ -78,10 +75,12 @@ public class ForeslåBehandlingsresultatTjenesteTest extends EntityManagerAwareT
         when(medlemTjeneste.utledVilkårUtfall(any())).thenReturn(new MedlemTjeneste.VilkårUtfallMedÅrsak(VilkårUtfallType.OPPFYLT, Avslagsårsak.UDEFINERT));
         when(beregningTjeneste.hent(any())).thenReturn(Optional.empty());
         var entityManager = getEntityManager();
-        this.repositoryProvider = new BehandlingRepositoryProvider(entityManager);
+        repositoryProvider = new BehandlingRepositoryProvider(entityManager);
+        grunnlagRepositoryProvider = new BehandlingGrunnlagRepositoryProvider(entityManager);
         fpUttakRepository = this.repositoryProvider.getFpUttakRepository();
         var uttakTjeneste = new ForeldrepengerUttakTjeneste(fpUttakRepository);
-        revurderingBehandlingsresultatutleder = spy(new RevurderingBehandlingsresultatutleder(this.repositoryProvider,
+        revurderingBehandlingsresultatutleder = spy(new RevurderingBehandlingsresultatutleder(repositoryProvider,
+                grunnlagRepositoryProvider,
                 beregningTjeneste,
                 opphørUttakTjeneste,
                 skjæringstidspunktTjeneste,

--- a/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/foreslåresultat/svp/ForeslåBehandlingsresultatTjenesteTest.java
+++ b/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/foreslåresultat/svp/ForeslåBehandlingsresultatTjenesteTest.java
@@ -26,6 +26,7 @@ import no.nav.foreldrepenger.behandlingslager.behandling.Behandlingsresultat;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingÅrsak;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingÅrsakType;
 import no.nav.foreldrepenger.behandlingslager.behandling.KonsekvensForYtelsen;
+import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingGrunnlagRepositoryProvider;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepositoryProvider;
 import no.nav.foreldrepenger.behandlingslager.behandling.vedtak.BehandlingVedtak;
@@ -61,6 +62,7 @@ public class ForeslåBehandlingsresultatTjenesteTest extends EntityManagerAwareT
     private static final LocalDate SKJÆRINGSTIDSPUNKT = LocalDate.now();
 
     private BehandlingRepositoryProvider repositoryProvider;
+    private BehandlingGrunnlagRepositoryProvider grunnlagRepositoryProvider;
 
     private final BeregningTjeneste beregningTjeneste = mock(BeregningTjeneste.class);
     private final DokumentBehandlingTjeneste dokumentBehandlingTjeneste = mock(DokumentBehandlingTjeneste.class);
@@ -79,10 +81,12 @@ public class ForeslåBehandlingsresultatTjenesteTest extends EntityManagerAwareT
         when(medlemTjeneste.utledVilkårUtfall(any())).thenReturn(new MedlemTjeneste.VilkårUtfallMedÅrsak(VilkårUtfallType.OPPFYLT, Avslagsårsak.UDEFINERT));
         var entityManager = getEntityManager();
         repositoryProvider = new BehandlingRepositoryProvider(entityManager);
+        grunnlagRepositoryProvider = new BehandlingGrunnlagRepositoryProvider(entityManager);
         behandlingRepository = repositoryProvider.getBehandlingRepository();
         behandlingVedtakRepository = repositoryProvider.getBehandlingVedtakRepository();
         var svpUttakRepository = new SvangerskapspengerUttakResultatRepository(entityManager);
         revurderingBehandlingsresultatutleder = spy(new RevurderingBehandlingsresultatutleder(repositoryProvider,
+                grunnlagRepositoryProvider,
                 svpUttakRepository,
             beregningTjeneste,
                 opphørUttakTjeneste,

--- a/domenetjenester/behandling-revurdering/src/main/java/no/nav/foreldrepenger/behandling/revurdering/felles/UttakResultatHolder.java
+++ b/domenetjenester/behandling-revurdering/src/main/java/no/nav/foreldrepenger/behandling/revurdering/felles/UttakResultatHolder.java
@@ -23,6 +23,10 @@ public interface UttakResultatHolder {
      */
     boolean kontrollerErSisteUttakAvslåttMedÅrsak();
 
+    default boolean harOpphørsUttakNyeInnvilgetePerioder(UttakResultatHolder other) {
+        return false;
+    }
+
     boolean harUlikUttaksplan(UttakResultatHolder other);
 
     Optional<BehandlingVedtak> getBehandlingVedtak();

--- a/domenetjenester/behandling-revurdering/src/main/java/no/nav/foreldrepenger/behandling/revurdering/ytelse/fp/RevurderingBehandlingsresultatutleder.java
+++ b/domenetjenester/behandling-revurdering/src/main/java/no/nav/foreldrepenger/behandling/revurdering/ytelse/fp/RevurderingBehandlingsresultatutleder.java
@@ -8,6 +8,7 @@ import no.nav.foreldrepenger.behandling.revurdering.felles.UttakResultatHolder;
 import no.nav.foreldrepenger.behandlingskontroll.BehandlingTypeRef;
 import no.nav.foreldrepenger.behandlingskontroll.FagsakYtelseTypeRef;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingType;
+import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingGrunnlagRepositoryProvider;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepositoryProvider;
 import no.nav.foreldrepenger.behandlingslager.behandling.vedtak.BehandlingVedtakRepository;
 import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakYtelseType;
@@ -27,12 +28,14 @@ public class RevurderingBehandlingsresultatutleder extends RevurderingBehandling
 
     @Inject
     public RevurderingBehandlingsresultatutleder(BehandlingRepositoryProvider repositoryProvider, // NOSONAR
+                                                 BehandlingGrunnlagRepositoryProvider grunnlagRepositoryProvider,
             BeregningTjeneste beregningTjeneste,
             OpphørUttakTjeneste opphørUttakTjeneste,
             @FagsakYtelseTypeRef(FagsakYtelseType.FORELDREPENGER) SkjæringstidspunktTjeneste skjæringstidspunktTjeneste,
             MedlemTjeneste medlemTjeneste,
             ForeldrepengerUttakTjeneste foreldrepengerUttakTjeneste) {
         super(repositoryProvider,
+                grunnlagRepositoryProvider,
                 beregningTjeneste,
                 medlemTjeneste,
                 opphørUttakTjeneste,

--- a/domenetjenester/behandling-revurdering/src/main/java/no/nav/foreldrepenger/behandling/revurdering/ytelse/fp/UttakResultatHolderFP.java
+++ b/domenetjenester/behandling-revurdering/src/main/java/no/nav/foreldrepenger/behandling/revurdering/ytelse/fp/UttakResultatHolderFP.java
@@ -69,6 +69,17 @@ public class UttakResultatHolderFP implements UttakResultatHolder {
     }
 
     @Override
+    public boolean harOpphørsUttakNyeInnvilgetePerioder(UttakResultatHolder other) {
+        var uttakresultatSammenligneMed = (UttakResultatHolderFP) other;
+        var uttaksTL = lagTidslinjeFraUttaksPerioder(uttakresultatSammenligneMed.getGjeldendePerioder());
+        var originalTL = lagTidslinjeFraUttaksPerioder(getGjeldendePerioder());
+        return uttaksTL.combine(originalTL, this::fjernLikePerioder, LocalDateTimeline.JoinStyle.CROSS_JOIN)
+            .toSegments().stream().map(LocalDateSegment::getValue).filter(Objects::nonNull)
+            .map(WrapUttakPeriode::getP)
+            .anyMatch(ForeldrepengerUttakPeriode::harAktivtUttak);
+    }
+
+    @Override
     public boolean harUlikUttaksplan(UttakResultatHolder other) {
         var uttakresultatSammenligneMed = (UttakResultatHolderFP) other;
         var uttaksTL = lagTidslinjeFraUttaksPerioder(uttakresultatSammenligneMed.getGjeldendePerioder());
@@ -84,6 +95,7 @@ public class UttakResultatHolderFP implements UttakResultatHolder {
     public Optional<BehandlingVedtak> getBehandlingVedtak() {
         return Optional.ofNullable(vedtak);
     }
+
 
     private LocalDateTimeline<WrapUttakPeriode> lagTidslinjeFraUttaksPerioder(List<ForeldrepengerUttakPeriode> uttaksPerioder) {
         return new LocalDateTimeline<>(uttaksPerioder.stream()

--- a/domenetjenester/behandling-revurdering/src/main/java/no/nav/foreldrepenger/behandling/revurdering/ytelse/svp/RevurderingBehandlingsresultatutleder.java
+++ b/domenetjenester/behandling-revurdering/src/main/java/no/nav/foreldrepenger/behandling/revurdering/ytelse/svp/RevurderingBehandlingsresultatutleder.java
@@ -8,6 +8,7 @@ import no.nav.foreldrepenger.behandling.revurdering.felles.UttakResultatHolder;
 import no.nav.foreldrepenger.behandlingskontroll.BehandlingTypeRef;
 import no.nav.foreldrepenger.behandlingskontroll.FagsakYtelseTypeRef;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingType;
+import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingGrunnlagRepositoryProvider;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepositoryProvider;
 import no.nav.foreldrepenger.behandlingslager.behandling.vedtak.BehandlingVedtakRepository;
 import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakYtelseType;
@@ -27,12 +28,14 @@ public class RevurderingBehandlingsresultatutleder extends RevurderingBehandling
 
     @Inject
     public RevurderingBehandlingsresultatutleder(BehandlingRepositoryProvider repositoryProvider,
+            BehandlingGrunnlagRepositoryProvider grunnlagRepositoryProvider,
             SvangerskapspengerUttakResultatRepository uttakResultatRepository,
             BeregningTjeneste beregningTjeneste,
             OpphørUttakTjeneste opphørUttakTjeneste,
             @FagsakYtelseTypeRef(FagsakYtelseType.SVANGERSKAPSPENGER) SkjæringstidspunktTjeneste skjæringstidspunktTjeneste,
             MedlemTjeneste medlemTjeneste) {
         super(repositoryProvider,
+                grunnlagRepositoryProvider,
                 beregningTjeneste,
                 medlemTjeneste,
                 opphørUttakTjeneste,

--- a/domenetjenester/behandling-revurdering/src/test/java/no/nav/foreldrepenger/behandling/revurdering/ytelse/fp/RevurderingBehandlingsresultatutlederTest.java
+++ b/domenetjenester/behandling-revurdering/src/test/java/no/nav/foreldrepenger/behandling/revurdering/ytelse/fp/RevurderingBehandlingsresultatutlederTest.java
@@ -41,6 +41,7 @@ import no.nav.foreldrepenger.behandlingslager.behandling.RettenTil;
 import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.AksjonspunktDefinisjon;
 import no.nav.foreldrepenger.behandlingslager.behandling.beregning.BeregningsresultatRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.opptjening.OpptjeningRepository;
+import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingGrunnlagRepositoryProvider;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepositoryProvider;
 import no.nav.foreldrepenger.behandlingslager.behandling.vedtak.VedtakResultatType;
@@ -104,6 +105,8 @@ public class RevurderingBehandlingsresultatutlederTest {
     @Inject
     private BehandlingRepositoryProvider repositoryProvider;
     @Inject
+    private BehandlingGrunnlagRepositoryProvider grunnlagRepositoryProvider;
+    @Inject
     private ForeldrepengerUttakTjeneste foreldrepengerUttakTjeneste;
     @Mock
     private BeregningTjeneste beregningTjeneste;
@@ -119,6 +122,7 @@ public class RevurderingBehandlingsresultatutlederTest {
     @BeforeEach
     public void setup() {
         revurderingBehandlingsresultatutleder = new RevurderingBehandlingsresultatutleder(repositoryProvider,
+            grunnlagRepositoryProvider,
             beregningTjeneste,
             opphørUttakTjeneste,
             skjæringstidspunktTjeneste,

--- a/domenetjenester/behandling-revurdering/src/test/java/no/nav/foreldrepenger/behandling/revurdering/ytelse/svp/RevurderingBehandlingsresultatutlederTest.java
+++ b/domenetjenester/behandling-revurdering/src/test/java/no/nav/foreldrepenger/behandling/revurdering/ytelse/svp/RevurderingBehandlingsresultatutlederTest.java
@@ -138,6 +138,7 @@ public class RevurderingBehandlingsresultatutlederTest {
         revurderingTestUtil.avsluttBehandling(behandlingSomSkalRevurderes);
 
         revurderingBehandlingsresultatutleder = new RevurderingBehandlingsresultatutleder(repositoryProvider,
+                grunnlagRepositoryProvider,
                 uttakResultatRepository,
                 beregningTjeneste,
                 opphørUttakTjeneste,


### PR DESCRIPTION
Se TFP. Sørger for at endringssøknader rundt to tette ikke setter resultat opphør dersom det er innvilget perioder etter stønadsperiode for neste barn selv om enkelte perioder er avslått med årsak som tilsier opphørsbrev
Se også TFP-5360 for flere scenarier