### PR TITLE
Oppvarming med adresse for omsorgs-ap

### DIFF
--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/aktør/Adresseinfo.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/aktør/Adresseinfo.java
@@ -1,6 +1,7 @@
 package no.nav.foreldrepenger.behandlingslager.aktør;
 
 import java.util.Objects;
+import java.util.Optional;
 
 public class Adresseinfo {
 
@@ -78,9 +79,19 @@ public class Adresseinfo {
         if (a1 == null && a2 == null) return true;
         if (a1 == null || a2 == null) return false;
         if (a1.matrikkelId != null || a2.matrikkelId != null) return Objects.equals(a1.matrikkelId, a2.matrikkelId);
-        return Objects.equals(a1.adresselinje1, a2.adresselinje1) &&
+        return likeAdresselinjer(a1, a2) &&
             Objects.equals(a1.postNr, a2.postNr) &&
             Objects.equals(a1.land, a2.land);
+    }
+
+    private static boolean likeAdresselinjer(Adresseinfo a1, Adresseinfo a2) {
+        var a1l1 = kompaktAdresseline(a1.adresselinje1);
+        var a2l1 = kompaktAdresseline(a2.adresselinje1);
+        return Objects.equals(a1l1, a2l1) || Objects.equals(a1l1, kompaktAdresseline(a2.adresselinje2)) || Objects.equals(kompaktAdresseline(a1.adresselinje2), a2l1);
+    }
+
+    private static String kompaktAdresseline(String adresselinje) {
+        return Optional.ofNullable(adresselinje).map(a -> a.replaceAll("\\s", "")).orElse(null);
     }
 
     public static Builder builder(AdresseType gjeldende) {

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/personopplysning/PersonAdresseEntitet.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/personopplysning/PersonAdresseEntitet.java
@@ -1,6 +1,7 @@
 package no.nav.foreldrepenger.behandlingslager.behandling.personopplysning;
 
 import java.util.Objects;
+import java.util.Optional;
 
 import javax.persistence.AttributeOverride;
 import javax.persistence.AttributeOverrides;
@@ -201,6 +202,25 @@ public class PersonAdresseEntitet extends BaseEntitet implements HarAktørId, In
 
     public boolean erUtlandskAdresse() {
         return !Landkoder.erNorge(land) || adresseType.erUtlandsAdresseType();
+    }
+
+    public static boolean likeAdresser(PersonAdresseEntitet a1, PersonAdresseEntitet a2) {
+        if (a1 == null && a2 == null) return true;
+        if (a1 == null || a2 == null) return false;
+        if (a1.matrikkelId != null || a2.matrikkelId != null) return Objects.equals(a1.matrikkelId, a2.matrikkelId);
+        return likeAdresselinjer(a1, a2) &&
+            Objects.equals(a1.postnummer, a2.postnummer) &&
+            Objects.equals(a1.land, a2.land);
+    }
+
+    private static boolean likeAdresselinjer(PersonAdresseEntitet a1, PersonAdresseEntitet a2) {
+        var a1l1 = kompaktAdresseline(a1.adresselinje1);
+        var a2l1 = kompaktAdresseline(a2.adresselinje1);
+        return Objects.equals(a1l1, a2l1) || Objects.equals(a1l1, kompaktAdresseline(a2.adresselinje2)) || Objects.equals(kompaktAdresseline(a1.adresselinje2), a2l1);
+    }
+
+    private static String kompaktAdresseline(String adresselinje) {
+        return Optional.ofNullable(adresselinje).map(a -> a.replaceAll("\\s", "")).orElse(null);
     }
 
     @Override

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/personopplysning/PersonopplysningerAggregat.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/personopplysning/PersonopplysningerAggregat.java
@@ -274,24 +274,13 @@ public class PersonopplysningerAggregat {
         for (var opplysningAdresseSøker : getAdresserFor(søkerAktørId)) {
             for (var opplysningAdresseAnnenpart : getAdresserFor(aktørId)) {
                 var sammeperiode = opplysningAdresseSøker.getPeriode().overlapper(opplysningAdresseAnnenpart.getPeriode());
-                var sammeMatrikkel = likAdresseIgnoringCase(opplysningAdresseSøker.getMatrikkelId(), opplysningAdresseAnnenpart.getMatrikkelId());
-                if (sammeperiode && (sammeMatrikkel || (likAdresseIgnoringCase(opplysningAdresseSøker.getAdresselinje1(), opplysningAdresseAnnenpart.getAdresselinje1())
-                    && Objects.equals(opplysningAdresseSøker.getPostnummer(), opplysningAdresseAnnenpart.getPostnummer())))) {
+                if (sammeperiode && PersonAdresseEntitet.likeAdresser(opplysningAdresseSøker, opplysningAdresseAnnenpart)) {
                     return true;
                 }
             }
         }
         return false;
     }
-
-    private boolean likAdresseIgnoringCase(String adresse1, String adresse2) {
-        if (adresse1 == null && adresse2 == null)
-            return true;
-        if (adresse1 == null || adresse2 == null)
-            return false;
-        return adresse1.equalsIgnoreCase(adresse2);
-    }
-
 
     @Override
     public boolean equals(Object o) {


### PR DESCRIPTION
Utvide intervaller der man sjekker samme bosted - dvs det blir flere brukers-adresse når vi angir et intervall enn kun STP (fx at foreldre flytter sammen). UtledetMedlemsintervall er laget for å dekke omsøkt stønadsperiode til bruk i løpende medlemskap
Så får det heller stå seg at "harSammeAdresse" sjekker at man noensinne har hatt samme adresse ....
Bedre presisjon på adressesammenligning der det mangler matrikkel og lik logikk for barn og ektefelle og utledning.