### PR TITLE
TFP-5036 legg til overstyrt omsorg i db. dto, oppdaterer

### DIFF
--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/ytelsefordeling/YtelseFordelingAggregat.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/ytelsefordeling/YtelseFordelingAggregat.java
@@ -19,6 +19,8 @@ public class YtelseFordelingAggregat {
     private AvklarteUttakDatoerEntitet avklarteDatoer;
     private AktivitetskravPerioderEntitet opprinneligeAktivitetskravPerioder;
     private AktivitetskravPerioderEntitet saksbehandledeAktivitetskravPerioder;
+    private Boolean overstyrtOmsorg;
+    private Boolean migrertDokumentasjonsPerioder;
 
     protected YtelseFordelingAggregat() {
     }
@@ -42,6 +44,18 @@ public class YtelseFordelingAggregat {
 
     public Optional<OppgittRettighetEntitet> getOverstyrtRettighet() {
         return Optional.ofNullable(overstyrtRettighet);
+    }
+
+    public Boolean getOverstyrtOmsorg() {
+        return overstyrtOmsorg;
+    }
+
+    public Boolean harOmsorg() {
+        return overstyrtOmsorg == null || overstyrtOmsorg;
+    }
+
+    public Boolean getMigrertDokumentasjonsPerioder() {
+        return migrertDokumentasjonsPerioder;
     }
 
     public Optional<PerioderUtenOmsorgEntitet> getPerioderUtenOmsorg() {
@@ -173,6 +187,11 @@ public class YtelseFordelingAggregat {
             return this;
         }
 
+        public Builder medOverstyrtOmsorg(Boolean harOmsorg) {
+            kladd.overstyrtOmsorg = harOmsorg;
+            return this;
+        }
+
         public Builder medPerioderUtenOmsorg(PerioderUtenOmsorgEntitet perioderUtenOmsorg) {
             kladd.perioderUtenOmsorg = perioderUtenOmsorg;
             return this;
@@ -195,6 +214,11 @@ public class YtelseFordelingAggregat {
 
         public Builder medAvklarteDatoer(AvklarteUttakDatoerEntitet avklarteUttakDatoer) {
             kladd.avklarteDatoer = avklarteUttakDatoer;
+            return this;
+        }
+
+        public Builder migrertDokumentasjonsPerioder(Boolean migrert) {
+            kladd.migrertDokumentasjonsPerioder = migrert;
             return this;
         }
 

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/ytelsefordeling/YtelseFordelingGrunnlagEntitet.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/ytelsefordeling/YtelseFordelingGrunnlagEntitet.java
@@ -59,6 +59,11 @@ public class YtelseFordelingGrunnlagEntitet extends BaseEntitet {
     @ChangeTracked
     private OppgittDekningsgradEntitet oppgittDekningsgrad;
 
+    @Convert(converter = BooleanToStringConverter.class)
+    @Column(name = "overstyrt_omsorg")
+    @ChangeTracked
+    private Boolean overstyrtOmsorg;
+
     @ManyToOne
     @JoinColumn(name = "utenomsorg_id", updatable = false, unique = true)
     @ChangeTracked
@@ -91,6 +96,11 @@ public class YtelseFordelingGrunnlagEntitet extends BaseEntitet {
     @Version
     @Column(name = "versjon", nullable = false)
     private long versjon;
+
+    @Convert(converter = BooleanToStringConverter.class)
+    @Column(name = "migrert_dok")
+    @ChangeTracked
+    private Boolean migrertDokumentasjonsPerioder;
 
     YtelseFordelingGrunnlagEntitet() {
     }
@@ -150,6 +160,22 @@ public class YtelseFordelingGrunnlagEntitet extends BaseEntitet {
 
     void setAktiv(boolean aktiv) {
         this.aktiv = aktiv;
+    }
+
+    public Boolean getOverstyrtOmsorg() {
+        return overstyrtOmsorg;
+    }
+
+    void setOverstyrtOmsorg(Boolean overstyrtOmsorg) {
+        this.overstyrtOmsorg = overstyrtOmsorg;
+    }
+
+    public Boolean getMigrertDokumentasjonsPerioder() {
+        return migrertDokumentasjonsPerioder;
+    }
+
+    void setMigrertDokumentasjonsPerioder(Boolean migrertDokumentasjonsPerioder) {
+        this.migrertDokumentasjonsPerioder = migrertDokumentasjonsPerioder;
     }
 
     PerioderUtenOmsorgEntitet getPerioderUtenOmsorg() {

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/ytelsefordeling/YtelsesFordelingRepository.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/ytelsefordeling/YtelsesFordelingRepository.java
@@ -68,10 +68,10 @@ public class YtelsesFordelingRepository {
             .medOverstyrtFordeling(ytelseFordelingGrunnlagEntitet.getOverstyrtFordeling())
             .medPerioderUttakDokumentasjon(ytelseFordelingGrunnlagEntitet.getPerioderUttakDokumentasjon())
             .medAvklarteDatoer(ytelseFordelingGrunnlagEntitet.getAvklarteUttakDatoer())
-            .medOpprinneligeAktivitetskravPerioder(
-                ytelseFordelingGrunnlagEntitet.getOpprinneligeAktivitetskravPerioder())
-            .medSaksbehandledeAktivitetskravPerioder(
-                ytelseFordelingGrunnlagEntitet.getSaksbehandledeAktivitetskravPerioder())
+            .medOpprinneligeAktivitetskravPerioder(ytelseFordelingGrunnlagEntitet.getOpprinneligeAktivitetskravPerioder())
+            .medSaksbehandledeAktivitetskravPerioder(ytelseFordelingGrunnlagEntitet.getSaksbehandledeAktivitetskravPerioder())
+            .medOverstyrtOmsorg(ytelseFordelingGrunnlagEntitet.getOverstyrtOmsorg())
+            .migrertDokumentasjonsPerioder(ytelseFordelingGrunnlagEntitet.getMigrertDokumentasjonsPerioder())
             .build();
     }
 
@@ -147,6 +147,8 @@ public class YtelsesFordelingRepository {
         aggregat.getAvklarteDatoer().ifPresent(grunnlag::setAvklarteUttakDatoerEntitet);
         aggregat.getOpprinneligeAktivitetskravPerioder().ifPresent(grunnlag::setOpprinneligeAktivitetskravPerioder);
         aggregat.getSaksbehandledeAktivitetskravPerioder().ifPresent(grunnlag::setSaksbehandledeAktivitetskravPerioder);
+        Optional.ofNullable(aggregat.getOverstyrtOmsorg()).ifPresent(grunnlag::setOverstyrtOmsorg);
+        Optional.ofNullable(aggregat.getMigrertDokumentasjonsPerioder()).ifPresent(grunnlag::setMigrertDokumentasjonsPerioder);
         return grunnlag;
     }
 

--- a/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/ytelsefordeling/YtelseFordelingTjeneste.java
+++ b/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/ytelsefordeling/YtelseFordelingTjeneste.java
@@ -51,6 +51,7 @@ public class YtelseFordelingTjeneste {
         }
         var ytelseFordelingAggregat = ytelsesFordelingRepository.opprettBuilder(behandlingId)
             .medPerioderUtenOmsorg(perioderUtenOmsorg)
+            .medOverstyrtOmsorg(omsorg)
             .build();
         ytelsesFordelingRepository.lagre(behandlingId, ytelseFordelingAggregat);
     }

--- a/domenetjenester/uttak/src/test/java/no/nav/foreldrepenger/domene/uttak/fastsetteperioder/FastsettePerioderRegelAdapterTest.java
+++ b/domenetjenester/uttak/src/test/java/no/nav/foreldrepenger/domene/uttak/fastsetteperioder/FastsettePerioderRegelAdapterTest.java
@@ -832,7 +832,7 @@ public class FastsettePerioderRegelAdapterTest {
         var perioderUtenOmsorg = new PerioderUtenOmsorgEntitet();
         perioderUtenOmsorg.leggTil(new PeriodeUtenOmsorgEntitet(fom, tom));
 
-        var behandling = setupFar(oppgittPeriode, virksomhet, fom, tom, perioderUtenOmsorg);
+        var behandling = setupFar(oppgittPeriode, virksomhet, fom, tom, perioderUtenOmsorg, Boolean.FALSE);
         var beregningsandelTjeneste = new UttakBeregningsandelTjenesteTestUtil();
         beregningsandelTjeneste.leggTilOrdinærtArbeid(virksomhet(), null);
 
@@ -894,7 +894,7 @@ public class FastsettePerioderRegelAdapterTest {
 
         var scenario = ScenarioMorSøkerForeldrepenger.forAdopsjon();
         var behandling = setup(List.of(oppgittPeriode), virksomhet(), startdato.minusYears(2),
-            startdato.plusYears(2), scenario, null, BigDecimal.valueOf(100));
+            startdato.plusYears(2), scenario, null, BigDecimal.valueOf(100), null);
         var beregningsandelTjeneste = new UttakBeregningsandelTjenesteTestUtil();
         beregningsandelTjeneste.leggTilOrdinærtArbeid(virksomhet(), null);
 
@@ -1206,7 +1206,7 @@ public class FastsettePerioderRegelAdapterTest {
             .medSamtidigUttaksprosent(samtidigUttaksprosent)
             .build();
 
-        var behandling = setupFar(oppgittPeriode, arbeidsgiver, start, slutt, null);
+        var behandling = setupFar(oppgittPeriode, arbeidsgiver, start, slutt, null, null);
         var beregningsandelTjeneste = new UttakBeregningsandelTjenesteTestUtil();
         beregningsandelTjeneste.leggTilOrdinærtArbeid(virksomhet(), null);
 
@@ -1799,7 +1799,7 @@ public class FastsettePerioderRegelAdapterTest {
                                 LocalDate arbeidFom,
                                 LocalDate arbeidTom) {
         return setupFødsel(oppgittPerioder, arbeidsgiver, arbeidFom, arbeidTom,
-            ScenarioMorSøkerForeldrepenger.forFødsel(), null);
+            ScenarioMorSøkerForeldrepenger.forFødsel(), null, null);
     }
 
     private Behandling setupFar(OppgittPeriodeEntitet oppgittPeriode,
@@ -1807,16 +1807,16 @@ public class FastsettePerioderRegelAdapterTest {
                                 LocalDate arbeidFom,
                                 LocalDate arbeidTom) {
         return setupFødsel(List.of(oppgittPeriode), arbeidsgiver, arbeidFom, arbeidTom,
-            ScenarioFarSøkerForeldrepenger.forFødsel(), null);
+            ScenarioFarSøkerForeldrepenger.forFødsel(), null, null);
     }
 
     private Behandling setupFar(OppgittPeriodeEntitet oppgittPeriode,
                                 Arbeidsgiver arbeidsgiver,
                                 LocalDate arbeidFom,
                                 LocalDate arbeidTom,
-                                PerioderUtenOmsorgEntitet perioderUtenOmsorg) {
+                                PerioderUtenOmsorgEntitet perioderUtenOmsorg, Boolean overstyrtOmsorg) {
         return setupFødsel(List.of(oppgittPeriode), arbeidsgiver, arbeidFom, arbeidTom,
-            ScenarioFarSøkerForeldrepenger.forFødsel(), perioderUtenOmsorg);
+            ScenarioFarSøkerForeldrepenger.forFødsel(), perioderUtenOmsorg, overstyrtOmsorg);
     }
 
     private Behandling setupFødsel(List<OppgittPeriodeEntitet> oppgittPerioder,
@@ -1824,9 +1824,9 @@ public class FastsettePerioderRegelAdapterTest {
                                    LocalDate arbeidFom,
                                    LocalDate arbeidTom,
                                    AbstractTestScenario<?> scenario,
-                                   PerioderUtenOmsorgEntitet perioderUtenOmsorg) {
+                                   PerioderUtenOmsorgEntitet perioderUtenOmsorg, Boolean overstyrtOmsorg) {
         return setup(oppgittPerioder, arbeidsgiver, arbeidFom, arbeidTom, scenario, perioderUtenOmsorg,
-            BigDecimal.valueOf(100));
+            BigDecimal.valueOf(100), overstyrtOmsorg);
     }
 
     private Behandling setup(List<OppgittPeriodeEntitet> oppgittPerioder,
@@ -1835,9 +1835,10 @@ public class FastsettePerioderRegelAdapterTest {
                              LocalDate arbeidTom,
                              AbstractTestScenario<?> scenario,
                              PerioderUtenOmsorgEntitet perioderUtenOmsorg,
-                             BigDecimal stillingsprosent) {
+                             BigDecimal stillingsprosent, Boolean overstyrtOmsorg) {
 
         scenario.medFordeling(new OppgittFordelingEntitet(oppgittPerioder, true));
+        scenario.medOverstyrtOmsorg(overstyrtOmsorg);
         scenario.medPerioderUtenOmsorg(perioderUtenOmsorg);
         scenario.medOppgittRettighet(new OppgittRettighetEntitet(true, false, false, false));
 

--- a/domenetjenester/uttak/src/test/java/no/nav/foreldrepenger/domene/uttak/testutilities/behandling/AbstractTestScenario.java
+++ b/domenetjenester/uttak/src/test/java/no/nav/foreldrepenger/domene/uttak/testutilities/behandling/AbstractTestScenario.java
@@ -63,6 +63,7 @@ public abstract class AbstractTestScenario<S extends AbstractTestScenario<S>> {
 
     private Behandling originalBehandling;
     private Set<BehandlingÅrsakType> behandlingÅrsaker;
+    private Boolean overstyrtOmsorg;
     private PerioderUtenOmsorgEntitet perioderUtenOmsorg;
     private UttakResultatPerioderEntitet uttak;
     private AktivitetskravPerioderEntitet opprinneligeAktivitetskravPerioder;
@@ -156,7 +157,7 @@ public abstract class AbstractTestScenario<S extends AbstractTestScenario<S>> {
     private void lagreYtelseFordeling(UttakRepositoryProvider repositoryProvider, Behandling behandling) {
         if (oppgittRettighet == null && oppgittDekningsgrad == null && oppgittFordeling == null && overstyrtRettighet == null
             && avklarteUttakDatoer == null && perioderUtenOmsorg == null && opprinneligeAktivitetskravPerioder == null && justertFordeling == null
-            && saksbehandledeAktivitetskravPerioder == null) {
+            && saksbehandledeAktivitetskravPerioder == null && overstyrtOmsorg == null) {
             return;
         }
         var ytelsesFordelingRepository = repositoryProvider.getYtelsesFordelingRepository();
@@ -168,6 +169,7 @@ public abstract class AbstractTestScenario<S extends AbstractTestScenario<S>> {
             .medJustertFordeling(justertFordeling)
             .medAvklarteDatoer(avklarteUttakDatoer)
             .medPerioderUtenOmsorg(perioderUtenOmsorg)
+            .medOverstyrtOmsorg(overstyrtOmsorg)
             .medOpprinneligeAktivitetskravPerioder(opprinneligeAktivitetskravPerioder)
             .medSaksbehandledeAktivitetskravPerioder(saksbehandledeAktivitetskravPerioder)
             ;
@@ -271,6 +273,12 @@ public abstract class AbstractTestScenario<S extends AbstractTestScenario<S>> {
     @SuppressWarnings("unchecked")
     public S medAvklarteUttakDatoer(AvklarteUttakDatoerEntitet avklarteUttakDatoer) {
         this.avklarteUttakDatoer = avklarteUttakDatoer;
+        return (S) this;
+    }
+
+    @SuppressWarnings("unchecked")
+    public S medOverstyrtOmsorg(Boolean overstyrtOmsorg) {
+        this.overstyrtOmsorg = overstyrtOmsorg;
         return (S) this;
     }
 

--- a/migreringer/src/main/resources/db/migration/defaultDS/4.1/V4.1_11__TFP-5036_nye_felt.sql
+++ b/migreringer/src/main/resources/db/migration/defaultDS/4.1/V4.1_11__TFP-5036_nye_felt.sql
@@ -1,0 +1,6 @@
+ALTER TABLE GR_YTELSES_FORDELING ADD (
+    OVERSTYRT_OMSORG VARCHAR2(1 char),
+    MIGRERT_DOK VARCHAR2(1 char) default 'N'
+);
+COMMENT ON COLUMN GR_YTELSES_FORDELING.OVERSTYRT_OMSORG IS 'Vurdering av omsorg for barnet (ved utledet avklaringsbehov)';
+COMMENT ON COLUMN GR_YTELSES_FORDELING.MIGRERT_DOK IS 'Er dokumentasjonsperiode og aktivitetskrav migrert';

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/ytelsefordeling/YtelseFordelingDto.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/ytelsefordeling/YtelseFordelingDto.java
@@ -7,6 +7,7 @@ import no.nav.foreldrepenger.familiehendelse.rest.PeriodeDto;
 
 public class YtelseFordelingDto {
     private List<PeriodeDto> ikkeOmsorgPerioder;
+    private Boolean overstyrtOmsorg;
     private Boolean bekreftetAleneomsorg;
     private RettigheterAnnenforelderDto rettigheterAnnenforelder;
     private LocalDate endringsdato;
@@ -15,6 +16,10 @@ public class YtelseFordelingDto {
     private boolean ønskerJustertVedFødsel;
 
     private YtelseFordelingDto() {
+    }
+
+    public Boolean getOverstyrtOmsorg() {
+        return overstyrtOmsorg;
     }
 
     public List<PeriodeDto> getIkkeOmsorgPerioder() {
@@ -48,6 +53,12 @@ public class YtelseFordelingDto {
     public static class Builder {
 
         private final YtelseFordelingDto kladd = new YtelseFordelingDto();
+
+        public Builder medOverstyrtOmsorg(Boolean overstyrtOmsorg) {
+            kladd.overstyrtOmsorg = overstyrtOmsorg;
+            return this;
+        }
+
 
         public Builder medIkkeOmsorgPerioder(List<PeriodeDto> ikkeOmsorgPerioder) {
             kladd.ikkeOmsorgPerioder = ikkeOmsorgPerioder;

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/ytelsefordeling/YtelseFordelingDtoTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/ytelsefordeling/YtelseFordelingDtoTjeneste.java
@@ -41,6 +41,7 @@ public class YtelseFordelingDtoTjeneste {
         var dtoBuilder = new YtelseFordelingDto.Builder();
         ytelseFordelingAggregat.ifPresent(yfa -> {
             dtoBuilder.medBekreftetAleneomsorg(yfa.getAleneomsorgAvklaring());
+            dtoBuilder.medOverstyrtOmsorg(yfa.getOverstyrtOmsorg());
             yfa.getPerioderUtenOmsorg()
                 .ifPresent(uenOmsorg -> dtoBuilder.medIkkeOmsorgPerioder(PeriodeKonverter.mapUtenOmsorgperioder(uenOmsorg.getPerioder())));
             yfa.getAvklarteDatoer().ifPresent(avklarteUttakDatoer -> dtoBuilder.medEndringsdato(avklarteUttakDatoer.getGjeldendeEndringsdato()));


### PR DESCRIPTION
Første runde - legger til YF-kolonner for overstyrtOmsorg og migrertDokPeriode
Du får se hvor mye som trengs på sistnevnte

Tar med overstyrtOmsorg i Dto og oppdaterer
Neste steg:
* Migrering
* Frontend - populere basert på overstyrtOmsorg isf perioder (fjerne perioder frontend)
* Uttaksregler - flytte så høyt opp som mulig
* Aksjonspunktutleder / Revurdering: Kun dersom ulike adresser og overstyrt == null eller 'N'

Innspill?