### PR TITLE
Håndtere flere saker med overlappende pleiepenger

### DIFF
--- a/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/uttaksgrunnlag/fp/EndringsdatoRevurderingUtlederImpl.java
+++ b/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/uttaksgrunnlag/fp/EndringsdatoRevurderingUtlederImpl.java
@@ -359,7 +359,7 @@ public class EndringsdatoRevurderingUtlederImpl implements EndringsdatoRevurderi
     private Optional<LocalDate> førsteDatoMedOverlappPleiepenger(UttakInput input) {
         var tidslinjeUtbetalt = tidslinjeUttakMedUtbetaling(finnForrigeBehandling(input.getBehandlingReferanse()));
         var segmentPleiepenger = PleiepengerJustering.pleiepengerUtsettelser(input.getBehandlingReferanse().aktørId(), input.getIayGrunnlag()).stream()
-            .map(p -> new LocalDateSegment<>(p.oppgittPeriode().getFom(), p.oppgittPeriode().getTom(), Boolean.TRUE))
+            .map(p -> new LocalDateSegment<>(p.getFom(), p.getTom(), Boolean.TRUE))
             .toList();
         var tidslinjePleiepenger = new LocalDateTimeline<>(segmentPleiepenger, StandardCombinators::alwaysTrueForMatch);
         var tidslinjeOverlapp = tidslinjeUtbetalt.intersection(tidslinjePleiepenger);

--- a/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/uttaksgrunnlag/fp/PleiepengerJustering.java
+++ b/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/uttaksgrunnlag/fp/PleiepengerJustering.java
@@ -42,48 +42,38 @@ final class PleiepengerJustering {
             return oppgittePerioder;
         }
 
-        var pleiepengerUtsettelser = pleiepengerUtsettelser(aktørId, inntektArbeidYtelseGrunnlag);
-        if (pleiepengerUtsettelser.isEmpty()) {
-            LOG.info("Ingen pleiepenger fra register");
-            return oppgittePerioder;
-        }
-
-        exceptionHvisOverlapp(pleiepengerUtsettelser);
         if (finnesOverlapp(oppgittePerioder)) {
             LOG.warn("Finnes overlapp i oppgitte perioder");
             //Støtter ikke overlapp videre
             return oppgittePerioder;
         }
 
-        if (!pleiepengerUtsettelser.isEmpty()) {
+        var pleiepengerUtsettelser = pleiepengerUtsettelser(aktørId, inntektArbeidYtelseGrunnlag);
+        if (pleiepengerUtsettelser.isEmpty()) {
+            LOG.info("Ingen pleiepenger fra register");
+            return oppgittePerioder;
+        } else {
             LOG.info("Behandlingen har vedtak om pleiepenger. Oppretter utsettelser");
         }
 
         return combine(pleiepengerUtsettelser, oppgittePerioder);
     }
 
-    static List<PleiepengerUtsettelse> pleiepengerUtsettelser(AktørId aktørId, InntektArbeidYtelseGrunnlag inntektArbeidYtelseGrunnlag) {
+    static List<LocalDateSegment<PleiepengerUtsettelseNy>> pleiepengerUtsettelser(AktørId aktørId, InntektArbeidYtelseGrunnlag inntektArbeidYtelseGrunnlag) {
         return inntektArbeidYtelseGrunnlag.getAktørYtelseFraRegister(aktørId)
             .map(AktørYtelse::getAlleYtelser).orElse(List.of()).stream()
             .filter(ytelse1 -> K9SAK.equals(ytelse1.getKilde()))
             .filter(ytelse1 -> RelatertYtelseType.PLEIEPENGER.contains(ytelse1.getRelatertYtelseType()))
             .flatMap(ytelse -> ytelse.getYtelseAnvist().stream()
                 .filter(ya -> !ya.getUtbetalingsgradProsent().orElse(Stillingsprosent.ZERO).erNulltall())
-                .map(ya -> new PleiepengerUtsettelse(ytelse.getVedtattTidspunkt(), map(ytelse, ya))))
+                .map(ya -> mapNy(ytelse, ya)))
             .toList();
     }
 
-    private static void exceptionHvisOverlapp(List<PleiepengerUtsettelse> pleiepengerUtsettelser) {
-        var oppgittPerioder = pleiepengerUtsettelser.stream().map(u -> u.oppgittPeriode()).toList();
-        if (finnesOverlapp(oppgittPerioder)) {
-            throw new IllegalStateException("Utviklerfeil: Overlappende utsettelser pga pleiepenger " + oppgittPerioder);
-        }
-    }
-
-    static List<OppgittPeriodeEntitet> combine(List<PleiepengerUtsettelse> pleiepengerUtsettelser,
+    static List<OppgittPeriodeEntitet> combine(List<LocalDateSegment<PleiepengerUtsettelseNy>> pleiepengerUtsettelser,
                                                List<OppgittPeriodeEntitet> foreldrepenger) {
         var foreldrepengerTimeline = oppgittPeriodeTimeline(foreldrepenger);
-        var pleiepengerTimeline = pleiepengerUtsettelseTimeline(pleiepengerUtsettelser);
+        var pleiepengerTimeline = new LocalDateTimeline<>(pleiepengerUtsettelser, PleiepengerJustering::slåSammenOverlappendePleiepenger);
         var førsteSøkteDag = foreldrepengerTimeline.getMinLocalDate();
         var sisteSøkteDag = foreldrepengerTimeline.getMaxLocalDate();
         var fellesTimeline = foreldrepengerTimeline.union(pleiepengerTimeline,
@@ -102,7 +92,11 @@ final class PleiepengerJustering {
                         return copy(interval, fp.getValue());
                     }
                 }
-                return copy(interval, pp.getValue().oppgittPeriode());
+                return copy(interval, OppgittPeriodeBuilder.ny()
+                    .medPeriode(pp.getFom(), pp.getTom())
+                    .medÅrsak(pp.getValue().årsak())
+                    .medPeriodeKilde(FordelingPeriodeKilde.ANDRE_NAV_VEDTAK)
+                    .build());
 
             });
         var combined = fellesTimeline.toSegments().stream().map(s -> s.getValue())
@@ -124,21 +118,26 @@ final class PleiepengerJustering {
         return new LocalDateTimeline<>(segments);
     }
 
-    private static LocalDateTimeline<PleiepengerUtsettelse> pleiepengerUtsettelseTimeline(List<PleiepengerUtsettelse> pleiepengerUtsettelser) {
-        var segments = pleiepengerUtsettelser.stream()
-            .map(op -> new LocalDateSegment<>(op.oppgittPeriode.getFom(), op.oppgittPeriode().getTom(), op)).toList();
-        return new LocalDateTimeline<>(segments);
+    private static LocalDateSegment<PleiepengerUtsettelseNy> slåSammenOverlappendePleiepenger(LocalDateInterval dateInterval,
+                                                                                              LocalDateSegment<PleiepengerUtsettelseNy> lhs,
+                                                                                              LocalDateSegment<PleiepengerUtsettelseNy> rhs) {
+        if (lhs != null && rhs != null) {
+            var årsak = UtsettelseÅrsak.INSTITUSJON_BARN.equals(lhs.getValue().årsak()) || UtsettelseÅrsak.INSTITUSJON_BARN.equals(rhs.getValue().årsak()) ?
+                UtsettelseÅrsak.INSTITUSJON_BARN : UtsettelseÅrsak.FRI;
+            var senesteVedtak =  lhs.getValue().vedtakstidspunkt().isAfter(rhs.getValue().vedtakstidspunkt()) ?
+                lhs.getValue().vedtakstidspunkt() : rhs.getValue().vedtakstidspunkt();
+            return new LocalDateSegment<>(dateInterval, new PleiepengerUtsettelseNy(senesteVedtak, årsak));
+        } else {
+            return lhs == null ? new LocalDateSegment<>(dateInterval, rhs.getValue()) : new LocalDateSegment<>(dateInterval, lhs.getValue());
+        }
     }
 
-    private static OppgittPeriodeEntitet map(Ytelse ytelse, YtelseAnvist periodeMedUtbetaltPleiepenger) {
+    private static LocalDateSegment<PleiepengerUtsettelseNy> mapNy(Ytelse ytelse, YtelseAnvist periodeMedUtbetaltPleiepenger) {
         var utsettelseÅrsak = RelatertYtelseType.PLEIEPENGER_SYKT_BARN.equals(ytelse.getRelatertYtelseType()) ?
             UtsettelseÅrsak.INSTITUSJON_BARN : UtsettelseÅrsak.FRI;
-        return OppgittPeriodeBuilder.ny()
-            .medPeriode(periodeMedUtbetaltPleiepenger.getAnvistFOM(), periodeMedUtbetaltPleiepenger.getAnvistTOM())
-            .medÅrsak(utsettelseÅrsak)
-            .medPeriodeKilde(FordelingPeriodeKilde.ANDRE_NAV_VEDTAK)
-            .build();
+        return new LocalDateSegment<>(periodeMedUtbetaltPleiepenger.getAnvistFOM(), periodeMedUtbetaltPleiepenger.getAnvistTOM(),
+            new PleiepengerUtsettelseNy(ytelse.getVedtattTidspunkt(), utsettelseÅrsak));
     }
 
-    record PleiepengerUtsettelse(LocalDateTime vedtakstidspunkt, OppgittPeriodeEntitet oppgittPeriode) { }
+    record PleiepengerUtsettelseNy(LocalDateTime vedtakstidspunkt, UtsettelseÅrsak årsak) { }
 }

--- a/domenetjenester/uttak/src/test/java/no/nav/foreldrepenger/domene/uttak/uttaksgrunnlag/fp/PleiepengerJusteringTest.java
+++ b/domenetjenester/uttak/src/test/java/no/nav/foreldrepenger/domene/uttak/uttaksgrunnlag/fp/PleiepengerJusteringTest.java
@@ -366,7 +366,7 @@ class PleiepengerJusteringTest {
             .medVedtattTidspunkt(LocalDateTime.now().minusMinutes(5));
     }
 
-    private LocalDateSegment<PleiepengerJustering.PleiepengerUtsettelseNy> pleiepenger(LocalDate fom, LocalDate tom) {
-        return new LocalDateSegment<>(fom, tom, new PleiepengerJustering.PleiepengerUtsettelseNy(LocalDateTime.now(), INSTITUSJON_BARN));
+    private LocalDateSegment<PleiepengerJustering.PleiepengerUtsettelse> pleiepenger(LocalDate fom, LocalDate tom) {
+        return new LocalDateSegment<>(fom, tom, new PleiepengerJustering.PleiepengerUtsettelse(LocalDateTime.now(), INSTITUSJON_BARN));
     }
 }


### PR DESCRIPTION
Stopper ikke dersom overlappende perioder med pleiepenger innen samme sak eller ved ulike saker.
Kommentar til koden som forsvinner: LocalDateTimeline<OppgittPeriodeEntitet> går glipp av fordelen med LDT - det er fortsatt fom+tom i objektet. Bør mappe til domeneobjekt uten fom+tom