### PR TITLE
TFP-5036 forberede sanering av perioder frontend

### DIFF
--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/historikk/HistorikkEndretFeltType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/historikk/HistorikkEndretFeltType.java
@@ -51,7 +51,7 @@ public enum HistorikkEndretFeltType implements Kodeverdi {
     OMSORG("OMSORG", "Omsorg"),
     OMSORGSOVERTAKELSESDATO("OMSORGSOVERTAKELSESDATO", "Omsorgsovertakelsesdato"),
     OMSORGSVILKAR("OMSORGSVILKAR", "Foreldreansvar"),
-    IKKE_OMSORG_PERIODEN("IKKE_OMSORG_PERIODEN", "Perioden Søker har ikke omsorg for barnet"),
+    IKKE_OMSORG_PERIODEN("IKKE_OMSORG_PERIODEN", "Søker har ikke omsorg for barnet"),
     INNTEKTSKATEGORI_FOR_ANDEL("INNTEKTSKATEGORI_FOR_ANDEL", "Inntektskategori for andel"),
     OPPHOLDSRETT_EOS("OPPHOLDSRETT_EOS", "Bruker har oppholdsrett i EØS"),
     OPPHOLDSRETT_IKKE_EOS("OPPHOLDSRETT_IKKE_EOS", "Bruker har ikke oppholdsrett i EØS"),

--- a/domenetjenester/behandling/src/main/java/no/nav/foreldrepenger/behandling/aksjonspunkt/AksjonspunktOppdaterParameter.java
+++ b/domenetjenester/behandling/src/main/java/no/nav/foreldrepenger/behandling/aksjonspunkt/AksjonspunktOppdaterParameter.java
@@ -13,8 +13,8 @@ import no.nav.foreldrepenger.domene.typer.AktørId;
 public final class AksjonspunktOppdaterParameter {
     private final Behandling behandling;
     private final Optional<Aksjonspunkt> aksjonspunkt;
-    private Skjæringstidspunkt skjæringstidspunkt;
-    private BehandlingReferanse ref;
+    private final Skjæringstidspunkt skjæringstidspunkt;
+    private final BehandlingReferanse ref;
     private final boolean erBegrunnelseEndret;
 
     private AksjonspunktOppdaterParameter(Behandling behandling,

--- a/domenetjenester/datavarehus/src/main/java/no/nav/foreldrepenger/datavarehus/xml/svp/DvhPersonopplysningXmlTjenesteImpl.java
+++ b/domenetjenester/datavarehus/src/main/java/no/nav/foreldrepenger/datavarehus/xml/svp/DvhPersonopplysningXmlTjenesteImpl.java
@@ -109,7 +109,6 @@ public class DvhPersonopplysningXmlTjenesteImpl extends DvhPersonopplysningXmlTj
         var skjæringstidspunkt = skjæringstidspunkter.getUtledetSkjæringstidspunkt();
         setAdresse(personopplysninger, personopplysningerAggregat);
         setInntekter(behandlingId, personopplysninger, skjæringstidspunkt);
-        setDokumentasjonsperioder(behandlingId, personopplysninger);
         setBruker(personopplysninger, personopplysningerAggregat);
         setFamilierelasjoner(personopplysninger, personopplysningerAggregat);
         setAnnenForelder(personopplysninger, personopplysningerAggregat);
@@ -257,19 +256,6 @@ public class DvhPersonopplysningXmlTjenesteImpl extends DvhPersonopplysningXmlTj
     private void setBruker(PersonopplysningerDvhForeldrepenger personopplysninger, PersonopplysningerAggregat personopplysningerAggregat) {
         var person = personopplysningFellesTjeneste.lagUidentifiserbarBruker(personopplysningerAggregat, personopplysningerAggregat.getSøker());
         personopplysninger.setBruker(person);
-    }
-
-    private void setDokumentasjonsperioder(Long behandlingId, PersonopplysningerDvhForeldrepenger personopplysninger) {
-        var dokumentasjonsperioder = personopplysningDvhObjectFactory
-            .createPersonopplysningerDvhForeldrepengerDokumentasjonsperioder();
-
-        ytelseFordelingTjeneste.hentAggregatHvisEksisterer(behandlingId).ifPresent(aggregat -> {
-            aggregat.getPerioderUttakDokumentasjon().ifPresent(
-                uttakDokumentasjon -> dokumentasjonsperioder.getDokumentasjonperiode().addAll(lagDokumentasjonPerioder(uttakDokumentasjon.getPerioder())));
-            aggregat.getPerioderUtenOmsorg()
-                .ifPresent(utenOmsorg -> dokumentasjonsperioder.getDokumentasjonperiode().addAll(lagDokumentasjonPerioder(utenOmsorg.getPerioder())));
-            personopplysninger.setDokumentasjonsperioder(dokumentasjonsperioder);
-        });
     }
 
     private List<? extends DokumentasjonPeriode> lagDokumentasjonPerioder(List<? extends DokumentasjonPeriodeEntitet<?>> perioder) {

--- a/domenetjenester/datavarehus/src/main/java/no/nav/foreldrepenger/datavarehus/xml/svp/PersonopplysningXmlTjenesteImpl.java
+++ b/domenetjenester/datavarehus/src/main/java/no/nav/foreldrepenger/datavarehus/xml/svp/PersonopplysningXmlTjenesteImpl.java
@@ -97,7 +97,6 @@ public class PersonopplysningXmlTjenesteImpl extends PersonopplysningXmlTjeneste
         });
         var skjæringstidspunkt = skjæringstidspunkter.getUtledetSkjæringstidspunkt();
         setAdresse(personopplysninger, personopplysningerAggregat);
-        setDokumentasjonsperioder(behandlingId, personopplysninger);
         setInntekter(behandlingId, personopplysninger, skjæringstidspunkt);
         setBruker(personopplysninger, personopplysningerAggregat);
         setRelaterteYtelser(behandlingId, aktørId, personopplysninger, skjæringstidspunkt);
@@ -202,19 +201,6 @@ public class PersonopplysningXmlTjenesteImpl extends PersonopplysningXmlTjeneste
         domene.getUtbetalingsgradProsent().ifPresent(prosent -> kontrakt.setUtbetalingsgradprosent(VedtakXmlUtil.lagDecimalOpplysning(prosent.getVerdi())));
 
         return kontrakt;
-    }
-
-    private void setDokumentasjonsperioder(Long behandlingId, PersonopplysningerSvangerskapspenger personopplysninger) {
-        var dokumentasjonsperioder = personopplysningObjectFactory
-            .createPersonopplysningerSvangerskapspengerDokumentasjonsperioder();
-
-        ytelseFordelingTjeneste.hentAggregatHvisEksisterer(behandlingId).ifPresent(aggregat -> {
-            aggregat.getPerioderUttakDokumentasjon().ifPresent(
-                uttakDokumentasjon -> dokumentasjonsperioder.getDokumentasjonperiode().addAll(lagDokumentasjonPerioder(uttakDokumentasjon.getPerioder())));
-            aggregat.getPerioderUtenOmsorg()
-                .ifPresent(utenOmsorg -> dokumentasjonsperioder.getDokumentasjonperiode().addAll(lagDokumentasjonPerioder(utenOmsorg.getPerioder())));
-            personopplysninger.setDokumentasjonsperioder(dokumentasjonsperioder);
-        });
     }
 
     private List<? extends DokumentasjonPeriode> lagDokumentasjonPerioder(List<? extends DokumentasjonPeriodeEntitet<?>> perioder) {

--- a/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/fastsetteperioder/grunnlagbyggere/RettOgOmsorgGrunnlagBygger.java
+++ b/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/fastsetteperioder/grunnlagbyggere/RettOgOmsorgGrunnlagBygger.java
@@ -47,7 +47,9 @@ public class RettOgOmsorgGrunnlagBygger {
                 .morHarRett(morHarRett(ref, ytelseFordelingAggregat, annenpartsUttaksplan))
                 .morUføretrygd(morUføretrygd(uttakInput, ytelseFordelingAggregat))
                 .morOppgittUføretrygd(morOppgittUføretrygd(uttakInput))
-                .samtykke(samtykke);
+                .samtykke(samtykke)
+                .harOmsorg(ytelseFordelingAggregat.harOmsorg())
+            ;
     }
 
     private Optional<ForeldrepengerUttak> hentAnnenpartsUttak(UttakInput uttakInput) {

--- a/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/fastsetteperioder/grunnlagbyggere/SøknadGrunnlagBygger.java
+++ b/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/fastsetteperioder/grunnlagbyggere/SøknadGrunnlagBygger.java
@@ -28,7 +28,6 @@ import javax.inject.Inject;
 
 import no.nav.foreldrepenger.behandlingslager.behandling.personopplysning.RelasjonsRolleType;
 import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.AktivitetskravPeriodeEntitet;
-import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.PeriodeUtenOmsorgEntitet;
 import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.PeriodeUttakDokumentasjonEntitet;
 import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.YtelseFordelingAggregat;
 import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.YtelsesFordelingRepository;
@@ -47,9 +46,7 @@ import no.nav.foreldrepenger.domene.uttak.input.UttakInput;
 import no.nav.foreldrepenger.domene.uttak.input.UttakYrkesaktiviteter;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.AktivitetIdentifikator;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.AktivitetType;
-import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.Dokumentasjon;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.OppgittPeriode;
-import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.PeriodeUtenOmsorg;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.SamtidigUttaksprosent;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.Stønadskontotype;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.Søknad;
@@ -77,7 +74,6 @@ public class SøknadGrunnlagBygger {
         var ytelseFordelingAggregat = ytelsesFordelingRepository.hentAggregat(ref.behandlingId());
         return new Søknad.Builder()
             .type(type(input.getYtelsespesifiktGrunnlag()))
-            .dokumentasjon(dokumentasjon(ytelseFordelingAggregat))
             .oppgittePerioder(oppgittePerioder(input, ytelseFordelingAggregat))
             .mottattTidspunkt(input.getSøknadOpprettetTidspunkt());
     }
@@ -295,16 +291,4 @@ public class SøknadGrunnlagBygger {
         return Søknadstype.ADOPSJON;
     }
 
-    private Dokumentasjon.Builder dokumentasjon(YtelseFordelingAggregat ytelseFordelingAggregat) {
-        var builder = new Dokumentasjon.Builder();
-        ytelseFordelingAggregat.getPerioderUtenOmsorg().ifPresent(puo -> leggTilPerioderUtenOmsorg(builder, puo.getPerioder()));
-        return builder;
-    }
-
-    private void leggTilPerioderUtenOmsorg(Dokumentasjon.Builder builder, List<PeriodeUtenOmsorgEntitet> perioder) {
-        for (var periodeUtenOmsorg : perioder) {
-            builder.periodeUtenOmsorg(new PeriodeUtenOmsorg(periodeUtenOmsorg.getPeriode().getFomDato(),
-                periodeUtenOmsorg.getPeriode().getTomDato()));
-        }
-    }
 }

--- a/domenetjenester/uttak/src/test/java/no/nav/foreldrepenger/domene/uttak/fakta/omsorg/AvklarLøpendeOmsorgAksjonspunktUtlederTest.java
+++ b/domenetjenester/uttak/src/test/java/no/nav/foreldrepenger/domene/uttak/fakta/omsorg/AvklarLøpendeOmsorgAksjonspunktUtlederTest.java
@@ -48,7 +48,7 @@ public class AvklarLøpendeOmsorgAksjonspunktUtlederTest {
     void setUp() {
         repositoryProvider = new UttakRepositoryStubProvider();
         personopplysninger = mock(PersonopplysningerForUttak.class);
-        aksjonspunktUtleder = new AvklarLøpendeOmsorgAksjonspunktUtleder(personopplysninger);
+        aksjonspunktUtleder = new AvklarLøpendeOmsorgAksjonspunktUtleder(personopplysninger, repositoryProvider);
     }
 
     @Test

--- a/domenetjenester/uttak/src/test/java/no/nav/foreldrepenger/domene/ytelsefordeling/BekreftFaktaForOmsorgAksjonspunktTest.java
+++ b/domenetjenester/uttak/src/test/java/no/nav/foreldrepenger/domene/ytelsefordeling/BekreftFaktaForOmsorgAksjonspunktTest.java
@@ -38,12 +38,19 @@ public class BekreftFaktaForOmsorgAksjonspunktTest {
         assertThat(periodeUtenOmsorg).hasSize(1);
         assertThat(periodeUtenOmsorg.get(0).getPeriode()).isEqualTo(ikkeOmsorgPeriode);
 
+        var overstyrtOmsorg = ytelsesFordelingRepository.hentAggregat(behandling.getId()).getOverstyrtOmsorg();
+        assertThat(overstyrtOmsorg).isNotNull();
+        assertThat(overstyrtOmsorg).isFalse();
+
         //må nullstille etter endret til har omsorg
         ytelseFordelingTjeneste.aksjonspunktBekreftFaktaForOmsorg(behandling.getId(), true, null);
         perioderUtenOmsorgOpt = ytelsesFordelingRepository.hentAggregat(behandling.getId()).getPerioderUtenOmsorg();
         assertThat(perioderUtenOmsorgOpt).isPresent();
         periodeUtenOmsorg = perioderUtenOmsorgOpt.get().getPerioder();
         assertThat(periodeUtenOmsorg).isEmpty();
+        overstyrtOmsorg = ytelsesFordelingRepository.hentAggregat(behandling.getId()).getOverstyrtOmsorg();
+        assertThat(overstyrtOmsorg).isNotNull();
+        assertThat(overstyrtOmsorg).isTrue();
     }
 
     private Behandling opprettBehandling() {

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
 
         <java.version>17</java.version>
 
-        <fp-uttak.version>14.3.3</fp-uttak.version>
+        <fp-uttak.version>14.3.4</fp-uttak.version>
         <svp-uttak.version>2.3.5</svp-uttak.version>
         <felles.version>4.2.22</felles.version>
         <prosesstask.version>3.1.17</prosesstask.version>


### PR DESCRIPTION
Ikke utled AP for revurdering dersom bekreftet at har omsorg
Fjerne all avhengighet til at Dto har perioder uten omsorg.
Regelinput basert på overstyrtOmsorg, ingen Dokumentasjonsperioder
Fjerne alle annen bruk av YFAggregat / perioderUtenOmsorg

Neste steg: Fjerne dokumentasjon fra regler og perioder fra frontend, fjerne resten av utenomsorg, set unused