### PR TITLE
TFP-4873 dokumentasjonsperioder i vedtaksxml

### DIFF
--- a/domenetjenester/datavarehus/src/test/java/no/nav/foreldrepenger/datavarehus/xml/DvhVedtakXmlTjenesteForeldrepengerTest.java
+++ b/domenetjenester/datavarehus/src/test/java/no/nav/foreldrepenger/datavarehus/xml/DvhVedtakXmlTjenesteForeldrepengerTest.java
@@ -104,6 +104,7 @@ import no.nav.foreldrepenger.domene.tid.DatoIntervallEntitet;
 import no.nav.foreldrepenger.domene.typer.AktørId;
 import no.nav.foreldrepenger.domene.typer.InternArbeidsforholdRef;
 import no.nav.foreldrepenger.domene.typer.Saksnummer;
+import no.nav.foreldrepenger.domene.uttak.ForeldrepengerUttakTjeneste;
 import no.nav.foreldrepenger.domene.ytelsefordeling.YtelseFordelingTjeneste;
 import no.nav.foreldrepenger.skjæringstidspunkt.SkjæringstidspunktTjeneste;
 import no.nav.foreldrepenger.økonomistøtte.HentOppdragMedPositivKvittering;
@@ -164,6 +165,9 @@ public class DvhVedtakXmlTjenesteForeldrepengerTest {
     @Inject
     private MedlemskapRepository medlemskapRepository;
 
+    @Inject
+    private ForeldrepengerUttakTjeneste foreldrepengerUttakTjeneste;
+
     private VirksomhetTjeneste virksomhetTjeneste;
 
     @BeforeEach
@@ -177,14 +181,8 @@ public class DvhVedtakXmlTjenesteForeldrepengerTest {
         virksomhetTjeneste = mock(VirksomhetTjeneste.class);
         var poXmlFelles = new PersonopplysningXmlFelles(tpsTjeneste);
 
-        var dvhPersonopplysningXmlTjenesteImpl = new DvhPersonopplysningXmlTjenesteImpl(poXmlFelles,
-                familieHendelseRepository,
-                vergeRepository,
-                medlemskapRepository,
-                virksomhetTjeneste,
-                personopplysningTjeneste,
-                iayTjeneste,
-                ytelseFordelingTjeneste);
+        var dvhPersonopplysningXmlTjenesteImpl = new DvhPersonopplysningXmlTjenesteImpl(poXmlFelles, familieHendelseRepository, vergeRepository,
+            medlemskapRepository, virksomhetTjeneste, personopplysningTjeneste, iayTjeneste, ytelseFordelingTjeneste, foreldrepengerUttakTjeneste);
 
         var vedtakXmlTjeneste = new VedtakXmlTjeneste(repositoryProvider);
         var oppdragXmlTjenesteImpl = new OppdragXmlTjenesteImpl(hentOppdragMedPositivKvittering);

--- a/domenetjenester/datavarehus/src/test/java/no/nav/foreldrepenger/datavarehus/xml/fp/VedtakXmlTest.java
+++ b/domenetjenester/datavarehus/src/test/java/no/nav/foreldrepenger/datavarehus/xml/fp/VedtakXmlTest.java
@@ -87,6 +87,7 @@ import no.nav.foreldrepenger.domene.tid.DatoIntervallEntitet;
 import no.nav.foreldrepenger.domene.typer.AktørId;
 import no.nav.foreldrepenger.domene.typer.InternArbeidsforholdRef;
 import no.nav.foreldrepenger.domene.typer.Saksnummer;
+import no.nav.foreldrepenger.domene.uttak.ForeldrepengerUttakTjeneste;
 import no.nav.foreldrepenger.domene.ytelsefordeling.YtelseFordelingTjeneste;
 import no.nav.foreldrepenger.skjæringstidspunkt.SkjæringstidspunktTjeneste;
 import no.nav.vedtak.felles.testutilities.cdi.UnitTestLookupInstanceImpl;
@@ -132,6 +133,9 @@ public class VedtakXmlTest {
     @Inject
     private BehandlingsresultatXmlTjeneste behandlingsresultatXmlTjeneste;
 
+    @Inject
+    private ForeldrepengerUttakTjeneste foreldrepengerUttakTjeneste;
+
     private FatteVedtakXmlTjeneste fpSakVedtakXmlTjeneste;
 
     @BeforeEach
@@ -140,9 +144,9 @@ public class VedtakXmlTest {
         var stp = Skjæringstidspunkt.builder().medUtledetSkjæringstidspunkt(LocalDate.now()).build();
         Mockito.lenient().when(skjæringstidspunktTjeneste.getSkjæringstidspunkter(Mockito.any())).thenReturn(stp);
         var poXmlFelles = new PersonopplysningXmlFelles(personinfoAdapter);
-        var personopplysningXmlTjeneste = new PersonopplysningXmlTjenesteImpl(poXmlFelles, repositoryProvider,
-                personopplysningTjeneste,
-                iayTjeneste, ytelseFordelingTjeneste, mock(VergeRepository.class), mock(VirksomhetTjeneste.class));
+        var personopplysningXmlTjeneste = new PersonopplysningXmlTjenesteImpl(poXmlFelles, repositoryProvider, personopplysningTjeneste,
+                iayTjeneste, ytelseFordelingTjeneste, mock(VergeRepository.class), mock(VirksomhetTjeneste.class), foreldrepengerUttakTjeneste
+            );
         var vedtakXmlTjeneste = new VedtakXmlTjeneste(repositoryProvider);
         fpSakVedtakXmlTjeneste = new FatteVedtakXmlTjeneste(repositoryProvider, vedtakXmlTjeneste,
                 new UnitTestLookupInstanceImpl<>(personopplysningXmlTjeneste),

--- a/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/ForeldrepengerUttakPeriode.java
+++ b/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/ForeldrepengerUttakPeriode.java
@@ -3,8 +3,10 @@ package no.nav.foreldrepenger.domene.uttak;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 
 import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.MorsAktivitet;
+import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.periode.DokumentasjonVurdering;
 import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.periode.UttakPeriodeType;
 import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.årsak.OppholdÅrsak;
 import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.årsak.OverføringÅrsak;
@@ -38,6 +40,7 @@ public class ForeldrepengerUttakPeriode {
     private LocalDate mottattDato;
     private MorsAktivitet morsAktivitet;
     private boolean erFraSøknad = true;
+    private DokumentasjonVurdering dokumentasjonVurdering;
 
     private ForeldrepengerUttakPeriode() {
 
@@ -212,6 +215,11 @@ public class ForeldrepengerUttakPeriode {
         return erFraSøknad;
     }
 
+    public Optional<DokumentasjonVurdering> getDokumentasjonVurdering() {
+        return Optional.ofNullable(dokumentasjonVurdering);
+    }
+
+
     @Override
     public String toString() {
         return "ForeldrepengerUttakPeriode{" +
@@ -233,6 +241,7 @@ public class ForeldrepengerUttakPeriode {
             ", mottattDato=" + mottattDato +
             ", morsAktivitet=" + morsAktivitet +
             ", erFraSøknad=" + erFraSøknad +
+            ", dokumentasjonVurdering=" + dokumentasjonVurdering +
             '}';
     }
 
@@ -345,6 +354,11 @@ public class ForeldrepengerUttakPeriode {
 
         public Builder medErFraSøknad(boolean erFraSøknad) {
             kladd.erFraSøknad = erFraSøknad;
+            return this;
+        }
+
+        public Builder medDokumentasjonVurdering(DokumentasjonVurdering dokumentasjonVurdering) {
+            kladd.dokumentasjonVurdering = dokumentasjonVurdering;
             return this;
         }
 

--- a/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/ForeldrepengerUttakTjeneste.java
+++ b/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/ForeldrepengerUttakTjeneste.java
@@ -72,6 +72,7 @@ public class ForeldrepengerUttakTjeneste {
             .medMorsAktivitet(entitet.getPeriodeSøknad().map(UttakResultatPeriodeSøknadEntitet::getMorsAktivitet).orElse(MorsAktivitet.UDEFINERT))
             .medOpprinneligSendtTilManuellBehandling(entitet.opprinneligSendtTilManuellBehandling())
             .medErFraSøknad(entitet.getPeriodeSøknad().isPresent())
+            .medDokumentasjonVurdering(entitet.getPeriodeSøknad().map(s -> s.getDokumentasjonVurdering()).orElse(null))
             .medManueltBehandlet(entitet.isManueltBehandlet());
         return periodeBuilder.build();
     }

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/uttak/aksjonspunkt/UttakPerioderMapper.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/uttak/aksjonspunkt/UttakPerioderMapper.java
@@ -53,6 +53,7 @@ public final class UttakPerioderMapper {
             .medMottattDato(gjeldendePeriode.getMottattDato())
             .medMorsAktivitet(gjeldendePeriode.getMorsAktivitet())
             .medErFraSøknad(gjeldendePeriode.erFraSøknad())
+            .medDokumentasjonVurdering(gjeldendePeriode.getDokumentasjonVurdering().orElse(null))
             .build();
     }
 


### PR DESCRIPTION
Henter fra uttak slik at alle dokvurderinger kommer med, ikke bare de som ligger etter endringsdato.
Tidlig oppstart dok vurderingen har de ikke fått tidligere, så sender heller ikke med nå.
Har kanskje en forbedring der