### PR TITLE
TFP-4873 setter unused på gamle fakta om uttak kolonner i db

### DIFF
--- a/migreringer/src/main/resources/db/migration/defaultDS/4.1/V4.1_12__TFP-4873_gammel_fakta_uttak.sql
+++ b/migreringer/src/main/resources/db/migration/defaultDS/4.1/V4.1_12__TFP-4873_gammel_fakta_uttak.sql
@@ -1,0 +1,1 @@
+alter table GR_YTELSES_FORDELING set unused (uttak_dokumentasjon_id, opprinnelige_aktkrav_per_id, saksbehandlede_aktkrav_per_id, migrert_dok, utenomsorg_id);


### PR DESCRIPTION
Hva tenker du at det best å gjøre med de 2 tabellene? La de ligge for evt sporing/historikk eller droppe helt?