### PR TITLE
TFP-4873 behold overstyrt dersom uendret justert fordeling

### DIFF
--- a/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/uttaksgrunnlag/fp/SammenlignFordeling.java
+++ b/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/uttaksgrunnlag/fp/SammenlignFordeling.java
@@ -1,0 +1,68 @@
+package no.nav.foreldrepenger.domene.uttak.uttaksgrunnlag.fp;
+
+import java.util.Objects;
+
+import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.MorsAktivitet;
+import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.periode.GraderingAktivitetType;
+import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.periode.OppgittFordelingEntitet;
+import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.periode.OppgittPeriodeEntitet;
+import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.periode.UttakPeriodeType;
+import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.årsak.Årsak;
+import no.nav.foreldrepenger.behandlingslager.uttak.fp.SamtidigUttaksprosent;
+import no.nav.foreldrepenger.behandlingslager.virksomhet.Arbeidsgiver;
+import no.nav.foreldrepenger.domene.tid.VirkedagUtil;
+import no.nav.foreldrepenger.domene.typer.Stillingsprosent;
+import no.nav.fpsak.tidsserie.LocalDateSegment;
+import no.nav.fpsak.tidsserie.LocalDateTimeline;
+
+public final class SammenlignFordeling {
+
+    private SammenlignFordeling() {
+    }
+
+    public static boolean erLikeFordelinger(OppgittFordelingEntitet fordelingEntitet1, OppgittFordelingEntitet fordelingEntitet2) {
+        if (fordelingEntitet1 == null && fordelingEntitet2 == null) {
+            return true;
+        }
+        if (fordelingEntitet1 == null || fordelingEntitet2 == null ||
+            !Objects.equals(fordelingEntitet1.ønskerJustertVedFødsel(), fordelingEntitet2.ønskerJustertVedFødsel()) ||
+            !Objects.equals(fordelingEntitet1.getErAnnenForelderInformert(), fordelingEntitet2.getErAnnenForelderInformert())) {
+            return false;
+        }
+
+        // Tidslinje og tidligste/seneste dato fra ny søknad
+        var segmenter1 = fordelingEntitet1.getPerioder().stream().map(SammenlignFordeling::segmentForOppgittPeriode).toList();
+        var tidslinjeSammenlign1 =  new LocalDateTimeline<>(segmenter1);
+        var segmenter2 = fordelingEntitet2.getPerioder().stream().map(SammenlignFordeling::segmentForOppgittPeriode).toList();
+        var tidslinjeSammenlign2 =  new LocalDateTimeline<>(segmenter2);
+
+        // Finner segmenter der de to tidslinjene (søknad vs vedtakFomTidligsteDatoSøknad) er ulike
+        var ulike = tidslinjeSammenlign1.combine(tidslinjeSammenlign2, (i, l, r) -> new LocalDateSegment<>(i, !Objects.equals(l ,r)), LocalDateTimeline.JoinStyle.CROSS_JOIN)
+            .filterValue(v -> v);
+
+        // Sjekk om finnes segment som er ulike
+        return ulike.isEmpty();
+    }
+
+    private static LocalDateSegment<SammenligningPeriodeForOppgitt> segmentForOppgittPeriode(OppgittPeriodeEntitet periode) {
+        var fom = VirkedagUtil.lørdagSøndagTilMandag(periode.getFom());
+        var tom = VirkedagUtil.fredagLørdagTilSøndag(periode.getTom());
+        if (fom.isAfter(tom)) {
+            fom = periode.getFom();
+        }
+        return new LocalDateSegment<>(fom, tom, new SammenligningPeriodeForOppgitt(periode));
+    }
+
+    private record SammenligningPeriodeForOppgitt(Årsak årsak, UttakPeriodeType periodeType, SamtidigUttaksprosent samtidigUttaksprosent, SammenligningGraderingForOppgitt gradering, boolean flerbarnsdager, MorsAktivitet morsAktivitet) {
+        SammenligningPeriodeForOppgitt(OppgittPeriodeEntitet periode) {
+            this(periode.getÅrsak(), periode.getPeriodeType(), periode.getSamtidigUttaksprosent(), periode.isGradert() ? new SammenligningGraderingForOppgitt(periode) : null, periode.isFlerbarnsdager(), periode.getMorsAktivitet());
+        }
+    }
+
+    private record SammenligningGraderingForOppgitt(GraderingAktivitetType gradertAktivitet, Stillingsprosent arbeidsprosent, Arbeidsgiver arbeidsgiver) {
+        SammenligningGraderingForOppgitt(OppgittPeriodeEntitet periode) {
+            this(periode.getGraderingAktivitetType(), periode.getArbeidsprosentSomStillingsprosent(), periode.getArbeidsgiver());
+        }
+    }
+
+}

--- a/domenetjenester/uttak/src/test/java/no/nav/foreldrepenger/domene/uttak/testutilities/behandling/AbstractTestScenario.java
+++ b/domenetjenester/uttak/src/test/java/no/nav/foreldrepenger/domene/uttak/testutilities/behandling/AbstractTestScenario.java
@@ -56,6 +56,7 @@ public abstract class AbstractTestScenario<S extends AbstractTestScenario<S>> {
     private OppgittDekningsgradEntitet oppgittDekningsgrad;
     private OppgittFordelingEntitet oppgittFordeling;
     private OppgittFordelingEntitet justertFordeling;
+    private OppgittFordelingEntitet overstyrtFordeling;
     private AvklarteUttakDatoerEntitet avklarteUttakDatoer;
 
     private Behandling originalBehandling;
@@ -150,7 +151,7 @@ public abstract class AbstractTestScenario<S extends AbstractTestScenario<S>> {
 
     private void lagreYtelseFordeling(UttakRepositoryProvider repositoryProvider, Behandling behandling) {
         if (oppgittRettighet == null && oppgittDekningsgrad == null && oppgittFordeling == null && overstyrtRettighet == null
-            && avklarteUttakDatoer == null && justertFordeling == null && overstyrtOmsorg == null) {
+            && avklarteUttakDatoer == null && justertFordeling == null && overstyrtFordeling == null && overstyrtOmsorg == null) {
             return;
         }
         var ytelsesFordelingRepository = repositoryProvider.getYtelsesFordelingRepository();
@@ -160,6 +161,7 @@ public abstract class AbstractTestScenario<S extends AbstractTestScenario<S>> {
             .medOppgittDekningsgrad(oppgittDekningsgrad)
             .medOppgittFordeling(oppgittFordeling)
             .medJustertFordeling(justertFordeling)
+            .medOverstyrtFordeling(overstyrtFordeling)
             .medAvklarteDatoer(avklarteUttakDatoer)
             .medOverstyrtOmsorg(overstyrtOmsorg)
             ;
@@ -257,6 +259,12 @@ public abstract class AbstractTestScenario<S extends AbstractTestScenario<S>> {
     @SuppressWarnings("unchecked")
     public S medJustertFordeling(OppgittFordelingEntitet justertFordeling) {
         this.justertFordeling = justertFordeling;
+        return (S) this;
+    }
+
+    @SuppressWarnings("unchecked")
+    public S medOverstyrtFordeling(OppgittFordelingEntitet overstyrtFordeling) {
+        this.overstyrtFordeling = overstyrtFordeling;
         return (S) this;
     }
 


### PR DESCRIPTION
Forberedelse til å å fjerne nullstilling av justert+overstyrt ved hopp tilbake til/forbi FastsettUttaksgrunnlagSteg