### PR TITLE
TFP-5444 lagre riktig utbetalingsgrad SVP og bedre utregning ved pub vedtak

### DIFF
--- a/domenetjenester/beregning-ytelse/src/main/java/no/nav/foreldrepenger/ytelse/beregning/fp/MapUttakResultatFraVLTilRegel.java
+++ b/domenetjenester/beregning-ytelse/src/main/java/no/nav/foreldrepenger/ytelse/beregning/fp/MapUttakResultatFraVLTilRegel.java
@@ -58,9 +58,8 @@ public class MapUttakResultatFraVLTilRegel {
 
         var skalGraderes = periodeGraderingInvilget && uttakResultatPeriodeAktivitet.isSøktGraderingForAktivitetIPeriode();
 
-        return UttakAktivitet.ny(aktivitetStatus)
+        return UttakAktivitet.ny(aktivitetStatus, utbetalingsgrad.decimalValue(), true)
             .medArbeidsforhold(arbeidsforhold)
-            .medUtbetalingsgrad(utbetalingsgrad.decimalValue())
             .medStillingsgrad(stillingsprosent, totalStillingsprosent)
             .medGradering(skalGraderes, arbeidstidsprosent);
     }

--- a/domenetjenester/beregning-ytelse/src/main/java/no/nav/foreldrepenger/ytelse/beregning/regelmodell/fastsett/FinnOverlappendeBeregningsgrunnlagOgUttaksPerioder.java
+++ b/domenetjenester/beregning-ytelse/src/main/java/no/nav/foreldrepenger/ytelse/beregning/regelmodell/fastsett/FinnOverlappendeBeregningsgrunnlagOgUttaksPerioder.java
@@ -205,8 +205,9 @@ class FinnOverlappendeBeregningsgrunnlagOgUttaksPerioder extends LeafSpecificati
         var utbetalingsgrad = uttakAktivitet.utbetalingsgrad().scaleByPowerOfTen(-2);
         var andelArbeidsgiver = Optional.ofNullable(redusertRefusjonPrÅr).orElse(BigDecimal.ZERO);
         var andelBruker = Optional.ofNullable(redusertBrukersAndelPrÅr).orElse(BigDecimal.ZERO);
-        var redusertAndelArb = andelArbeidsgiver.multiply(utbetalingsgrad);
-        var redusertAndelBruker = andelBruker.multiply(utbetalingsgrad);
+        // FP skal videre reduseres med gradering, mens SVP er ferdig redusert
+        var redusertAndelArb = uttakAktivitet.reduserDagsatsMedUtbetalingsgrad() ? andelArbeidsgiver.multiply(utbetalingsgrad) : andelArbeidsgiver;
+        var redusertAndelBruker = uttakAktivitet.reduserDagsatsMedUtbetalingsgrad() ? andelBruker.multiply(utbetalingsgrad) : andelBruker;
 
         if (skalGjøreOverkompensasjon(uttakAktivitet)) {
             var permisjonsProsent = finnPermisjonsprosent(uttakAktivitet);

--- a/domenetjenester/beregning-ytelse/src/main/java/no/nav/foreldrepenger/ytelse/beregning/regelmodell/uttakresultat/UttakAktivitet.java
+++ b/domenetjenester/beregning-ytelse/src/main/java/no/nav/foreldrepenger/ytelse/beregning/regelmodell/uttakresultat/UttakAktivitet.java
@@ -8,29 +8,26 @@ import no.nav.foreldrepenger.ytelse.beregning.regelmodell.beregningsgrunnlag.Arb
 public record UttakAktivitet(BigDecimal stillingsgrad,
                              BigDecimal arbeidstidsprosent,
                              BigDecimal utbetalingsgrad,
+                             boolean reduserDagsatsMedUtbetalingsgrad,
                              Arbeidsforhold arbeidsforhold,
                              AktivitetStatus aktivitetStatus,
                              boolean erGradering,
                              BigDecimal totalStillingsgradHosAG) {
 
-    public static UttakAktivitet ny(AktivitetStatus aktivitetStatus) {
-        return new UttakAktivitet(null, null, null, null, aktivitetStatus, false, null);
+    public static UttakAktivitet ny(AktivitetStatus aktivitetStatus, BigDecimal utbetalingsgrad, boolean reduserDagsatsMedUtbetalingsgrad) {
+        return new UttakAktivitet(null, null, utbetalingsgrad, reduserDagsatsMedUtbetalingsgrad, null, aktivitetStatus, false, null);
     }
 
     public UttakAktivitet medArbeidsforhold(Arbeidsforhold arbeidsforhold) {
-        return new UttakAktivitet(stillingsgrad(), arbeidstidsprosent(), utbetalingsgrad(), arbeidsforhold, aktivitetStatus(), erGradering(), totalStillingsgradHosAG());
+        return new UttakAktivitet(stillingsgrad(), arbeidstidsprosent(), utbetalingsgrad(), reduserDagsatsMedUtbetalingsgrad(), arbeidsforhold, aktivitetStatus(), erGradering(), totalStillingsgradHosAG());
     }
 
     public UttakAktivitet medStillingsgrad(BigDecimal stillingsgrad, BigDecimal totalStillingsgradHosAG) {
-        return new UttakAktivitet(stillingsgrad, arbeidstidsprosent(), utbetalingsgrad(), arbeidsforhold(), aktivitetStatus(), erGradering(), totalStillingsgradHosAG);
-    }
-
-    public UttakAktivitet medUtbetalingsgrad(BigDecimal utbetalingsgrad) {
-        return new UttakAktivitet(stillingsgrad(), arbeidstidsprosent(), utbetalingsgrad, arbeidsforhold(), aktivitetStatus(), erGradering(), totalStillingsgradHosAG());
+        return new UttakAktivitet(stillingsgrad, arbeidstidsprosent(), utbetalingsgrad(), reduserDagsatsMedUtbetalingsgrad(), arbeidsforhold(), aktivitetStatus(), erGradering(), totalStillingsgradHosAG);
     }
 
     public UttakAktivitet medGradering(boolean erGradering, BigDecimal arbeidstidsprosent) {
-        return new UttakAktivitet(stillingsgrad(), arbeidstidsprosent, utbetalingsgrad(), arbeidsforhold(), aktivitetStatus(), erGradering, totalStillingsgradHosAG());
+        return new UttakAktivitet(stillingsgrad(), arbeidstidsprosent, utbetalingsgrad(), reduserDagsatsMedUtbetalingsgrad(), arbeidsforhold(), aktivitetStatus(), erGradering, totalStillingsgradHosAG());
     }
 
 }

--- a/domenetjenester/beregning-ytelse/src/main/java/no/nav/foreldrepenger/ytelse/beregning/svp/MapUttakResultatFraVLTilRegel.java
+++ b/domenetjenester/beregning-ytelse/src/main/java/no/nav/foreldrepenger/ytelse/beregning/svp/MapUttakResultatFraVLTilRegel.java
@@ -95,15 +95,13 @@ public class MapUttakResultatFraVLTilRegel {
     }
 
     private UttakAktivitet mapAktivitet(UttakInput input, SvangerskapspengerUttakResultatArbeidsforholdEntitet uttakArbeidsforhold, SvangerskapspengerUttakResultatPeriodeEntitet periode) {
-        var utbetalingsgrad = periode.getUtbetalingsgrad().harUtbetaling() ? BigDecimal.valueOf(100) : BigDecimal.ZERO;
         var stillingsprosent = mapStillingsprosent(input, uttakArbeidsforhold);
         var totalStillingsprosent = finnTotalStillingsprosentHosAG(input, uttakArbeidsforhold);
         var arbeidsforhold = mapArbeidsforhold(uttakArbeidsforhold);
         var aktivitetStatus = MapUttakArbeidTypeTilAktivitetStatus.map(uttakArbeidsforhold.getUttakArbeidType());
 
-        return UttakAktivitet.ny(aktivitetStatus)
+        return UttakAktivitet.ny(aktivitetStatus, periode.getUtbetalingsgrad().decimalValue(), false)
             .medArbeidsforhold(arbeidsforhold)
-            .medUtbetalingsgrad(utbetalingsgrad)
             .medStillingsgrad(stillingsprosent, totalStillingsprosent);
     }
 

--- a/domenetjenester/beregning-ytelse/src/test/java/no/nav/foreldrepenger/ytelse/beregning/regelmodell/BeregningsresultatInputVerifisererTest.java
+++ b/domenetjenester/beregning-ytelse/src/test/java/no/nav/foreldrepenger/ytelse/beregning/regelmodell/BeregningsresultatInputVerifisererTest.java
@@ -1,5 +1,7 @@
 package no.nav.foreldrepenger.ytelse.beregning.regelmodell;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.ArrayList;
@@ -20,8 +22,6 @@ import no.nav.foreldrepenger.ytelse.beregning.regelmodell.uttakresultat.UttakAkt
 import no.nav.foreldrepenger.ytelse.beregning.regelmodell.uttakresultat.UttakResultat;
 import no.nav.foreldrepenger.ytelse.beregning.regelmodell.uttakresultat.UttakResultatPeriode;
 import no.nav.fpsak.tidsserie.LocalDateInterval;
-
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 class BeregningsresultatInputVerifisererTest {
     private List<BeregningsgrunnlagPeriode> bgPerioder = new ArrayList<>();
@@ -92,9 +92,8 @@ class BeregningsresultatInputVerifisererTest {
     private UttakAktivitet lagUttakAktivitet(String orgnr, String referanse, boolean erFrilans) {
         var arbeidsforhold = erFrilans ? Arbeidsforhold.frilansArbeidsforhold()
                 : Arbeidsforhold.nyttArbeidsforholdHosVirksomhet(orgnr, referanse);
-        return UttakAktivitet.ny(AktivitetStatus.ATFL)
+        return UttakAktivitet.ny(AktivitetStatus.ATFL, BigDecimal.valueOf(100), true)
             .medArbeidsforhold(arbeidsforhold)
-            .medUtbetalingsgrad( BigDecimal.valueOf(100))
             .medStillingsgrad( BigDecimal.valueOf(100),  BigDecimal.valueOf(100))
             .medGradering(false, BigDecimal.ZERO);
     }

--- a/domenetjenester/beregning-ytelse/src/test/java/no/nav/foreldrepenger/ytelse/beregning/regelmodell/fastsett/FinnOverlappendeBeregningsgrunnlagOgUttaksPerioderTest.java
+++ b/domenetjenester/beregning-ytelse/src/test/java/no/nav/foreldrepenger/ytelse/beregning/regelmodell/fastsett/FinnOverlappendeBeregningsgrunnlagOgUttaksPerioderTest.java
@@ -581,9 +581,8 @@ class FinnOverlappendeBeregningsgrunnlagOgUttaksPerioderTest {
     private List<UttakResultatPeriode> lagUttakResultatPeriode(LocalDate fom, LocalDate tom, BigDecimal stillingsgrad, BigDecimal arbeidstidsprosent,
             BigDecimal utbetalingsgrad, AktivitetStatus aktivitetStatus, boolean erGradering) {
 
-        var uttakAktivitet = UttakAktivitet.ny(aktivitetStatus)
+        var uttakAktivitet = UttakAktivitet.ny(aktivitetStatus, utbetalingsgrad, true)
             .medArbeidsforhold(arbeidsforhold)
-            .medUtbetalingsgrad(utbetalingsgrad)
             .medStillingsgrad(stillingsgrad, stillingsgrad)
             .medGradering(erGradering, arbeidstidsprosent);
         var periode = new UttakResultatPeriode(fom, tom, List.of(uttakAktivitet), false);

--- a/domenetjenester/beregning-ytelse/src/test/java/no/nav/foreldrepenger/ytelse/beregning/regelmodell/fastsett/RegelFastsettBeregningsresultatFPTest.java
+++ b/domenetjenester/beregning-ytelse/src/test/java/no/nav/foreldrepenger/ytelse/beregning/regelmodell/fastsett/RegelFastsettBeregningsresultatFPTest.java
@@ -333,12 +333,12 @@ class RegelFastsettBeregningsresultatFPTest {
         var erGradering = false;
         if (arbeidsforholdList.isEmpty()) {
             return Collections.singletonList(new UttakAktivitet(stillingsgrad, null, utbetalingsgrad,
-                    aktivitetsStatus.equals(AktivitetStatus.ATFL) ? ARBEIDSFORHOLD_1 : null, aktivitetsStatus, erGradering, stillingsgrad));
+                true, aktivitetsStatus.equals(AktivitetStatus.ATFL) ? ARBEIDSFORHOLD_1 : null, aktivitetsStatus, erGradering, stillingsgrad));
         }
         return arbeidsforholdList.stream()
                 .map(arb -> {
                     var arbeidsforhold = aktivitetsStatus.equals(AktivitetStatus.ATFL) ? arb : null;
-                    return new UttakAktivitet(stillingsgrad, null, utbetalingsgrad, arbeidsforhold, aktivitetsStatus, erGradering, stillingsgrad);
+                    return new UttakAktivitet(stillingsgrad, null, utbetalingsgrad, true, arbeidsforhold, aktivitetsStatus, erGradering, stillingsgrad);
                 }).toList();
     }
 }

--- a/domenetjenester/beregning-ytelse/src/test/java/no/nav/foreldrepenger/ytelse/beregning/regelmodell/fastsett/RegelFastsettBeregningsresultatSVPTest.java
+++ b/domenetjenester/beregning-ytelse/src/test/java/no/nav/foreldrepenger/ytelse/beregning/regelmodell/fastsett/RegelFastsettBeregningsresultatSVPTest.java
@@ -7,7 +7,10 @@ import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Test;
 
@@ -37,13 +40,20 @@ class RegelFastsettBeregningsresultatSVPTest {
     private static final Arbeidsforhold ARBEIDSFORHOLD_2 = Arbeidsforhold.nyttArbeidsforholdHosVirksomhet("222", UUID.randomUUID().toString());
     private static final Arbeidsforhold ARBEIDSFORHOLD_3 = Arbeidsforhold.nyttArbeidsforholdHosVirksomhet("333", UUID.randomUUID().toString());
 
+    private static final BigDecimal HUNDRE = BigDecimal.valueOf(100);
+    private static final BigDecimal FØRTI = BigDecimal.valueOf(40);
+    private static final BigDecimal SEKSTI = BigDecimal.valueOf(60);
+    private static final BigDecimal ÅTTI = BigDecimal.valueOf(60);
+
+    private record Tilrettelegging(Arbeidsforhold arbeidsforhold, BigDecimal utbetalingsgrad) {}
+
     @Test
     void skalTesteSVPUttaksperioderMedForskjelligeAntallAktiviteter() {
         // Arrange
         var periodeMap = Map.of(
-                PERIODE_1, List.of(ARBEIDSFORHOLD_1),
-                PERIODE_2, List.of(ARBEIDSFORHOLD_1, ARBEIDSFORHOLD_2),
-                PERIODE_3, List.of(ARBEIDSFORHOLD_1, ARBEIDSFORHOLD_2, ARBEIDSFORHOLD_3));
+                PERIODE_1, List.of(new Tilrettelegging(ARBEIDSFORHOLD_1, HUNDRE)),
+                PERIODE_2, List.of(new Tilrettelegging(ARBEIDSFORHOLD_1, HUNDRE), new Tilrettelegging(ARBEIDSFORHOLD_2, HUNDRE)),
+                PERIODE_3, List.of(new Tilrettelegging(ARBEIDSFORHOLD_1, HUNDRE), new Tilrettelegging(ARBEIDSFORHOLD_2, HUNDRE), new Tilrettelegging(ARBEIDSFORHOLD_3, HUNDRE)));
         var modell = opprettRegelmodell(periodeMap);
         var output = Beregningsresultat.opprett();
 
@@ -54,17 +64,64 @@ class RegelFastsettBeregningsresultatSVPTest {
         var perioder = resultat.beregningsresultat().getBeregningsresultatPerioder();
         assertThat(perioder).hasSize(3);
         assertThat(perioder.get(0).getBeregningsresultatAndelList()).hasSize(2);
+        assertThat(perioder.get(0).getBeregningsresultatAndelList()).allMatch(p -> BigDecimal.valueOf(100).compareTo(p.getUtbetalingsgrad()) == 0);
         assertThat(perioder.get(1).getBeregningsresultatAndelList()).hasSize(4);
         assertThat(perioder.get(2).getBeregningsresultatAndelList()).hasSize(6);
 
     }
 
-    private BeregningsresultatGrunnlag opprettRegelmodell(Map<LocalDateInterval, List<Arbeidsforhold>> periodeMap) {
+    @Test
+    void skalTesteSVPUttaksperioderMedDelvisTilrettelegging() {
+        // Arrange
+        var periodeMap = Map.of(PERIODE_1, List.of(new Tilrettelegging(ARBEIDSFORHOLD_1, SEKSTI)));
+        var modell = opprettRegelmodell(periodeMap);
+        var output = Beregningsresultat.opprett();
+
+        // Act
+        var resultat = BeregningsresultatRegler.fastsettBeregningsresultat(modell);
+
+        // Assert
+        var perioder = resultat.beregningsresultat().getBeregningsresultatPerioder();
+        assertThat(perioder).hasSize(1);
+        assertThat(perioder.get(0).getBeregningsresultatAndelList()).hasSize(2);
+        assertThat(perioder.get(0).getBeregningsresultatAndelList()).allMatch(p -> SEKSTI.compareTo(p.getUtbetalingsgrad()) == 0);
+        assertThat(perioder.get(0).getBeregningsresultatAndelList()).allMatch(p -> Objects.equals(p.getDagsats(), p.getDagsatsFraBg()));
+    }
+
+    @Test
+    void skalTesteSVPUttaksperioderMeSynkendeTilrettelegging() {
+        // Arrange
+        var periodeMap = Map.of(
+            PERIODE_1, List.of(new Tilrettelegging(ARBEIDSFORHOLD_1, FØRTI)),
+            PERIODE_2, List.of(new Tilrettelegging(ARBEIDSFORHOLD_1, ÅTTI)),
+            PERIODE_3, List.of(new Tilrettelegging(ARBEIDSFORHOLD_1, HUNDRE), new Tilrettelegging(ARBEIDSFORHOLD_2, SEKSTI)));
+        var modell = opprettRegelmodell(periodeMap);
+        var output = Beregningsresultat.opprett();
+
+        // Act
+        var resultat = BeregningsresultatRegler.fastsettBeregningsresultat(modell);
+
+        // Assert
+        var perioder = resultat.beregningsresultat().getBeregningsresultatPerioder();
+        assertThat(perioder).hasSize(3);
+        assertThat(perioder.get(0).getBeregningsresultatAndelList()).hasSize(2);
+        assertThat(perioder.get(0).getBeregningsresultatAndelList()).allMatch(p -> FØRTI.compareTo(p.getUtbetalingsgrad()) == 0);
+        assertThat(perioder.get(0).getBeregningsresultatAndelList()).allMatch(p -> Objects.equals(p.getDagsats(), p.getDagsatsFraBg()));
+        assertThat(perioder.get(1).getBeregningsresultatAndelList()).hasSize(2);
+        assertThat(perioder.get(1).getBeregningsresultatAndelList()).allMatch(p -> ÅTTI.compareTo(p.getUtbetalingsgrad()) == 0);
+        assertThat(perioder.get(1).getBeregningsresultatAndelList()).allMatch(p -> Objects.equals(p.getDagsats(), p.getDagsatsFraBg()));
+        assertThat(perioder.get(2).getBeregningsresultatAndelList()).hasSize(4);
+        assertThat(perioder.get(2).getBeregningsresultatAndelList().stream().filter(p -> ARBEIDSFORHOLD_1.equals(p.getArbeidsforhold())).toList()).allMatch(p -> HUNDRE.compareTo(p.getUtbetalingsgrad()) == 0);
+        assertThat(perioder.get(2).getBeregningsresultatAndelList().stream().filter(p -> ARBEIDSFORHOLD_2.equals(p.getArbeidsforhold())).toList()).allMatch(p -> SEKSTI.compareTo(p.getUtbetalingsgrad()) == 0);
+        assertThat(perioder.get(2).getBeregningsresultatAndelList()).allMatch(p -> Objects.equals(p.getDagsats(), p.getDagsatsFraBg()));
+    }
+
+    private BeregningsresultatGrunnlag opprettRegelmodell(Map<LocalDateInterval, List<Tilrettelegging>> periodeMap) {
         var arbeidsforhold = periodeMap.entrySet().stream()
                 .flatMap(entry -> entry.getValue().stream())
                 .distinct()
-                .map(arb -> lagPrArbeidsforhold(1000, 500, arb))
-                .toList();
+                .map(arb -> lagPrArbeidsforhold(1000, 500, arb.arbeidsforhold()))
+                .collect(Collectors.toSet());
         var beregningsgrunnlag = opprettBeregningsgrunnlag(arbeidsforhold);
         var uttakResultat = opprettUttak(periodeMap);
         return new BeregningsresultatGrunnlag(beregningsgrunnlag, uttakResultat);
@@ -76,26 +133,26 @@ class RegelFastsettBeregningsresultatSVPTest {
             .medRedusertBrukersAndelPrÅr(BigDecimal.valueOf(260 * dagsatsBruker));
     }
 
-    private Beregningsgrunnlag opprettBeregningsgrunnlag(List<BeregningsgrunnlagPrArbeidsforhold> ekstraArbeidsforhold) {
-        var prStatus = new BeregningsgrunnlagPrStatus(AktivitetStatus.ATFL, ekstraArbeidsforhold);
+    private Beregningsgrunnlag opprettBeregningsgrunnlag(Set<BeregningsgrunnlagPrArbeidsforhold> ekstraArbeidsforhold) {
+        var prStatus = new BeregningsgrunnlagPrStatus(AktivitetStatus.ATFL, ekstraArbeidsforhold.stream().toList());
         var periode = new BeregningsgrunnlagPeriode(START, LocalDate.MAX, List.of(prStatus));
         return Beregningsgrunnlag.enkelPeriode(periode);
     }
 
-    private UttakResultat opprettUttak(Map<LocalDateInterval, List<Arbeidsforhold>> arbeidsforholdPerioder) {
+    private UttakResultat opprettUttak(Map<LocalDateInterval, List<Tilrettelegging>> arbeidsforholdPerioder) {
         List<UttakResultatPeriode> periodeListe = new ArrayList<>();
         for (var arbPeriode : arbeidsforholdPerioder.entrySet()) {
             var periode = arbPeriode.getKey();
             var arbeidsforhold = arbPeriode.getValue();
-            var uttakAktiviteter = lagUttakAktiviteter(BigDecimal.valueOf(100), BigDecimal.valueOf(100), arbeidsforhold);
+            var uttakAktiviteter = lagUttakAktiviteter(BigDecimal.valueOf(100), arbeidsforhold);
             periodeListe.add(new UttakResultatPeriode(periode.getFomDato(), periode.getTomDato(), uttakAktiviteter, false));
         }
         return new UttakResultat(periodeListe);
     }
 
-    private List<UttakAktivitet> lagUttakAktiviteter(BigDecimal stillingsgrad, BigDecimal utbetalingsgrad, List<Arbeidsforhold> arbeidsforholdList) {
+    private List<UttakAktivitet> lagUttakAktiviteter(BigDecimal stillingsgrad, List<Tilrettelegging> arbeidsforholdList) {
         return arbeidsforholdList.stream()
-                .map(arb -> new UttakAktivitet(stillingsgrad, null, utbetalingsgrad, arb, AktivitetStatus.ATFL, false, stillingsgrad))
+                .map(arb -> new UttakAktivitet(stillingsgrad, null, arb.utbetalingsgrad(), false, arb.arbeidsforhold(), AktivitetStatus.ATFL, false, stillingsgrad))
                 .toList();
     }
 }

--- a/domenetjenester/beregning-ytelse/src/test/java/no/nav/foreldrepenger/ytelse/beregning/svp/MapUttakResultatFraVLTilRegelTest.java
+++ b/domenetjenester/beregning-ytelse/src/test/java/no/nav/foreldrepenger/ytelse/beregning/svp/MapUttakResultatFraVLTilRegelTest.java
@@ -31,6 +31,7 @@ class MapUttakResultatFraVLTilRegelTest {
     private static final int STILLING_70 = 70;
     private static final String ORGNR = "000000000";
     private static final InternArbeidsforholdRef ARB_ID = InternArbeidsforholdRef.namedRef("TEST-REF");
+    private static final BigDecimal SEKSTISEKS = BigDecimal.valueOf(66);
 
     private Behandling behandling;
     private MapUttakResultatFraVLTilRegel mapper;
@@ -60,7 +61,7 @@ class MapUttakResultatFraVLTilRegelTest {
         // Arrange
         var fom = LocalDate.of(2019, Month.JANUARY, 1);
         var tom = LocalDate.of(2019, Month.MARCH, 31);
-        var uttakPeriode = lagUttaksperiode(fom, tom, new Utbetalingsgrad(66));
+        var uttakPeriode = lagUttaksperiode(fom, tom, new Utbetalingsgrad(SEKSTISEKS));
         var uttakArbeidsforhold = lagArbeidsforhold(ORGNR, ARB_ID, uttakPeriode);
         var uttakResultat = lagUttak(uttakArbeidsforhold);
         // Act
@@ -74,7 +75,7 @@ class MapUttakResultatFraVLTilRegelTest {
         assertThat(periode1.tom()).isEqualTo(tom);
         var uttakAktiviteter = periode1.uttakAktiviteter();
         assertThat(uttakAktiviteter).hasSize(1);
-        assertThat(uttakAktiviteter.get(0).utbetalingsgrad()).isEqualByComparingTo(BigDecimal.valueOf(100));
+        assertThat(uttakAktiviteter.get(0).utbetalingsgrad()).isEqualByComparingTo(SEKSTISEKS);
         assertThat(uttakAktiviteter.get(0).stillingsgrad()).isEqualByComparingTo(BigDecimal.valueOf(STILLING_70));
         assertThat(uttakAktiviteter.get(0).arbeidsforhold().identifikator()).isEqualTo(ORGNR);
         assertThat(uttakAktiviteter.get(0).arbeidsforhold().arbeidsforholdId()).isEqualTo(ARB_ID.getReferanse());
@@ -86,7 +87,7 @@ class MapUttakResultatFraVLTilRegelTest {
         // Arrange
         var fom = LocalDate.of(2019, Month.JANUARY, 1);
         var tom = LocalDate.of(2019, Month.MARCH, 31);
-        var uttakPeriode = lagUttaksperiode(fom, tom, new Utbetalingsgrad(66));
+        var uttakPeriode = lagUttaksperiode(fom, tom, new Utbetalingsgrad(SEKSTISEKS));
         var uttakArbeidsforhold = lagUttakResultatArbeidsforhold(UttakArbeidType.SELVSTENDIG_NÆRINGSDRIVENDE, null, null, uttakPeriode);
         var uttakResultat = lagUttak(uttakArbeidsforhold);
         // Act
@@ -100,7 +101,7 @@ class MapUttakResultatFraVLTilRegelTest {
         assertThat(periode1.tom()).isEqualTo(tom);
         var uttakAktiviteter = periode1.uttakAktiviteter();
         assertThat(uttakAktiviteter).hasSize(1);
-        assertThat(uttakAktiviteter.get(0).utbetalingsgrad()).isEqualByComparingTo(BigDecimal.valueOf(100));
+        assertThat(uttakAktiviteter.get(0).utbetalingsgrad()).isEqualByComparingTo(SEKSTISEKS);
         assertThat(uttakAktiviteter.get(0).stillingsgrad()).isEqualByComparingTo(BigDecimal.valueOf(100));
         assertThat(uttakAktiviteter.get(0).aktivitetStatus()).isEqualTo(AktivitetStatus.SN);
     }
@@ -110,10 +111,10 @@ class MapUttakResultatFraVLTilRegelTest {
         // Arrange
         var fom = LocalDate.of(2019, Month.JANUARY, 1);
         var tom = LocalDate.of(2019, Month.MARCH, 31);
-        var uttakPeriode = lagUttaksperiode(fom, tom, new Utbetalingsgrad(66));
+        var uttakPeriode = lagUttaksperiode(fom, tom, new Utbetalingsgrad(SEKSTISEKS));
         var fom2 = tom.plusDays(1);
         var tom2 = LocalDate.of(2019, 4, 30);
-        var uttakPeriode2 = lagUttaksperiode(fom2, tom2, new Utbetalingsgrad(66));
+        var uttakPeriode2 = lagUttaksperiode(fom2, tom2, new Utbetalingsgrad(SEKSTISEKS));
         var uttakArbeidsforhold = lagArbeidsforhold(ORGNR, ARB_ID, uttakPeriode, uttakPeriode2);
         var uttakResultat = lagUttak(uttakArbeidsforhold);
         // Act
@@ -130,7 +131,7 @@ class MapUttakResultatFraVLTilRegelTest {
         perioder.forEach(periode -> {
             var uttakAktiviteter = periode.uttakAktiviteter();
             assertThat(uttakAktiviteter).hasSize(1);
-            assertThat(uttakAktiviteter.get(0).utbetalingsgrad()).isEqualByComparingTo(BigDecimal.valueOf(100));
+            assertThat(uttakAktiviteter.get(0).utbetalingsgrad()).isEqualByComparingTo(SEKSTISEKS);
             assertThat(uttakAktiviteter.get(0).stillingsgrad()).isEqualByComparingTo(BigDecimal.valueOf(STILLING_70));
             assertThat(uttakAktiviteter.get(0).arbeidsforhold().identifikator()).isEqualTo(ORGNR);
             assertThat(uttakAktiviteter.get(0).arbeidsforhold().arbeidsforholdId()).isEqualTo(ARB_ID.getReferanse());
@@ -147,16 +148,16 @@ class MapUttakResultatFraVLTilRegelTest {
         var tom = LocalDate.of(2019, Month.MARCH, 31);
         var fom2 = tom.plusDays(1);
         var tom2 = LocalDate.of(2019, 4, 30);
-        var uttakPeriode = lagUttaksperiode(fom, tom, new Utbetalingsgrad(66));
-        var uttakPeriode2 = lagUttaksperiode(fom2, tom2, new Utbetalingsgrad(66));
+        var uttakPeriode = lagUttaksperiode(fom, tom, new Utbetalingsgrad(SEKSTISEKS));
+        var uttakPeriode2 = lagUttaksperiode(fom2, tom2, new Utbetalingsgrad(SEKSTISEKS));
         var uttakArbeidsforhold = lagArbeidsforhold(ORGNR, ARB_ID, uttakPeriode, uttakPeriode2);
         // Arbeidsforhold 2
         var fom3 = LocalDate.of(2019, Month.FEBRUARY, 1);
         var tom3 = LocalDate.of(2019, Month.APRIL, 15);
         var fom4 = tom3.plusDays(1);
         var tom4 = LocalDate.of(2019, 5, 15);
-        var uttakPeriode3 = lagUttaksperiode(fom3, tom3, new Utbetalingsgrad(66));
-        var uttakPeriode4 = lagUttaksperiode(fom4, tom4, new Utbetalingsgrad(66));
+        var uttakPeriode3 = lagUttaksperiode(fom3, tom3, new Utbetalingsgrad(SEKSTISEKS));
+        var uttakPeriode4 = lagUttaksperiode(fom4, tom4, new Utbetalingsgrad(SEKSTISEKS));
         var arbeidsforholdId = InternArbeidsforholdRef.nyRef();
         var uttakArbeidsforhold2 = lagArbeidsforhold("123", arbeidsforholdId, uttakPeriode3, uttakPeriode4);
         var uttakResultat = lagUttak(uttakArbeidsforhold, uttakArbeidsforhold2);

--- a/domenetjenester/vedtak/pom.xml
+++ b/domenetjenester/vedtak/pom.xml
@@ -42,10 +42,6 @@
             <groupId>no.nav.foreldrepenger</groupId>
             <artifactId>skjaeringstidspunkt</artifactId>
         </dependency>
-        <dependency>
-            <groupId>no.nav.foreldrepenger</groupId>
-            <artifactId>beregningsgrunnlag</artifactId>
-        </dependency>
 
         <!-- Prosjektinterne avhengigheter -->
 		<dependency>

--- a/domenetjenester/vedtak/src/main/java/no/nav/foreldrepenger/domene/vedtak/observer/PubliserVedtattYtelseHendelseTask.java
+++ b/domenetjenester/vedtak/src/main/java/no/nav/foreldrepenger/domene/vedtak/observer/PubliserVedtattYtelseHendelseTask.java
@@ -62,7 +62,7 @@ public class PubliserVedtattYtelseHendelseTask implements ProsessTaskHandler {
     }
 
     private String generatePayload(Behandling behandling) {
-        var ytelse = vedtakTjeneste.genererYtelse(behandling, true);
+        var ytelse = vedtakTjeneste.genererYtelse(behandling);
 
         var violations = validator.validate(ytelse);
         if (!violations.isEmpty()) {

--- a/domenetjenester/vedtak/src/test/java/no/nav/foreldrepenger/domene/vedtak/observer/VedtattYtelseTjenesteTest.java
+++ b/domenetjenester/vedtak/src/test/java/no/nav/foreldrepenger/domene/vedtak/observer/VedtattYtelseTjenesteTest.java
@@ -23,20 +23,7 @@ import no.nav.foreldrepenger.behandlingslager.behandling.vedtak.BehandlingVedtak
 import no.nav.foreldrepenger.behandlingslager.behandling.vedtak.BehandlingVedtakRepository;
 import no.nav.foreldrepenger.behandlingslager.testutilities.behandling.ScenarioMorSøkerEngangsstønad;
 import no.nav.foreldrepenger.behandlingslager.testutilities.behandling.ScenarioMorSøkerSvangerskapspenger;
-import no.nav.foreldrepenger.behandlingslager.virksomhet.Arbeidsgiver;
 import no.nav.foreldrepenger.domene.arbeidsforhold.InntektArbeidYtelseTjeneste;
-import no.nav.foreldrepenger.domene.modell.Beregningsgrunnlag;
-import no.nav.foreldrepenger.domene.modell.BeregningsgrunnlagGrunnlag;
-import no.nav.foreldrepenger.domene.modell.BeregningsgrunnlagGrunnlagBuilder;
-import no.nav.foreldrepenger.domene.modell.kodeverk.AktivitetStatus;
-import no.nav.foreldrepenger.domene.modell.BGAndelArbeidsforhold;
-import no.nav.foreldrepenger.domene.modell.BeregningsgrunnlagPeriode;
-import no.nav.foreldrepenger.domene.modell.BeregningsgrunnlagPrStatusOgAndel;
-import no.nav.foreldrepenger.domene.modell.kodeverk.AndelKilde;
-import no.nav.foreldrepenger.domene.modell.kodeverk.BeregningsgrunnlagTilstand;
-import no.nav.foreldrepenger.domene.prosess.BeregningTjeneste;
-import no.nav.foreldrepenger.domene.typer.InternArbeidsforholdRef;
-import no.nav.vedtak.konfig.Tid;
 
 @ExtendWith(MockitoExtension.class)
 class VedtattYtelseTjenesteTest {
@@ -45,8 +32,6 @@ class VedtattYtelseTjenesteTest {
     private BehandlingVedtakRepository behandlingVedtakRepository;
     @Mock
     private BehandlingVedtak vedtak;
-    @Mock
-    private BeregningTjeneste beregningTjeneste;
     @Mock
     private BeregningsresultatRepository beregningsresultatRepository;
     @Mock
@@ -63,15 +48,13 @@ class VedtattYtelseTjenesteTest {
     void skal_teste_arena_ytelser_finnes_ikke() {
         // Arrange
         var behandling = ScenarioMorSøkerSvangerskapspenger.forSvangerskapspenger().lagMocked();
-        var bg = lagBG();
         var br = lagBR();
-        when(beregningTjeneste.hent(behandling.getId())).thenReturn(Optional.of(bg));
         when(beregningsresultatRepository.hentUtbetBeregningsresultat(behandling.getId())).thenReturn(Optional.of(br));
         when(behandlingVedtakRepository.hentForBehandling(behandling.getId())).thenReturn(vedtak);
         when(vedtak.getVedtakstidspunkt()).thenReturn(stp.atStartOfDay());
-        var tjeneste = new VedtattYtelseTjeneste(behandlingVedtakRepository, beregningTjeneste, beregningsresultatRepository, inntektArbeidYtelseTjeneste, familieHendelseRepository);
+        var tjeneste = new VedtattYtelseTjeneste(behandlingVedtakRepository, beregningsresultatRepository, inntektArbeidYtelseTjeneste, familieHendelseRepository);
 
-        var ytelse= (YtelseV1)tjeneste.genererYtelse(behandling, false);
+        var ytelse= (YtelseV1)tjeneste.genererYtelse(behandling);
         // Assert
         assertThat(ytelse.getAnvist()).hasSize(4);
         assertThat(ytelse.getAnvist().get(0).getUtbetalingsgrad().getVerdi().longValue()).isEqualTo(20);
@@ -96,72 +79,14 @@ class VedtattYtelseTjenesteTest {
         when(beregningsresultatRepository.hentUtbetBeregningsresultat(behandling.getId())).thenReturn(Optional.empty());
         when(behandlingVedtakRepository.hentForBehandling(behandling.getId())).thenReturn(vedtak);
         when(vedtak.getVedtakstidspunkt()).thenReturn(stp.atStartOfDay());
-        var tjeneste = new VedtattYtelseTjeneste(behandlingVedtakRepository, beregningTjeneste, beregningsresultatRepository, inntektArbeidYtelseTjeneste, rp.getFamilieHendelseRepository());
+        var tjeneste = new VedtattYtelseTjeneste(behandlingVedtakRepository, beregningsresultatRepository, inntektArbeidYtelseTjeneste, rp.getFamilieHendelseRepository());
 
-        var ytelse= (YtelseV1)tjeneste.genererYtelse(behandling, false);
+        var ytelse= (YtelseV1)tjeneste.genererYtelse(behandling);
         // Assert
         assertThat(ytelse.getAnvist()).isEmpty();
         assertThat(ytelse.getPeriode().getFom()).isEqualTo(stp);
         assertThat(ytelse.getPeriode().getTom()).isEqualTo(stp);
     }
-
-    private BeregningsgrunnlagGrunnlag lagBG() {
-        var beregningsgrunnlag = Beregningsgrunnlag.builder()
-            .medSkjæringstidspunkt(LocalDate.now())
-            .medGrunnbeløp(new BigDecimal(100000))
-            .leggTilBeregningsgrunnlagPeriode(BeregningsgrunnlagPeriode.builder()
-                .medBeregningsgrunnlagPeriode(stp, knekk1.minusDays(1))
-                .medBruttoPrÅr(BigDecimal.valueOf(2100000))
-                .medRedusertPrÅr(new BigDecimal(120000))
-                .leggTilBeregningsgrunnlagPrStatusOgAndel(BeregningsgrunnlagPrStatusOgAndel.builder()
-                    .medBeregnetPrÅr(new BigDecimal(700000))
-                    .medBruttoPrÅr(new BigDecimal(700000))
-                    .medRedusertPrÅr(new BigDecimal(120000))
-                    .medKilde(AndelKilde.PROSESS_START)
-                    .medRedusertBrukersAndelPrÅr(new BigDecimal(120000))
-                    .medDagsatsBruker(462L)
-                    .medBGAndelArbeidsforhold(BGAndelArbeidsforhold.builder()
-                        .medArbeidsforholdRef(InternArbeidsforholdRef.nullRef())
-                        .medArbeidsgiver(Arbeidsgiver.virksomhet("999999999")))
-                    .medAktivitetStatus(AktivitetStatus.ARBEIDSTAKER)
-                    .build())
-                .build())
-            .leggTilBeregningsgrunnlagPeriode(BeregningsgrunnlagPeriode.builder()
-                .medBeregningsgrunnlagPeriode(knekk1, knekk2.minusDays(1))
-                .medRedusertPrÅr(new BigDecimal(240000))
-                .leggTilBeregningsgrunnlagPrStatusOgAndel(BeregningsgrunnlagPrStatusOgAndel.builder()
-                    .medBeregnetPrÅr(new BigDecimal(700000))
-                    .medBruttoPrÅr(new BigDecimal(700000))
-                    .medRedusertPrÅr(new BigDecimal(240000))
-                    .medKilde(AndelKilde.PROSESS_START)
-                    .medRedusertBrukersAndelPrÅr(new BigDecimal(240000))
-                    .medDagsatsBruker(923L)
-                    .medBGAndelArbeidsforhold(BGAndelArbeidsforhold.builder()
-                        .medArbeidsforholdRef(InternArbeidsforholdRef.nullRef())
-                        .medArbeidsgiver(Arbeidsgiver.virksomhet("999999999")))
-                    .medAktivitetStatus(AktivitetStatus.ARBEIDSTAKER)
-                    .build())
-                .build())
-            .leggTilBeregningsgrunnlagPeriode(BeregningsgrunnlagPeriode.builder()
-                .medBeregningsgrunnlagPeriode(knekk2, Tid.TIDENES_ENDE)
-                .medRedusertPrÅr(new BigDecimal(360000))
-                .leggTilBeregningsgrunnlagPrStatusOgAndel(BeregningsgrunnlagPrStatusOgAndel.builder()
-                    .medBeregnetPrÅr(new BigDecimal(700000))
-                    .medBruttoPrÅr(new BigDecimal(700000))
-                    .medRedusertPrÅr(new BigDecimal(360000))
-                    .medKilde(AndelKilde.PROSESS_START)
-                    .medRedusertBrukersAndelPrÅr(new BigDecimal(360000))
-                    .medDagsatsBruker(1385L)
-                    .medBGAndelArbeidsforhold(BGAndelArbeidsforhold.builder()
-                        .medArbeidsforholdRef(InternArbeidsforholdRef.nullRef())
-                        .medArbeidsgiver(Arbeidsgiver.virksomhet("999999999")))
-                    .medAktivitetStatus(AktivitetStatus.ARBEIDSTAKER)
-                    .build())
-                .build())
-            .build();
-        return BeregningsgrunnlagGrunnlagBuilder.nytt().medBeregningsgrunnlag(beregningsgrunnlag).build(BeregningsgrunnlagTilstand.FASTSATT);
-    }
-
 
     private BeregningsresultatEntitet lagBR() {
         var beregningsresultat = BeregningsresultatEntitet.builder()
@@ -180,20 +105,20 @@ class VedtattYtelseTjenesteTest {
         var per3 = BeregningsresultatPeriode.builder()
             .medBeregningsresultatPeriodeFomOgTom(knekk2, LocalDate.now().plusWeeks(2))
             .build(beregningsresultat);
-        byggandel(per1a, 460);
-        byggandel(per1b, 460);
-        byggandel(per2, 920);
-        byggandel(per3, 1380);
+        byggandel(per1a, 460, BigDecimal.valueOf(20));
+        byggandel(per1b, 460, BigDecimal.valueOf(20));
+        byggandel(per2, 920, BigDecimal.valueOf(40));
+        byggandel(per3, 1380, BigDecimal.valueOf(60));
         return beregningsresultat;
     }
 
-    private void byggandel(BeregningsresultatPeriode periode, int dagsats) {
+    private void byggandel(BeregningsresultatPeriode periode, int dagsats, BigDecimal utbetalingsgrad) {
         BeregningsresultatAndel.builder()
             .medDagsats(dagsats)
             .medDagsatsFraBg(dagsats)
             .medBrukerErMottaker(true)
             .medStillingsprosent(BigDecimal.TEN.multiply(BigDecimal.TEN))
-            .medUtbetalingsgrad(BigDecimal.TEN.multiply(BigDecimal.TEN))
+            .medUtbetalingsgrad(utbetalingsgrad)
             .medInntektskategori(Inntektskategori.ARBEIDSTAKER)
             .build(periode);
     }


### PR DESCRIPTION
Endre tilkjent-reglene til å ikke alltid gradere ned dagsats fra svp-uttak-aktivitet
Sende inn utbetalingsgrad fra SVP-søknad til tilkjent-regler og bruke den - nå er det alltid 100% eller 0% i BR-andel
Resultat:
* SVP-BR-andel vil få dagsats=dagsatsFraBG men utbetalingsgrad iht tilrettelegging
* Vedtak publisert til abakus får riktigere utbetalingsgrad

Trenger litt bistand til å validere og sjekke om dette påvirker oppdrag utover å gi en riktigere utbetalingsgrad (som de ønsker)