### PR TITLE
Fpoversikt: fikser bug med saker som står til punching

### DIFF
--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/forvaltning/fpoversikt/FpoversiktMigeringBehandlingHendelseTask.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/forvaltning/fpoversikt/FpoversiktMigeringBehandlingHendelseTask.java
@@ -73,7 +73,7 @@ class FpoversiktMigeringBehandlingHendelseTask implements ProsessTaskHandler {
     private void pushKafkaHendelse(Long fagsakId) {
         var behandlingOpt = behandlingRepository.hentSisteYtelsesBehandlingForFagsakIdReadOnly(fagsakId);
         if (behandlingOpt.isEmpty()) {
-            LOG.info("Publiser migreringshendelse, ingen behandlig for fagsak {}", fagsakId);
+            LOG.info("Publiser migreringshendelse, ingen behandling for fagsak {}", fagsakId);
             return;
         }
         var behandling = behandlingOpt.get();


### PR DESCRIPTION
Fagsakrelasjon repo kaster tomtresultatexception, denne catcher av exceptionmapper og konverteres til en 404 uten logging