### PR TITLE
TFP-5486 basis fagsak-notat

### DIFF
--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/fagsak/FagsakNotat.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/fagsak/FagsakNotat.java
@@ -1,0 +1,79 @@
+package no.nav.foreldrepenger.behandlingslager.fagsak;
+
+import java.util.Objects;
+
+import javax.persistence.Column;
+import javax.persistence.Convert;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+import no.nav.foreldrepenger.behandlingslager.BaseCreateableEntitet;
+import no.nav.vedtak.felles.jpa.converters.BooleanToStringConverter;
+
+@Entity(name = "FagsakNotat")
+@Table(name = "FAGSAK_NOTAT")
+public class FagsakNotat extends BaseCreateableEntitet {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "SEQ_FAGSAK_NOTAT")
+    private Long id;
+
+    @Column(name = "fagsak_id", nullable = false)
+    private Long fagsakId;
+
+    // Placeholder i fall man ønsker en skjuling (feilregistrer)
+    @Convert(converter = BooleanToStringConverter.class)
+    @Column(name = "aktiv", nullable = false)
+    private boolean aktiv = true;
+
+    @Column(name = "notat", nullable = false)
+    private String notat;
+
+    public FagsakNotat() {
+        // For Hibernate
+    }
+
+    FagsakNotat(Long fagsakId, String notat) {
+        Objects.requireNonNull(notat,"tomt notat");
+        this.fagsakId = fagsakId;
+        this.notat = notat;
+    }
+
+
+    public Long getId() {
+        return id;
+    }
+
+    public Long getFagsakId() {
+        return fagsakId;
+    }
+
+    public String getNotat() {
+        return notat;
+    }
+
+    void setAktiv(boolean aktivt) {
+        this.aktiv = aktivt;
+    }
+
+    public boolean getErAktiv() {
+        return aktiv;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (!(o instanceof FagsakNotat that))
+            return false;
+        return fagsakId.equals(that.fagsakId) && Objects.equals(notat, that.notat);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(fagsakId, notat);
+    }
+}

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/fagsak/FagsakRepository.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/fagsak/FagsakRepository.java
@@ -236,4 +236,20 @@ public class FagsakRepository {
 
        return query.getResultList();
     }
+
+    public void lagreFagsakNotat(Long fagsakId, String notat) {
+        if (notat == null || notat.isEmpty()) {
+            return;
+        }
+        var nyttnotat = new FagsakNotat(fagsakId, notat);
+        entityManager.persist(nyttnotat);
+        entityManager.flush();
+    }
+
+    public List<FagsakNotat> hentFagsakNotater(Long fagsakId) {
+        var query = entityManager.createQuery("from FagsakNotat where fagsakId=:fagsakId order by opprettetTidspunkt desc", FagsakNotat.class)
+            .setParameter("fagsakId", fagsakId);
+        return query.getResultList();
+    }
+
 }

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/fagsak/FagsakRepository.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/fagsak/FagsakRepository.java
@@ -247,7 +247,7 @@ public class FagsakRepository {
     }
 
     public List<FagsakNotat> hentFagsakNotater(Long fagsakId) {
-        var query = entityManager.createQuery("from FagsakNotat where fagsakId=:fagsakId order by opprettetTidspunkt desc", FagsakNotat.class)
+        var query = entityManager.createQuery("from FagsakNotat where fagsakId=:fagsakId AND aktiv = true order by opprettetTidspunkt desc", FagsakNotat.class)
             .setParameter("fagsakId", fagsakId);
         return query.getResultList();
     }

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/fagsak/FagsakRepository.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/fagsak/FagsakRepository.java
@@ -247,7 +247,7 @@ public class FagsakRepository {
     }
 
     public List<FagsakNotat> hentFagsakNotater(Long fagsakId) {
-        var query = entityManager.createQuery("from FagsakNotat where fagsakId=:fagsakId AND aktiv = true order by opprettetTidspunkt desc", FagsakNotat.class)
+        var query = entityManager.createQuery("from FagsakNotat where fagsakId=:fagsakId AND aktiv = true order by opprettetTidspunkt asc", FagsakNotat.class)
             .setParameter("fagsakId", fagsakId);
         return query.getResultList();
     }

--- a/behandlingslager/domene/src/main/resources/META-INF/pu-default.fagsak.orm.xml
+++ b/behandlingslager/domene/src/main/resources/META-INF/pu-default.fagsak.orm.xml
@@ -9,6 +9,7 @@
 	<sequence-generator name="SEQ_FAGSAK_PROSESS_TASK" allocation-size="50" sequence-name="SEQ_FAGSAK_PROSESS_TASK"/>
 	<sequence-generator name="SEQ_FAGSAK_RELASJON" allocation-size="50" sequence-name="SEQ_FAGSAK_RELASJON" />
     <sequence-generator name="SEQ_FAGSAK_EGENSKAP" allocation-size="50" sequence-name="SEQ_FAGSAK_EGENSKAP" />
+    <sequence-generator name="SEQ_FAGSAK_NOTAT" allocation-size="50" sequence-name="SEQ_FAGSAK_NOTAT" />
     <sequence-generator name="SEQ_JOURNALPOST" allocation-size="50" sequence-name="SEQ_JOURNALPOST" />
 
 	<sequence-generator name="SEQ_BRUKER" allocation-size="50" sequence-name="SEQ_BRUKER" />
@@ -17,6 +18,7 @@
     <entity class="no.nav.foreldrepenger.behandlingslager.fagsak.FagsakProsessTask"/>
 	<entity class="no.nav.foreldrepenger.behandlingslager.fagsak.FagsakRelasjon" />
     <entity class="no.nav.foreldrepenger.behandlingslager.fagsak.FagsakEgenskap" />
+    <entity class="no.nav.foreldrepenger.behandlingslager.fagsak.FagsakNotat" />
     <entity class="no.nav.foreldrepenger.behandlingslager.fagsak.Journalpost"/>
 
     <entity class="no.nav.foreldrepenger.behandlingslager.aktør.NavBruker" />

--- a/migreringer/src/main/resources/db/migration/defaultDS/4.1/V4.1_18__TFP-5486-fagsak-notat.sql
+++ b/migreringer/src/main/resources/db/migration/defaultDS/4.1/V4.1_18__TFP-5486-fagsak-notat.sql
@@ -1,0 +1,17 @@
+create sequence SEQ_FAGSAK_NOTAT minvalue 1000000 increment by 50;
+
+create table FAGSAK_NOTAT
+(
+    ID            NUMBER(19) not null constraint PK_FAGSAK_EGENSKAP primary key,
+    FAGSAK_ID     NUMBER(19) not null constraint FK_FAGSAK_EGENSKAP references FAGSAK,
+    OPPRETTET_AV  VARCHAR2(20 char) default 'VL' not null,
+    OPPRETTET_TID TIMESTAMP(3) default systimestamp not null,
+    AKTIV         VARCHAR2(1 char) default 'J' not null,
+    NOTAT         VARCHAR2(4000 char)
+);
+comment on table FAGSAK_NOTAT is 'Generell notatblokk for saken';
+comment on column FAGSAK_NOTAT.ID is 'Primary Key';
+comment on column FAGSAK_NOTAT.FAGSAK_ID is 'FK:FAGSAK Fremmednøkkel for kobling til fagsak';
+comment on column FAGSAK_NOTAT.NOTAT is 'Tekstlig notat';
+
+create index IDX_FAGSAK_NOTAT_1 on FAGSAK_NOTAT (FAGSAK_ID);

--- a/migreringer/src/main/resources/db/migration/defaultDS/4.1/V4.1_18__TFP-5486-fagsak-notat.sql
+++ b/migreringer/src/main/resources/db/migration/defaultDS/4.1/V4.1_18__TFP-5486-fagsak-notat.sql
@@ -2,8 +2,8 @@ create sequence SEQ_FAGSAK_NOTAT minvalue 1000000 increment by 50;
 
 create table FAGSAK_NOTAT
 (
-    ID            NUMBER(19) not null constraint PK_FAGSAK_EGENSKAP primary key,
-    FAGSAK_ID     NUMBER(19) not null constraint FK_FAGSAK_EGENSKAP references FAGSAK,
+    ID            NUMBER(19) not null constraint PK_FAGSAK_NOTAT primary key,
+    FAGSAK_ID     NUMBER(19) not null constraint FK_FAGSAK_NOTAT references FAGSAK,
     OPPRETTET_AV  VARCHAR2(20 char) default 'VL' not null,
     OPPRETTET_TID TIMESTAMP(3) default systimestamp not null,
     AKTIV         VARCHAR2(1 char) default 'J' not null,

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/fagsak/app/FagsakFullTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/fagsak/app/FagsakFullTjeneste.java
@@ -35,6 +35,7 @@ import no.nav.foreldrepenger.web.app.tjenester.behandling.dto.behandling.AnnenPa
 import no.nav.foreldrepenger.web.app.tjenester.behandling.dto.behandling.FagsakBehandlingDtoTjeneste;
 import no.nav.foreldrepenger.web.app.tjenester.behandling.historikk.HistorikkRequestPath;
 import no.nav.foreldrepenger.web.app.tjenester.fagsak.dto.FagsakFullDto;
+import no.nav.foreldrepenger.web.app.tjenester.fagsak.dto.FagsakNotatDto;
 import no.nav.foreldrepenger.web.app.tjenester.fagsak.dto.PersonDto;
 import no.nav.foreldrepenger.web.app.tjenester.fagsak.dto.SakHendelseDto;
 import no.nav.foreldrepenger.web.app.util.StringUtils;
@@ -102,7 +103,9 @@ public class FagsakFullTjeneste {
         var behandlinger = behandlingDtoTjeneste.lagBehandlingDtoer(behandlingRepository.hentAbsoluttAlleBehandlingerForFagsak(fagsak.getId()));
         var dokumentPath = HistorikkRequestPath.getRequestPath(request);
         var historikk = historikkTjenesteAdapter.hentAlleHistorikkInnslagForSak(saksnummer, dokumentPath);
-        var dto = new FagsakFullDto(fagsak, dekningsgrad, bruker, manglerAdresse, annenpart, annenpartSak, familiehendelse, fagsakMarkering, oppretting, behandlinger, historikk);
+        var notater = fagsakRepository.hentFagsakNotater(fagsak.getId()).stream().map(FagsakNotatDto::fraNotat).toList();
+        var dto = new FagsakFullDto(fagsak, dekningsgrad, bruker, manglerAdresse, annenpart, annenpartSak, familiehendelse, fagsakMarkering,
+            oppretting, behandlinger, historikk, notater);
         return Optional.of(dto);
     }
 

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/fagsak/app/FagsakTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/fagsak/app/FagsakTjeneste.java
@@ -134,6 +134,10 @@ public class FagsakTjeneste {
             .toList();
     }
 
+    public void lagreFagsakNotat(Fagsak fagsak, String notat) {
+        fagsakRepository.lagreFagsakNotat(fagsak.getId(), notat);
+    }
+
     public List<Behandling> hentÅpneBehandlinger(Fagsak fagsak) {
         return behandlingRepository.hentÅpneBehandlingerForFagsakId(fagsak.getId());
     }

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/fagsak/dto/FagsakFullDto.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/fagsak/dto/FagsakFullDto.java
@@ -28,7 +28,8 @@ public record FagsakFullDto(String saksnummer,
                             FagsakMarkering fagsakMarkering,
                             List<BehandlingOpprettingDto> behandlingTypeKanOpprettes,
                             List<FagsakBehandlingDto> behandlinger,
-                            List<HistorikkinnslagDto> historikkinnslag) {
+                            List<HistorikkinnslagDto> historikkinnslag,
+                            List<FagsakNotatDto> notater) {
 
     public FagsakFullDto(Fagsak fagsak, Integer dekningsgrad, PersonDto bruker,
                          boolean brukerManglerAdresse,
@@ -38,9 +39,10 @@ public record FagsakFullDto(String saksnummer,
                          FagsakMarkering fagsakMarkering,
                          List<BehandlingOpprettingDto> behandlingTypeKanOpprettes,
                          List<FagsakBehandlingDto> behandlinger,
-                         List<HistorikkinnslagDto> historikkinnslag) {
-        this(fagsak.getSaksnummer().getVerdi(), fagsak.getYtelseType(), fagsak.getRelasjonsRolleType(), fagsak.getStatus(), fagsak.getAktørId().getId(),
-            fagsak.erStengt(), dekningsgrad, bruker, brukerManglerAdresse, annenPart, annenpartBehandling,
-            familiehendelse, fagsakMarkering, fagsakMarkering, behandlingTypeKanOpprettes, behandlinger, historikkinnslag);
+                         List<HistorikkinnslagDto> historikkinnslag,
+                         List<FagsakNotatDto> notater) {
+        this(fagsak.getSaksnummer().getVerdi(), fagsak.getYtelseType(), fagsak.getRelasjonsRolleType(), fagsak.getStatus(),
+            fagsak.getAktørId().getId(), fagsak.erStengt(), dekningsgrad, bruker, brukerManglerAdresse, annenPart, annenpartBehandling,
+            familiehendelse, fagsakMarkering, fagsakMarkering, behandlingTypeKanOpprettes, behandlinger, historikkinnslag, notater);
     }
 }

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/fagsak/dto/FagsakNotatDto.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/fagsak/dto/FagsakNotatDto.java
@@ -1,0 +1,12 @@
+package no.nav.foreldrepenger.web.app.tjenester.fagsak.dto;
+
+import java.time.LocalDateTime;
+
+import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakNotat;
+
+public record FagsakNotatDto(String opprettetAv, LocalDateTime opprettetTidspunkt, String notat) {
+
+    public static FagsakNotatDto fraNotat(FagsakNotat notat) {
+        return new FagsakNotatDto(notat.getOpprettetAv(), notat.getOpprettetTidspunkt(), notat.getNotat());
+    }
+}

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/fagsak/dto/LagreFagsakNotatDto.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/fagsak/dto/LagreFagsakNotatDto.java
@@ -1,0 +1,15 @@
+package no.nav.foreldrepenger.web.app.tjenester.fagsak.dto;
+
+import javax.validation.constraints.Digits;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Pattern;
+import javax.validation.constraints.Size;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import no.nav.vedtak.util.InputValideringRegex;
+
+// Begynner med 500 tegn så får vi se behovet. Tabell har max 4000 tegn
+public record LagreFagsakNotatDto(@JsonProperty("saksnummer") @NotNull @Digits(integer = 18, fraction = 0) String saksnummer,
+                                  @NotNull @Size(max = 500) @Pattern(regexp = InputValideringRegex.FRITEKST) String notat) {
+}

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/saksbehandler/InitielleLinksRestTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/saksbehandler/InitielleLinksRestTjeneste.java
@@ -57,6 +57,7 @@ public class InitielleLinksRestTjeneste {
         saklenker.add(get(FagsakRestTjeneste.FAGSAK_FULL_PATH, "fagsak-full"));
         saklenker.add(get(DokumentRestTjeneste.DOKUMENTER_PATH, "sak-dokumentliste"));
         saklenker.add(post(FagsakRestTjeneste.ENDRE_UTLAND_PATH, "endre-utland-markering"));
+        saklenker.add(post(FagsakRestTjeneste.NOTAT_PATH, "lagre-notat"));
         return new InitLinksDto(tilgangerTjeneste.innloggetBruker(), BehandlendeEnhetTjeneste.hentEnhetListe(), lenkene, saklenker);
     }
 


### PR DESCRIPTION
Mekanisme for korte saksrelaterte notat (gule lapper).
Tenkt vist i egen fane rundt historikk/dokumentliste.
Kommer opp med FagsakNotatDto som del av FagsakFullDto
Eget endepunkt for å lagre nye notat tar objekt med saksnummer + tekst