### PR TITLE
TFP-2836 Del 4 Avklart opphold

### DIFF
--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/uttak/svp/PeriodeIkkeOppfyltÅrsak.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/uttak/svp/PeriodeIkkeOppfyltÅrsak.java
@@ -28,7 +28,8 @@ public enum PeriodeIkkeOppfyltÅrsak implements Kodeverdi, ÅrsakskodeMedLovrefe
     _8313("8313", "Perioden er etter et opphold i ytelsen", null),
     _8314("8314", "Perioden er etter startdato foreldrepenger", null),
     SVANGERSKAPSVILKÅRET_IKKE_OPPFYLT("8315", "Svangerskapsvilkåret er ikke oppfylt", null),
-    OPPTJENINGSVILKÅRET_IKKE_OPPFYLT("8316", "Opptjeningsvilkåret er ikke oppfylt", null)
+    OPPTJENINGSVILKÅRET_IKKE_OPPFYLT("8316", "Opptjeningsvilkåret er ikke oppfylt", null),
+    PERIODEN_ER_SAMTIDIG_SOM_SYKEPENGER("8317", "Uttaksperioden er samtidig som det mottas sykepenger", null)
     ;
 
     private static final Map<String, PeriodeIkkeOppfyltÅrsak> KODER = new LinkedHashMap<>();
@@ -48,10 +49,6 @@ public enum PeriodeIkkeOppfyltÅrsak implements Kodeverdi, ÅrsakskodeMedLovrefe
     private String kode;
 
     private String lovHjemmel;
-
-    PeriodeIkkeOppfyltÅrsak(String kode) {
-        this.kode = kode;
-    }
 
     PeriodeIkkeOppfyltÅrsak(String kode, String navn, String lovHjemmel) {
         this.kode = kode;

--- a/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/svp/AvklarteDatoerTjeneste.java
+++ b/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/svp/AvklarteDatoerTjeneste.java
@@ -79,8 +79,7 @@ class AvklarteDatoerTjeneste {
         if (levendeBarn.isEmpty()) {
             return barna.stream()
                 .map(Barn::getDødsdato)
-                .filter(Optional::isPresent)
-                .map(Optional::get)
+                .flatMap(Optional::stream)
                 .max(LocalDate::compareTo);
         }
         return Optional.empty();

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
 
         <fp-uttak.version>14.3.14</fp-uttak.version>
         <fp-stonadskonto.version>1.0.1</fp-stonadskonto.version>
-        <svp-uttak.version>2.3.8</svp-uttak.version>
+        <svp-uttak.version>2.3.9</svp-uttak.version>
 
         <felles.version>4.2.46</felles.version>
         <prosesstask.version>3.1.29</prosesstask.version>


### PR DESCRIPTION
Tar inn ny versjon av svp-uttak som håndterer avslag av oppholdsperiode med ulike typer (Ferie og sykepenger). Henter registrerte oppholdsperioder fra saksbehandler i svp_avklart_opphold, og legger de inn, sammen med ferie fra IM, som Opphold til avklaring i uttaksreglene.