### PR TITLE
TFP-5494 automatiser SVP revurdering med opphør + ingenEndring uten aksjonspunkt

### DIFF
--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/tilrettelegging/SvangerskapspengerRepository.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/tilrettelegging/SvangerskapspengerRepository.java
@@ -81,10 +81,4 @@ public class SvangerskapspengerRepository {
                 lagreOgFlush(nyttGrunnlag);
             }
         }
-
-    public void fjernOverstyrtGrunnlag(Behandling behandling) {
-        hentGrunnlag(behandling.getId())
-            .ifPresent(grunnlag -> lagreOgFlush(new SvpGrunnlagEntitet.Builder(grunnlag).medOverstyrteTilrettelegginger(null).build()));
-
-    }
 }

--- a/behandlingsprosess/src/main/java/no/nav/foreldrepenger/behandling/steg/foreslåvedtak/ForeslåVedtakTjeneste.java
+++ b/behandlingsprosess/src/main/java/no/nav/foreldrepenger/behandling/steg/foreslåvedtak/ForeslåVedtakTjeneste.java
@@ -1,6 +1,7 @@
 package no.nav.foreldrepenger.behandling.steg.foreslåvedtak;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 
 import javax.enterprise.context.ApplicationScoped;
@@ -11,8 +12,12 @@ import org.slf4j.LoggerFactory;
 
 import no.nav.foreldrepenger.behandlingskontroll.BehandleStegResultat;
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
+import no.nav.foreldrepenger.behandlingslager.behandling.Behandlingsresultat;
+import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingsresultatRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingÅrsakType;
+import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.Aksjonspunkt;
 import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.AksjonspunktDefinisjon;
+import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.AksjonspunktType;
 import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakRepository;
 import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakYtelseType;
 import no.nav.foreldrepenger.dokumentbestiller.DokumentBehandlingTjeneste;
@@ -25,6 +30,7 @@ class ForeslåVedtakTjeneste {
 
     private SjekkMotEksisterendeOppgaverTjeneste sjekkMotEksisterendeOppgaverTjeneste;
     private FagsakRepository fagsakRepository;
+    private BehandlingsresultatRepository behandlingsresultatRepository;
     private KlageAnkeVedtakTjeneste klageAnkeVedtakTjeneste;
     private DokumentBehandlingTjeneste dokumentBehandlingTjeneste;
 
@@ -34,6 +40,7 @@ class ForeslåVedtakTjeneste {
 
     @Inject
     ForeslåVedtakTjeneste(FagsakRepository fagsakRepository,
+                          BehandlingsresultatRepository behandlingsresultatRepository,
                           KlageAnkeVedtakTjeneste klageAnkeVedtakTjeneste,
                           SjekkMotEksisterendeOppgaverTjeneste sjekkMotEksisterendeOppgaverTjeneste,
                           DokumentBehandlingTjeneste dokumentBehandlingTjeneste) {
@@ -44,13 +51,17 @@ class ForeslåVedtakTjeneste {
     }
 
     public BehandleStegResultat foreslåVedtak(Behandling behandling) {
+        return foreslåVedtak(behandling, List.of());
+    }
+
+    public BehandleStegResultat foreslåVedtak(Behandling behandling, Collection<AksjonspunktDefinisjon> aksjonspunkterFraSteg) {
         var fagsakId = behandling.getFagsakId();
         var fagsak = fagsakRepository.finnEksaktFagsak(fagsakId);
         if (fagsak.erStengt()) {
             return BehandleStegResultat.utførtUtenAksjonspunkter();
         }
 
-        List<AksjonspunktDefinisjon> aksjonspunktDefinisjoner = new ArrayList<>();
+        List<AksjonspunktDefinisjon> aksjonspunktDefinisjoner = new ArrayList<>(aksjonspunkterFraSteg);
         if (KlageAnkeVedtakTjeneste.behandlingErKlageEllerAnke(behandling)) {
             if (klageAnkeVedtakTjeneste.erKlageResultatHjemsendt(behandling) || klageAnkeVedtakTjeneste.erBehandletAvKabal(behandling)) {
                 behandling.nullstillToTrinnsBehandling();
@@ -84,7 +95,7 @@ class ForeslåVedtakTjeneste {
         } else {
             behandling.nullstillToTrinnsBehandling();
             LOG.info("To-trinn fjernet på behandling={}", behandling.getId());
-            if (skalOppretteForeslåVedtakManuelt(behandling)) {
+            if (skalOppretteForeslåVedtakManuelt(behandling, aksjonspunktDefinisjoner)) {
                 aksjonspunktDefinisjoner.add(AksjonspunktDefinisjon.FORESLÅ_VEDTAK_MANUELT);
             } else {
                 dokumentBehandlingTjeneste.nullstillVedtakFritekstHvisFinnes(behandling.getId());
@@ -92,21 +103,34 @@ class ForeslåVedtakTjeneste {
         }
     }
 
-    private boolean skalOppretteForeslåVedtakManuelt(Behandling behandling) {
+    private boolean skalOppretteForeslåVedtakManuelt(Behandling behandling, List<AksjonspunktDefinisjon> aksjonspunktDefinisjoner) {
         if (behandling.erRevurdering() && behandling.erManueltOpprettet()) {
             return true;
         }
         if (behandling.harNoenBehandlingÅrsaker(BehandlingÅrsakType.årsakerRelatertTilDød())) {
             return true;
         }
-        return FagsakYtelseType.SVANGERSKAPSPENGER.equals(behandling.getFagsakYtelseType()) && behandling.erYtelseBehandling();
-        // TODO (jol) ta med dette leddet når brev / SVP er gjennomgått.
-        //  && behandling.getAksjonspunktMedDefinisjonOptional(AksjonspunktDefinisjon.VURDER_SVP_TILRETTELEGGING).filter(Aksjonspunkt::erUtført).isPresent();
+        return FagsakYtelseType.SVANGERSKAPSPENGER.equals(behandling.getFagsakYtelseType()) && behandling.erYtelseBehandling()
+            && !erOpphørEllerUendretUtenAndreAksjonspunkt(behandling, aksjonspunktDefinisjoner);
     }
 
     private boolean skalUtføreTotrinnsbehandling(Behandling behandling) {
         return !behandling.harÅpentAksjonspunktMedType(AksjonspunktDefinisjon.VEDTAK_UTEN_TOTRINNSKONTROLL) &&
                 behandling.harAksjonspunktMedTotrinnskontroll();
+    }
+
+    private boolean erOpphørEllerUendretUtenAndreAksjonspunkt(Behandling behandling, List<AksjonspunktDefinisjon> aksjonspunktDefinisjoner) {
+        // TODO: Dra med til kon aksjonspunkt rundt tilrettelegging/vilkår.
+        var aksjonspunktSomSkalGiManueltVedtak = behandling.getAksjonspunkter().stream()
+            .filter(Aksjonspunkt::erUtført)
+            .map(Aksjonspunkt::getAksjonspunktDefinisjon)
+            .filter(ad -> !AksjonspunktType.AUTOPUNKT.equals(ad.getAksjonspunktType()))
+            .filter(ad -> !AksjonspunktDefinisjon.FORESLÅ_VEDTAK_MANUELT.equals(ad))
+            .toList();
+        return behandling.erRevurdering() && aksjonspunktDefinisjoner.isEmpty() && aksjonspunktSomSkalGiManueltVedtak.isEmpty() &&
+            behandlingsresultatRepository.hentHvisEksisterer(behandling.getId())
+                .filter(br -> br.isBehandlingsresultatOpphørt() || br.isBehandlingsresultatIkkeEndret())
+                .isPresent();
     }
 
 }

--- a/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/foreslåvedtak/ForeslåVedtakRevurderingStegImplTest.java
+++ b/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/foreslåvedtak/ForeslåVedtakRevurderingStegImplTest.java
@@ -1,13 +1,17 @@
 package no.nav.foreldrepenger.behandling.steg.foreslåvedtak;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.time.LocalDate;
 import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -18,6 +22,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 
+import no.nav.foreldrepenger.behandlingskontroll.AksjonspunktResultat;
 import no.nav.foreldrepenger.behandlingskontroll.BehandleStegResultat;
 import no.nav.foreldrepenger.behandlingskontroll.BehandlingskontrollKontekst;
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
@@ -95,7 +100,7 @@ class ForeslåVedtakRevurderingStegImplTest {
 
         foreslåVedtakRevurderingStegForeldrepenger = new ForeslåVedtakRevurderingStegImpl(foreslåVedtakTjeneste, beregningTjeneste,
                 repositoryProvider);
-        when(foreslåVedtakTjeneste.foreslåVedtak(revurdering)).thenReturn(behandleStegResultat);
+        when(foreslåVedtakTjeneste.foreslåVedtak(eq(revurdering), any())).thenReturn(behandleStegResultat);
         when(behandleStegResultat.getAksjonspunktResultater()).thenReturn(Collections.emptyList());
     }
 
@@ -124,8 +129,8 @@ class ForeslåVedtakRevurderingStegImplTest {
                 .thenReturn(Optional.of(buildBeregningsgrunnlag(900L)));
         when(behandlingRepository.hentBehandling(orginalBehandling.getId())).thenReturn(orginalBehandling);
 
-        assertThat(foreslåVedtakRevurderingStegForeldrepenger.utførSteg(kontekstRevurdering).getAksjonspunktListe().get(0))
-                .isEqualTo(AksjonspunktDefinisjon.KONTROLLER_REVURDERINGSBEHANDLING_VARSEL_VED_UGUNST);
+        foreslåVedtakRevurderingStegForeldrepenger.utførSteg(kontekstRevurdering);
+        verify(foreslåVedtakTjeneste).foreslåVedtak(revurdering, List.of(AksjonspunktDefinisjon.KONTROLLER_REVURDERINGSBEHANDLING_VARSEL_VED_UGUNST));
     }
 
     @Test

--- a/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/foreslåvedtak/ForeslåVedtakTjenesteTest.java
+++ b/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/foreslåvedtak/ForeslåVedtakTjenesteTest.java
@@ -20,6 +20,7 @@ import no.nav.foreldrepenger.behandlingskontroll.BehandlingskontrollTjeneste;
 import no.nav.foreldrepenger.behandlingskontroll.transisjoner.FellesTransisjoner;
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingType;
+import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingsresultatRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingÅrsak;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingÅrsakType;
 import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.AksjonspunktDefinisjon;
@@ -52,13 +53,13 @@ class ForeslåVedtakTjenesteTest {
     private FagsakRepository fagsakRepository;
 
     @Inject
+    BehandlingsresultatRepository behandlingsresultatRepository;
+
+    @Inject
     private KlageRepository klageRepository;
 
     @Inject
     private AnkeRepository ankeRepository;
-
-    @Inject
-    private BehandlingskontrollTjeneste behandlingskontrollTjeneste;
 
     @Mock
     private OppgaveTjeneste oppgaveTjeneste;
@@ -67,7 +68,6 @@ class ForeslåVedtakTjenesteTest {
     private HistorikkRepository historikkRepository;
     @Mock
     private Behandling behandling;
-    private BehandlingskontrollKontekst kontekst;
 
     private ForeslåVedtakTjeneste tjeneste;
 
@@ -76,16 +76,15 @@ class ForeslåVedtakTjenesteTest {
         historikkRepository = spy(repositoryProvider.getHistorikkRepository());
         behandling = ScenarioMorSøkerEngangsstønad.forFødsel().lagre(repositoryProvider);
         em.persist(behandling.getBehandlingsresultat());
-        kontekst = behandlingskontrollTjeneste.initBehandlingskontroll(behandling);
 
         lenient().when(oppgaveTjeneste.harÅpneVurderKonsekvensOppgaver(any(AktørId.class))).thenReturn(Boolean.FALSE);
         lenient().when(oppgaveTjeneste.harÅpneVurderDokumentOppgaver(any(AktørId.class))).thenReturn(Boolean.FALSE);
         lenient().when(dokumentBehandlingTjeneste.erDokumentBestilt(anyLong(), any())).thenReturn(true);
 
-        var sjekkMotEksisterendeOppgaverTjeneste = new SjekkMotEksisterendeOppgaverTjeneste(historikkRepository,
-                oppgaveTjeneste);
+        var sjekkMotEksisterendeOppgaverTjeneste = new SjekkMotEksisterendeOppgaverTjeneste(historikkRepository, oppgaveTjeneste);
         var klageAnke = new KlageAnkeVedtakTjeneste(klageRepository, ankeRepository);
-        tjeneste = new ForeslåVedtakTjeneste(fagsakRepository, klageAnke, sjekkMotEksisterendeOppgaverTjeneste, dokumentBehandlingTjeneste);
+        tjeneste = new ForeslåVedtakTjeneste(fagsakRepository, behandlingsresultatRepository,
+            klageAnke, sjekkMotEksisterendeOppgaverTjeneste, dokumentBehandlingTjeneste);
     }
 
     @Test

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/forvaltning/ForvaltningUttrekkRestTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/forvaltning/ForvaltningUttrekkRestTjeneste.java
@@ -151,8 +151,9 @@ public class ForvaltningUttrekkRestTjeneste {
             and not exists (select * from fpsak.behandling_arsak ba where ba.behandling_id = b.id and manuelt_opprettet = 'J')
             and not exists (select * from fpsak.behandling_arsak ba where ba.behandling_id = b.id and behandling_arsak_type = 'RE-END-FRA-BRUKER')
             and not exists (select * from fpsak.behandling_arsak ba where ba.behandling_id = b.id and behandling_arsak_type like 'RE-HENDELSE-D%')
-            and exists (select * from fpsak.aksjonspunkt ap where ap.behandling_id = b.id and aksjonspunkt_def = '5091' and aksjonspunkt_status = 'OPPR')
-            and not exists (select * from fpsak.aksjonspunkt ap where ap.behandling_id = b.id and aksjonspunkt_def <> '5091' )
+            and exists (select * from fpsak.aksjonspunkt ap where ap.behandling_id = b.id and aksjonspunkt_def = '5028' and aksjonspunkt_status = 'OPPR')
+            and exists (select * from fpsak.behandling_resultat ba where ba.behandling_id = b.id and behandling_resultat_type in ('OPPHØR', 'INGEN_ENDRING'))
+            and not exists (select * from fpsak.aksjonspunkt ap where ap.behandling_id = b.id and aksjonspunkt_status <> 'AVBR' and aksjonspunkt_def not in ('5028') )
              """);
         @SuppressWarnings("unchecked")
         List<BigDecimal> resultatList = query.getResultList();
@@ -163,7 +164,7 @@ public class ForvaltningUttrekkRestTjeneste {
 
     private void flyttTilbakeTilStart(Long behandlingId) {
         var behandling = behandlingRepository.hentBehandling(behandlingId);
-        if (!BehandlingStegType.KONTROLLER_FAKTA.equals(behandling.getAktivtBehandlingSteg())) {
+        if (!BehandlingStegType.FORESLÅ_VEDTAK.equals(behandling.getAktivtBehandlingSteg())) {
             return;
         }
         var task = ProsessTaskData.forProsessTask(MigrerTilOmsorgRettTask.class);

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/forvaltning/MigrerTilOmsorgRettTask.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/forvaltning/MigrerTilOmsorgRettTask.java
@@ -43,7 +43,7 @@ public class MigrerTilOmsorgRettTask extends BehandlingProsessTask {
         var kontekst = behandlingskontrollTjeneste.initBehandlingskontroll(behandlingId);
         var behandling = behandlingRepository.hentBehandling(behandlingId);
         behandlingskontrollTjeneste.taBehandlingAvVentSetAlleAutopunktUtført(behandling, kontekst);
-        behandlingskontrollTjeneste.behandlingTilbakeføringTilTidligereBehandlingSteg(kontekst, BehandlingStegType.FORESLÅ_VEDTAK);
+        behandlingskontrollTjeneste.behandlingTilbakeføringTilTidligereBehandlingSteg(kontekst, BehandlingStegType.SIMULER_OPPDRAG);
         if (behandling.isBehandlingPåVent()) {
             behandlingskontrollTjeneste.taBehandlingAvVentSetAlleAutopunktUtført(behandling, kontekst);
         }

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/forvaltning/MigrerTilOmsorgRettTask.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/forvaltning/MigrerTilOmsorgRettTask.java
@@ -7,7 +7,6 @@ import no.nav.foreldrepenger.behandlingskontroll.BehandlingskontrollTjeneste;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingStegType;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepositoryProvider;
-import no.nav.foreldrepenger.behandlingslager.behandling.tilrettelegging.SvangerskapspengerRepository;
 import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakProsesstaskRekkefølge;
 import no.nav.foreldrepenger.behandlingslager.task.BehandlingProsessTask;
 import no.nav.foreldrepenger.web.app.tjenester.behandling.aksjonspunkt.BehandlingsprosessTjeneste;
@@ -22,7 +21,6 @@ public class MigrerTilOmsorgRettTask extends BehandlingProsessTask {
     private BehandlingRepository behandlingRepository;
     private BehandlingskontrollTjeneste behandlingskontrollTjeneste;
     private BehandlingsprosessTjeneste prosesseringTjeneste;
-    private SvangerskapspengerRepository svangerskapspengerRepository;
 
     public MigrerTilOmsorgRettTask() {
         // For CDI
@@ -31,13 +29,11 @@ public class MigrerTilOmsorgRettTask extends BehandlingProsessTask {
     @Inject
     public MigrerTilOmsorgRettTask(BehandlingRepositoryProvider repositoryProvider,
                                    BehandlingskontrollTjeneste behandlingskontrollTjeneste,
-                                   BehandlingsprosessTjeneste prosesseringTjeneste,
-                                   SvangerskapspengerRepository svangerskapspengerRepository) {
+                                   BehandlingsprosessTjeneste prosesseringTjeneste) {
         super(repositoryProvider.getBehandlingLåsRepository());
         this.behandlingRepository = repositoryProvider.getBehandlingRepository();
         this.behandlingskontrollTjeneste = behandlingskontrollTjeneste;
         this.prosesseringTjeneste = prosesseringTjeneste;
-        this.svangerskapspengerRepository = svangerskapspengerRepository;
     }
 
 
@@ -47,11 +43,10 @@ public class MigrerTilOmsorgRettTask extends BehandlingProsessTask {
         var kontekst = behandlingskontrollTjeneste.initBehandlingskontroll(behandlingId);
         var behandling = behandlingRepository.hentBehandling(behandlingId);
         behandlingskontrollTjeneste.taBehandlingAvVentSetAlleAutopunktUtført(behandling, kontekst);
-        behandlingskontrollTjeneste.behandlingTilbakeføringTilTidligereBehandlingSteg(kontekst, BehandlingStegType.INNHENT_REGISTEROPP);
+        behandlingskontrollTjeneste.behandlingTilbakeføringTilTidligereBehandlingSteg(kontekst, BehandlingStegType.FORESLÅ_VEDTAK);
         if (behandling.isBehandlingPåVent()) {
             behandlingskontrollTjeneste.taBehandlingAvVentSetAlleAutopunktUtført(behandling, kontekst);
         }
-        svangerskapspengerRepository.fjernOverstyrtGrunnlag(behandling);
         prosesseringTjeneste.asynkKjørProsess(behandling);
     }
 }


### PR DESCRIPTION
Vil automatisere (skippe foreslå vedtak manuelt) dersom ingen aksjonspunkter i revurderingen og det er behandlingsresultat ingen endring eller opphør.