### PR TITLE
TFP-2836 Del 5 Avklart opphold

### DIFF
--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/svp/BekreftSvangerskapspengerOppdaterer.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/svp/BekreftSvangerskapspengerOppdaterer.java
@@ -336,12 +336,14 @@ public class BekreftSvangerskapspengerOppdaterer implements AksjonspunktOppdater
         }
 
         if (arbeidsforholdDto.getAvklarteOppholdPerioder() != null) {
-            arbeidsforholdDto.getAvklarteOppholdPerioder().forEach( avklartOpphold -> {
-                var nyttOpphold = SvpAvklartOpphold.Builder.nytt()
-                    .medOppholdPeriode(avklartOpphold.fom(), avklartOpphold.tom())
-                    .medOppholdÅrsak(avklartOpphold.oppholdÅrsak())
-                    .build();
-                nyTilretteleggingEntitetBuilder.medAvklartOpphold(nyttOpphold);
+            arbeidsforholdDto.getAvklarteOppholdPerioder().stream()
+                .filter(oppholdDto -> !oppholdDto.forVisning()) //Vi viser opphold fra IM - disse skal ikke lagres i grunnlaget
+                .forEach( oppholdDto -> {
+                    var nyttAvklartOpphold = SvpAvklartOpphold.Builder.nytt()
+                        .medOppholdPeriode(oppholdDto.fom(), oppholdDto.tom())
+                        .medOppholdÅrsak(oppholdDto.oppholdÅrsak())
+                        .build();
+                    nyTilretteleggingEntitetBuilder.medAvklartOpphold(nyttAvklartOpphold);
             });
         }
         return nyTilretteleggingEntitetBuilder.build();

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/svp/SvpArbeidsforholdDto.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/svp/SvpArbeidsforholdDto.java
@@ -146,6 +146,10 @@ public class SvpArbeidsforholdDto {
         this.avklarteOppholdPerioder = avklarteOppholdPerioder;
     }
 
+    public void leggTilOppholdPerioder(List<SvpAvklartOppholdPeriodeDto> oppholdPerioder) {
+        this.avklarteOppholdPerioder.addAll(oppholdPerioder);
+    }
+
     public String getArbeidsgiverReferanse() {
         return arbeidsgiverReferanse;
     }

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/svp/SvpAvklartOppholdPeriodeDto.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/svp/SvpAvklartOppholdPeriodeDto.java
@@ -6,5 +6,5 @@ import javax.validation.constraints.NotNull;
 
 import java.time.LocalDate;
 
-public record SvpAvklartOppholdPeriodeDto(@NotNull LocalDate fom, @NotNull LocalDate tom, @NotNull SvpOppholdÅrsak oppholdÅrsak) {
+public record SvpAvklartOppholdPeriodeDto(@NotNull LocalDate fom, @NotNull LocalDate tom, @NotNull SvpOppholdÅrsak oppholdÅrsak, boolean forVisning) {
 }

--- a/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/svp/BekreftSvangerskapspengerOppdatererTest.java
+++ b/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/svp/BekreftSvangerskapspengerOppdatererTest.java
@@ -224,8 +224,8 @@ class BekreftSvangerskapspengerOppdatererTest {
             true, null, null,
             List.of(new SvpTilretteleggingDatoDto(TLR_FRA_2, TilretteleggingType.INGEN_TILRETTELEGGING, null),
                 new SvpTilretteleggingDatoDto(BEHOV_FRA_DATO, TilretteleggingType.DELVIS_TILRETTELEGGING, BigDecimal.valueOf(50), null)),
-            List.of(new SvpAvklartOppholdPeriodeDto(BEHOV_FRA_DATO,BEHOV_FRA_DATO.plusWeeks(1), SvpOppholdÅrsak.SYKEPENGER ),
-                new SvpAvklartOppholdPeriodeDto(TLR_FRA_2, TLR_FRA_2.plusWeeks(3), SvpOppholdÅrsak.FERIE)));
+            List.of(new SvpAvklartOppholdPeriodeDto(BEHOV_FRA_DATO,BEHOV_FRA_DATO.plusWeeks(1), SvpOppholdÅrsak.SYKEPENGER, false ),
+                new SvpAvklartOppholdPeriodeDto(TLR_FRA_2, TLR_FRA_2.plusWeeks(3), SvpOppholdÅrsak.FERIE, false)));
 
         var param = new AksjonspunktOppdaterParameter(behandling, Optional.empty(), dto);
 
@@ -247,8 +247,8 @@ class BekreftSvangerskapspengerOppdatererTest {
             true, null, null,
             List.of(new SvpTilretteleggingDatoDto(TLR_FRA_2, TilretteleggingType.INGEN_TILRETTELEGGING, null),
             new SvpTilretteleggingDatoDto(BEHOV_FRA_DATO, TilretteleggingType.DELVIS_TILRETTELEGGING, BigDecimal.valueOf(50))),
-            List.of(new SvpAvklartOppholdPeriodeDto(BEHOV_FRA_DATO, BEHOV_FRA_DATO.plusWeeks(1), SvpOppholdÅrsak.SYKEPENGER),
-            new SvpAvklartOppholdPeriodeDto(TLR_FRA_2, TLR_FRA_2.plusWeeks(4), SvpOppholdÅrsak.FERIE)));
+            List.of(new SvpAvklartOppholdPeriodeDto(BEHOV_FRA_DATO, BEHOV_FRA_DATO.plusWeeks(1), SvpOppholdÅrsak.SYKEPENGER, false),
+            new SvpAvklartOppholdPeriodeDto(TLR_FRA_2, TLR_FRA_2.plusWeeks(4), SvpOppholdÅrsak.FERIE, false)));
         var param = new AksjonspunktOppdaterParameter(behandling, Optional.empty(), dto);
 
         var resultat = oppdaterer.oppdater(dto, param);


### PR DESCRIPTION
Henter ferier fra inntektsmelding for å vise disse som oppholdsperioder som informasjon til saksbehandler i tilretteleggingsbildet. Det er ikke tillatt å endre disse, og de skal ikke lagres i svp_avklart_opphold