### PR TITLE
Forenkler redirect til A-inntekt

### DIFF
--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/register/RedirectToRegisterRestTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/register/RedirectToRegisterRestTjeneste.java
@@ -30,20 +30,13 @@ import no.nav.vedtak.sikkerhet.abac.beskyttet.ResourceType;
 @Transactional
 @Path(RedirectToRegisterRestTjeneste.BASE_PATH)
 public class RedirectToRegisterRestTjeneste {
-    public static final String BASE_PATH = "/register/redirect-to";
 
-    private static final String PGI = "PensjonsgivendeA-Inntekt";
-    private static final String BEREGNING = "8-28Foreldrepenger";
-    private static final String SAMMENLIGN = "8-30Foreldrepenger";
+    public static final String BASE_PATH = "/register/redirect-to";
 
     private static final String AAREG_REG_POSTFIX = "/aa-reg";
     private static final String AINNTEKT_REG_POSTFIX = "/a-inntekt";
-    private static final String AINNTEKT_PGI_REG_POSTFIX = "/a-inntekt-pgi";
-    private static final String AINNTEKT_BEREGNING_REG_POSTFIX = "/a-inntekt-beregn";
     public static final String AAREG_REG_PATH = BASE_PATH + AAREG_REG_POSTFIX;
     public static final String AINNTEKT_REG_PATH = BASE_PATH + AINNTEKT_REG_POSTFIX;
-    public static final String AINNTEKT_PGI_REG_PATH = BASE_PATH + AINNTEKT_PGI_REG_POSTFIX;
-    public static final String AINNTEKT_BEREGNING_REG_PATH = BASE_PATH + AINNTEKT_BEREGNING_REG_POSTFIX;
 
     private PersoninfoAdapter personinfoAdapter;
     private FagsakRepository fagsakRepository;
@@ -77,7 +70,7 @@ public class RedirectToRegisterRestTjeneste {
     }
 
     @GET
-    @Operation(description = "Redirecter til a-inntekt 8-30 for arbeidstakeren", tags = "aktoer", responses = {
+    @Operation(description = "Redirecter til a-inntekt for arbeidstakeren forhåndsvalgt nasjonal enhet og filter 8-30", tags = "aktoer", responses = {
         @ApiResponse(responseCode = "307", description = "Redirecter til a-inntekt for arbeidstakeren")
     })
     @BeskyttetRessurs(actionType = ActionType.READ, resourceType = ResourceType.FAGSAK)
@@ -86,37 +79,7 @@ public class RedirectToRegisterRestTjeneste {
         var fagsak = fagsakRepository.hentSakGittSaksnummer(new Saksnummer(saksnummerDto.getVerdi())).orElseThrow();
         var personIdent = personinfoAdapter.hentFnrForAktør(fagsak.getAktørId());
 
-        var respons = registerPathTjeneste.hentAinntektPath(personIdent, saksnummerDto.getVerdi(), SAMMENLIGN);
-        var redirectUri = URI.create(respons);
-        return Response.temporaryRedirect(redirectUri).build();
-    }
-
-    @GET
-    @Operation(description = "Redirecter til a-inntekt 8-28 for arbeidstakeren", tags = "aktoer", responses = {
-        @ApiResponse(responseCode = "307", description = "Redirecter til a-inntekt for arbeidstakeren")
-    })
-    @BeskyttetRessurs(actionType = ActionType.READ, resourceType = ResourceType.FAGSAK)
-    @Path(AINNTEKT_BEREGNING_REG_POSTFIX)
-    public Response getAInntektBeregningUrl(@TilpassetAbacAttributt(supplierClass = SaksnummerAbacSupplier.Supplier.class) @NotNull @QueryParam("saksnummer") @Valid SaksnummerDto saksnummerDto) {
-        var fagsak = fagsakRepository.hentSakGittSaksnummer(new Saksnummer(saksnummerDto.getVerdi())).orElseThrow();
-        var personIdent = personinfoAdapter.hentFnrForAktør(fagsak.getAktørId());
-
-        var respons = registerPathTjeneste.hentAinntektPath(personIdent, saksnummerDto.getVerdi(), BEREGNING);
-        var redirectUri = URI.create(respons);
-        return Response.temporaryRedirect(redirectUri).build();
-    }
-
-    @GET
-    @Operation(description = "Redirecter til a-inntekt PGI  for arbeidstakeren", tags = "aktoer", responses = {
-        @ApiResponse(responseCode = "307", description = "Redirecter til a-inntekt for arbeidstakeren")
-    })
-    @BeskyttetRessurs(actionType = ActionType.READ, resourceType = ResourceType.FAGSAK)
-    @Path(AINNTEKT_PGI_REG_POSTFIX)
-    public Response getAInntektPGIUrl(@TilpassetAbacAttributt(supplierClass = SaksnummerAbacSupplier.Supplier.class) @NotNull @QueryParam("saksnummer") @Valid SaksnummerDto saksnummerDto) {
-        var fagsak = fagsakRepository.hentSakGittSaksnummer(new Saksnummer(saksnummerDto.getVerdi())).orElseThrow();
-        var personIdent = personinfoAdapter.hentFnrForAktør(fagsak.getAktørId());
-
-        var respons = registerPathTjeneste.hentAinntektPath(personIdent, saksnummerDto.getVerdi(), PGI);
+        var respons = registerPathTjeneste.hentAinntektPath(personIdent, saksnummerDto.getVerdi());
         var redirectUri = URI.create(respons);
         return Response.temporaryRedirect(redirectUri).build();
     }

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/register/RegisterPathTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/register/RegisterPathTjeneste.java
@@ -29,6 +29,7 @@ public class RegisterPathTjeneste {
     private static final String HEADER_SAKSNUMMER_FILTER = "Nav-FagsakId";
 
     private static final String NASJONAL_ENHET = BehandlendeEnhetTjeneste.getNasjonalEnhet().enhetId();
+    private static final String SAMMENLIGNING_FILTER = "8-30Foreldrepenger";
 
     private final RestClient restClient;
     private final RestConfig restConfig;
@@ -49,11 +50,11 @@ public class RegisterPathTjeneste {
         return path;
     }
 
-    public String hentAinntektPath(PersonIdent ident, String saksnummer, String filter) {
+    public String hentAinntektPath(PersonIdent ident, String saksnummer) {
         var uri = UriBuilder.fromUri(restConfig.endpoint()).path(AINNTEKT_PATH).build();
         var request = RestRequest.newGET(uri, restConfig)
             .header(NavHeaders.HEADER_NAV_PERSONIDENT, ident.getIdent())
-            .header(HEADER_INNTEKT_FILTER, filter)
+            .header(HEADER_INNTEKT_FILTER, SAMMENLIGNING_FILTER)
             .header(HEADER_SAKSNUMMER_FILTER, saksnummer)
             .header(HEADER_ENHET_FILTER, NASJONAL_ENHET);
         var path = restClient.send(request, String.class);

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/saksbehandler/InitielleLinksRestTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/saksbehandler/InitielleLinksRestTjeneste.java
@@ -61,8 +61,6 @@ public class InitielleLinksRestTjeneste {
         saklenker.add(post(FagsakRestTjeneste.NOTAT_PATH, "lagre-notat"));
         saklenker.add(get(RedirectToRegisterRestTjeneste.AAREG_REG_PATH, "arbeidstaker-redirect"));
         saklenker.add(get(RedirectToRegisterRestTjeneste.AINNTEKT_REG_PATH, "ainntekt-redirect"));
-        saklenker.add(get(RedirectToRegisterRestTjeneste.AINNTEKT_PGI_REG_PATH, "ainntekt-pgi-redirect"));
-        saklenker.add(get(RedirectToRegisterRestTjeneste.AINNTEKT_BEREGNING_REG_PATH, "ainntekt-beregning-redirect"));
         return new InitLinksDto(tilgangerTjeneste.innloggetBruker(), BehandlendeEnhetTjeneste.hentEnhetListe(), lenkene, saklenker);
     }
 


### PR DESCRIPTION
Har lagt inn forhåndsvalg av nasjonal enhet og 8-30Foreldrepenger.
Saksbehandler kan endre enhet og filter, så må de velge periode, deretter trykke hent.
Dermed holder det med 1 lenke, ikke mange.