### PR TITLE
Forsøk på å stabilisere situasjonen for SVP

### DIFF
--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/opptjening/Opptjening.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/opptjening/Opptjening.java
@@ -98,7 +98,7 @@ public class Opptjening extends BaseEntitet {
         if (!(obj instanceof Opptjening other)) {
             return false;
         }
-        return Objects.equals(this.getFom(), other.getFom())
+        return aktiv == other.aktiv && Objects.equals(this.getFom(), other.getFom())
                 && Objects.equals(this.getTom(), other.getTom());
     }
 
@@ -146,7 +146,7 @@ public class Opptjening extends BaseEntitet {
 
     @Override
     public int hashCode() {
-        return Objects.hash(opptjeningPeriode);
+        return Objects.hash(opptjeningPeriode, aktiv);
     }
 
     public void setInaktiv() {

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/opptjening/OpptjeningRepository.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/opptjening/OpptjeningRepository.java
@@ -68,18 +68,9 @@ public class OpptjeningRepository {
      * Finn gjeldende opptjening for denne behandlingen.
      */
     public Optional<Opptjening> finnOpptjening(Long behandlingId) {
-        var behandlingsresultat = getBehandlingsresultat(behandlingId);
-
-        if (behandlingsresultat == null) {
-            return Optional.empty();
-        }
-
-        var vilkårResultat = behandlingsresultat.getVilkårResultat();
-        if (vilkårResultat == null) {
-            return Optional.empty();
-        }
-
-        return finnOpptjening(vilkårResultat);
+        return Optional.ofNullable(getBehandlingsresultat(behandlingId))
+            .map(Behandlingsresultat::getVilkårResultat)
+            .flatMap(this::finnOpptjening);
     }
 
     private Behandlingsresultat getBehandlingsresultat(Long behandlingId) {

--- a/behandlingsprosess/src/main/java/no/nav/foreldrepenger/behandling/steg/inngangsvilkår/opptjening/svp/FastsettOpptjeningsperiodeSteg.java
+++ b/behandlingsprosess/src/main/java/no/nav/foreldrepenger/behandling/steg/inngangsvilkår/opptjening/svp/FastsettOpptjeningsperiodeSteg.java
@@ -35,6 +35,11 @@ public class FastsettOpptjeningsperiodeSteg extends FastsettOpptjeningsperiodeSt
                                    BehandlingStegModell modell,
                                    BehandlingStegType førsteSteg,
                                    BehandlingStegType sisteSteg) {
+        // TODO: Gjennomgå tankeganger her i VK21 + FP + begge VK23-steg
+        // Både super sin vedHoppOverBakover og ryddOpp vil antagelig rydde vilkår+vilkårresultat med nullstillVilkår + leggTilIkkeVurdert
+        // Behov for å nullstille Opptjening (evt opptjeningAktivtiteter i equals/hc)
+        // Scenario a) Tilbakehop pga overstyring eller retur beslutter vil gå gjennom steg på nytt
+        // Scenario b) Tilbakehopp til startpunkt KOARB (fx pga IM) - behov for at KofakRevurdering kopierer opptjening før spolfram-til-startpunkt
         if (!erVilkårOverstyrt(kontekst.getBehandlingId())) {
             super.vedHoppOverBakover(kontekst, modell, førsteSteg, sisteSteg);
             new RyddOpptjening(repositoryProvider, kontekst).ryddOpp();


### PR DESCRIPTION
En del feil i SVP etter innføring av startpunkt. 
Skyldes startpunkt i beregning eller senere, fulgt av IM som tvinger tilbakehopp til KOARB.
Da blir opptjening nullstilt ved tilbakehopp, men så ikke re-initialisert i KofakRevurdering.
Opptjening blir kopiert med ved opprettelse av revurdering - for å sette skjæringstidspunkt uten søknad tidlig i prosessen.

Løsning: KofakRevurdering kopierer inn opptjening dersom den mangler (restore tilbake til tilstand ved opprettet)
Riktig equals for Opptjening (den har ikke med lista over opptjeningAktivitet heller).

Sjekke om virker etter hensikten, så oppdatere foreldrepenger tilsvarende. OBS på Endringskontroller doSpolTilStartpunkt