### PR TITLE
Kofak Revurdering mer konsekvent ved tilbakehopp til koarb/im

### DIFF
--- a/behandlingsprosess/src/main/java/no/nav/foreldrepenger/behandling/steg/avklarfakta/svp/KontrollerFaktaRevurderingStegImpl.java
+++ b/behandlingsprosess/src/main/java/no/nav/foreldrepenger/behandling/steg/avklarfakta/svp/KontrollerFaktaRevurderingStegImpl.java
@@ -122,11 +122,6 @@ class KontrollerFaktaRevurderingStegImpl implements KontrollerFaktaSteg {
     public BehandleStegResultat utførSteg(BehandlingskontrollKontekst kontekst) {
         var behandlingId = kontekst.getBehandlingId();
         var behandling = behandlingRepository.hentBehandling(behandlingId);
-        if (behandling.harSattStartpunkt()) {
-            // Startpunkt kan bare initieres én gang, og det gjøres i dette steget.
-            // Suksessive eksekveringer av stegets aksjonspunktsutledere skjer utenfor steget
-            return BehandleStegResultat.utførtUtenAksjonspunkter();
-        }
 
         var skjæringstidspunkter = skjæringstidspunktTjeneste.getSkjæringstidspunkter(behandlingId);
         var ref = BehandlingReferanse.fra(behandling, skjæringstidspunkter);

--- a/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/avklarfakta/fp/KontrollerFaktaRevurderingStegImplTest.java
+++ b/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/avklarfakta/fp/KontrollerFaktaRevurderingStegImplTest.java
@@ -58,22 +58,6 @@ class KontrollerFaktaRevurderingStegImplTest {
     private KontrollerFaktaRevurderingStegImpl steg;
 
     @Test
-    void skal_fjerne_aksjonspunkter_som_er_utledet_før_startpunktet() {
-        var behandling = opprettRevurdering();
-        var fagsak = behandling.getFagsak();
-        // Arrange
-        var lås = behandlingRepository.taSkriveLås(behandling);
-        var kontekst = new BehandlingskontrollKontekst(fagsak.getId(), fagsak.getAktørId(), lås);
-        behandling.setStartpunkt(StartpunktType.UTTAKSVILKÅR);
-
-        // Act
-        var aksjonspunkter = steg.utførSteg(kontekst).getAksjonspunktListe();
-
-        // Assert
-        assertThat(aksjonspunkter).isEmpty();
-    }
-
-    @Test
     void skal_ikke_fjerne_aksjonspunkter_som_er_utledet_etter_startpunktet() {
         var behandling = opprettRevurdering();
         var fagsak = behandling.getFagsak();

--- a/domenetjenester/registerinnhenting/src/main/java/no/nav/foreldrepenger/domene/registerinnhenting/impl/behandlingårsak/BehandlingÅrsakUtlederInntektArbeidYtelse.java
+++ b/domenetjenester/registerinnhenting/src/main/java/no/nav/foreldrepenger/domene/registerinnhenting/impl/behandlingårsak/BehandlingÅrsakUtlederInntektArbeidYtelse.java
@@ -43,7 +43,6 @@ class BehandlingÅrsakUtlederInntektArbeidYtelse implements BehandlingÅrsakUtle
             endringResultatTyper.add(EndringResultatType.REGISTEROPPLYSNING);
         }
         if (aktørYtelseEndring.erEndret()) {
-            endringResultatTyper.add(EndringResultatType.REGISTEROPPLYSNING);
             endringResultatTyper.add(EndringResultatType.OPPLYSNING_OM_YTELSER);
         }
         if (erInntektsmeldingEndret) {

--- a/domenetjenester/registerinnhenting/src/main/java/no/nav/foreldrepenger/domene/registerinnhenting/impl/behandlingårsak/BehandlingÅrsakUtlederMedlemskap.java
+++ b/domenetjenester/registerinnhenting/src/main/java/no/nav/foreldrepenger/domene/registerinnhenting/impl/behandlingårsak/BehandlingÅrsakUtlederMedlemskap.java
@@ -1,6 +1,5 @@
 package no.nav.foreldrepenger.domene.registerinnhenting.impl.behandlingårsak;
 
-import java.util.Collections;
 import java.util.Set;
 
 import javax.enterprise.context.ApplicationScoped;
@@ -20,6 +19,6 @@ class BehandlingÅrsakUtlederMedlemskap implements BehandlingÅrsakUtleder {
 
     @Override
     public Set<EndringResultatType> utledEndringsResultat(BehandlingReferanse ref, Object grunnlagId1, Object grunnlagId2) {
-        return Collections.singleton(EndringResultatType.REGISTEROPPLYSNING);
+        return Set.of();
     }
 }

--- a/migreringer/src/test/java/no/nav/foreldrepenger/dbstoette/Databaseskjemainitialisering.java
+++ b/migreringer/src/test/java/no/nav/foreldrepenger/dbstoette/Databaseskjemainitialisering.java
@@ -44,8 +44,8 @@ public final class Databaseskjemainitialisering {
     }
 
     public static void migrerUnittestSkjemaer() {
-        migrerUnittestSkjemaer(DEFAULTDS_SCHEMA, DEFAULTDS_USER);
-        migrerUnittestSkjemaer("dvhDS", "fpsak_hist");
+        //migrerUnittestSkjemaer(DEFAULTDS_SCHEMA, DEFAULTDS_USER);
+        //migrerUnittestSkjemaer("dvhDS", "fpsak_hist");
     }
 
     private static void migrerUnittestSkjemaer(String schemaName, String user) {
@@ -133,7 +133,7 @@ public final class Databaseskjemainitialisering {
     private static String buildJdbcUrl() {
         return String.format("jdbc:oracle:thin:@//%s:%s/%s",
             ENV.getProperty("database.host", "localhost"),
-            ENV.getProperty("database.post", "1521"),
-            ENV.getProperty("database.service", "XE"));
+            ENV.getProperty("database.post", "1522"),
+            ENV.getProperty("database.service", "XEPDB1"));
     }
 }

--- a/migreringer/src/test/java/no/nav/foreldrepenger/dbstoette/Databaseskjemainitialisering.java
+++ b/migreringer/src/test/java/no/nav/foreldrepenger/dbstoette/Databaseskjemainitialisering.java
@@ -44,8 +44,8 @@ public final class Databaseskjemainitialisering {
     }
 
     public static void migrerUnittestSkjemaer() {
-        //migrerUnittestSkjemaer(DEFAULTDS_SCHEMA, DEFAULTDS_USER);
-        //migrerUnittestSkjemaer("dvhDS", "fpsak_hist");
+        migrerUnittestSkjemaer(DEFAULTDS_SCHEMA, DEFAULTDS_USER);
+        migrerUnittestSkjemaer("dvhDS", "fpsak_hist");
     }
 
     private static void migrerUnittestSkjemaer(String schemaName, String user) {
@@ -133,7 +133,7 @@ public final class Databaseskjemainitialisering {
     private static String buildJdbcUrl() {
         return String.format("jdbc:oracle:thin:@//%s:%s/%s",
             ENV.getProperty("database.host", "localhost"),
-            ENV.getProperty("database.post", "1522"),
-            ENV.getProperty("database.service", "XEPDB1"));
+            ENV.getProperty("database.post", "1521"),
+            ENV.getProperty("database.service", "XE"));
     }
 }

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/forvaltning/ForvaltningStegRestTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/forvaltning/ForvaltningStegRestTjeneste.java
@@ -24,7 +24,6 @@ import no.nav.foreldrepenger.behandlingslager.behandling.historikk.HistorikkAktÃ
 import no.nav.foreldrepenger.behandlingslager.behandling.historikk.HistorikkRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.historikk.Historikkinnslag;
 import no.nav.foreldrepenger.behandlingslager.behandling.historikk.HistorikkinnslagType;
-import no.nav.foreldrepenger.behandlingslager.behandling.opptjening.OpptjeningRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepositoryProvider;
 import no.nav.foreldrepenger.behandlingslager.hendelser.StartpunktType;
@@ -49,7 +48,6 @@ public class ForvaltningStegRestTjeneste {
     private HistorikkRepository historikkRepository;
     private FamilieHendelseRepository familieHendelseRepository;
     private BehandlingRepository behandlingRepository;
-    private OpptjeningRepository opptjeningRepository;
     private ArbeidsforholdInntektsmeldingMangelTjeneste arbeidsforholdInntektsmeldingMangelTjeneste;
 
     @Inject
@@ -64,7 +62,6 @@ public class ForvaltningStegRestTjeneste {
         this.historikkRepository = repositoryProvider.getHistorikkRepository();
         this.familieHendelseRepository = repositoryProvider.getFamilieHendelseRepository();
         this.behandlingRepository = repositoryProvider.getBehandlingRepository();
-        this.opptjeningRepository = repositoryProvider.getOpptjeningRepository();
         this.arbeidsforholdInntektsmeldingMangelTjeneste = arbeidsforholdInntektsmeldingMangelTjeneste;
     }
 
@@ -125,13 +122,6 @@ public class ForvaltningStegRestTjeneste {
 
     private void resetStartpunkt(Behandling behandling) {
         if (behandling.erRevurdering() && behandling.harSattStartpunkt()) {
-            behandling.getOriginalBehandlingId()
-                .filter(id -> opptjeningRepository.finnOpptjening(id).isPresent())
-                .ifPresent(originalId -> {
-                    var origBehandling = behandlingRepository.hentBehandling(originalId);
-                    opptjeningRepository.kopierGrunnlagFraEksisterendeBehandling(origBehandling, behandling);
-
-            });
             behandling.setStartpunkt(StartpunktType.UDEFINERT);
             behandlingRepository.lagre(behandling, behandlingRepository.taSkriveLÃ¥s(behandling.getId()));
         }


### PR DESCRIPTION
Se også https://github.com/navikt/fp-sak/pull/5835 
Dersom tilbakehopp til KOARB/IM så kjøres KOFAK på nytt og opptjening kopieres på nytt dersom den er nullstilt ved tilbakehopp fra etter opptjening - 2 scenarier: koarb/im fører til potensielt nytt startpunkt (før/etter opptjening), mens overstyring vil gå gjennom alle steg i prosessen.

Denne bør gjøre situasjonen mer stabil - men kan gi behov for re-bekreftelse av tidlig aksjonspunkt i en liten andel (har løst aksjonspunkt, så kommer IM som hopper tilbake til før KOFAK (dvs korab/im)