### PR TITLE
Automatisk journalfør dersom 1 fersk sak basert kun på IM

### DIFF
--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/vurderfagsystem/fp/VurderFagsystemTjenesteImpl.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/vurderfagsystem/fp/VurderFagsystemTjenesteImpl.java
@@ -74,6 +74,12 @@ public class VurderFagsystemTjenesteImpl implements VurderFagsystemTjeneste {
         var sakOpprettetInnenIntervall = fellesUtils.sakerOpprettetInnenIntervall(sakerGittYtelseType).stream()
             .filter(s -> !fellesUtils.erFagsakMedAnnenFamilieHendelseEnnSøknadFamilieHendelse(vurderFagsystem, s))
             .toList();
+        // Mønster av 1 sak basert på inntektsmelding som blir henlagt ila siste 10 mnd. Bruk saken hvis fersk nok IM.
+        var potensiellImSak = sakOpprettetInnenIntervall.size() == 1 ? sakOpprettetInnenIntervall.get(0) : null;
+        if (potensiellImSak != null && fellesUtils.fagsakBasertPåInntektsmeldingMedSenestMottatt(potensiellImSak)) {
+            return fellesUtils.inntektsmeldingMottattFireUkerFørStartUttak(vurderFagsystem, potensiellImSak) ?
+                new BehandlendeFagsystem(VEDTAKSLØSNING, potensiellImSak.getSaksnummer()) :  new BehandlendeFagsystem(VEDTAKSLØSNING);
+        }
         if (!sakOpprettetInnenIntervall.isEmpty()) {
             LOG.info("VurderFagsystem FP strukturert søknad nyere sak enn 10mnd for {}", sakOpprettetInnenIntervall);
             return new BehandlendeFagsystem(MANUELL_VURDERING);

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/register/RegisterPathTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/register/RegisterPathTjeneste.java
@@ -5,9 +5,6 @@ import java.net.URI;
 import javax.enterprise.context.ApplicationScoped;
 import javax.ws.rs.core.UriBuilder;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import no.nav.foreldrepenger.domene.typer.PersonIdent;
 import no.nav.foreldrepenger.produksjonsstyring.behandlingenhet.BehandlendeEnhetTjeneste;
 import no.nav.vedtak.felles.integrasjon.rest.NavHeaders;
@@ -20,8 +17,6 @@ import no.nav.vedtak.felles.integrasjon.rest.TokenFlow;
 @ApplicationScoped
 @RestClientConfig(tokenConfig = TokenFlow.NO_AUTH_NEEDED, endpointProperty = "arbeid.og.inntekt.base.url", endpointDefault = "https://arbeid-og-inntekt.nais.adeo.no")
 public class RegisterPathTjeneste {
-
-    private static final Logger LOG = LoggerFactory.getLogger(RegisterPathTjeneste.class);
 
     private static final String AAREG_PATH = "/api/v2/redirect/sok/arbeidstaker";
     private static final String AINNTEKT_PATH = "/api/v2/redirect/sok/a-inntekt";
@@ -47,9 +42,7 @@ public class RegisterPathTjeneste {
         var uri = UriBuilder.fromUri(restConfig.endpoint()).path(AAREG_PATH).build();
         var request = RestRequest.newGET(uri, restConfig)
             .header(NavHeaders.HEADER_NAV_PERSONIDENT, ident.getIdent());
-        var path = restClient.send(request, String.class);
-        LOG.info("ARBEIDOGINNTEKT aareg respons {}", path);
-        return path;
+        return restClient.send(request, String.class);
     }
 
     public String hentAinntektPath(PersonIdent ident, String saksnummer) {
@@ -59,9 +52,7 @@ public class RegisterPathTjeneste {
             .header(HEADER_INNTEKT_FILTER, SAMMENLIGNING_FILTER)
             .header(HEADER_SAKSNUMMER_FILTER, saksnummer)
             .header(HEADER_ENHET_FILTER, NASJONAL_ENHET);
-        var path = restClient.send(request, String.class);
-        LOG.info("ARBEIDOGINNTEKT ainntekt respons {}", path);
-        return path;
+        return restClient.send(request, String.class);
     }
 
     public URI hentTomPath() {


### PR DESCRIPTION
Denne går på journalføring av elektronisk søknad om foreldrepenger. 
Vi oppdaget et mønster der det var sak opprettet siste 10 mnd som ga manuell journalføring og at mange av disse tilfellene var 1 sak basert på inntektsmelding.
Volum: 1-2 saker pr dag. Kanskje 40-50 ila en måned. Potensiale: Øke automatisering opp til 99.5%
Logikken nå: Dersom kun 1 sak opprettet siste 10 mnd og den har Inntektsmelding og ikke har søknad: Velg vedtaksløsningen. Bruk den ene saken dersom IM er fersk nok ift første uttaksdato - ellers opprett ny sak i VL.
