### PR TITLE
Forbedre logikk for å velge sak basert på IM når kun 1 relevant sak

### DIFF
--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/vurderfagsystem/VurderFagsystemFellesUtils.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/vurderfagsystem/VurderFagsystemFellesUtils.java
@@ -208,8 +208,8 @@ public class VurderFagsystemFellesUtils {
             .orElseGet(() -> kanFagsakUtenGrunnlagBrukesForDokument(vurderFagsystem, behandling.get()));
     }
 
-    public boolean fagsakBasertPåInntektsmeldingMedSenestMottatt(Fagsak fagsak) {
-        // Sjekk om sak er basert på innsendt inntektsmelding, ikke har søknader/familiehendelse. Returnere senest ankomne IM sin dato
+    public boolean erFagsakBasertPåInntektsmeldingUtenSøknad(Fagsak fagsak) {
+        // Sjekk om sak er basert på innsendt inntektsmelding, ikke har søknader/familiehendelse.
         var harSøknad = mottatteDokumentTjeneste.hentMottatteDokumentFagsak(fagsak.getId()).stream().anyMatch(MottattDokument::erSøknadsDokument);
         var harFamilieHendelse = behandlingRepository.hentSisteYtelsesBehandlingForFagsakId(fagsak.getId())
             .flatMap(this::hentAktuellFamilieHendelse)
@@ -220,14 +220,9 @@ public class VurderFagsystemFellesUtils {
         return !harSøknad && !harFamilieHendelse && harMottattInntektsmelding;
     }
 
-    public boolean inntektsmeldingMottattFireUkerFørStartUttak(VurderFagsystem vurderFagsystem, Fagsak fagsak) {
-        // Akseptabel tidsramme der inntektsmelding kan brukes i sak uavhengig av startdato
-        var referansedato = getReferanseDatoFraInnkommendeForVurdering(vurderFagsystem).minusDays(28).minusDays(1);
-        return mottatteDokumentTjeneste.hentMottatteDokumentFagsak(fagsak.getId()).stream()
-            .filter(d -> DokumentTypeId.INNTEKTSMELDING.equals(d.getDokumentType()))
-            .map(MottattDokument::getMottattTidspunkt)
-            .map(LocalDateTime::toLocalDate)
-            .anyMatch(d -> d.isAfter(referansedato));
+    public boolean fagsakBasertPåInntektsmeldingKanBrukesFor(VurderFagsystem vurderFagsystem, Fagsak fagsak) {
+        var behandling = behandlingRepository.hentSisteYtelsesBehandlingForFagsakId(fagsak.getId());
+        return behandling.map(b -> kanFagsakUtenGrunnlagBrukesForDokument(vurderFagsystem, b)).orElse(true);
     }
 
     private boolean erGrunnlagPassendeFor(FamilieHendelseGrunnlagEntitet grunnlag, FagsakYtelseType ytelseType, VurderFagsystem vurderFagsystem) {

--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/vurderfagsystem/VurderFagsystemFellesUtils.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/vurderfagsystem/VurderFagsystemFellesUtils.java
@@ -408,6 +408,7 @@ public class VurderFagsystemFellesUtils {
             return Optional.of(new BehandlendeFagsystem(VEDTAKSLØSNING, åpneFagsaker.get(0).getSaksnummer()));
         }
         if (åpneFagsaker.size() > 1) {
+            LOG.info("VurderFagsystem ustrukturert søknad flere åpne saker {}", åpneFagsaker.stream().map(Fagsak::getSaksnummer).toList());
             return Optional.of(new BehandlendeFagsystem(MANUELL_VURDERING));
         }
         var avslagDokumentasjon = harSakMedAvslagGrunnetManglendeDok(sakerTilVurdering);

--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/vurderfagsystem/fp/VurderFagsystemTjenesteImpl.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/vurderfagsystem/fp/VurderFagsystemTjenesteImpl.java
@@ -77,7 +77,7 @@ public class VurderFagsystemTjenesteImpl implements VurderFagsystemTjeneste {
         // Mønster av 1 sak basert på inntektsmelding som blir henlagt ila siste 10 mnd. Bruk saken hvis fersk nok IM.
         var potensiellImSak = sakOpprettetInnenIntervall.size() == 1 ? sakOpprettetInnenIntervall.get(0) : null;
         if (potensiellImSak != null && fellesUtils.erFagsakBasertPåInntektsmeldingUtenSøknad(potensiellImSak)) {
-            return fellesUtils.fagsakBasertPåInntektsmeldingKanBrukesFor(vurderFagsystem, potensiellImSak) ?
+            return fellesUtils.kanFagsakBasertPåInntektsmeldingBrukesForSøknad(vurderFagsystem, potensiellImSak) ?
                 new BehandlendeFagsystem(VEDTAKSLØSNING, potensiellImSak.getSaksnummer()) :  new BehandlendeFagsystem(VEDTAKSLØSNING);
         }
         if (!sakOpprettetInnenIntervall.isEmpty()) {

--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/vurderfagsystem/fp/VurderFagsystemTjenesteImpl.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/vurderfagsystem/fp/VurderFagsystemTjenesteImpl.java
@@ -76,8 +76,8 @@ public class VurderFagsystemTjenesteImpl implements VurderFagsystemTjeneste {
             .toList();
         // Mønster av 1 sak basert på inntektsmelding som blir henlagt ila siste 10 mnd. Bruk saken hvis fersk nok IM.
         var potensiellImSak = sakOpprettetInnenIntervall.size() == 1 ? sakOpprettetInnenIntervall.get(0) : null;
-        if (potensiellImSak != null && fellesUtils.fagsakBasertPåInntektsmeldingMedSenestMottatt(potensiellImSak)) {
-            return fellesUtils.inntektsmeldingMottattFireUkerFørStartUttak(vurderFagsystem, potensiellImSak) ?
+        if (potensiellImSak != null && fellesUtils.erFagsakBasertPåInntektsmeldingUtenSøknad(potensiellImSak)) {
+            return fellesUtils.fagsakBasertPåInntektsmeldingKanBrukesFor(vurderFagsystem, potensiellImSak) ?
                 new BehandlendeFagsystem(VEDTAKSLØSNING, potensiellImSak.getSaksnummer()) :  new BehandlendeFagsystem(VEDTAKSLØSNING);
         }
         if (!sakOpprettetInnenIntervall.isEmpty()) {

--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/vurderfagsystem/svp/VurderFagsystemTjenesteImpl.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/vurderfagsystem/svp/VurderFagsystemTjenesteImpl.java
@@ -74,10 +74,15 @@ public class VurderFagsystemTjenesteImpl implements VurderFagsystemTjeneste {
         if (relevanteFagsaker.isEmpty()) {
             return new BehandlendeFagsystem(VEDTAKSLØSNING);
         }
-        // Tidslinje: IM 13/4. Henlagt tidlig mai og sak lukket. Søknad 16/5 -> relevanteFagsaker.get(0) er avsluttet.
-        // Sjekk om sak basert på IM. og bruk den.
-        return relevanteFagsaker.get(0).erÅpen() ? new BehandlendeFagsystem(VEDTAKSLØSNING, relevanteFagsaker.get(0).getSaksnummer()):
-            new BehandlendeFagsystem(MANUELL_VURDERING);
+        // Har har vi kun 1 relevant sak. Sjekker om åpen eller basert på inntektsmelding og så henlagt før søknad kommer.
+        if (relevanteFagsaker.get(0).erÅpen()) {
+            new BehandlendeFagsystem(VEDTAKSLØSNING, relevanteFagsaker.get(0).getSaksnummer());
+        }
+        if (fellesUtils.erFagsakBasertPåInntektsmeldingUtenSøknad(relevanteFagsaker.get(0))) {
+            return fellesUtils.fagsakBasertPåInntektsmeldingKanBrukesFor(vurderFagsystem, relevanteFagsaker.get(0)) ?
+                new BehandlendeFagsystem(VEDTAKSLØSNING, relevanteFagsaker.get(0).getSaksnummer()) : new BehandlendeFagsystem(VEDTAKSLØSNING);
+        }
+        return new BehandlendeFagsystem(MANUELL_VURDERING);
     }
 
     @Override

--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/vurderfagsystem/svp/VurderFagsystemTjenesteImpl.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/vurderfagsystem/svp/VurderFagsystemTjenesteImpl.java
@@ -82,6 +82,7 @@ public class VurderFagsystemTjenesteImpl implements VurderFagsystemTjeneste {
             return fellesUtils.kanFagsakBasertPåInntektsmeldingBrukesForSøknad(vurderFagsystem, relevanteFagsaker.get(0)) ?
                 new BehandlendeFagsystem(VEDTAKSLØSNING, relevanteFagsaker.get(0).getSaksnummer()) : new BehandlendeFagsystem(VEDTAKSLØSNING);
         }
+        LOG.info("VurderFagsystem SV strukturert søknad 1 relevant saker som ikke matchet {}", relevanteFagsaker.get(0).getSaksnummer());
         return new BehandlendeFagsystem(MANUELL_VURDERING);
     }
 
@@ -156,6 +157,7 @@ public class VurderFagsystemTjenesteImpl implements VurderFagsystemTjeneste {
         if (fellesUtils.finnGjeldendeFamilieHendelseSVP(fagsak).map(this::hendelseDatoIPeriode).orElse(Boolean.TRUE)) {
             return new BehandlendeFagsystem(VEDTAKSLØSNING, fagsak.getSaksnummer());
         }
+        LOG.info("VurderFagsystem SV strukturert søknad førstegang gir manuell {}", fagsak.getSaksnummer());
         return new BehandlendeFagsystem(MANUELL_VURDERING);
     }
 

--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/vurderfagsystem/svp/VurderFagsystemTjenesteImpl.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/vurderfagsystem/svp/VurderFagsystemTjenesteImpl.java
@@ -76,7 +76,7 @@ public class VurderFagsystemTjenesteImpl implements VurderFagsystemTjeneste {
         }
         // Har har vi kun 1 relevant sak. Sjekker om åpen eller basert på inntektsmelding og så henlagt før søknad kommer.
         if (relevanteFagsaker.get(0).erÅpen()) {
-            new BehandlendeFagsystem(VEDTAKSLØSNING, relevanteFagsaker.get(0).getSaksnummer());
+            return new BehandlendeFagsystem(VEDTAKSLØSNING, relevanteFagsaker.get(0).getSaksnummer());
         }
         if (fellesUtils.erFagsakBasertPåInntektsmeldingUtenSøknad(relevanteFagsaker.get(0))) {
             return fellesUtils.fagsakBasertPåInntektsmeldingKanBrukesFor(vurderFagsystem, relevanteFagsaker.get(0)) ?

--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/vurderfagsystem/svp/VurderFagsystemTjenesteImpl.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/vurderfagsystem/svp/VurderFagsystemTjenesteImpl.java
@@ -79,7 +79,7 @@ public class VurderFagsystemTjenesteImpl implements VurderFagsystemTjeneste {
             return new BehandlendeFagsystem(VEDTAKSLØSNING, relevanteFagsaker.get(0).getSaksnummer());
         }
         if (fellesUtils.erFagsakBasertPåInntektsmeldingUtenSøknad(relevanteFagsaker.get(0))) {
-            return fellesUtils.fagsakBasertPåInntektsmeldingKanBrukesFor(vurderFagsystem, relevanteFagsaker.get(0)) ?
+            return fellesUtils.kanFagsakBasertPåInntektsmeldingBrukesForSøknad(vurderFagsystem, relevanteFagsaker.get(0)) ?
                 new BehandlendeFagsystem(VEDTAKSLØSNING, relevanteFagsaker.get(0).getSaksnummer()) : new BehandlendeFagsystem(VEDTAKSLØSNING);
         }
         return new BehandlendeFagsystem(MANUELL_VURDERING);


### PR DESCRIPTION
Typisk eksempel:
* IM 13/4. Henlagt tidlig mai og sak lukket. 
* Søknad 16/5 -> relevanteFagsaker.get(0) er avsluttet.

Dvs sjekk om sak basert på IM. og bruk den saken med mindre den er veldig gammel (im innsendt for mer enn 6 mnd siden).