### PR TITLE
Utleder ikke 5056 ved opprettelse av manuell revurdering

### DIFF
--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/aksjonspunkt/AksjonspunktDefinisjon.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/aksjonspunkt/AksjonspunktDefinisjon.java
@@ -181,6 +181,7 @@ public enum AksjonspunktDefinisjon implements Kodeverdi {
             AksjonspunktKodeDefinisjon.KONTROLLER_REVURDERINGSBEHANDLING_VARSEL_VED_UGUNST_KODE, AksjonspunktType.MANUELL,
             "Vurder varsel ved vedtak til ugunst",
             BehandlingStegType.FORESLÅ_VEDTAK, VurderingspunktType.UT, UTEN_VILKÅR, UTEN_SKJERMLENKE, ENTRINN, EnumSet.of(ES, FP, SVP)),
+    //TODO deprecate når alle AP av denne typen i prod er løst
     KONTROLL_AV_MANUELT_OPPRETTET_REVURDERINGSBEHANDLING(
             AksjonspunktKodeDefinisjon.KONTROLL_AV_MANUELT_OPPRETTET_REVURDERINGSBEHANDLING_KODE, AksjonspunktType.MANUELL,
             "Kontroll av manuelt opprettet revurderingsbehandling", BehandlingStegType.FORESLÅ_VEDTAK, VurderingspunktType.UT, UTEN_VILKÅR, UTEN_SKJERMLENKE, ENTRINN,

--- a/domenetjenester/behandling-revurdering/src/main/java/no/nav/foreldrepenger/behandling/revurdering/ytelse/fp/RevurderingTjenesteImpl.java
+++ b/domenetjenester/behandling-revurdering/src/main/java/no/nav/foreldrepenger/behandling/revurdering/ytelse/fp/RevurderingTjenesteImpl.java
@@ -1,6 +1,5 @@
 package no.nav.foreldrepenger.behandling.revurdering.ytelse.fp;
 
-import java.util.List;
 import java.util.Optional;
 
 import javax.enterprise.context.ApplicationScoped;
@@ -19,7 +18,6 @@ import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingType;
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandlingsresultat;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingsresultatRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingÅrsakType;
-import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.AksjonspunktDefinisjon;
 import no.nav.foreldrepenger.behandlingslager.behandling.arbeidsforhold.ArbeidsforholdValgRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.familiehendelse.FamilieHendelseRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.medlemskap.MedlemskapRepository;
@@ -95,11 +93,7 @@ public class RevurderingTjenesteImpl implements RevurderingTjeneste {
                                                 BehandlingÅrsakType revurderingsÅrsak,
                                                 OrganisasjonsEnhet enhet,
                                                 String opprettetAv) {
-        var behandling = opprettRevurdering(fagsak, revurderingsÅrsak, true, enhet, opprettetAv);
-        var kontekst = behandlingskontrollTjeneste.initBehandlingskontroll(behandling);
-        behandlingskontrollTjeneste.lagreAksjonspunkterFunnet(kontekst,
-            List.of(AksjonspunktDefinisjon.KONTROLL_AV_MANUELT_OPPRETTET_REVURDERINGSBEHANDLING));
-        return behandling;
+        return opprettRevurdering(fagsak, revurderingsÅrsak, true, enhet, opprettetAv);
     }
 
     @Override


### PR DESCRIPTION
Kan ikke se at dette bruker til noe. Sjekker DB i prod og ser at det bare er 6 saker i 2019 der dette AP er opprettet uten at behandlingen i tillegg har en av de andre 3 foreslå vedtak aksjonspunktene utledet (5018, 5015, 5028).
Er det noe jeg har glemt?

select f.saksnummer, b.id, b.BEHANDLING_TYPE, b.AVSLUTTET_DATO from fpsak.behandling b
join fpsak.aksjonspunkt a on b.id = a.behandling_id
join fpsak.fagsak f on f.id = b.fagsak_id
where a.aksjonspunkt_def = '5056'
and b.AVSLUTTET_DATO is not null
and not exists (select 1 from fpsak.aksjonspunkt a2 where a2.behandling_id = a.behandling_id and a2.id <> a.id and a2.AKSJONSPUNKT_DEF in ('5015', '5028', '5018'))
and a.AKSJONSPUNKT_STATUS <> 'AVBR'
order by b.AVSLUTTET_DATO desc;