### PR TITLE
TFP-5509 Rettelse svp

### DIFF
--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/tilrettelegging/SvangerskapspengerRepository.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/tilrettelegging/SvangerskapspengerRepository.java
@@ -69,7 +69,9 @@ public class SvangerskapspengerRepository {
             .map(SvpGrunnlagEntitet::getGjeldendeVersjon)
             .map(SvpTilretteleggingerEntitet::getTilretteleggingListe)
             .orElse(Collections.emptyList()).stream()
-            .map(ot -> new SvpTilretteleggingEntitet.Builder(ot).medKopiertFraTidligereBehandling(true).build())
+            .map(ot -> new SvpTilretteleggingEntitet.Builder(ot)
+                .medKopiertFraTidligereBehandling(true)
+                .medInternArbeidsforholdRef(null).build())
             .toList();
 
             if(!kopiGjeldendeGrunnlag.isEmpty()) {


### PR DESCRIPTION
Når vi oppretter revurdering på en svp sak, nuller vi alltid ut en eventuell arbeidsforholdsid. Dette for å ivareta eventuelle endringer på arbeidsforhold (feks nye arbeidsforholdsid`er)