### PR TITLE
TFP-5478 Migrering for ny sats engangsstønad

### DIFF
--- a/migreringer/src/main/resources/db/migration/defaultDS/4.1/V4.1_19__TFP-5478-engang-2023.sql
+++ b/migreringer/src/main/resources/db/migration/defaultDS/4.1/V4.1_19__TFP-5478-engang-2023.sql
@@ -1,0 +1,9 @@
+UPDATE BR_SATS set TOM = to_date('2022-12-31', 'YYYY-MM-DD')
+where verdi = 90300 AND sats_type = 'ENGANG';
+
+MERGE INTO br_sats s
+USING dual b
+ON (s.fom = TO_DATE('2023-01-01', 'YYYY-MM-DD') AND s.sats_type = 'ENGANG' )
+when not matched then
+    INSERT (ID, SATS_TYPE, FOM, TOM, VERDI)
+    VALUES (seq_br_sats.nextval, 'ENGANG', TO_DATE('2023-01-01', 'YYYY-MM-DD'), TO_DATE('9999-12-31', 'YYYY-MM-DD'), 92648);

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/forvaltning/MigrerTilOmsorgRettTask.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/forvaltning/MigrerTilOmsorgRettTask.java
@@ -43,7 +43,7 @@ public class MigrerTilOmsorgRettTask extends BehandlingProsessTask {
         var kontekst = behandlingskontrollTjeneste.initBehandlingskontroll(behandlingId);
         var behandling = behandlingRepository.hentBehandling(behandlingId);
         behandlingskontrollTjeneste.taBehandlingAvVentSetAlleAutopunktUtført(behandling, kontekst);
-        behandlingskontrollTjeneste.behandlingTilbakeføringTilTidligereBehandlingSteg(kontekst, BehandlingStegType.VARSEL_REVURDERING);
+        behandlingskontrollTjeneste.behandlingTilbakeføringTilTidligereBehandlingSteg(kontekst, BehandlingStegType.SIMULER_OPPDRAG);
         if (behandling.isBehandlingPåVent()) {
             behandlingskontrollTjeneste.taBehandlingAvVentSetAlleAutopunktUtført(behandling, kontekst);
         }


### PR DESCRIPTION
Migreringen er tingen å se på + dobbelsjekke. Sats økes fra 90300 til 92648 fom 1/1-2023.
Det finnes tasks som gjør etterregulering på tilsvarede måte som for G - de ble diskret lagt inn i vår
Resten av PR var noe opprydding fordi det bla AP i varsel revurdering.