### PR TITLE
Fjerner årsak og begrunnelse fra oppgitt annenpart

### DIFF
--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/personopplysning/OppgittAnnenPartBuilder.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/personopplysning/OppgittAnnenPartBuilder.java
@@ -7,7 +7,7 @@ import no.nav.foreldrepenger.behandlingslager.geografisk.Landkoder;
 import no.nav.foreldrepenger.domene.typer.AktørId;
 
 public class OppgittAnnenPartBuilder implements Serializable {
-    private OppgittAnnenPartEntitet søknadAnnenPartMal;
+    private final OppgittAnnenPartEntitet søknadAnnenPartMal;
 
     public OppgittAnnenPartBuilder() {
         søknadAnnenPartMal = new OppgittAnnenPartEntitet();
@@ -31,11 +31,6 @@ public class OppgittAnnenPartBuilder implements Serializable {
         return this;
     }
 
-    public OppgittAnnenPartBuilder medBegrunnelse(String begrunnelse) {
-        søknadAnnenPartMal.setBegrunnelse(begrunnelse);
-        return this;
-    }
-
     public OppgittAnnenPartBuilder medType(SøknadAnnenPartType type) {
         søknadAnnenPartMal.setType(type);
         return this;
@@ -48,11 +43,6 @@ public class OppgittAnnenPartBuilder implements Serializable {
 
     public OppgittAnnenPartBuilder medUtenlandskFnrLand(Landkoder utenlandskFnrLand) {
         søknadAnnenPartMal.setUtenlandskPersonidentLand(utenlandskFnrLand);
-        return this;
-    }
-
-    public OppgittAnnenPartBuilder medÅrsak(String årsak) {
-        søknadAnnenPartMal.setÅrsak(årsak);
         return this;
     }
 

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/personopplysning/OppgittAnnenPartEntitet.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/personopplysning/OppgittAnnenPartEntitet.java
@@ -49,12 +49,6 @@ public class OppgittAnnenPartEntitet extends BaseEntitet implements HarAktørId 
     @Column(name="utl_person_ident_land", nullable = false)
     private Landkoder utenlandskPersonidentLand = Landkoder.UDEFINERT;
 
-    @Column(name = "ARSAK")
-    private String årsak;
-
-    @Column(name = "begrunnelse")
-    private String begrunnelse;
-
     @Convert(converter = SøknadAnnenPartType.KodeverdiConverter.class)
     @Column(name = "type", nullable = false)
     private SøknadAnnenPartType type = SøknadAnnenPartType.UDEFINERT;
@@ -70,19 +64,13 @@ public class OppgittAnnenPartEntitet extends BaseEntitet implements HarAktørId 
     void deepCopyFra(OppgittAnnenPartEntitet mal) {
         this.aktørId = mal.getAktørId();
         this.navn = mal.getNavn();
-        this.begrunnelse = mal.getBegrunnelse();
         this.utenlandskPersonident = mal.getUtenlandskPersonident();
-        this.årsak = mal.getÅrsak();
         this.setUtenlandskPersonidentLand(mal.getUtenlandskFnrLand());
         this.setType(mal.getType());
     }
 
     public Long getId() {
         return id;
-    }
-
-    public String getBegrunnelse() {
-        return begrunnelse;
     }
 
     @Override
@@ -102,10 +90,6 @@ public class OppgittAnnenPartEntitet extends BaseEntitet implements HarAktørId 
         return Objects.equals(utenlandskPersonidentLand, Landkoder.UDEFINERT) ? null : utenlandskPersonidentLand;
     }
 
-    public String getÅrsak() {
-        return årsak;
-    }
-
     public SøknadAnnenPartType getType() {
         return Objects.equals(SøknadAnnenPartType.UDEFINERT, type) ? null : type;
     }
@@ -122,20 +106,12 @@ public class OppgittAnnenPartEntitet extends BaseEntitet implements HarAktørId 
         this.utenlandskPersonidentLand = personidentLand == null ? Landkoder.UDEFINERT : personidentLand;
     }
 
-    void setÅrsak(String årsak) {
-        this.årsak = årsak;
-    }
-
     void setType(SøknadAnnenPartType type) {
         this.type = type == null ? SøknadAnnenPartType.UDEFINERT : type;
     }
 
     void setNavn(String navn) {
         this.navn = navn;
-    }
-
-    void setBegrunnelse(String begrunnelse) {
-        this.begrunnelse = begrunnelse;
     }
 
     @Override
@@ -147,16 +123,14 @@ public class OppgittAnnenPartEntitet extends BaseEntitet implements HarAktørId 
             return false;
         }
         return Objects.equals(this.aktørId, other.getAktørId())
-            && Objects.equals(this.begrunnelse, other.getBegrunnelse())
             && Objects.equals(this.getType(), other.getType())
             && Objects.equals(this.utenlandskPersonident, other.getUtenlandskPersonident())
-            && Objects.equals(this.getUtenlandskFnrLand(), other.getUtenlandskFnrLand())
-            && Objects.equals(this.årsak, other.getÅrsak());
+            && Objects.equals(this.getUtenlandskFnrLand(), other.getUtenlandskFnrLand());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(aktørId, begrunnelse, getType(), utenlandskPersonident, getUtenlandskFnrLand(), årsak);
+        return Objects.hash(aktørId, getType(), utenlandskPersonident, getUtenlandskFnrLand());
     }
 
 }


### PR DESCRIPTION
Disse har ikke vært brukt siden 2018. Ligger 4 saker i prod der begrunnelse ikke er null, og 553 der årsak ikke er null.
Navn burde vi også ta en diskusjon på. Ser navnet bare brukes til å sende til dvh, kanskje ikke nødvendig??
Sånn jeg ser det er annen parts navn en opplysning vi spør om som vi ikke trenger