### PR TITLE
Oppdater orginalt hent-dokument endepunkt med endringer som er implementert i v2 endepunktet og deprecater v2 tjenesten

### DIFF
--- a/domenetjenester/dokumentarkiv/src/main/java/no/nav/foreldrepenger/dokumentarkiv/DokumentArkivTjeneste.java
+++ b/domenetjenester/dokumentarkiv/src/main/java/no/nav/foreldrepenger/dokumentarkiv/DokumentArkivTjeneste.java
@@ -73,7 +73,7 @@ public class DokumentArkivTjeneste {
         this.safKlient = safTjeneste;
     }
 
-    public DokumentRespons hentDokumentRespons(JournalpostId journalpostId, String dokumentId) {
+    public DokumentRespons hentDokument(JournalpostId journalpostId, String dokumentId) {
         var query = new HentDokumentQuery(journalpostId.getVerdi(), dokumentId, VARIANT_FORMAT_ARKIV.getOffisiellKode());
         var httpResponse = safKlient.hentDokumentResponse(query);
         return tilDokumentRespons(httpResponse.body(), httpResponse.headers());
@@ -83,12 +83,6 @@ public class DokumentArkivTjeneste {
         return new DokumentRespons(innhold,
                 headers.firstValue(CONTENT_TYPE).orElse(DEFAULT_CONTENT_TYPE_SAF),
                 headers.firstValue(CONTENT_DISPOSITION).orElse(DEFAULT_CONTENT_DISPOSITION_SAF));
-    }
-
-    public DokumentRespons hentDokument(JournalpostId journalpostId, String dokumentId) {
-        var query = new HentDokumentQuery(journalpostId.getVerdi(), dokumentId, VARIANT_FORMAT_ARKIV.getOffisiellKode());
-        var innhold = safKlient.hentDokument(query);
-        return new DokumentRespons(innhold, DEFAULT_CONTENT_TYPE_SAF, DEFAULT_CONTENT_DISPOSITION_SAF);
     }
 
     public String hentStrukturertDokument(JournalpostId journalpostId, String dokumentId) {

--- a/domenetjenester/dokumentarkiv/src/test/java/no/nav/foreldrepenger/dokumentarkiv/DokumentArkivTjenesteTest.java
+++ b/domenetjenester/dokumentarkiv/src/test/java/no/nav/foreldrepenger/dokumentarkiv/DokumentArkivTjenesteTest.java
@@ -7,9 +7,11 @@ import static no.nav.foreldrepenger.dokumentarkiv.DokumentArkivTjeneste.DEFAULT_
 import static no.nav.foreldrepenger.dokumentarkiv.DokumentArkivTjeneste.tilDokumentRespons;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.net.http.HttpHeaders;
+import java.net.http.HttpResponse;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -175,14 +177,21 @@ class DokumentArkivTjenesteTest {
     @Test
     void skal_kalle_web_service_og_oversette_fra_() {
         // Arrange
-        final byte[] bytesExpected = { 1, 2, 7 };
-        when(saf.hentDokument(any())).thenReturn(bytesExpected);
+        final byte[] bytesForventet = { 1, 2, 7 };
+        var headers = HttpHeaders.of(Map.of(
+            CONTENT_TYPE, List.of(DEFAULT_CONTENT_TYPE_SAF),
+            CONTENT_DISPOSITION, List.of(DEFAULT_CONTENT_DISPOSITION_SAF)
+        ), (x, y) -> true);
+        var httpRespons = mock(HttpResponse.class);
+        when(httpRespons.body()).thenReturn(bytesForventet);
+        when(httpRespons.headers()).thenReturn(headers);
+        when(saf.hentDokumentResponse(any())).thenReturn(httpRespons);
 
         // Act
         var dokumentRespons = dokumentApplikasjonTjeneste.hentDokument(new JournalpostId("123"), "456");
 
         // Assert
-        assertThat(dokumentRespons.innhold()).isEqualTo(bytesExpected);
+        assertThat(dokumentRespons.innhold()).isEqualTo(bytesForventet);
         assertThat(dokumentRespons.contentType()).isEqualTo(DEFAULT_CONTENT_TYPE_SAF);
         assertThat(dokumentRespons.contentDisp()).isEqualTo(DEFAULT_CONTENT_DISPOSITION_SAF);
     }

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/dokument/DokumentRestTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/dokument/DokumentRestTjeneste.java
@@ -171,8 +171,16 @@ public class DokumentRestTjeneste {
         }
     }
 
+    static Response tilRespons(DokumentRespons dokumentRespons) {
+        var responseBuilder = Response.ok(new ByteArrayInputStream(dokumentRespons.innhold()));
+        responseBuilder.type(dokumentRespons.contentType());
+        responseBuilder.header("Content-Disposition", dokumentRespons.contentDisp());
+        return responseBuilder.build();
+    }
+
 
     @GET
+    @Deprecated
     @Path(DOKUMENT_PART_V2_PATH)
     @Operation(description = "Søk etter dokument på JOARK-identifikatorene journalpostId og dokumentId", summary = "Retunerer dokument som er tilknyttet saksnummer, journalpostId og dokumentId (jpeg/png/pdf).", tags = "dokument")
     @BeskyttetRessurs(actionType = ActionType.READ, resourceType = ResourceType.FAGSAK)
@@ -180,22 +188,10 @@ public class DokumentRestTjeneste {
             @NotNull @QueryParam("saksnummer") @Parameter(description = "Saksnummer") @Valid SaksnummerDto saksnummer,
             @TilpassetAbacAttributt(supplierClass = JournalIdAbacSupplier.class) @NotNull @QueryParam("journalpostId") @Parameter(description = "Unik identifikator av journalposten (forsendelsenivå)") @Valid JournalpostIdDto journalpostId,
             @TilpassetAbacAttributt(supplierClass = DokumentIdAbacSupplier.class) @NotNull @QueryParam("dokumentId") @Parameter(description = "Unik identifikator av DokumentInfo/Dokumentbeskrivelse (dokumentnivå)") @Valid DokumentIdDto dokumentId) {
-        try {
-            return tilRespons(dokumentArkivTjeneste.hentDokumentRespons(new JournalpostId(journalpostId.getJournalpostId()), dokumentId.getDokumentId()));
-        } catch (TekniskException e) {
-            var feilmelding = String.format("Dokument ikke funnet for journalpostId= %s dokumentId= %s",
-                journalpostId.getJournalpostId(), dokumentId.getDokumentId());
-            LOG.warn(feilmelding, e);
-            return notFound(feilmelding);
-        }
+        return hentDokument(saksnummer, journalpostId, dokumentId);
     }
 
-    static Response tilRespons(DokumentRespons dokumentRespons) {
-        var responseBuilder = Response.ok(new ByteArrayInputStream(dokumentRespons.innhold()));
-        responseBuilder.type(dokumentRespons.contentType());
-        responseBuilder.header("Content-Disposition", dokumentRespons.contentDisp());
-        return responseBuilder.build();
-    }
+
 
     public static class DokumentIdAbacSupplier implements Function<Object, AbacDataAttributter> {
         @Override


### PR DESCRIPTION
Denne må vel også endres for å gå mot nytt endepunkt. Så vidt jeg forstår så er det der disse vedleggene refereres til i historikkinnslagene. 