### PR TITLE
Et par endringer BigDecimal -> Number for native-tilfelle uten coverage

### DIFF
--- a/domenetjenester/behandling-prosessering/src/main/java/no/nav/foreldrepenger/behandlingsprosess/dagligejobber/infobrev/InformasjonssakRepository.java
+++ b/domenetjenester/behandling-prosessering/src/main/java/no/nav/foreldrepenger/behandlingsprosess/dagligejobber/infobrev/InformasjonssakRepository.java
@@ -216,7 +216,7 @@ public class InformasjonssakRepository {
                     .medYtelseType((String) resultat[1])
                     .medAktørId((String) resultat[2])
                     .medRolle((String) resultat[3])
-                    .medBehandlingId(((BigDecimal) resultat[4]).longValue())
+                    .medBehandlingId(Long.parseLong(resultat[4].toString()))
                     .medTidligsteDato(((Timestamp) resultat[5]).toLocalDateTime().toLocalDate());
             returnList.add(builder.build());
         });

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/forvaltning/ForvaltningUttrekkRestTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/forvaltning/ForvaltningUttrekkRestTjeneste.java
@@ -91,7 +91,7 @@ public class ForvaltningUttrekkRestTjeneste {
         @SuppressWarnings("unchecked")
         List<Object[]> resultatList = query.getResultList();
         var saker = resultatList.stream()
-            .map(row -> new FagsakTreff((String) row[0], ((BigDecimal) row[1]).longValue())).toList();
+            .map(row -> new FagsakTreff((String) row[0], Long.parseLong(row[1].toString()))).toList();
         saker.forEach(f -> fagsakRepository.oppdaterFagsakStatus(f.fagsakId(), FagsakStatus.UNDER_BEHANDLING));
         return Response.ok().build();
     }

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/forvaltning/fpoversikt/FpoversiktMigeringBehandlingHendelseTask.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/forvaltning/fpoversikt/FpoversiktMigeringBehandlingHendelseTask.java
@@ -65,10 +65,9 @@ class FpoversiktMigeringBehandlingHendelseTask implements ProsessTaskHandler {
         if (ytelseType != null) {
             query.setParameter("ytelseType", ytelseType);
         }
-        return query
-            .getResultList()
+        return query.getResultList()
             .stream()
-            .map(bd -> ((BigDecimal)bd).longValue())
+            .map(num -> Long.parseLong(num.toString()))
             .toList();
     }
 


### PR DESCRIPTION
Resterende 6 forekomster av cast (BigDecimal) gjelder native queries der man selecter count(*) eller <sequence>.nextval 
Disse skal være dekt av tester så vi må anta at det er rett å caste slikt til BigDecimal