### PR TITLE
Oppdater LOS dersom endret saksmerking ikke bytter enhet

### DIFF
--- a/domenetjenester/produksjonsstyring/src/main/java/no/nav/foreldrepenger/produksjonsstyring/behandlingenhet/BehandlendeEnhetTjeneste.java
+++ b/domenetjenester/produksjonsstyring/src/main/java/no/nav/foreldrepenger/produksjonsstyring/behandlingenhet/BehandlendeEnhetTjeneste.java
@@ -1,22 +1,40 @@
 package no.nav.foreldrepenger.produksjonsstyring.behandlingenhet;
 
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+
 import no.nav.foreldrepenger.behandlingslager.aktør.OrganisasjonsEnhet;
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingTema;
-import no.nav.foreldrepenger.behandlingslager.behandling.historikk.*;
-import no.nav.foreldrepenger.behandlingslager.behandling.personopplysning.*;
+import no.nav.foreldrepenger.behandlingslager.behandling.historikk.HistorikkAktør;
+import no.nav.foreldrepenger.behandlingslager.behandling.historikk.HistorikkEndretFeltType;
+import no.nav.foreldrepenger.behandlingslager.behandling.historikk.HistorikkRepository;
+import no.nav.foreldrepenger.behandlingslager.behandling.historikk.Historikkinnslag;
+import no.nav.foreldrepenger.behandlingslager.behandling.historikk.HistorikkinnslagType;
+import no.nav.foreldrepenger.behandlingslager.behandling.personopplysning.OppgittAnnenPartEntitet;
+import no.nav.foreldrepenger.behandlingslager.behandling.personopplysning.PersonInformasjonEntitet;
+import no.nav.foreldrepenger.behandlingslager.behandling.personopplysning.PersonopplysningEntitet;
+import no.nav.foreldrepenger.behandlingslager.behandling.personopplysning.PersonopplysningGrunnlagEntitet;
+import no.nav.foreldrepenger.behandlingslager.behandling.personopplysning.PersonopplysningRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepositoryProvider;
-import no.nav.foreldrepenger.behandlingslager.fagsak.*;
+import no.nav.foreldrepenger.behandlingslager.fagsak.Fagsak;
+import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakEgenskapRepository;
+import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakRelasjon;
+import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakRelasjonRepository;
+import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakRepository;
 import no.nav.foreldrepenger.behandlingslager.fagsak.egenskaper.FagsakMarkering;
 import no.nav.foreldrepenger.domene.typer.AktørId;
 import no.nav.foreldrepenger.historikk.HistorikkInnslagTekstBuilder;
 import no.nav.foreldrepenger.produksjonsstyring.behandlingenhet.event.BehandlingEnhetEventPubliserer;
-
-import java.util.*;
-import java.util.stream.Collectors;
 
 @ApplicationScoped
 public class BehandlendeEnhetTjeneste {
@@ -166,7 +184,7 @@ public class BehandlendeEnhetTjeneste {
         return sjekkSkalOppdatereEnhet(behandling, merking);
     }
 
-    public Optional<OrganisasjonsEnhet> sjekkSkalOppdatereEnhet(Behandling behandling, FagsakMarkering merking) {
+    public static Optional<OrganisasjonsEnhet> sjekkSkalOppdatereEnhet(Behandling behandling, FagsakMarkering merking) {
         var enhet = EnhetsTjeneste.velgEnhet(behandling.getBehandlendeOrganisasjonsEnhet(), merking);
         return Optional.ofNullable(enhet)
             .filter(e -> !Objects.equals(e.enhetId(), behandling.getBehandlendeEnhet()));

--- a/domenetjenester/produksjonsstyring/src/main/java/no/nav/foreldrepenger/produksjonsstyring/behandlingenhet/RegistrerFagsakEgenskaper.java
+++ b/domenetjenester/produksjonsstyring/src/main/java/no/nav/foreldrepenger/produksjonsstyring/behandlingenhet/RegistrerFagsakEgenskaper.java
@@ -1,7 +1,14 @@
 package no.nav.foreldrepenger.produksjonsstyring.behandlingenhet;
 
+import static java.time.temporal.ChronoUnit.DAYS;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
 import jakarta.enterprise.context.Dependent;
 import jakarta.inject.Inject;
+
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingType;
 import no.nav.foreldrepenger.behandlingslager.behandling.historikk.HistorikkAktør;
@@ -18,12 +25,6 @@ import no.nav.foreldrepenger.domene.person.PersoninfoAdapter;
 import no.nav.fpsak.tidsserie.LocalDateSegment;
 import no.nav.fpsak.tidsserie.LocalDateTimeline;
 import no.nav.fpsak.tidsserie.StandardCombinators;
-
-import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
-
-import static java.time.temporal.ChronoUnit.DAYS;
 
 @Dependent
 public class RegistrerFagsakEgenskaper {
@@ -59,7 +60,7 @@ public class RegistrerFagsakEgenskaper {
             return gjeldendeMarkering.orElse(FagsakMarkering.NASJONAL);
         }
         fagsakEgenskapRepository.lagreEgenskapUtenHistorikk(behandling.getFagsakId(), FagsakMarkering.BOSATT_UTLAND);
-        enhetTjeneste.sjekkSkalOppdatereEnhet(behandling, FagsakMarkering.BOSATT_UTLAND)
+        BehandlendeEnhetTjeneste.sjekkSkalOppdatereEnhet(behandling, FagsakMarkering.BOSATT_UTLAND)
             .ifPresent(e -> enhetTjeneste.oppdaterBehandlendeEnhet(behandling, e, HistorikkAktør.VEDTAKSLØSNINGEN, "Personopplysning"));
         return FagsakMarkering.BOSATT_UTLAND;
     }
@@ -81,7 +82,7 @@ public class RegistrerFagsakEgenskaper {
         }
         if (!FagsakMarkering.NASJONAL.equals(saksmarkering)) {
             fagsakEgenskapRepository.lagreEgenskapUtenHistorikk(behandling.getFagsakId(), saksmarkering);
-            enhetTjeneste.sjekkSkalOppdatereEnhet(behandling, saksmarkering)
+            BehandlendeEnhetTjeneste.sjekkSkalOppdatereEnhet(behandling, saksmarkering)
                 .ifPresent(e -> enhetTjeneste.oppdaterBehandlendeEnhet(behandling, e, HistorikkAktør.VEDTAKSLØSNINGEN, "Søknadsopplysning"));
         }
         return saksmarkering;

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/fagsak/app/FagsakTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/fagsak/app/FagsakTjeneste.java
@@ -1,11 +1,15 @@
 package no.nav.foreldrepenger.web.app.tjenester.fagsak.app;
 
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+
 import no.nav.foreldrepenger.behandling.FagsakRelasjonTjeneste;
 import no.nav.foreldrepenger.behandlingslager.aktør.PersoninfoBasis;
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
-import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.Aksjonspunkt;
 import no.nav.foreldrepenger.behandlingslager.behandling.familiehendelse.FamilieHendelseEntitet;
 import no.nav.foreldrepenger.behandlingslager.behandling.familiehendelse.FamilieHendelseGrunnlagEntitet;
 import no.nav.foreldrepenger.behandlingslager.behandling.familiehendelse.TerminbekreftelseEntitet;
@@ -23,12 +27,12 @@ import no.nav.foreldrepenger.domene.typer.Saksnummer;
 import no.nav.foreldrepenger.familiehendelse.FamilieHendelseTjeneste;
 import no.nav.foreldrepenger.web.app.tjenester.VurderProsessTaskStatusForPollingApi;
 import no.nav.foreldrepenger.web.app.tjenester.behandling.dto.AsyncPollingStatus;
-import no.nav.foreldrepenger.web.app.tjenester.fagsak.dto.*;
+import no.nav.foreldrepenger.web.app.tjenester.fagsak.dto.AktoerInfoDto;
+import no.nav.foreldrepenger.web.app.tjenester.fagsak.dto.FagsakBackendDto;
+import no.nav.foreldrepenger.web.app.tjenester.fagsak.dto.FagsakSøkDto;
+import no.nav.foreldrepenger.web.app.tjenester.fagsak.dto.PersonDto;
+import no.nav.foreldrepenger.web.app.tjenester.fagsak.dto.SakHendelseDto;
 import no.nav.foreldrepenger.web.app.util.StringUtils;
-
-import java.time.LocalDate;
-import java.util.List;
-import java.util.Optional;
 
 @ApplicationScoped
 public class FagsakTjeneste {
@@ -125,7 +129,7 @@ public class FagsakTjeneste {
 
     public List<Behandling> hentBehandlingerMedÅpentAksjonspunkt(Fagsak fagsak) {
         return behandlingRepository.hentÅpneBehandlingerForFagsakId(fagsak.getId()).stream()
-            .filter(b -> !b.getÅpneAksjonspunkter().isEmpty() && b.getÅpneAksjonspunkter().stream().noneMatch(Aksjonspunkt::erAutopunkt))
+            .filter(b -> !b.isBehandlingPåVent() && !b.getÅpneAksjonspunkter().isEmpty())
             .toList();
     }
 


### PR DESCRIPTION
Enkelte tilfeller av endret saksmerking fører til bytte av enhet (LOS oppdateres), mens andre endringer blir værende på samme enhet (LOS oppdateres ikke). Eksempel EØS bosatt Norge -> Nasjonal - blir værende på 4867 og LOS oppdateres ikke.

Denne endringen sørger for at det sendes LOS-hendelser for endret saksmerke også der det ikke byttes enhet