### PR TITLE
TFP-4391 lagre revurdering før historikkinnslag for revurdering

### DIFF
--- a/domenetjenester/behandling-revurdering/src/main/java/no/nav/foreldrepenger/behandling/revurdering/RevurderingTjenesteFelles.java
+++ b/domenetjenester/behandling-revurdering/src/main/java/no/nav/foreldrepenger/behandling/revurdering/RevurderingTjenesteFelles.java
@@ -74,8 +74,11 @@ public class RevurderingTjenesteFelles {
         if (manueltOpprettet && opprettetAv != null) {
             revurdering.setAnsvarligSaksbehandler(opprettetAv);
         }
-        revurderingHistorikk.opprettHistorikkinnslagOmRevurdering(revurdering, revurderingsÅrsak, manueltOpprettet);
         return revurdering;
+    }
+
+    public void opprettHistorikkInnslagForNyRevurdering(Behandling revurdering, BehandlingÅrsakType revurderingsÅrsak, boolean manueltOpprettet) {
+        revurderingHistorikk.opprettHistorikkinnslagOmRevurdering(revurdering, revurderingsÅrsak, manueltOpprettet);
     }
 
     public OppgittFordelingEntitet kopierOppgittFordelingFraForrigeBehandling(OppgittFordelingEntitet forrigeBehandlingFordeling) {

--- a/domenetjenester/behandling-revurdering/src/main/java/no/nav/foreldrepenger/behandling/revurdering/ytelse/fp/RevurderingTjenesteImpl.java
+++ b/domenetjenester/behandling-revurdering/src/main/java/no/nav/foreldrepenger/behandling/revurdering/ytelse/fp/RevurderingTjenesteImpl.java
@@ -112,6 +112,7 @@ public class RevurderingTjenesteImpl implements RevurderingTjeneste {
             manueltOpprettet, enhet, opprettetAv);
         var kontekst = behandlingskontrollTjeneste.initBehandlingskontroll(revurdering);
         behandlingskontrollTjeneste.opprettBehandling(kontekst, revurdering);
+        revurderingTjenesteFelles.opprettHistorikkInnslagForNyRevurdering(revurdering, revurderingsÅrsak, manueltOpprettet);
 
         // Kopier vilkår (samme vilkår vurderes i Revurdering)
         revurderingTjenesteFelles.kopierVilkårsresultat(origBehandling, revurdering, kontekst);

--- a/domenetjenester/behandling-revurdering/src/main/java/no/nav/foreldrepenger/behandling/revurdering/ytelse/svp/RevurderingTjenesteImpl.java
+++ b/domenetjenester/behandling-revurdering/src/main/java/no/nav/foreldrepenger/behandling/revurdering/ytelse/svp/RevurderingTjenesteImpl.java
@@ -103,6 +103,7 @@ public class RevurderingTjenesteImpl implements RevurderingTjeneste {
             manueltOpprettet, enhet, opprettetAv);
         var kontekst = behandlingskontrollTjeneste.initBehandlingskontroll(revurdering);
         behandlingskontrollTjeneste.opprettBehandling(kontekst, revurdering);
+        revurderingTjenesteFelles.opprettHistorikkInnslagForNyRevurdering(revurdering, revurderingsÅrsak, manueltOpprettet);
 
         // Kopier vilkår (samme vilkår vurderes i Revurdering)
         revurderingTjenesteFelles.kopierVilkårsresultat(origBehandling, revurdering, kontekst, Set.of(VilkårType.SVANGERSKAPSPENGERVILKÅR));


### PR DESCRIPTION
Flytter historikkinnslag for ny revurdering til etter at revurderingen er lagret - slik at revurderingen har en behandlingId ....