### PR TITLE
TFP-4977 unngå doble innslag ved mottak søknad

### DIFF
--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/dokumentmottak/HistorikkinnslagTjeneste.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/dokumentmottak/HistorikkinnslagTjeneste.java
@@ -43,16 +43,17 @@ public class HistorikkinnslagTjeneste {
             return;
         }
 
+        var innslagType = BehandlingType.KLAGE.equals(behandling.getType()) ? HistorikkinnslagType.KLAGEBEH_STARTET : HistorikkinnslagType.BEH_STARTET;
+
         var historikkinnslag = new Historikkinnslag();
         historikkinnslag.setAktør(HistorikkAktør.SØKER);
-        historikkinnslag.setType(HistorikkinnslagType.BEH_STARTET);
+        historikkinnslag.setType(innslagType);
         historikkinnslag.setBehandlingId(behandling.getId());
         historikkinnslag.setFagsakId(behandling.getFagsakId());
 
         leggTilHistorikkinnslagDokumentlinker(behandling.getType(), journalpostId, historikkinnslag, elektronisk, erIM);
 
-        var builder = new HistorikkInnslagTekstBuilder()
-            .medHendelse(BehandlingType.KLAGE.equals(behandling.getType()) ? HistorikkinnslagType.KLAGEBEH_STARTET : HistorikkinnslagType.BEH_STARTET);
+        var builder = new HistorikkInnslagTekstBuilder().medHendelse(innslagType);
         builder.build(historikkinnslag);
 
         historikkRepository.lagre(historikkinnslag);

--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/dokumentmottak/impl/DokumentmottakerFelles.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/dokumentmottak/impl/DokumentmottakerFelles.java
@@ -1,9 +1,21 @@
 package no.nav.foreldrepenger.mottak.dokumentmottak.impl;
 
+import java.time.LocalDateTime;
+import java.time.YearMonth;
+import java.util.Optional;
+
 import jakarta.enterprise.context.Dependent;
 import jakarta.inject.Inject;
+
 import no.nav.foreldrepenger.behandlingslager.aktør.OrganisasjonsEnhet;
-import no.nav.foreldrepenger.behandlingslager.behandling.*;
+import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
+import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingType;
+import no.nav.foreldrepenger.behandlingslager.behandling.Behandlingsresultat;
+import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingsresultatRepository;
+import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingÅrsakType;
+import no.nav.foreldrepenger.behandlingslager.behandling.DokumentKategori;
+import no.nav.foreldrepenger.behandlingslager.behandling.DokumentTypeId;
+import no.nav.foreldrepenger.behandlingslager.behandling.MottattDokument;
 import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.Venteårsak;
 import no.nav.foreldrepenger.behandlingslager.behandling.historikk.HistorikkinnslagType;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepository;
@@ -22,10 +34,6 @@ import no.nav.foreldrepenger.produksjonsstyring.oppgavebehandling.task.OpprettOp
 import no.nav.foreldrepenger.skjæringstidspunkt.TomtUttakTjeneste;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTaskData;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTaskTjeneste;
-
-import java.time.LocalDateTime;
-import java.time.YearMonth;
-import java.util.Optional;
 
 @Dependent
 public class DokumentmottakerFelles {
@@ -97,9 +105,9 @@ public class DokumentmottakerFelles {
         historikkinnslagTjeneste.opprettHistorikkinnslagForVenteFristRelaterteInnslag(behandling, historikkinnslagType, frist, venteårsak);
     }
 
-    void opprettHistorikkinnslagForAutomatiskHenlegelsePgaNySøknad(Behandling behandling, MottattDokument mottattDokument) {
+    void opprettHistorikkinnslagForAutomatiskHenlegelsePgaNySøknad(Behandling behandling, Behandling nyBehandling, MottattDokument mottattDokument) {
         historikkinnslagTjeneste.opprettHistorikkinnslagForAutomatiskHenlegelsePgaNySøknad(behandling);
-        historikkinnslagTjeneste.opprettHistorikkinnslag(behandling, mottattDokument.getJournalpostId(), true,
+        historikkinnslagTjeneste.opprettHistorikkinnslag(nyBehandling, mottattDokument.getJournalpostId(), true,
             mottattDokument.getElektroniskRegistrert(), DokumentTypeId.INNTEKTSMELDING.equals(mottattDokument.getDokumentType()));
     }
 
@@ -173,7 +181,7 @@ public class DokumentmottakerFelles {
 
     Behandling oppdatereViaHenleggelse(Behandling behandling, MottattDokument mottattDokument, BehandlingÅrsakType behandlingÅrsak) {
         var nyBehandling = behandlingsoppretter.oppdaterBehandlingViaHenleggelse(behandling, behandlingÅrsak);
-        opprettHistorikkinnslagForAutomatiskHenlegelsePgaNySøknad(behandling, mottattDokument);
+        opprettHistorikkinnslagForAutomatiskHenlegelsePgaNySøknad(behandling, nyBehandling, mottattDokument);
         var søknadsdato = revurderingRepository.finnSøknadsdatoFraHenlagtBehandling(nyBehandling);
         mottatteDokumentTjeneste.persisterDokumentinnhold(nyBehandling, mottattDokument, søknadsdato);
         return nyBehandling;
@@ -181,7 +189,7 @@ public class DokumentmottakerFelles {
 
     Behandling oppdatereViaHenleggelseEnkø(Behandling behandling, MottattDokument mottattDokument, BehandlingÅrsakType behandlingÅrsak) {
         var nyBehandling = behandlingsoppretter.oppdaterBehandlingViaHenleggelse(behandling, behandlingÅrsak);
-        opprettHistorikkinnslagForAutomatiskHenlegelsePgaNySøknad(behandling, mottattDokument);
+        opprettHistorikkinnslagForAutomatiskHenlegelsePgaNySøknad(behandling, nyBehandling, mottattDokument);
         var søknadsdato = revurderingRepository.finnSøknadsdatoFraHenlagtBehandling(nyBehandling);
         mottatteDokumentTjeneste.persisterDokumentinnhold(nyBehandling, mottattDokument, søknadsdato);
         behandlingsoppretter.settSomKøet(nyBehandling);

--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/dokumentmottak/impl/DokumentmottakerFelles.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/dokumentmottak/impl/DokumentmottakerFelles.java
@@ -115,7 +115,7 @@ public class DokumentmottakerFelles {
         var dokType = mottattDokument.getDokumentType();
         if (dokType.erSøknadType() || dokType.erEndringsSøknadType() || DokumentTypeId.KLAGE_DOKUMENT.equals(dokType) ||
             DokumentKategori.SØKNAD.equals(mottattDokument.getDokumentKategori())) {
-            historikkinnslagTjeneste.opprettHistorikkinnslag(behandling, mottattDokument.getJournalpostId(), false,
+            historikkinnslagTjeneste.opprettHistorikkinnslag(behandling, mottattDokument.getJournalpostId(), true,
                 mottattDokument.getElektroniskRegistrert(), false);
         } else {
             historikkinnslagTjeneste.opprettHistorikkinnslagForVedlegg(behandling.getFagsak(), mottattDokument.getJournalpostId(),

--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/dokumentmottak/impl/DokumentmottakerSøknad.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/dokumentmottak/impl/DokumentmottakerSøknad.java
@@ -37,8 +37,6 @@ public abstract class DokumentmottakerSøknad extends DokumentmottakerYtelsesesr
 
     @Override
     public void oppdaterÅpenBehandlingMedDokument(Behandling behandling, MottattDokument mottattDokument, BehandlingÅrsakType behandlingÅrsakType) {
-        dokumentmottakerFelles.opprettHistorikk(behandling, mottattDokument);
-
         var fagsak = behandling.getFagsak();
 
         if (dokumentmottakerFelles.harMottattSøknadTidligere(behandling.getId())) { //#S2
@@ -46,6 +44,7 @@ public abstract class DokumentmottakerSøknad extends DokumentmottakerYtelsesesr
             var nyBehandling = dokumentmottakerFelles.oppdatereViaHenleggelse(behandling, mottattDokument, getBehandlingÅrsakHvisUdefinert(behandlingÅrsakType));
             køKontroller.dekøFørsteBehandlingISakskompleks(nyBehandling);
         } else {
+            dokumentmottakerFelles.opprettHistorikk(behandling, mottattDokument);
             if (behandling.erRevurdering()) {
                 dokumentmottakerFelles.leggTilBehandlingsårsak(behandling, getBehandlingÅrsakHvisUdefinert(behandlingÅrsakType));
             }

--- a/domenetjenester/mottak/src/test/java/no/nav/foreldrepenger/mottak/dokumentmottak/impl/DokumentmottakerSøknadDefaultTest.java
+++ b/domenetjenester/mottak/src/test/java/no/nav/foreldrepenger/mottak/dokumentmottak/impl/DokumentmottakerSøknadDefaultTest.java
@@ -562,7 +562,7 @@ class DokumentmottakerSøknadDefaultTest extends EntityManagerAwareTest {
 
         // Assert
         verify(behandlingsoppretter).oppdaterBehandlingViaHenleggelse(behandling2, BehandlingÅrsakType.RE_ENDRING_FRA_BRUKER);
-        verify(dokumentmottakerFelles).opprettHistorikk(behandling2, mottattDokument);
+        verify(dokumentmottakerFelles).opprettHistorikkinnslagForAutomatiskHenlegelsePgaNySøknad(eq(behandling2), any(), eq(mottattDokument));
 
         verify(køKontroller).dekøFørsteBehandlingISakskompleks(behandling3);
     }
@@ -606,7 +606,7 @@ class DokumentmottakerSøknadDefaultTest extends EntityManagerAwareTest {
 
         // Assert
         verify(behandlingsoppretter).oppdaterBehandlingViaHenleggelse(behandling2, BehandlingÅrsakType.RE_ENDRING_FRA_BRUKER);
-        verify(dokumentmottakerFelles).opprettHistorikk(behandling2, mottattDokument);
+        verify(dokumentmottakerFelles).opprettHistorikkinnslagForAutomatiskHenlegelsePgaNySøknad(eq(behandling2), any(), eq(mottattDokument));
 
         verify(køKontroller).dekøFørsteBehandlingISakskompleks(behandling3);
     }


### PR DESCRIPTION
Unngå doble "Behandling startet" ved mottak av søknad på eksisterende behandling med søknad.
Legg historikkinnslag for ny behandlng ved henleggelse på riktig behandling og kan filtreres riktig