### PR TITLE
TFP-5569 ny simulering ved gjenopptak

### DIFF
--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/aksjonspunkt/AksjonspunktDefinisjon.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/aksjonspunkt/AksjonspunktDefinisjon.java
@@ -1,21 +1,39 @@
 package no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt;
 
+import static no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.AksjonspunktKodeDefinisjon.ENTRINN;
+import static no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.AksjonspunktKodeDefinisjon.FORBLI;
+import static no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.AksjonspunktKodeDefinisjon.SAMME_BEHFRIST;
+import static no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.AksjonspunktKodeDefinisjon.TILBAKE;
+import static no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.AksjonspunktKodeDefinisjon.TOTRINN;
+import static no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.AksjonspunktKodeDefinisjon.UTEN_FRIST;
+import static no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.AksjonspunktKodeDefinisjon.UTEN_SKJERMLENKE;
+import static no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.AksjonspunktKodeDefinisjon.UTEN_VILKÅR;
+import static no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.AksjonspunktKodeDefinisjon.UTVID_BEHFRIST;
+import static no.nav.foreldrepenger.behandlingslager.fagsak.FagsakYtelseType.YtelseType.ES;
+import static no.nav.foreldrepenger.behandlingslager.fagsak.FagsakYtelseType.YtelseType.FP;
+import static no.nav.foreldrepenger.behandlingslager.fagsak.FagsakYtelseType.YtelseType.SVP;
+
+import java.time.Period;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
 import com.fasterxml.jackson.annotation.JsonValue;
+
 import jakarta.persistence.AttributeConverter;
 import jakarta.persistence.Converter;
+
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingStegType;
 import no.nav.foreldrepenger.behandlingslager.behandling.skjermlenke.SkjermlenkeType;
 import no.nav.foreldrepenger.behandlingslager.behandling.vilkår.VilkårType;
 import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakYtelseType;
 import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakYtelseType.YtelseType;
 import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
-
-import java.time.Period;
-import java.util.*;
-import java.util.stream.Collectors;
-
-import static no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.AksjonspunktKodeDefinisjon.*;
-import static no.nav.foreldrepenger.behandlingslager.fagsak.FagsakYtelseType.YtelseType.*;
 
 /**
  * Definerer mulige Aksjonspunkter inkludert hvilket Vurderingspunkt de må løses i.
@@ -472,6 +490,10 @@ public enum AksjonspunktDefinisjon implements Kodeverdi {
     private static final Set<AksjonspunktDefinisjon> DYNAMISK_SKJERMLENKE = Set.of(AksjonspunktDefinisjon.AVKLAR_VILKÅR_FOR_OMSORGSOVERTAKELSE,
         AksjonspunktDefinisjon.AVKLAR_OM_SØKER_HAR_MOTTATT_STØTTE, AksjonspunktDefinisjon.AVKLAR_OM_ANNEN_FORELDRE_HAR_MOTTATT_STØTTE);
 
+    private static final Set<AksjonspunktDefinisjon> FORESLÅ_VEDTAK_AP = Set.of(AksjonspunktDefinisjon.FORESLÅ_VEDTAK,
+        AksjonspunktDefinisjon.FORESLÅ_VEDTAK_MANUELT, AksjonspunktDefinisjon.VEDTAK_UTEN_TOTRINNSKONTROLL);
+
+
     private static final Map<AksjonspunktDefinisjon, Set<AksjonspunktDefinisjon>> UTELUKKENDE_AP_MAP = Map.ofEntries(
         Map.entry(AksjonspunktDefinisjon.SJEKK_MANGLENDE_FØDSEL, Set.of(AksjonspunktDefinisjon.AVKLAR_TERMINBEKREFTELSE)),
         Map.entry(AksjonspunktDefinisjon.AVKLAR_TERMINBEKREFTELSE, Set.of(AksjonspunktDefinisjon.SJEKK_MANGLENDE_FØDSEL))
@@ -627,6 +649,10 @@ public enum AksjonspunktDefinisjon implements Kodeverdi {
     /** Returnerer kode verdi for aksjonspunkt utelukket av denne. */
     public Set<AksjonspunktDefinisjon> getUtelukkendeApdef() {
         return UTELUKKENDE_AP_MAP.getOrDefault(this, Set.of());
+    }
+
+    public static Set<AksjonspunktDefinisjon> getForeslåVedtakAksjonspunkter() {
+        return FORESLÅ_VEDTAK_AP;
     }
 
     @Override

--- a/domenetjenester/registerinnhenting/src/main/java/no/nav/foreldrepenger/domene/registerinnhenting/RegisterdataEndringshåndterer.java
+++ b/domenetjenester/registerinnhenting/src/main/java/no/nav/foreldrepenger/domene/registerinnhenting/RegisterdataEndringshåndterer.java
@@ -1,8 +1,24 @@
 package no.nav.foreldrepenger.domene.registerinnhenting;
 
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.temporal.TemporalAmount;
+import java.util.Collections;
+import java.util.Optional;
+
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
-import no.nav.foreldrepenger.behandlingslager.behandling.*;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
+import no.nav.foreldrepenger.behandlingslager.behandling.Behandlingsresultat;
+import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingsresultatRepository;
+import no.nav.foreldrepenger.behandlingslager.behandling.EndringsresultatDiff;
+import no.nav.foreldrepenger.behandlingslager.behandling.EndringsresultatSnapshot;
+import no.nav.foreldrepenger.behandlingslager.behandling.SpesialBehandling;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepositoryProvider;
 import no.nav.foreldrepenger.behandlingslager.behandling.vilkår.Vilkår;
@@ -13,15 +29,6 @@ import no.nav.foreldrepenger.behandlingslager.hendelser.StartpunktType;
 import no.nav.foreldrepenger.domene.registerinnhenting.impl.Endringskontroller;
 import no.nav.foreldrepenger.familiehendelse.FamilieHendelseTjeneste;
 import no.nav.foreldrepenger.konfig.KonfigVerdi;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.time.Duration;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.temporal.TemporalAmount;
-import java.util.Collections;
-import java.util.Optional;
 
 /**
  * Oppdaterer registeropplysninger for engangsstønader og skrur behandlingsprosessen tilbake
@@ -105,6 +112,7 @@ public class RegisterdataEndringshåndterer {
             endringskontroller.spolTilStartpunkt(behandling, endringsresultat,
                 senesteStartpunkt(behandling, gåttOverTerminDatoOgIngenFødselsdato));
         }
+        endringskontroller.vurderNySimulering(behandling);
     }
 
     private StartpunktType senesteStartpunkt(Behandling behandling, boolean gåttOverTerminDatoOgIngenFødselsdato) {

--- a/domenetjenester/registerinnhenting/src/main/java/no/nav/foreldrepenger/domene/registerinnhenting/impl/Endringskontroller.java
+++ b/domenetjenester/registerinnhenting/src/main/java/no/nav/foreldrepenger/domene/registerinnhenting/impl/Endringskontroller.java
@@ -25,6 +25,7 @@ import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.Aksjonspun
 import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.AksjonspunktDefinisjon;
 import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.AksjonspunktStatus;
 import no.nav.foreldrepenger.behandlingslager.behandling.totrinn.TotrinnRepository;
+import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakYtelseType;
 import no.nav.foreldrepenger.behandlingslager.hendelser.StartpunktType;
 import no.nav.foreldrepenger.domene.registerinnhenting.KontrollerFaktaInngangsVilkårUtleder;
 import no.nav.foreldrepenger.domene.registerinnhenting.StartpunktTjeneste;
@@ -72,8 +73,13 @@ public class Endringskontroller {
 
     // Kalles når behandlingen har ligget over natten (en dag) - selv om EndringsresultatDiff er tom.
     public void vurderNySimulering(Behandling behandling) {
-        // Vurder om man skal hoppe tilbake dersom ett av ForeslåVedtak-aksjonspunktene er åpne (og mer enn X dager gamle., evt ikke ES).
-        if (behandling.harÅpentAksjonspunktMedType(AksjonspunktDefinisjon.VURDER_FEILUTBETALING)) {
+        // Engangsstønad påvirkes ikke av andre ytelser. Førstegangsbehandlinger skal normalt ikke ha feilutbetaling (utenom spesielle tilfelle)
+        if (FagsakYtelseType.ENGANGSTØNAD.equals(behandling.getFagsakYtelseType()) ||
+            (BehandlingType.FØRSTEGANGSSØKNAD.equals(behandling.getType()) && !behandling.harAksjonspunktMedType(AksjonspunktDefinisjon.VURDER_FEILUTBETALING))) {
+            return;
+        }
+        if (behandling.harÅpentAksjonspunktMedType(AksjonspunktDefinisjon.VURDER_FEILUTBETALING) ||
+            !behandling.getÅpneAksjonspunkter(AksjonspunktDefinisjon.getForeslåVedtakAksjonspunkter()).isEmpty()) {
             var kontekst = behandlingskontrollTjeneste.initBehandlingskontroll(behandling);
             doSpolTilSteg(kontekst, behandling, BehandlingStegType.SIMULER_OPPDRAG, null);
         }

--- a/domenetjenester/registerinnhenting/src/main/java/no/nav/foreldrepenger/domene/registerinnhenting/impl/Endringskontroller.java
+++ b/domenetjenester/registerinnhenting/src/main/java/no/nav/foreldrepenger/domene/registerinnhenting/impl/Endringskontroller.java
@@ -71,11 +71,11 @@ public class Endringskontroller {
         return behandling.getType().erYtelseBehandlingType() && behandlingskontrollTjeneste.erStegPassert(behandling, BehandlingStegType.INNHENT_REGISTEROPP);
     }
 
-    // Kalles når behandlingen har ligget over natten (en dag) - selv om EndringsresultatDiff er tom.
+    // Kalles når behandlingen har ligget over natten (en dag) - selv om EndringsresultatDiff er tom. For å få med endringer i andre ytelser
     public void vurderNySimulering(Behandling behandling) {
-        // Engangsstønad påvirkes ikke av andre ytelser. Førstegangsbehandlinger skal normalt ikke ha feilutbetaling (utenom spesielle tilfelle)
+        // Engangsstønad påvirkes ikke av andre ytelser. Hvis det ikke ble feilutbetaling i forrige simulering så oppstår den ikke plutselig
         if (FagsakYtelseType.ENGANGSTØNAD.equals(behandling.getFagsakYtelseType()) ||
-            (BehandlingType.FØRSTEGANGSSØKNAD.equals(behandling.getType()) && !behandling.harAksjonspunktMedType(AksjonspunktDefinisjon.VURDER_FEILUTBETALING))) {
+            !behandling.harAksjonspunktMedType(AksjonspunktDefinisjon.VURDER_FEILUTBETALING)) {
             return;
         }
         if (behandling.harÅpentAksjonspunktMedType(AksjonspunktDefinisjon.VURDER_FEILUTBETALING) ||

--- a/domenetjenester/registerinnhenting/src/main/java/no/nav/foreldrepenger/domene/registerinnhenting/impl/Endringskontroller.java
+++ b/domenetjenester/registerinnhenting/src/main/java/no/nav/foreldrepenger/domene/registerinnhenting/impl/Endringskontroller.java
@@ -70,6 +70,15 @@ public class Endringskontroller {
         return behandling.getType().erYtelseBehandlingType() && behandlingskontrollTjeneste.erStegPassert(behandling, BehandlingStegType.INNHENT_REGISTEROPP);
     }
 
+    // Kalles når behandlingen har ligget over natten (en dag) - selv om EndringsresultatDiff er tom.
+    public void vurderNySimulering(Behandling behandling) {
+        // Vurder om man skal hoppe tilbake dersom ett av ForeslåVedtak-aksjonspunktene er åpne (og mer enn X dager gamle., evt ikke ES).
+        if (behandling.harÅpentAksjonspunktMedType(AksjonspunktDefinisjon.VURDER_FEILUTBETALING)) {
+            var kontekst = behandlingskontrollTjeneste.initBehandlingskontroll(behandling);
+            doSpolTilSteg(kontekst, behandling, BehandlingStegType.SIMULER_OPPDRAG, null);
+        }
+    }
+
     public void spolTilStartpunkt(Behandling behandling, EndringsresultatDiff endringsresultat, StartpunktType senesteStartpunkt) {
         var behandlingId = behandling.getId();
         var skjæringstidspunkter = skjæringstidspunktTjeneste.getSkjæringstidspunkter(behandlingId);
@@ -95,7 +104,6 @@ public class Endringskontroller {
     }
 
     private void doSpolTilStartpunkt(BehandlingReferanse ref, Behandling behandling, StartpunktType startpunktType) {
-        var fraSteg = behandling.getAktivtBehandlingSteg();
         var startPunktSteg = startpunktType.getBehandlingSteg();
         var skalSpesialHåndteres = behandling.getÅpentAksjonspunktMedDefinisjonOptional(SPESIALHÅNDTERT_AKSJONSPUNKT).isPresent() &&
             behandlingskontrollTjeneste.sammenlignRekkefølge(behandling.getFagsakYtelseType(), behandling.getType(),
@@ -103,14 +111,17 @@ public class Endringskontroller {
         var tilSteg = skalSpesialHåndteres ? SPESIALHÅNDTERT_AKSJONSPUNKT.getBehandlingSteg() : startPunktSteg;
 
         var kontekst = behandlingskontrollTjeneste.initBehandlingskontroll(behandling);
-        // Inkluderer tilbakeføring samme steg UTGANG->INNGANG
-        var tilbakeføres = skalTilbakeføres(behandling, fraSteg, tilSteg);
-
         oppdaterStartpunktVedBehov(behandling, startpunktType);
+        doSpolTilSteg(kontekst, behandling, tilSteg, ref);
+    }
 
+    private void doSpolTilSteg(BehandlingskontrollKontekst kontekst, Behandling behandling, BehandlingStegType tilSteg, BehandlingReferanse ref) {
+        // Inkluderer tilbakeføring samme steg UTGANG->INNGANG
+        var fraSteg = behandling.getAktivtBehandlingSteg();
+        var tilbakeføres = skalTilbakeføres(behandling, fraSteg, tilSteg);
         // Gjør aksjonspunktutledning utenom steg kun dersom man står i eller skal gå tilbake til inngangsvilkår
         var sjekkSteg = tilbakeføres ? tilSteg : fraSteg;
-        if (harUtførtKontrollerFakta(behandling) && STARTPUNKT_STEG_INNGANG_VILKÅR.contains(sjekkSteg)) {
+        if (ref != null && harUtførtKontrollerFakta(behandling) && STARTPUNKT_STEG_INNGANG_VILKÅR.contains(sjekkSteg)) {
             utledAksjonspunkterTilHøyreForStartpunkt(kontekst, sjekkSteg, ref, behandling);
         }
 


### PR DESCRIPTION
Gjelder tilfelle som er blitt satt på vent eller liggende og der gjenopptak/oppdatering ikke fører til tilbakehopp pga register.
Denne sørger for at simulering kjøres på nytt for behandlinger som tas av vent (eller fortsettes neste dag) og har åpent aksjonspunkt i simulering.
Kan også vurdere å gjøre det samme for tilfelle som har blitt liggende i Foreslå vedtak over natten