### PR TITLE
Cacher ikke journalposter i kompletthet

### DIFF
--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/søknad/SøknadEntitet.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/søknad/SøknadEntitet.java
@@ -1,16 +1,26 @@
 package no.nav.foreldrepenger.behandlingslager.behandling.søknad;
 
-import jakarta.persistence.*;
-import no.nav.foreldrepenger.behandlingslager.BaseEntitet;
-import no.nav.foreldrepenger.behandlingslager.behandling.personopplysning.RelasjonsRolleType;
-import no.nav.foreldrepenger.behandlingslager.geografisk.Språkkode;
-import no.nav.vedtak.felles.jpa.converters.BooleanToStringConverter;
-
 import java.time.LocalDate;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import jakarta.persistence.Version;
+
+import no.nav.foreldrepenger.behandlingslager.BaseEntitet;
+import no.nav.foreldrepenger.behandlingslager.behandling.personopplysning.RelasjonsRolleType;
+import no.nav.foreldrepenger.behandlingslager.geografisk.Språkkode;
+import no.nav.vedtak.felles.jpa.converters.BooleanToStringConverter;
 
 @Entity(name = "Søknad")
 @Table(name = "SO_SOEKNAD")

--- a/domenetjenester/behandling/src/main/java/no/nav/foreldrepenger/historikk/HistorikkTjenesteAdapter.java
+++ b/domenetjenester/behandling/src/main/java/no/nav/foreldrepenger/historikk/HistorikkTjenesteAdapter.java
@@ -1,7 +1,12 @@
 package no.nav.foreldrepenger.historikk;
 
+import java.net.URI;
+import java.util.List;
+import java.util.Optional;
+
 import jakarta.enterprise.context.RequestScoped;
 import jakarta.inject.Inject;
+
 import no.nav.foreldrepenger.behandlingslager.behandling.historikk.HistorikkAktør;
 import no.nav.foreldrepenger.behandlingslager.behandling.historikk.HistorikkRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.historikk.Historikkinnslag;
@@ -12,10 +17,6 @@ import no.nav.foreldrepenger.dokumentarkiv.DokumentArkivTjeneste;
 import no.nav.foreldrepenger.domene.typer.Saksnummer;
 import no.nav.foreldrepenger.historikk.dto.HistorikkInnslagKonverter;
 import no.nav.foreldrepenger.historikk.dto.HistorikkinnslagDto;
-
-import java.net.URI;
-import java.util.List;
-import java.util.Optional;
 
 /**
  * RequestScoped fordi HistorikkInnslagTekstBuilder inneholder state og denne
@@ -45,7 +46,7 @@ public class HistorikkTjenesteAdapter {
 
     public List<HistorikkinnslagDto> hentAlleHistorikkInnslagForSak(Saksnummer saksnummer, URI dokumentPath) {
         var historikkinnslagList = Optional.ofNullable(historikkRepository.hentHistorikkForSaksnummer(saksnummer)).orElse(List.of());
-        var journalPosterForSak = dokumentArkivTjeneste.hentAlleJournalposterForSak(saksnummer).stream()
+        var journalPosterForSak = dokumentArkivTjeneste.hentAlleJournalposterForSakCached(saksnummer).stream()
                 .map(ArkivJournalPost::getJournalpostId)
                 .toList();
         return historikkinnslagList.stream()

--- a/domenetjenester/behandling/src/main/java/no/nav/foreldrepenger/kompletthet/Kompletthetsjekker.java
+++ b/domenetjenester/behandling/src/main/java/no/nav/foreldrepenger/kompletthet/Kompletthetsjekker.java
@@ -1,8 +1,8 @@
 package no.nav.foreldrepenger.kompletthet;
 
-import no.nav.foreldrepenger.behandling.BehandlingReferanse;
-
 import java.util.List;
+
+import no.nav.foreldrepenger.behandling.BehandlingReferanse;
 
 public interface Kompletthetsjekker {
     KompletthetResultat vurderSøknadMottatt(BehandlingReferanse ref);

--- a/domenetjenester/dokumentarkiv/src/main/java/no/nav/foreldrepenger/dokumentarkiv/DokumentArkivTjeneste.java
+++ b/domenetjenester/dokumentarkiv/src/main/java/no/nav/foreldrepenger/dokumentarkiv/DokumentArkivTjeneste.java
@@ -1,29 +1,51 @@
 package no.nav.foreldrepenger.dokumentarkiv;
 
-import jakarta.enterprise.context.ApplicationScoped;
-import jakarta.inject.Inject;
-import no.nav.foreldrepenger.behandlingslager.behandling.DokumentTypeId;
-import no.nav.foreldrepenger.behandlingslager.behandling.VariantFormat;
-import no.nav.foreldrepenger.behandlingslager.kodeverk.Fagsystem;
-import no.nav.foreldrepenger.domene.typer.JournalpostId;
-import no.nav.foreldrepenger.domene.typer.Saksnummer;
-import no.nav.saf.*;
-import no.nav.vedtak.felles.integrasjon.saf.HentDokumentQuery;
-import no.nav.vedtak.felles.integrasjon.saf.Saf;
-import no.nav.vedtak.util.LRUCache;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import static jakarta.ws.rs.core.HttpHeaders.CONTENT_DISPOSITION;
+import static jakarta.ws.rs.core.HttpHeaders.CONTENT_TYPE;
 
 import java.net.http.HttpHeaders;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
-import java.util.*;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
-import static jakarta.ws.rs.core.HttpHeaders.CONTENT_DISPOSITION;
-import static jakarta.ws.rs.core.HttpHeaders.CONTENT_TYPE;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import no.nav.foreldrepenger.behandlingslager.behandling.DokumentTypeId;
+import no.nav.foreldrepenger.behandlingslager.behandling.VariantFormat;
+import no.nav.foreldrepenger.behandlingslager.kodeverk.Fagsystem;
+import no.nav.foreldrepenger.domene.typer.JournalpostId;
+import no.nav.foreldrepenger.domene.typer.Saksnummer;
+import no.nav.saf.DokumentInfo;
+import no.nav.saf.DokumentInfoResponseProjection;
+import no.nav.saf.DokumentoversiktFagsakQueryRequest;
+import no.nav.saf.DokumentoversiktResponseProjection;
+import no.nav.saf.Dokumentvariant;
+import no.nav.saf.DokumentvariantResponseProjection;
+import no.nav.saf.FagsakInput;
+import no.nav.saf.Journalpost;
+import no.nav.saf.JournalpostQueryRequest;
+import no.nav.saf.JournalpostResponseProjection;
+import no.nav.saf.Journalposttype;
+import no.nav.saf.Journalstatus;
+import no.nav.saf.LogiskVedleggResponseProjection;
+import no.nav.saf.TilleggsopplysningResponseProjection;
+import no.nav.saf.Variantformat;
+import no.nav.vedtak.felles.integrasjon.saf.HentDokumentQuery;
+import no.nav.vedtak.felles.integrasjon.saf.Saf;
+import no.nav.vedtak.util.LRUCache;
 
 @ApplicationScoped
 public class DokumentArkivTjeneste {
@@ -68,8 +90,8 @@ public class DokumentArkivTjeneste {
         return new String(safKlient.hentDokument(query));
     }
 
-    public List<ArkivJournalPost> hentAlleDokumenterForVisning(Saksnummer saksnummer) {
-        return hentAlleJournalposterForSak(saksnummer).stream()
+    public List<ArkivJournalPost> hentAlleDokumenterCached(Saksnummer saksnummer) {
+        return hentAlleJournalposterForSakCached(saksnummer).stream()
             .map(this::kopiMedKunArkivdokument)
             .filter(Objects::nonNull)
             .toList();
@@ -96,12 +118,18 @@ public class DokumentArkivTjeneste {
         return arkivDokument.getTilgjengeligSom().contains(VARIANT_FORMAT_ARKIV);
     }
 
-    public List<ArkivJournalPost> hentAlleJournalposterForSak(Saksnummer saksnummer) {
+    public List<ArkivJournalPost> hentAlleJournalposterForSakCached(Saksnummer saksnummer) {
         var cached = SAK_JOURNAL_CACHE.get(saksnummer.getVerdi());
         if (cached != null && !cached.isEmpty()) {
             SAK_JOURNAL_CACHE.put(saksnummer.getVerdi(), cached);
             return cached;
         }
+        var journalposter = hentAlleJournalposterForSak(saksnummer);
+        SAK_JOURNAL_CACHE.put(saksnummer.getVerdi(), journalposter);
+        return journalposter;
+    }
+
+    public List<ArkivJournalPost> hentAlleJournalposterForSak(Saksnummer saksnummer) {
         var query = new DokumentoversiktFagsakQueryRequest();
         query.setFagsak(new FagsakInput(saksnummer.getVerdi(), Fagsystem.FPSAK.getOffisiellKode()));
         query.setFoerste(1000);
@@ -111,13 +139,10 @@ public class DokumentArkivTjeneste {
 
         var resultat = safKlient.dokumentoversiktFagsak(query, projection);
 
-        var journalposter = resultat.getJournalposter().stream()
+        return resultat.getJournalposter().stream()
             .filter(j -> j.getJournalstatus() == null || !EKSKLUDER_STATUS.contains(j.getJournalstatus()))
             .map(this::mapTilArkivJournalPost)
             .toList();
-
-        SAK_JOURNAL_CACHE.put(saksnummer.getVerdi(), journalposter);
-        return journalposter;
     }
 
     public Optional<ArkivJournalPost> hentJournalpostForSak(JournalpostId journalpostId) {
@@ -181,14 +206,14 @@ public class DokumentArkivTjeneste {
 
     public Set<DokumentTypeId> hentDokumentTypeIdForSak(Saksnummer saksnummer, LocalDate mottattEtterDato) {
         Set<DokumentTypeId> dokumenttyper = new HashSet<>();
+        var innkommendeJournalposter = hentAlleJournalposterForSak(saksnummer).stream()
+            .filter(ajp -> Kommunikasjonsretning.INN.equals(ajp.getKommunikasjonsretning()));
         if (LocalDate.MIN.equals(mottattEtterDato)) {
-            dokumenttyper.addAll(hentAlleJournalposterForSak(saksnummer).stream()
-                .filter(ajp -> Kommunikasjonsretning.INN.equals(ajp.getKommunikasjonsretning()))
+            dokumenttyper.addAll(innkommendeJournalposter
                 .flatMap(jp -> ekstraherJournalpostDTID(jp).stream())
                 .collect(Collectors.toSet()));
         } else {
-            dokumenttyper.addAll(hentAlleJournalposterForSak(saksnummer).stream()
-                .filter(ajp -> Kommunikasjonsretning.INN.equals(ajp.getKommunikasjonsretning()))
+            dokumenttyper.addAll(innkommendeJournalposter
                 .filter(jpost -> jpost.getTidspunkt() != null && jpost.getTidspunkt().isAfter(mottattEtterDato.atStartOfDay()))
                 .flatMap(jp -> ekstraherJournalpostDTID(jp).stream())
                 .collect(Collectors.toSet()));

--- a/domenetjenester/dokumentarkiv/src/test/java/no/nav/foreldrepenger/dokumentarkiv/DokumentArkivTjenesteTest.java
+++ b/domenetjenester/dokumentarkiv/src/test/java/no/nav/foreldrepenger/dokumentarkiv/DokumentArkivTjenesteTest.java
@@ -22,11 +22,15 @@ import java.util.Date;
 import java.util.List;
 import java.util.Map;
 
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
 import no.nav.foreldrepenger.behandlingslager.behandling.DokumentTypeId;
 import no.nav.foreldrepenger.domene.typer.JournalpostId;
-
 import no.nav.foreldrepenger.domene.typer.Saksnummer;
-
 import no.nav.saf.DokumentInfo;
 import no.nav.saf.Dokumentoversikt;
 import no.nav.saf.Dokumentvariant;
@@ -36,28 +40,7 @@ import no.nav.saf.Journalstatus;
 import no.nav.saf.Tema;
 import no.nav.saf.Tilleggsopplysning;
 import no.nav.saf.Variantformat;
-
 import no.nav.vedtak.felles.integrasjon.saf.Saf;
-
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-
-import java.net.http.HttpHeaders;
-import java.time.*;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.List;
-import java.util.Map;
-
-import static jakarta.ws.rs.core.HttpHeaders.CONTENT_DISPOSITION;
-import static jakarta.ws.rs.core.HttpHeaders.CONTENT_TYPE;
-import static no.nav.foreldrepenger.dokumentarkiv.DokumentArkivTjeneste.*;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class DokumentArkivTjenesteTest {
@@ -87,7 +70,7 @@ class DokumentArkivTjenesteTest {
         response.getJournalposter().add(createJournalpost(Variantformat.ARKIV, YESTERDAY, Journalposttype.U));
         when(saf.dokumentoversiktFagsak(any(), any())).thenReturn(response);
 
-        var arkivDokuments = dokumentApplikasjonTjeneste.hentAlleDokumenterForVisning(SAF_SAK);
+        var arkivDokuments = dokumentApplikasjonTjeneste.hentAlleDokumenterCached(SAF_SAK);
 
         assertThat(arkivDokuments).isNotEmpty();
         var arkivJournalPost = arkivDokuments.get(0);
@@ -104,7 +87,7 @@ class DokumentArkivTjenesteTest {
         response.getJournalposter().add(createJournalpost(Variantformat.ARKIV, YESTERDAY, Journalposttype.I));
         when(saf.dokumentoversiktFagsak(any(), any())).thenReturn(response);
 
-        var arkivDokuments = dokumentApplikasjonTjeneste.hentAlleDokumenterForVisning(SAF_SAK);
+        var arkivDokuments = dokumentApplikasjonTjeneste.hentAlleDokumenterCached(SAF_SAK);
 
         assertThat(arkivDokuments.get(0).getTidspunkt()).isEqualTo(YESTERDAY);
         assertThat(arkivDokuments.get(0).getKommunikasjonsretning()).isEqualTo(Kommunikasjonsretning.INN);
@@ -131,7 +114,7 @@ class DokumentArkivTjenesteTest {
         when(saf.dokumentoversiktFagsak(any(), any())).thenReturn(response);
 
 
-        var arkivDokuments = dokumentApplikasjonTjeneste.hentAlleDokumenterForVisning(SAF_SAK);
+        var arkivDokuments = dokumentApplikasjonTjeneste.hentAlleDokumenterCached(SAF_SAK);
 
         assertThat(arkivDokuments).hasSize(2);
     }
@@ -144,7 +127,7 @@ class DokumentArkivTjenesteTest {
             createJournalpost(Variantformat.ARKIV, YESTERDAY.minusHours(1), Journalposttype.I)));
         when(saf.dokumentoversiktFagsak(any(), any())).thenReturn(response);
 
-        var arkivDokuments = dokumentApplikasjonTjeneste.hentAlleDokumenterForVisning(SAF_SAK);
+        var arkivDokuments = dokumentApplikasjonTjeneste.hentAlleDokumenterCached(SAF_SAK);
 
         assertThat(arkivDokuments.stream().anyMatch(d -> d.getTidspunkt().equals(NOW) && Kommunikasjonsretning.UT.equals(d.getKommunikasjonsretning()))).isTrue();
         assertThat(arkivDokuments.stream().anyMatch(d -> d.getTidspunkt().equals(YESTERDAY.minusHours(1)) && Kommunikasjonsretning.INN.equals(d.getKommunikasjonsretning()))).isTrue();

--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/kompletthettjeneste/impl/fp/KompletthetssjekkerSøknadFørstegangsbehandlingImpl.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/kompletthettjeneste/impl/fp/KompletthetssjekkerSøknadFørstegangsbehandlingImpl.java
@@ -1,7 +1,15 @@
 package no.nav.foreldrepenger.mottak.kompletthettjeneste.impl.fp;
 
+import java.time.LocalDate;
+import java.time.Period;
+import java.util.List;
+
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import no.nav.foreldrepenger.behandling.BehandlingReferanse;
 import no.nav.foreldrepenger.behandlingskontroll.BehandlingTypeRef;
 import no.nav.foreldrepenger.behandlingskontroll.FagsakYtelseTypeRef;
@@ -12,12 +20,6 @@ import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakYtelseType;
 import no.nav.foreldrepenger.dokumentarkiv.DokumentArkivTjeneste;
 import no.nav.foreldrepenger.kompletthet.ManglendeVedlegg;
 import no.nav.foreldrepenger.konfig.KonfigVerdi;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.time.LocalDate;
-import java.time.Period;
-import java.util.List;
 
 @ApplicationScoped
 @BehandlingTypeRef(BehandlingType.FØRSTEGANGSSØKNAD)
@@ -45,7 +47,7 @@ public class KompletthetssjekkerSøknadFørstegangsbehandlingImpl extends Komple
      * Spør Joark om dokumentliste og sjekker det som finnes i vedleggslisten på søknaden mot det som ligger i Joark.
      * Vedleggslisten på søknaden regnes altså i denne omgang som fasit på hva som er påkrevd.
      *
-     * @param behandling
+     * @param ref behandlingen
      * @return Liste over manglende vedlegg
      */
     @Override

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/arbeidInntektsmelding/ArbeidOgInntektsmeldingDtoTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/arbeidInntektsmelding/ArbeidOgInntektsmeldingDtoTjeneste.java
@@ -107,7 +107,7 @@ public class ArbeidOgInntektsmeldingDtoTjeneste {
             .map(ArbeidsforholdInformasjon::getArbeidsforholdReferanser)
             .orElse(Collections.emptyList());
         var motatteDokumenter = mottatteDokumentRepository.hentMottatteDokumentMedFagsakId(referanse.fagsakId());
-        var alleInntektsmeldingerFraArkiv = dokumentArkivTjeneste.hentAlleDokumenterForVisning(referanse.saksnummer()).stream()
+        var alleInntektsmeldingerFraArkiv = dokumentArkivTjeneste.hentAlleDokumenterCached(referanse.saksnummer()).stream()
             .filter(this::gjelderInntektsmelding)
             .toList();
         return inntektsmeldinger.stream().map(im -> {

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/dokument/DokumentRestTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/dokument/DokumentRestTjeneste.java
@@ -135,7 +135,7 @@ public class DokumentRestTjeneste {
                 .filter(mdok -> DokumentTypeId.INNTEKTSMELDING.getKode().equals(mdok.getDokumentType().getKode()))
                 .collect(Collectors.groupingBy(MottattDokument::getJournalpostId));
 
-        var journalPostList = dokumentArkivTjeneste.hentAlleDokumenterForVisning(saksnummer);
+        var journalPostList = dokumentArkivTjeneste.hentAlleDokumenterCached(saksnummer);
         List<DokumentDto> dokumentResultat = new ArrayList<>();
         journalPostList.forEach(
                 arkivJournalPost -> dokumentResultat.addAll(mapFraArkivJournalPost(arkivJournalPost, mottatteIMDokument, inntektsMeldinger)));

--- a/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/dokument/DokumentRestTjenesteTest.java
+++ b/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/dokument/DokumentRestTjenesteTest.java
@@ -126,7 +126,7 @@ class DokumentRestTjenesteTest {
             .medHoveddokument(im)
             .build();
 
-        when(dokumentArkivTjeneste.hentAlleDokumenterForVisning(any())).thenReturn(List.of(søknadJP, søknadV, imJP));
+        when(dokumentArkivTjeneste.hentAlleDokumenterCached(any())).thenReturn(List.of(søknadJP, søknadV, imJP));
 
         var mds = new MottattDokument.Builder().medId(1001L).medJournalPostId(new JournalpostId("123"))
                 .medDokumentType(DokumentTypeId.SØKNAD_ENGANGSSTØNAD_FØDSEL).medFagsakId(fagsakId).medBehandlingId(behandlingId).build();


### PR DESCRIPTION
Siden fpoversikt bruker kompletthetssjekken for manglende vedlegg, men jeg synes det uansett ikke er bra å cache her.

Ser opplysningsplikt vindu i i fp-frontend bruker /soknad endepunktet som igjen bruker kompletthetssjekk som treffer cachen. 
Regner med at vi ikke vil komme til å gjøre mange ekstra kall hvis vi fjerne cachen ettersom kallet gjøres bare fra frontend en gang hvis man klikker på opplysningsplikt vindu