### PR TITLE
TFP-5553 fpsak oppdaterer fagsakstatus når TBK opprettes/avsluttes

### DIFF
--- a/domenetjenester/produksjonsstyring/pom.xml
+++ b/domenetjenester/produksjonsstyring/pom.xml
@@ -31,6 +31,10 @@
             <groupId>no.nav.foreldrepenger</groupId>
             <artifactId>batch</artifactId>
         </dependency>
+        <dependency>
+            <groupId>no.nav.foreldrepenger</groupId>
+            <artifactId>tilbakekreving</artifactId>
+        </dependency>
 
         <!-- Integrasjon klient avhengigheter -->
         <dependency>

--- a/domenetjenester/produksjonsstyring/src/main/java/no/nav/foreldrepenger/produksjonsstyring/behandlinghendelse/BehandlingHendelseConsumer.java
+++ b/domenetjenester/produksjonsstyring/src/main/java/no/nav/foreldrepenger/produksjonsstyring/behandlinghendelse/BehandlingHendelseConsumer.java
@@ -1,0 +1,98 @@
+package no.nav.foreldrepenger.produksjonsstyring.behandlinghendelse;
+
+import java.time.Duration;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import org.apache.kafka.streams.KafkaStreams;
+import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.Topology;
+import org.apache.kafka.streams.kstream.Consumed;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import no.nav.foreldrepenger.konfig.Environment;
+import no.nav.foreldrepenger.konfig.KonfigVerdi;
+import no.nav.vedtak.felles.integrasjon.kafka.KafkaProperties;
+import no.nav.vedtak.log.metrics.Controllable;
+import no.nav.vedtak.log.metrics.LiveAndReadinessAware;
+
+@ApplicationScoped
+public class BehandlingHendelseConsumer implements LiveAndReadinessAware, Controllable {
+
+    private static final Logger LOG = LoggerFactory.getLogger(BehandlingHendelseConsumer.class);
+    private static final Environment ENV = Environment.current();
+    private static final String PROD_APP_ID = "fpsak-behandling-hendelse";  // Hold konstant pga offset commit !!
+
+    private String topicName;
+    private KafkaStreams stream;
+
+    public BehandlingHendelseConsumer() {
+    }
+
+    @Inject
+    public BehandlingHendelseConsumer(@KonfigVerdi(value = "kafka.behandlinghendelse.topic", defaultVerdi = "teamforeldrepenger.behandling-hendelse-v1") String topicName,
+                                      BehandlingHendelseHåndterer behandlingHendelseHåndterer) {
+        this.topicName = topicName;
+
+        final Consumed<String, String> consumed = Consumed.with(Topology.AutoOffsetReset.EARLIEST);
+
+        var builder = new StreamsBuilder();
+        builder.stream(topicName, consumed)
+            .foreach(behandlingHendelseHåndterer::handleMessage);
+
+        this.stream = new KafkaStreams(builder.build(), KafkaProperties.forStreamsStringValue(getApplicationId()));
+    }
+
+    @Override
+    public void start() {
+        addShutdownHooks();
+        stream.start();
+        LOG.info("Starter konsumering av topic={}, tilstand={}", getTopicName(), stream.state());
+    }
+
+    @Override
+    public void stop() {
+        LOG.info("Starter shutdown av topic={}, tilstand={} med 15 sekunder timeout", getTopicName(), stream.state());
+        stream.close(Duration.ofSeconds(15));
+        LOG.info("Shutdown av topic={}, tilstand={} med 15 sekunder timeout", getTopicName(), stream.state());
+    }
+
+    @Override
+    public boolean isAlive() {
+        return stream != null && stream.state().isRunningOrRebalancing();
+    }
+
+    @Override
+    public boolean isReady() {
+        return isAlive();
+    }
+
+    private void addShutdownHooks() {
+        stream.setStateListener((newState, oldState) -> {
+            LOG.info("{} :: From state={} to state={}", getTopicName(), oldState, newState);
+
+            if (newState == KafkaStreams.State.ERROR) {
+                // if the stream has died there is no reason to keep spinning
+                LOG.warn("{} :: No reason to keep living, closing stream", getTopicName());
+                stop();
+            }
+        });
+        stream.setUncaughtExceptionHandler((t, e) -> {
+            LOG.error("{} :: Caught exception in stream, exiting", getTopicName(), e);
+            stop();
+        });
+    }
+
+    private String getTopicName() {
+        return topicName;
+    }
+
+    private static String getApplicationId() {
+        if (!ENV.isProd()) {
+            return PROD_APP_ID + (ENV.isDev() ? "-dev" : "-vtp");
+        }
+        return PROD_APP_ID;
+    }
+}

--- a/domenetjenester/produksjonsstyring/src/main/java/no/nav/foreldrepenger/produksjonsstyring/behandlinghendelse/BehandlingHendelseHåndterer.java
+++ b/domenetjenester/produksjonsstyring/src/main/java/no/nav/foreldrepenger/produksjonsstyring/behandlinghendelse/BehandlingHendelseHåndterer.java
@@ -1,0 +1,69 @@
+package no.nav.foreldrepenger.produksjonsstyring.behandlinghendelse;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.control.ActivateRequestContext;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import no.nav.foreldrepenger.behandling.FagsakTjeneste;
+import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingStatus;
+import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakStatus;
+import no.nav.foreldrepenger.domene.json.StandardJsonConfig;
+import no.nav.foreldrepenger.domene.typer.Saksnummer;
+import no.nav.foreldrepenger.produksjonsstyring.fagsakstatus.OppdaterFagsakStatusTjeneste;
+import no.nav.vedtak.exception.VLException;
+import no.nav.vedtak.hendelser.behandling.BehandlingHendelse;
+import no.nav.vedtak.hendelser.behandling.Hendelse;
+import no.nav.vedtak.hendelser.behandling.Kildesystem;
+import no.nav.vedtak.hendelser.behandling.v1.BehandlingHendelseV1;
+import no.nav.vedtak.log.util.LoggerUtils;
+
+@ApplicationScoped
+@ActivateRequestContext
+@Transactional
+public class BehandlingHendelseHåndterer {
+
+    private static final Logger LOG = LoggerFactory.getLogger(BehandlingHendelseHåndterer.class);
+
+    private FagsakTjeneste fagsakTjeneste;
+    private OppdaterFagsakStatusTjeneste fagsakStatusTjeneste;
+
+    public BehandlingHendelseHåndterer() {
+    }
+
+    @Inject
+    public BehandlingHendelseHåndterer(FagsakTjeneste fagsakTjeneste, OppdaterFagsakStatusTjeneste fagsakStatusTjeneste) {
+        this.fagsakTjeneste = fagsakTjeneste;
+        this.fagsakStatusTjeneste = fagsakStatusTjeneste;
+    }
+
+    void handleMessage(String key, String payload) {
+        // enhver exception ut fra denne metoden medfører at tråden som leser fra kafka gir opp og dør på seg.
+        try {
+            var mottattHendelse = StandardJsonConfig.fromJson(payload, BehandlingHendelse.class);
+            if (Kildesystem.FPTILBAKE.equals(mottattHendelse.getKildesystem()) && mottattHendelse instanceof BehandlingHendelseV1 hendelseV1) {
+                handleMessageIntern(hendelseV1);
+            }
+        } catch (VLException e) {
+            LOG.warn("FP-328773 Vedtatt-Ytelse Feil under parsing av vedtak. key={} payload={}", key, payload, e);
+        } catch (Exception e) {
+            LOG.warn("Vedtatt-Ytelse exception ved håndtering av vedtaksmelding, ignorerer key={}", LoggerUtils.removeLineBreaks(payload), e);
+        }
+    }
+
+    // Foreløpig håndteres bare behandling opprettet/avsluttet i fptilbake her.
+    private void handleMessageIntern(BehandlingHendelseV1 mottattHendelse) {
+        var fagsak = fagsakTjeneste.finnFagsakGittSaksnummer(new Saksnummer(mottattHendelse.getSaksnummer()), true).orElse(null);
+        if (fagsak != null) {
+            if (Hendelse.AVSLUTTET.equals(mottattHendelse.getHendelse()) && !FagsakStatus.AVSLUTTET.equals(fagsak.getStatus())) {
+                fagsakStatusTjeneste.oppdaterFagsakNårBehandlingAvsluttet(fagsak, null);
+            } else if (!FagsakStatus.UNDER_BEHANDLING.equals(fagsak.getStatus())) {
+                fagsakStatusTjeneste.oppdaterFagsakNårBehandlingOpprettet(fagsak, null, BehandlingStatus.UTREDES);
+            }
+        }
+    }
+
+}

--- a/domenetjenester/produksjonsstyring/src/main/java/no/nav/foreldrepenger/produksjonsstyring/fagsakstatus/BehandlingAvsluttetHendelseTask.java
+++ b/domenetjenester/produksjonsstyring/src/main/java/no/nav/foreldrepenger/produksjonsstyring/fagsakstatus/BehandlingAvsluttetHendelseTask.java
@@ -1,0 +1,42 @@
+package no.nav.foreldrepenger.produksjonsstyring.fagsakstatus;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepositoryProvider;
+import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakProsesstaskRekkefølge;
+import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakRepository;
+import no.nav.foreldrepenger.behandlingslager.task.FagsakProsessTask;
+import no.nav.vedtak.felles.prosesstask.api.ProsessTask;
+import no.nav.vedtak.felles.prosesstask.api.ProsessTaskData;
+
+
+@ApplicationScoped
+@ProsessTask("behandlingskontroll.behandlingAvsluttetFagsak")
+@FagsakProsesstaskRekkefølge(gruppeSekvens = false)
+public class BehandlingAvsluttetHendelseTask extends FagsakProsessTask {
+
+    private OppdaterFagsakStatusTjeneste oppdaterFagsakStatusTjeneste;
+    private FagsakRepository fagsakRepository;
+
+    BehandlingAvsluttetHendelseTask() {
+        // for CDI proxy
+    }
+
+    @Inject
+    public BehandlingAvsluttetHendelseTask(BehandlingRepositoryProvider repositoryProvider,
+                                           OppdaterFagsakStatusTjeneste oppdaterFagsakStatusTjeneste,
+                                           FagsakRepository fagsakRepository) {
+        super(repositoryProvider.getFagsakLåsRepository(), repositoryProvider.getBehandlingLåsRepository());
+        this.oppdaterFagsakStatusTjeneste = oppdaterFagsakStatusTjeneste;
+        this.fagsakRepository = fagsakRepository;
+    }
+
+    @Override
+    protected void prosesser(ProsessTaskData prosessTaskData, Long fagsakId, Long behandlingId) {
+        // For å sikre at fagsaken hentes opp i cache - ellers dukker den opp via readonly-query og det blir problem.
+        var fagsak = fagsakRepository.finnEksaktFagsak(fagsakId);
+
+        oppdaterFagsakStatusTjeneste.oppdaterFagsakNårBehandlingAvsluttet(fagsak, behandlingId);
+    }
+}

--- a/domenetjenester/produksjonsstyring/src/main/java/no/nav/foreldrepenger/produksjonsstyring/fagsakstatus/FagsakStatusOppdateringResultat.java
+++ b/domenetjenester/produksjonsstyring/src/main/java/no/nav/foreldrepenger/produksjonsstyring/fagsakstatus/FagsakStatusOppdateringResultat.java
@@ -1,4 +1,4 @@
-package no.nav.foreldrepenger.domene.vedtak;
+package no.nav.foreldrepenger.produksjonsstyring.fagsakstatus;
 
 public enum FagsakStatusOppdateringResultat {
     FAGSAK_AVSLUTTET, FAGSAK_UNDER_BEHANDLING, FAGSAK_LØPENDE, INGEN_OPPDATERING

--- a/domenetjenester/produksjonsstyring/src/main/java/no/nav/foreldrepenger/produksjonsstyring/sakogbehandling/observer/OppdaterSakOgBehandlingEventObserver.java
+++ b/domenetjenester/produksjonsstyring/src/main/java/no/nav/foreldrepenger/produksjonsstyring/sakogbehandling/observer/OppdaterSakOgBehandlingEventObserver.java
@@ -3,9 +3,8 @@ package no.nav.foreldrepenger.produksjonsstyring.sakogbehandling.observer;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.event.Observes;
 import jakarta.inject.Inject;
+
 import no.nav.foreldrepenger.behandlingskontroll.events.BehandlingStatusEvent;
-import no.nav.foreldrepenger.behandlingskontroll.events.BehandlingStatusEvent.BehandlingAvsluttetEvent;
-import no.nav.foreldrepenger.behandlingskontroll.events.BehandlingStatusEvent.BehandlingOpprettetEvent;
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingStatus;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingTema;
@@ -39,11 +38,11 @@ public class OppdaterSakOgBehandlingEventObserver {
         this.familieGrunnlagRepository = repositoryProvider.getFamilieHendelseRepository();
     }
 
-    public void observerBehandlingStatus(@Observes BehandlingAvsluttetEvent event) {
+    public void observerBehandlingStatus(@Observes BehandlingStatusEvent.BehandlingAvsluttetEvent event) {
         oppdaterSakOgBehandlingVedBehandlingsstatusEndring(event);
     }
 
-    public void observerBehandlingStatus(@Observes BehandlingOpprettetEvent event) {
+    public void observerBehandlingStatus(@Observes BehandlingStatusEvent.BehandlingOpprettetEvent event) {
         oppdaterSakOgBehandlingVedBehandlingsstatusEndring(event);
     }
 

--- a/domenetjenester/tilbakekreving/src/main/java/no/nav/foreldrepenger/økonomi/tilbakekreving/klient/FptilbakeRestKlient.java
+++ b/domenetjenester/tilbakekreving/src/main/java/no/nav/foreldrepenger/økonomi/tilbakekreving/klient/FptilbakeRestKlient.java
@@ -1,17 +1,25 @@
 package no.nav.foreldrepenger.økonomi.tilbakekreving.klient;
 
+import java.util.UUID;
+
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.ws.rs.core.UriBuilder;
-import no.nav.foreldrepenger.domene.typer.Saksnummer;
-import no.nav.vedtak.felles.integrasjon.rest.*;
 
-import java.util.UUID;
+import no.nav.foreldrepenger.domene.typer.Saksnummer;
+import no.nav.vedtak.felles.integrasjon.rest.FpApplication;
+import no.nav.vedtak.felles.integrasjon.rest.RestClient;
+import no.nav.vedtak.felles.integrasjon.rest.RestClientConfig;
+import no.nav.vedtak.felles.integrasjon.rest.RestConfig;
+import no.nav.vedtak.felles.integrasjon.rest.RestRequest;
+import no.nav.vedtak.felles.integrasjon.rest.TokenFlow;
 
 @ApplicationScoped
 @RestClientConfig(tokenConfig = TokenFlow.ADAPTIVE, application = FpApplication.FPTILBAKE)
 public class FptilbakeRestKlient {
 
     public static final String FPTILBAKE_HENT_ÅPEN_TILBAKEKREVING = "/api/behandlinger/tilbakekreving/aapen";
+
+    public static final String FPTILBAKE_HENT_ÅPEN_BEHANDLING = "/api/behandlinger/tilbakekreving/aapen-behandling";
 
     public static final String FPTILBAKE_HENT_TILBAKEKREVING_VEDTAK_INFO = "/api/behandlinger/tilbakekreving/vedtak-info";
 
@@ -26,7 +34,12 @@ public class FptilbakeRestKlient {
     }
 
     public boolean harÅpenTilbakekrevingsbehandling(Saksnummer saksnummer) {
-        var uriHentÅpenTilbakekreving = lagRequestUri(saksnummer);
+        var uriHentÅpenTilbakekreving = lagRequestUri(saksnummer, FPTILBAKE_HENT_ÅPEN_TILBAKEKREVING);
+        return restClient.send(uriHentÅpenTilbakekreving, Boolean.class);
+    }
+
+    public boolean harÅpenBehandling(Saksnummer saksnummer) {
+        var uriHentÅpenTilbakekreving = lagRequestUri(saksnummer, FPTILBAKE_HENT_ÅPEN_BEHANDLING);
         return restClient.send(uriHentÅpenTilbakekreving, Boolean.class);
     }
 
@@ -40,11 +53,12 @@ public class FptilbakeRestKlient {
         return restClient.send(uriHentTilbakekrevingVedtaksInfo, TilbakeBehandlingDto.class);
     }
 
-    private RestRequest lagRequestUri(Saksnummer saksnummer) {
-        var target =  UriBuilder.fromUri(restConfig.fpContextPath()).path(FPTILBAKE_HENT_ÅPEN_TILBAKEKREVING)
+    private RestRequest lagRequestUri(Saksnummer saksnummer, String path) {
+        var target =  UriBuilder.fromUri(restConfig.fpContextPath()).path(path)
             .queryParam("saksnummer", saksnummer.getVerdi()).build();
         return RestRequest.newGET(target, restConfig);
     }
+
     private RestRequest lagRequestUri(UUID uuid, String endpoint) {
         var target = UriBuilder.fromUri(restConfig.fpContextPath()).path(endpoint)
             .queryParam("uuid", uuid.toString()).build();

--- a/domenetjenester/vedtak/pom.xml
+++ b/domenetjenester/vedtak/pom.xml
@@ -94,10 +94,6 @@
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>no.nav.foreldrepenger</groupId>
-            <artifactId>tilbakekreving</artifactId>
-        </dependency>
 
     </dependencies>
 </project>

--- a/domenetjenester/vedtak/src/main/java/no/nav/foreldrepenger/domene/vedtak/intern/AutomatiskFagsakAvslutningTask.java
+++ b/domenetjenester/vedtak/src/main/java/no/nav/foreldrepenger/domene/vedtak/intern/AutomatiskFagsakAvslutningTask.java
@@ -1,20 +1,26 @@
 package no.nav.foreldrepenger.domene.vedtak.intern;
 
+import java.util.Optional;
+
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepositoryProvider;
-import no.nav.foreldrepenger.behandlingslager.fagsak.*;
+import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakLås;
+import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakLåsRepository;
+import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakProsesstaskRekkefølge;
+import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakRelasjon;
+import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakRepository;
+import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakYtelseType;
 import no.nav.foreldrepenger.behandlingslager.laas.FagsakRelasjonLås;
 import no.nav.foreldrepenger.behandlingslager.laas.FagsakRelasjonLåsRepository;
 import no.nav.foreldrepenger.behandlingslager.task.FagsakRelasjonProsessTask;
-import no.nav.foreldrepenger.domene.vedtak.FagsakStatusOppdateringResultat;
-import no.nav.foreldrepenger.domene.vedtak.OppdaterFagsakStatusTjeneste;
+import no.nav.foreldrepenger.produksjonsstyring.fagsakstatus.FagsakStatusOppdateringResultat;
+import no.nav.foreldrepenger.produksjonsstyring.fagsakstatus.OppdaterFagsakStatusTjeneste;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTask;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTaskData;
-
-import java.util.Optional;
 
 
 @ApplicationScoped

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/forvaltning/ForvaltningFagsakRestTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/forvaltning/ForvaltningFagsakRestTjeneste.java
@@ -1,17 +1,28 @@
 package no.nav.foreldrepenger.web.app.tjenester.forvaltning;
 
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.Schema;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
+
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
-import jakarta.ws.rs.*;
+import jakarta.ws.rs.BeanParam;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import no.nav.foreldrepenger.behandling.FagsakRelasjonTjeneste;
 import no.nav.foreldrepenger.behandlingslager.behandling.personopplysning.PersonopplysningRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepository;
@@ -23,7 +34,7 @@ import no.nav.foreldrepenger.domene.bruker.NavBrukerTjeneste;
 import no.nav.foreldrepenger.domene.person.PersoninfoAdapter;
 import no.nav.foreldrepenger.domene.typer.JournalpostId;
 import no.nav.foreldrepenger.domene.typer.Saksnummer;
-import no.nav.foreldrepenger.domene.vedtak.OppdaterFagsakStatusTjeneste;
+import no.nav.foreldrepenger.produksjonsstyring.fagsakstatus.OppdaterFagsakStatusTjeneste;
 import no.nav.foreldrepenger.web.app.soap.sak.tjeneste.OpprettSakTjeneste;
 import no.nav.foreldrepenger.web.app.tjenester.fagsak.dto.SaksnummerAbacSupplier;
 import no.nav.foreldrepenger.web.app.tjenester.fagsak.dto.SaksnummerDto;
@@ -34,10 +45,6 @@ import no.nav.vedtak.sikkerhet.abac.BeskyttetRessurs;
 import no.nav.vedtak.sikkerhet.abac.TilpassetAbacAttributt;
 import no.nav.vedtak.sikkerhet.abac.beskyttet.ActionType;
 import no.nav.vedtak.sikkerhet.abac.beskyttet.ResourceType;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
 
 @Path("/forvaltningFagsak")
 @ApplicationScoped


### PR DESCRIPTION
FPtilbake vil publisere opprettet og avsluttet-hendelser.
Legger til behandling-hendelse-consumer som sørger for å oppdatere fagsakstatus deretter.
FagsakStatus-oppdaterer vil sjekke fptilbake for åpne behandlinger
Ommøblert fagsakstatus-sjekking fra vedtak til produksjonsstyring - men avslutningsbatch mm ligger i vedtak pga datologikk.