### PR TITLE
TFP-4697 Feil med fritekst til brev ved skjønnsmessig fastsatt inntekt

### DIFF
--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/Behandling.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/Behandling.java
@@ -597,6 +597,16 @@ public class Behandling extends BaseEntitet {
             .anyMatch(Aksjonspunkt::erAvbrutt);
     }
 
+    public boolean harAvbruttAlleAksjonspunktAvTyper(Set<AksjonspunktDefinisjon> aksjonspunktTyper) {
+        var relevanteAksjonspunkter = getAksjonspunkter().stream()
+            .filter(ap -> aksjonspunktTyper.contains(ap.getAksjonspunktDefinisjon()))
+            .toList();
+        if (relevanteAksjonspunkter.isEmpty()) {
+            return false;
+        }
+        return relevanteAksjonspunkter.stream().allMatch(Aksjonspunkt::erAvbrutt);
+    }
+
     public boolean harÅpentEllerLøstAksjonspunktMedType(AksjonspunktDefinisjon aksjonspunktDefinisjon) {
         return getAksjonspunktMedDefinisjonOptional(aksjonspunktDefinisjon)
                 .map(ap -> ap.getStatus().equals(AksjonspunktStatus.OPPRETTET) || ap.getStatus().equals(AksjonspunktStatus.UTFØRT)).orElse(false);

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/aksjonspunkt/AksjonspunktDefinisjon.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/aksjonspunkt/AksjonspunktDefinisjon.java
@@ -493,6 +493,10 @@ public enum AksjonspunktDefinisjon implements Kodeverdi {
     private static final Set<AksjonspunktDefinisjon> FORESLÅ_VEDTAK_AP = Set.of(AksjonspunktDefinisjon.FORESLÅ_VEDTAK,
         AksjonspunktDefinisjon.FORESLÅ_VEDTAK_MANUELT, AksjonspunktDefinisjon.VEDTAK_UTEN_TOTRINNSKONTROLL);
 
+    private static final Set<AksjonspunktDefinisjon> AVVIK_I_BEREGNING = Set.of(AksjonspunktDefinisjon.FASTSETT_BEREGNINGSGRUNNLAG_ARBEIDSTAKER_FRILANS,
+        AksjonspunktDefinisjon.FASTSETT_BEREGNINGSGRUNNLAG_FOR_SN_NY_I_ARBEIDSLIVET, FASTSETT_BEREGNINGSGRUNNLAG_TIDSBEGRENSET_ARBEIDSFORHOLD,
+        AksjonspunktDefinisjon.VURDER_VARIG_ENDRET_ELLER_NYOPPSTARTET_NÆRING_SELVSTENDIG_NÆRINGSDRIVENDE);
+
 
     private static final Map<AksjonspunktDefinisjon, Set<AksjonspunktDefinisjon>> UTELUKKENDE_AP_MAP = Map.ofEntries(
         Map.entry(AksjonspunktDefinisjon.SJEKK_MANGLENDE_FØDSEL, Set.of(AksjonspunktDefinisjon.AVKLAR_TERMINBEKREFTELSE)),
@@ -653,6 +657,10 @@ public enum AksjonspunktDefinisjon implements Kodeverdi {
 
     public static Set<AksjonspunktDefinisjon> getForeslåVedtakAksjonspunkter() {
         return FORESLÅ_VEDTAK_AP;
+    }
+
+    public static Set<AksjonspunktDefinisjon> getAvvikIBeregning() {
+        return AVVIK_I_BEREGNING;
     }
 
     @Override

--- a/behandlingsprosess/src/main/java/no/nav/foreldrepenger/behandling/steg/foreslåvedtak/ForeslåVedtakTjeneste.java
+++ b/behandlingsprosess/src/main/java/no/nav/foreldrepenger/behandling/steg/foreslåvedtak/ForeslåVedtakTjeneste.java
@@ -60,6 +60,10 @@ class ForeslåVedtakTjeneste {
         }
 
         List<AksjonspunktDefinisjon> aksjonspunktDefinisjoner = new ArrayList<>(aksjonspunkterFraSteg);
+        if (behandling.harAvbruttAlleAksjonspunktAvTyper(AksjonspunktDefinisjon.getAvvikIBeregning())) {
+            dokumentBehandlingTjeneste.nullstillVedtakFritekstHvisFinnes(behandling.getId());
+        }
+
         if (KlageAnkeVedtakTjeneste.behandlingErKlageEllerAnke(behandling)) {
             if (klageAnkeVedtakTjeneste.erKlageResultatHjemsendt(behandling) || klageAnkeVedtakTjeneste.erBehandletAvKabal(behandling)) {
                 behandling.nullstillToTrinnsBehandling();


### PR DESCRIPTION
Rettet at fritekst til vedtaksbrev ved skjønnsmessig fastsatt inntekt blir nullstilt dersom det ikke lenger er relevant, altså alle aksjonspunktene er avbrutt