### PR TITLE
TFP-5391 start i beregning dersom endring til/fra gitt arbforholdId

### DIFF
--- a/domenetjenester/registerinnhenting/src/main/java/no/nav/foreldrepenger/domene/registerinnhenting/impl/startpunkt/StartpunktUtlederInntektsmelding.java
+++ b/domenetjenester/registerinnhenting/src/main/java/no/nav/foreldrepenger/domene/registerinnhenting/impl/startpunkt/StartpunktUtlederInntektsmelding.java
@@ -1,7 +1,17 @@
 package no.nav.foreldrepenger.domene.registerinnhenting.impl.startpunkt;
 
+import static java.util.Collections.emptyList;
+
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+
 import jakarta.enterprise.context.Dependent;
 import jakarta.inject.Inject;
+
 import no.nav.foreldrepenger.behandling.BehandlingReferanse;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingType;
 import no.nav.foreldrepenger.behandlingslager.behandling.arbeidsforhold.ArbeidsforholdKomplettVurderingType;
@@ -10,12 +20,13 @@ import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakYtelseType;
 import no.nav.foreldrepenger.behandlingslager.hendelser.StartpunktType;
 import no.nav.foreldrepenger.domene.arbeidInntektsmelding.ArbeidsforholdInntektsmeldingMangelTjeneste;
 import no.nav.foreldrepenger.domene.arbeidsforhold.InntektArbeidYtelseTjeneste;
-import no.nav.foreldrepenger.domene.iay.modell.*;
+import no.nav.foreldrepenger.domene.iay.modell.ArbeidsforholdOverstyring;
+import no.nav.foreldrepenger.domene.iay.modell.InntektArbeidYtelseGrunnlag;
+import no.nav.foreldrepenger.domene.iay.modell.Inntektsmelding;
+import no.nav.foreldrepenger.domene.iay.modell.InntektsmeldingAggregat;
+import no.nav.foreldrepenger.domene.iay.modell.NaturalYtelse;
+import no.nav.foreldrepenger.domene.iay.modell.Refusjon;
 import no.nav.foreldrepenger.domene.iay.modell.kodeverk.ArbeidsforholdHandlingType;
-
-import java.util.*;
-
-import static java.util.Collections.emptyList;
 
 @Dependent
 class StartpunktUtlederInntektsmelding {
@@ -127,6 +138,13 @@ class StartpunktUtlederInntektsmelding {
         var origIM = sisteInntektsmeldingForArbeidsforhold(nyIm, origIm).orElse(null);
         if (origIM == null) { // Finnes ikke tidligere IM fra denne AG
             FellesStartpunktUtlederLogger.skrivLoggStartpunktIM(klassenavn, "første", ref.behandlingId(), nyIm.getKanalreferanse());
+            return true;
+        }
+
+        // Endring til/fra angitt arbeidsforholdId og ingen slik id
+        if ((origIM.gjelderForEtSpesifiktArbeidsforhold() && !nyIm.gjelderForEtSpesifiktArbeidsforhold()) ||
+            (!origIM.gjelderForEtSpesifiktArbeidsforhold() && nyIm.gjelderForEtSpesifiktArbeidsforhold())) {
+            FellesStartpunktUtlederLogger.skrivLoggStartpunktIM(klassenavn, "im-arbeidsforhold", ref.behandlingId(), nyIm.getKanalreferanse());
             return true;
         }
 

--- a/domenetjenester/registerinnhenting/src/main/java/no/nav/foreldrepenger/domene/registerinnhenting/impl/startpunkt/StartpunktUtlederInntektsmelding.java
+++ b/domenetjenester/registerinnhenting/src/main/java/no/nav/foreldrepenger/domene/registerinnhenting/impl/startpunkt/StartpunktUtlederInntektsmelding.java
@@ -138,7 +138,7 @@ class StartpunktUtlederInntektsmelding {
         }
 
         // Endring til/fra angitt arbeidsforholdId og ingen slik id
-        if ((origIM.gjelderForEtSpesifiktArbeidsforhold() && !nyIm.gjelderForEtSpesifiktArbeidsforhold()) ||
+        if ((origIM.gjelderForEtSpesifiktArbeidsforhold() && harFlereImFraSammeArbeidsgiver(nyIm, gamleIm) && !nyIm.gjelderForEtSpesifiktArbeidsforhold()) ||
             (!origIM.gjelderForEtSpesifiktArbeidsforhold() && nyIm.gjelderForEtSpesifiktArbeidsforhold())) {
             FellesStartpunktUtlederLogger.skrivLoggStartpunktIM(klassenavn, "im-arbeidsforhold", ref.behandlingId(), nyIm.getKanalreferanse());
             return true;
@@ -176,10 +176,16 @@ class StartpunktUtlederInntektsmelding {
 
     }
 
-    private Optional<Inntektsmelding> sisteInntektsmeldingForArbeidsforhold(Inntektsmelding ny, List<Inntektsmelding> origIM) {
-        return origIM.stream()
+    private Optional<Inntektsmelding> sisteInntektsmeldingForArbeidsforhold(Inntektsmelding ny, List<Inntektsmelding> gamleIm) {
+        return gamleIm.stream()
             .filter(ny::gjelderSammeArbeidsforhold)
             .max(COMP_REKKEFØLGE);
+    }
+
+    private boolean harFlereImFraSammeArbeidsgiver(Inntektsmelding ny, List<Inntektsmelding> gamleIm) {
+        return gamleIm.stream()
+            .filter(im -> Objects.equals(im.getArbeidsgiver(), ny.getArbeidsgiver()))
+            .count() > 1;
     }
 
     private boolean nyttArbForholdForEksisterendeArbgiver(Inntektsmelding ny, List<Inntektsmelding> origIM) {

--- a/domenetjenester/registerinnhenting/src/main/java/no/nav/foreldrepenger/domene/registerinnhenting/impl/startpunkt/StartpunktUtlederInntektsmelding.java
+++ b/domenetjenester/registerinnhenting/src/main/java/no/nav/foreldrepenger/domene/registerinnhenting/impl/startpunkt/StartpunktUtlederInntektsmelding.java
@@ -138,7 +138,7 @@ class StartpunktUtlederInntektsmelding {
         }
 
         // Endring til/fra angitt arbeidsforholdId og ingen slik id
-        if ((origIM.gjelderForEtSpesifiktArbeidsforhold() && harFlereImFraSammeArbeidsgiver(nyIm, gamleIm) && !nyIm.gjelderForEtSpesifiktArbeidsforhold()) ||
+        if ((origIM.gjelderForEtSpesifiktArbeidsforhold() && !nyIm.gjelderForEtSpesifiktArbeidsforhold() && harFlereImFraSammeArbeidsgiver(nyIm, gamleIm)) ||
             (!origIM.gjelderForEtSpesifiktArbeidsforhold() && nyIm.gjelderForEtSpesifiktArbeidsforhold())) {
             FellesStartpunktUtlederLogger.skrivLoggStartpunktIM(klassenavn, "im-arbeidsforhold", ref.behandlingId(), nyIm.getKanalreferanse());
             return true;

--- a/domenetjenester/registerinnhenting/src/test/java/no/nav/foreldrepenger/domene/registerinnhenting/impl/startpunkt/StartpunktUtlederInntektsmeldingTest.java
+++ b/domenetjenester/registerinnhenting/src/test/java/no/nav/foreldrepenger/domene/registerinnhenting/impl/startpunkt/StartpunktUtlederInntektsmeldingTest.java
@@ -138,6 +138,8 @@ class StartpunktUtlederInntektsmeldingTest extends EntityManagerAwareTest {
         var førstegangsbehandlingInntekt = new BigDecimal(30000);
         var førstegangsbehandlingIM = lagInntektsmelding(InntektsmeldingInnsendingsårsak.NY, førstegangsbehandlingInntekt,
             førsteUttaksdato, ARBEIDSID_DEFAULT);
+        lagEkstraInntektsmelding(InntektsmeldingInnsendingsårsak.NY, førstegangsbehandlingInntekt, førsteUttaksdato, lagArbeidsgiver(),
+            ARBEIDSID_EKSTRA, førstegangsbehandlingIM);
         lenient().when(førstegangsbehandlingIMAggregat.getInntektsmeldingerSomSkalBrukes()).thenReturn(førstegangsbehandlingIM);
 
         // Arrange - opprette revurderingsbehandling
@@ -265,6 +267,8 @@ class StartpunktUtlederInntektsmeldingTest extends EntityManagerAwareTest {
         // Arrange - opprette avsluttet førstegangsbehandling
         var behandling = opprettFørstegangsbehandling();
 
+        var ekstraArbeidsgiver = Arbeidsgiver.virksomhet("456");
+
         var førsteUttaksdato = LocalDate.now();
 
         var førstegangsbehandlingInntekt = new BigDecimal(30000);
@@ -272,7 +276,8 @@ class StartpunktUtlederInntektsmeldingTest extends EntityManagerAwareTest {
 
         var førstegangsbehandlingIM = lagInntektsmelding(InntektsmeldingInnsendingsårsak.ENDRING, revurderingInntekt,
                 førsteUttaksdato, ARBEIDSID_DEFAULT);
-        lagEkstraInntektsmelding(InntektsmeldingInnsendingsårsak.NY, førstegangsbehandlingInntekt, førsteUttaksdato, ARBEIDSID_EKSTRA,
+        lagEkstraInntektsmelding(InntektsmeldingInnsendingsårsak.NY, førstegangsbehandlingInntekt, førsteUttaksdato, ekstraArbeidsgiver,
+            ARBEIDSID_EKSTRA,
                 førstegangsbehandlingIM);
         lenient().when(førstegangsbehandlingIMAggregat.getInntektsmeldingerSomSkalBrukes()).thenReturn(førstegangsbehandlingIM);
 
@@ -281,7 +286,7 @@ class StartpunktUtlederInntektsmeldingTest extends EntityManagerAwareTest {
 
         var inntektsmeldingerMottattEtterVedtak = lagInntektsmelding(InntektsmeldingInnsendingsårsak.ENDRING, revurderingInntekt,
                 førsteUttaksdato, ARBEIDSID_DEFAULT);
-        lagEkstraInntektsmelding(InntektsmeldingInnsendingsårsak.ENDRING, revurderingInntekt, førsteUttaksdato, ARBEIDSID_EKSTRA,
+        lagEkstraInntektsmelding(InntektsmeldingInnsendingsårsak.ENDRING, revurderingInntekt, førsteUttaksdato, ekstraArbeidsgiver, ARBEIDSID_EKSTRA,
                 inntektsmeldingerMottattEtterVedtak);
         var ref = lagReferanse(revurdering, førsteUttaksdato);
         lenient().when(inntektArbeidYtelseTjeneste.finnGrunnlag(behandling.getId())).thenReturn(Optional.of(førstegangsbehandlingGrunnlagIAY));
@@ -450,12 +455,13 @@ class StartpunktUtlederInntektsmeldingTest extends EntityManagerAwareTest {
     }
 
     private void lagEkstraInntektsmelding(InntektsmeldingInnsendingsårsak innsendingsårsak, BigDecimal beløp, LocalDate førsteUttaksdato,
-            InternArbeidsforholdRef arbeidID, List<Inntektsmelding> im) {
+                                          Arbeidsgiver arbeidsgiver,
+                                          InternArbeidsforholdRef arbeidID, List<Inntektsmelding> im) {
         var inntektsmelding = getInntektsmeldingBuilder()
                 .medBeløp(beløp)
                 .medArbeidsforholdId(arbeidID)
                 .medStartDatoPermisjon(førsteUttaksdato)
-                .medArbeidsgiver(Arbeidsgiver.virksomhet("456"))
+                .medArbeidsgiver(arbeidsgiver)
                 .medJournalpostId(InntektsmeldingInnsendingsårsak.NY.equals(innsendingsårsak) ? "456" : "456E")
                 .medInntektsmeldingaarsak(innsendingsårsak)
                 .build();


### PR DESCRIPTION
Skal dekke endring fra ingen afid til angitt afid og vv.
Noe usikker på om grunnlaget (som kommer fra InntektArbeidYtelseTjeneste.hentGrunnlagPåId) vil inneholde kun 1 IM pr arbgiver / arbforhold - eller om det kan komme flere. Hva tror dere?
Bør vi ta inn IM-comparator fra abakus - eller kan vi anta at de kommer ferdig sortert fra abakus (dvs bør vi fjerne origIm = gamle.stream.sort? den burde sortere på AR-ref dersom det kan komme flere pr AG/AF)