### PR TITLE
TFP-5588 TFP-5589 endringsdato for revurdering + ventefristfordeling

### DIFF
--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/nøkkeltallbehandling/NøkkeltallBehandlingFørsteUttak.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/nøkkeltallbehandling/NøkkeltallBehandlingFørsteUttak.java
@@ -5,7 +5,7 @@ import java.time.LocalDate;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingType;
 
 
-public record NøkkeltallBehandlingVentestatus(String behandlendeEnhet, BehandlingType behandlingType,
+public record NøkkeltallBehandlingFørsteUttak(String behandlendeEnhet, BehandlingType behandlingType,
                                               BehandlingVenteStatus behandlingVenteStatus, LocalDate førsteUttakMåned,
                                               int antall) {
 

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/nøkkeltallbehandling/NøkkeltallBehandlingVentefristUtløper.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/nøkkeltallbehandling/NøkkeltallBehandlingVentefristUtløper.java
@@ -1,0 +1,10 @@
+package no.nav.foreldrepenger.behandlingslager.behandling.nøkkeltallbehandling;
+
+import java.time.LocalDate;
+
+import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakYtelseType;
+
+
+public record NøkkeltallBehandlingVentefristUtløper(String behandlendeEnhet, FagsakYtelseType fagsakYtelseType, LocalDate behandlingFrist, Long antall) {
+
+}

--- a/behandlingslager/testutil/src/test/java/no/nav/foreldrepenger/behandlingslager/behandling/NøkkeltallBehandlingRepositoryTest.java
+++ b/behandlingslager/testutil/src/test/java/no/nav/foreldrepenger/behandlingslager/behandling/NøkkeltallBehandlingRepositoryTest.java
@@ -1,24 +1,28 @@
 package no.nav.foreldrepenger.behandlingslager.behandling;
 
-import jakarta.persistence.EntityManager;
-import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.AksjonspunktDefinisjon;
-import no.nav.foreldrepenger.behandlingslager.behandling.nøkkeltallbehandling.BehandlingVenteStatus;
-import no.nav.foreldrepenger.behandlingslager.behandling.nøkkeltallbehandling.NøkkeltallBehandlingRepository;
-import no.nav.foreldrepenger.behandlingslager.behandling.nøkkeltallbehandling.NøkkeltallBehandlingVentestatus;
-import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepositoryProvider;
-import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.periode.OppgittPeriodeEntitet;
-import no.nav.foreldrepenger.behandlingslager.testutilities.behandling.ScenarioMorSøkerForeldrepenger;
-import no.nav.foreldrepenger.dbstoette.JpaExtension;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.LocalDate;
 import java.time.temporal.TemporalAdjusters;
 import java.util.List;
 import java.util.Objects;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import jakarta.persistence.EntityManager;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.Aksjonspunkt;
+import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.AksjonspunktDefinisjon;
+import no.nav.foreldrepenger.behandlingslager.behandling.nøkkeltallbehandling.BehandlingVenteStatus;
+import no.nav.foreldrepenger.behandlingslager.behandling.nøkkeltallbehandling.NøkkeltallBehandlingFørsteUttak;
+import no.nav.foreldrepenger.behandlingslager.behandling.nøkkeltallbehandling.NøkkeltallBehandlingRepository;
+import no.nav.foreldrepenger.behandlingslager.behandling.nøkkeltallbehandling.NøkkeltallBehandlingVentefristUtløper;
+import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepositoryProvider;
+import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.periode.OppgittPeriodeEntitet;
+import no.nav.foreldrepenger.behandlingslager.testutilities.behandling.ScenarioMorSøkerForeldrepenger;
+import no.nav.foreldrepenger.dbstoette.JpaExtension;
 
 @ExtendWith(JpaExtension.class)
 class NøkkeltallBehandlingRepositoryTest {
@@ -40,27 +44,58 @@ class NøkkeltallBehandlingRepositoryTest {
             .leggTilAksjonspunkt(AksjonspunktDefinisjon.AUTO_MANUELT_SATT_PÅ_VENT, BehandlingStegType.INNHENT_PERSONOPPLYSNINGER);
         søknad.lagre(repositoryProvider);
         var forventetNøkkeltallBehandlingVentestatus = forventet(søknad);
-        var nøkkeltall = nøkkeltallBehandlingRepository.hentNøkkeltallBehandlingVentestatus();
+        var nøkkeltall = nøkkeltallBehandlingRepository.hentNøkkeltallSøknadFørsteUttakPrMånedForeldrepenger();
         var resultat = antallTreff(nøkkeltall, forventetNøkkeltallBehandlingVentestatus);
         assertThat(resultat).isGreaterThanOrEqualTo(1);
     }
 
-    private NøkkeltallBehandlingVentestatus forventet(ScenarioMorSøkerForeldrepenger søknad) {
+    private NøkkeltallBehandlingFørsteUttak forventet(ScenarioMorSøkerForeldrepenger søknad) {
         var forventetEnhet = søknad.getBehandling().getBehandlendeEnhet();
         var forventetFørsteUttakMåned = finnFørsteUttakMånedDato(søknad);
         var forventetStatus = BehandlingVenteStatus.PÅ_VENT;
         var forventetBehandlingType = søknad.getBehandling().getType();
-        return new NøkkeltallBehandlingVentestatus(forventetEnhet, forventetBehandlingType, forventetStatus, forventetFørsteUttakMåned, 1);
+        return new NøkkeltallBehandlingFørsteUttak(forventetEnhet, forventetBehandlingType, forventetStatus, forventetFørsteUttakMåned, 1);
     }
 
-    private static int antallTreff(List<NøkkeltallBehandlingVentestatus> nøkkeltallInitiell,
-                                   NøkkeltallBehandlingVentestatus forventet) {
+    @Test
+    void skalRapportereFristUtløper() {
+        var søknad = ScenarioMorSøkerForeldrepenger.forFødsel()
+            .medBehandlendeEnhet("4833")
+            .medDefaultFordeling(LocalDate.now().plusDays(20))
+            .leggTilAksjonspunkt(AksjonspunktDefinisjon.AUTO_MANUELT_SATT_PÅ_VENT, BehandlingStegType.INNHENT_PERSONOPPLYSNINGER);
+        søknad.lagre(repositoryProvider);
+        var forventetNøkkeltallBehandlingVentestatus = forventetFrist(søknad);
+        var nøkkeltall = nøkkeltallBehandlingRepository.hentNøkkeltallVentefristUtløperPrUke();
+        var resultat = antallTreff(nøkkeltall, forventetNøkkeltallBehandlingVentestatus);
+        assertThat(resultat).isGreaterThanOrEqualTo(1);
+    }
+
+    private NøkkeltallBehandlingVentefristUtløper forventetFrist(ScenarioMorSøkerForeldrepenger søknad) {
+        var forventetEnhet = søknad.getBehandling().getBehandlendeEnhet();
+        var forventetFrist = søknad.getBehandling().getAksjonspunkter().stream().findFirst().map(Aksjonspunkt::getFristTid).orElseThrow()
+            .plusDays(1).toLocalDate();
+        var forventetYtelseType = søknad.getFagsak().getYtelseType();
+        return new NøkkeltallBehandlingVentefristUtløper(forventetEnhet, forventetYtelseType, forventetFrist, 1L);
+    }
+
+    private static int antallTreff(List<NøkkeltallBehandlingFørsteUttak> nøkkeltallInitiell,
+                                   NøkkeltallBehandlingFørsteUttak forventet) {
         return nøkkeltallInitiell.stream()
             .filter(i -> Objects.equals(i.behandlendeEnhet(), forventet.behandlendeEnhet()))
             .filter(i -> Objects.equals(i.behandlingType(), forventet.behandlingType()))
             .filter(i -> Objects.equals(i.førsteUttakMåned(), forventet.førsteUttakMåned()))
             .filter(i -> i.behandlingVenteStatus() == forventet.behandlingVenteStatus())
-            .mapToInt(NøkkeltallBehandlingVentestatus::antall)
+            .mapToInt(NøkkeltallBehandlingFørsteUttak::antall)
+            .sum();
+    }
+
+    private static Long antallTreff(List<NøkkeltallBehandlingVentefristUtløper> nøkkeltallInitiell,
+                                   NøkkeltallBehandlingVentefristUtløper forventet) {
+        return nøkkeltallInitiell.stream()
+            .filter(i -> Objects.equals(i.behandlendeEnhet(), forventet.behandlendeEnhet()))
+            .filter(i -> Objects.equals(i.fagsakYtelseType(), forventet.fagsakYtelseType()))
+            .filter(i -> Objects.equals(i.behandlingFrist(), forventet.behandlingFrist()))
+            .mapToLong(NøkkeltallBehandlingVentefristUtløper::antall)
             .sum();
     }
 

--- a/behandlingslager/testutil/src/test/java/no/nav/foreldrepenger/behandlingslager/behandling/NøkkeltallBehandlingRepositoryTest.java
+++ b/behandlingslager/testutil/src/test/java/no/nav/foreldrepenger/behandlingslager/behandling/NøkkeltallBehandlingRepositoryTest.java
@@ -2,6 +2,7 @@ package no.nav.foreldrepenger.behandlingslager.behandling;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.temporal.TemporalAdjusters;
 import java.util.List;
@@ -72,8 +73,9 @@ class NøkkeltallBehandlingRepositoryTest {
 
     private NøkkeltallBehandlingVentefristUtløper forventetFrist(ScenarioMorSøkerForeldrepenger søknad) {
         var forventetEnhet = søknad.getBehandling().getBehandlendeEnhet();
+        // Skal legge til start of week (IW = mandag) + 4 dager = fredag
         var forventetFrist = søknad.getBehandling().getAksjonspunkter().stream().findFirst().map(Aksjonspunkt::getFristTid).orElseThrow()
-            .plusDays(1).toLocalDate();
+            .with(DayOfWeek.FRIDAY).toLocalDate();
         var forventetYtelseType = søknad.getFagsak().getYtelseType();
         return new NøkkeltallBehandlingVentefristUtløper(forventetEnhet, forventetYtelseType, forventetFrist, 1L);
     }

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/los/LosBehandlingDtoTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/los/LosBehandlingDtoTjeneste.java
@@ -1,7 +1,16 @@
 package no.nav.foreldrepenger.web.app.tjenester.los;
 
+import java.time.LocalDate;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+
 import no.nav.foreldrepenger.behandling.BehandlingReferanse;
 import no.nav.foreldrepenger.behandling.Skjæringstidspunkt;
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
@@ -25,11 +34,15 @@ import no.nav.foreldrepenger.domene.risikoklassifisering.tjeneste.Risikovurderin
 import no.nav.foreldrepenger.domene.typer.Beløp;
 import no.nav.foreldrepenger.domene.ytelsefordeling.YtelseFordelingTjeneste;
 import no.nav.foreldrepenger.skjæringstidspunkt.SkjæringstidspunktTjeneste;
-import no.nav.vedtak.hendelser.behandling.*;
+import no.nav.vedtak.hendelser.behandling.Aksjonspunktstatus;
+import no.nav.vedtak.hendelser.behandling.AktørId;
+import no.nav.vedtak.hendelser.behandling.Behandlingsstatus;
+import no.nav.vedtak.hendelser.behandling.Behandlingstype;
+import no.nav.vedtak.hendelser.behandling.Behandlingsårsak;
+import no.nav.vedtak.hendelser.behandling.Kildesystem;
+import no.nav.vedtak.hendelser.behandling.Ytelse;
 import no.nav.vedtak.hendelser.behandling.los.LosBehandlingDto;
 import no.nav.vedtak.hendelser.behandling.los.LosFagsakEgenskaperDto;
-
-import java.util.*;
 
 /**
  * Returnerer behandlingsinformasjon tilpasset behov i FP-LOS
@@ -168,18 +181,25 @@ public class LosBehandlingDtoTjeneste {
         if (FagsakYtelseType.FORELDREPENGER.equals(behandling.getFagsakYtelseType()) && ytelseFordelingTjeneste.hentAggregatHvisEksisterer(behandling.getId()).isEmpty()) {
             return null;
         }
-        Skjæringstidspunkt stp = null;
-        try {
-            stp = skjæringstidspunktTjeneste.getSkjæringstidspunkter(behandling.getId());
-        } catch (Exception e) {
-            // Intentionally ignored
-        }
-        var førsteUttaksdato = Optional.ofNullable(stp).flatMap(Skjæringstidspunkt::getSkjæringstidspunktHvisUtledet).orElse(null);
         var aggregat = ytelseFordelingTjeneste.hentAggregatHvisEksisterer(behandling.getId());
         var vurderSykdom = aggregat.map(YtelseFordelingAggregat::getGjeldendeFordeling).map(OppgittFordelingEntitet::getPerioder).orElse(List.of())
             .stream().anyMatch(LosBehandlingDtoTjeneste::periodeGjelderSykdom);
         var gradering = aggregat.map(YtelseFordelingAggregat::getGjeldendeFordeling).map(OppgittFordelingEntitet::getPerioder).orElse(List.of())
             .stream().anyMatch(OppgittPeriodeEntitet::isGradert);
+        LocalDate førsteUttaksdato = null;
+        if (BehandlingType.FØRSTEGANGSSØKNAD.equals(behandling.getType())) {
+            try {
+                førsteUttaksdato = Optional.ofNullable(skjæringstidspunktTjeneste.getSkjæringstidspunkter(behandling.getId()))
+                    .flatMap(Skjæringstidspunkt::getSkjæringstidspunktHvisUtledet).orElse(null);
+            } catch (Exception e) {
+                // Intentionally ignored
+            }
+        } else if (BehandlingType.REVURDERING.equals(behandling.getType())) {
+            førsteUttaksdato = aggregat.map(YtelseFordelingAggregat::getGjeldendeFordeling)
+                .map(OppgittFordelingEntitet::getPerioder).orElse(List.of()).stream()
+                .map(OppgittPeriodeEntitet::getFom)
+                .min(Comparator.naturalOrder()).orElse(null);
+        }
         return new LosBehandlingDto.LosForeldrepengerDto(førsteUttaksdato, vurderSykdom, gradering);
     }
 

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/los/LosRestTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/los/LosRestTjeneste.java
@@ -1,20 +1,28 @@
 package no.nav.foreldrepenger.web.app.tjenester.los;
 
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.Schema;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import java.util.List;
+
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
-import jakarta.ws.rs.*;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import no.nav.foreldrepenger.behandlingslager.behandling.nøkkeltallbehandling.NøkkeltallBehandlingFørsteUttak;
 import no.nav.foreldrepenger.behandlingslager.behandling.nøkkeltallbehandling.NøkkeltallBehandlingRepository;
-import no.nav.foreldrepenger.behandlingslager.behandling.nøkkeltallbehandling.NøkkeltallBehandlingVentestatus;
+import no.nav.foreldrepenger.behandlingslager.behandling.nøkkeltallbehandling.NøkkeltallBehandlingVentefristUtløper;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepository;
 import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakRepository;
 import no.nav.foreldrepenger.domene.typer.Saksnummer;
@@ -29,8 +37,6 @@ import no.nav.vedtak.sikkerhet.abac.TilpassetAbacAttributt;
 import no.nav.vedtak.sikkerhet.abac.beskyttet.ActionType;
 import no.nav.vedtak.sikkerhet.abac.beskyttet.ResourceType;
 
-import java.util.List;
-
 @ApplicationScoped
 @Transactional
 @Path(LosRestTjeneste.BASE_PATH)
@@ -42,6 +48,7 @@ public class LosRestTjeneste {
     private static final String LOS_BEHANDLING_PATH = "/los-behandling";
     private static final String LOS_FAGSAK_EGENSKAP_PATH = "/los-egenskap";
     public static final String LOS_NØKKELTALL_PATH = "/los-nokkeltall";
+    public static final String LOS_FRISTUTLOP_PATH = "/los-fristutlop";
 
     private FagsakRepository fagsakRepository;
     private BehandlingRepository behandlingRepository;
@@ -94,10 +101,19 @@ public class LosRestTjeneste {
     @Path(LOS_NØKKELTALL_PATH)
     @GET
     @Produces(MediaType.APPLICATION_JSON)
-    @Operation(description = "Tilbyr data over ikke-avsluttede behandlinger på vent vs ikke på vent", tags = "los-data")
+    @Operation(description = "Tilbyr første søkte uttaksdato for åpne foreldrepenge-behandlinger med info om venting", tags = "los-data")
     @BeskyttetRessurs(actionType = ActionType.READ, resourceType = ResourceType.OPPGAVESTYRING_AVDELINGENHET, sporingslogg = false)
-    public List<NøkkeltallBehandlingVentestatus> innloggetBruker() {
-        return nøkkeltallBehandlingRepository.hentNøkkeltallBehandlingVentestatus();
+    public List<NøkkeltallBehandlingFørsteUttak> nøkkeltallFørsteUttakPrMåned() {
+        return nøkkeltallBehandlingRepository.hentNøkkeltallSøknadFørsteUttakPrMånedForeldrepenger();
+    }
+
+    @Path(LOS_FRISTUTLOP_PATH)
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @Operation(description = "Tilbyr data over når førstegangsbehandlinger går av vent", tags = "los-data")
+    @BeskyttetRessurs(actionType = ActionType.READ, resourceType = ResourceType.OPPGAVESTYRING_AVDELINGENHET, sporingslogg = false)
+    public List<NøkkeltallBehandlingVentefristUtløper> nøkkeltallFristUtløper() {
+        return nøkkeltallBehandlingRepository.hentNøkkeltallVentefristUtløperPrUke();
     }
 
 }


### PR DESCRIPTION
Sender opp første søknadsperiode for endringssøknader i stedet for STP, som kan være år tilbake i tid.

Nytt endepunkt for å hente fristutløp neste 6 mnd fordelt på uke (bruker fredag) - de med senere frist havner på siste uke i utvalget. Gruppert på enhet og ytelsetype. Ser bort fra VentPåSøknad og KøetBehandling