### PR TITLE
TFP-5463 første utgave av infotrygd-søk

### DIFF
--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/vedtak/rest/InfotrygdFPGrunnlag.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/vedtak/rest/InfotrygdFPGrunnlag.java
@@ -1,0 +1,19 @@
+package no.nav.foreldrepenger.mottak.vedtak.rest;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import no.nav.vedtak.felles.integrasjon.infotrygd.grunnlag.AbstractInfotrygdGrunnlag;
+import no.nav.vedtak.felles.integrasjon.rest.RestClientConfig;
+import no.nav.vedtak.felles.integrasjon.rest.TokenFlow;
+
+// Brukes ikke av mottak, men av egen innsynsløsning / ui.
+@ApplicationScoped
+@RestClientConfig(tokenConfig = TokenFlow.AZUREAD_CC, endpointProperty = "fpsak.it.fp.grunnlag.url",
+    endpointDefault = "http://fp-infotrygd-foreldrepenger.teamforeldrepenger/grunnlag",
+    scopesProperty = "fpsak.it.fp.scopes", scopesDefault = "api://prod-fss.teamforeldrepenger.fp-infotrygd-foreldrepenger/.default")
+public class InfotrygdFPGrunnlag extends AbstractInfotrygdGrunnlag {
+
+    public InfotrygdFPGrunnlag() {
+        super();
+    }
+}

--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/vedtak/rest/InfotrygdSvpGrunnlag.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/vedtak/rest/InfotrygdSvpGrunnlag.java
@@ -1,0 +1,19 @@
+package no.nav.foreldrepenger.mottak.vedtak.rest;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import no.nav.vedtak.felles.integrasjon.infotrygd.grunnlag.AbstractInfotrygdGrunnlag;
+import no.nav.vedtak.felles.integrasjon.rest.RestClientConfig;
+import no.nav.vedtak.felles.integrasjon.rest.TokenFlow;
+
+// Brukes ikke av mottak, men av egen innsynsløsning / ui.
+@ApplicationScoped
+@RestClientConfig(tokenConfig = TokenFlow.AZUREAD_CC, endpointProperty = "fpsak.it.sv.grunnlag.url",
+    endpointDefault = "http://fp-infotrygd-svangerskapspenger.teamforeldrepenger/grunnlag",
+    scopesProperty = "fpsak.it.sv.scopes", scopesDefault = "api://prod-fss.teamforeldrepenger.fp-infotrygd-svangerskapspenger/.default")
+public class InfotrygdSvpGrunnlag extends AbstractInfotrygdGrunnlag {
+
+    public InfotrygdSvpGrunnlag() {
+        super();
+    }
+}

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/RestImplementationClasses.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/RestImplementationClasses.java
@@ -1,5 +1,10 @@
 package no.nav.foreldrepenger.web.app.tjenester;
 
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
 import io.swagger.v3.jaxrs2.integration.resources.OpenApiResource;
 import no.nav.foreldrepenger.web.app.exceptions.ConstraintViolationMapper;
 import no.nav.foreldrepenger.web.app.exceptions.GeneralRestExceptionMapper;
@@ -41,10 +46,23 @@ import no.nav.foreldrepenger.web.app.tjenester.fordeling.FordelRestTjeneste;
 import no.nav.foreldrepenger.web.app.tjenester.formidling.FormidlingRestTjeneste;
 import no.nav.foreldrepenger.web.app.tjenester.formidling.beregningsgrunnlag.BeregningsgrunnlagFormidlingRestTjeneste;
 import no.nav.foreldrepenger.web.app.tjenester.formidling.tilkjentytelse.TilkjentYtelseFormidlingRestTjeneste;
-import no.nav.foreldrepenger.web.app.tjenester.forvaltning.*;
+import no.nav.foreldrepenger.web.app.tjenester.forvaltning.ForvaltningBehandlingRestTjeneste;
+import no.nav.foreldrepenger.web.app.tjenester.forvaltning.ForvaltningBehandlingskontrollRestTjeneste;
+import no.nav.foreldrepenger.web.app.tjenester.forvaltning.ForvaltningBeregningRestTjeneste;
+import no.nav.foreldrepenger.web.app.tjenester.forvaltning.ForvaltningFagsakRestTjeneste;
+import no.nav.foreldrepenger.web.app.tjenester.forvaltning.ForvaltningOppdragRestTjeneste;
+import no.nav.foreldrepenger.web.app.tjenester.forvaltning.ForvaltningOpptjeningRestTjeneste;
+import no.nav.foreldrepenger.web.app.tjenester.forvaltning.ForvaltningStegRestTjeneste;
+import no.nav.foreldrepenger.web.app.tjenester.forvaltning.ForvaltningSvangerskapspengerRestTjeneste;
+import no.nav.foreldrepenger.web.app.tjenester.forvaltning.ForvaltningSøknadRestTjeneste;
+import no.nav.foreldrepenger.web.app.tjenester.forvaltning.ForvaltningTekniskRestTjeneste;
+import no.nav.foreldrepenger.web.app.tjenester.forvaltning.ForvaltningTilkjentYtelseRestTjeneste;
+import no.nav.foreldrepenger.web.app.tjenester.forvaltning.ForvaltningUttakRestTjeneste;
+import no.nav.foreldrepenger.web.app.tjenester.forvaltning.ForvaltningUttrekkRestTjeneste;
 import no.nav.foreldrepenger.web.app.tjenester.forvaltning.fpoversikt.FpoversiktMigreringRestTjeneste;
 import no.nav.foreldrepenger.web.app.tjenester.fpoversikt.FpOversiktRestTjeneste;
 import no.nav.foreldrepenger.web.app.tjenester.hendelser.HendelserRestTjeneste;
+import no.nav.foreldrepenger.web.app.tjenester.infotrygd.InfotrygdOppslagRestTjeneste;
 import no.nav.foreldrepenger.web.app.tjenester.kodeverk.KodeverkRestTjeneste;
 import no.nav.foreldrepenger.web.app.tjenester.los.LosRestTjeneste;
 import no.nav.foreldrepenger.web.app.tjenester.register.RedirectToRegisterRestTjeneste;
@@ -54,11 +72,6 @@ import no.nav.foreldrepenger.web.app.tjenester.vedtak.vedtakfattet.VedtakJsonFee
 import no.nav.foreldrepenger.web.server.abac.PipRestTjeneste;
 import no.nav.foreldrepenger.web.server.jetty.TimingFilter;
 import no.nav.vedtak.felles.prosesstask.rest.ProsessTaskRestTjeneste;
-
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.Set;
 
 public class RestImplementationClasses {
 
@@ -107,6 +120,9 @@ public class RestImplementationClasses {
         classes.add(BrevRestTjeneste.class);
         classes.add(LosRestTjeneste.class);
         classes.add(RedirectToRegisterRestTjeneste.class);
+
+        // Søk infotrygd
+        classes.add(InfotrygdOppslagRestTjeneste.class);
 
         // Formidlingstjenester
         classes.add(FormidlingRestTjeneste.class);

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/fagsak/FagsakRestTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/fagsak/FagsakRestTjeneste.java
@@ -42,6 +42,8 @@ import no.nav.foreldrepenger.behandlingslager.behandling.historikk.Historikkinns
 import no.nav.foreldrepenger.behandlingslager.fagsak.Fagsak;
 import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakEgenskapRepository;
 import no.nav.foreldrepenger.behandlingslager.fagsak.egenskaper.FagsakMarkering;
+import no.nav.foreldrepenger.domene.typer.AktørId;
+import no.nav.foreldrepenger.domene.typer.PersonIdent;
 import no.nav.foreldrepenger.domene.typer.Saksnummer;
 import no.nav.foreldrepenger.historikk.HistorikkInnslagTekstBuilder;
 import no.nav.foreldrepenger.produksjonsstyring.behandlingenhet.BehandlendeEnhetTjeneste;
@@ -182,9 +184,12 @@ public class FagsakRestTjeneste {
         public AbacDataAttributter apply(Object obj) {
             var req = (SokefeltDto) obj;
             var attributter = AbacDataAttributter.opprett();
-            if (req.getSearchString().length() == 13 /* guess - aktørId */) {
-                attributter.leggTil(AppAbacAttributtType.AKTØR_ID, req.getSearchString())
-                    .leggTil(AppAbacAttributtType.SAKER_FOR_AKTØR, req.getSearchString());
+            var søkestring = req.getSearchString() != null ? req.getSearchString().trim() : "";
+            if (AktørId.erGyldigAktørId(søkestring)) {
+                attributter.leggTil(AppAbacAttributtType.AKTØR_ID, søkestring)
+                    .leggTil(AppAbacAttributtType.SAKER_FOR_AKTØR, søkestring);
+            } else if (PersonIdent.erGyldigFnr(søkestring)) {
+                attributter.leggTil(AppAbacAttributtType.FNR, søkestring);
             } else {
                 attributter.leggTil(AppAbacAttributtType.SAKSNUMMER, req.getSearchString());
             }

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/infotrygd/InfotrygdOppslagRestTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/infotrygd/InfotrygdOppslagRestTjeneste.java
@@ -1,0 +1,144 @@
+package no.nav.foreldrepenger.web.app.tjenester.infotrygd;
+
+import java.net.HttpURLConnection;
+import java.net.SocketTimeoutException;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Function;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+import jakarta.validation.Valid;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.ProcessingException;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import no.nav.foreldrepenger.domene.typer.AktørId;
+import no.nav.foreldrepenger.domene.typer.PersonIdent;
+import no.nav.foreldrepenger.mottak.vedtak.rest.InfotrygdFPGrunnlag;
+import no.nav.foreldrepenger.mottak.vedtak.rest.InfotrygdSvpGrunnlag;
+import no.nav.foreldrepenger.web.app.tjenester.fagsak.dto.SokefeltDto;
+import no.nav.foreldrepenger.web.server.abac.AppAbacAttributtType;
+import no.nav.pdl.HentIdenterQueryRequest;
+import no.nav.pdl.IdentGruppe;
+import no.nav.pdl.IdentInformasjon;
+import no.nav.pdl.IdentInformasjonResponseProjection;
+import no.nav.pdl.IdentlisteResponseProjection;
+import no.nav.vedtak.exception.IntegrasjonException;
+import no.nav.vedtak.exception.VLException;
+import no.nav.vedtak.felles.integrasjon.infotrygd.grunnlag.v1.respons.Grunnlag;
+import no.nav.vedtak.felles.integrasjon.person.Persondata;
+import no.nav.vedtak.sikkerhet.abac.AbacDataAttributter;
+import no.nav.vedtak.sikkerhet.abac.BeskyttetRessurs;
+import no.nav.vedtak.sikkerhet.abac.TilpassetAbacAttributt;
+import no.nav.vedtak.sikkerhet.abac.beskyttet.ActionType;
+import no.nav.vedtak.sikkerhet.abac.beskyttet.ResourceType;
+
+@Path(InfotrygdOppslagRestTjeneste.BASE_PATH)
+@ApplicationScoped
+@Transactional
+public class InfotrygdOppslagRestTjeneste {
+
+    private static final Logger LOG = LoggerFactory.getLogger(InfotrygdOppslagRestTjeneste.class);
+
+    private static final LocalDate FOM = LocalDate.of(2000, 1,1);
+
+    static final String BASE_PATH = "/infotrygd";
+    private static final String INFOTRYGD_SOK_PART_PATH = "/sok";
+    public static final String INFOTRYGD_SOK_PATH = BASE_PATH + INFOTRYGD_SOK_PART_PATH;
+
+    private Persondata pdlKlient;
+    private InfotrygdFPGrunnlag foreldrepenger;
+    private InfotrygdSvpGrunnlag svangerskapspenger;
+
+    public InfotrygdOppslagRestTjeneste() {
+        // For Rest-CDI
+    }
+
+    @Inject
+    public InfotrygdOppslagRestTjeneste(Persondata pdlKlient,
+                                        InfotrygdFPGrunnlag foreldrepenger,
+                                        InfotrygdSvpGrunnlag svangerskapspenger) {
+        this.pdlKlient = pdlKlient;
+        this.foreldrepenger = foreldrepenger;
+        this.svangerskapspenger = svangerskapspenger;
+    }
+
+    @POST
+    @Path(INFOTRYGD_SOK_PART_PATH)
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    @Operation(description = "Søk etter utbetalinger i Infotrygd for fødselsnummer", tags = "infotrygd",
+        summary = "Oversikt over utbetalinger knyttet til en bruker kan søkes via fødselsnummer eller d-nummer.")
+    @BeskyttetRessurs(actionType = ActionType.READ, resourceType = ResourceType.FAGSAK)
+    public Response sokInfotrygd(@TilpassetAbacAttributt(supplierClass = SøkeFeltAbacDataSupplier.class)
+        @Parameter(description = "Søkestreng kan være aktørId, fødselsnummer eller D-nummer.") @Valid SokefeltDto søkestreng) {
+        var trimmed = søkestreng.getSearchString() != null ? søkestreng.getSearchString().trim() : "";
+        var ident = PersonIdent.erGyldigFnr(trimmed) || AktørId.erGyldigAktørId(trimmed) ? trimmed : null;
+        if (ident == null) {
+            return Response.status(HttpURLConnection.HTTP_BAD_REQUEST).build();
+        }
+        var identer = finnAlleHistoriskeFødselsnummer(ident);
+        if (identer.isEmpty()) {
+            return Response.status(HttpURLConnection.HTTP_NOT_FOUND).build();
+        }
+        List<Grunnlag> grunnlagene = new ArrayList<>();
+        identer.forEach(i -> {
+            // Ser på Dtos senere. Først må vi utforske litt innhold via swagger.
+            grunnlagene.addAll(foreldrepenger.hentGrunnlagFailSoft(i, FOM, LocalDate.now()));
+            grunnlagene.addAll(svangerskapspenger.hentGrunnlagFailSoft(i, FOM, LocalDate.now()));
+        });
+        return Response.ok(grunnlagene).build();
+    }
+
+    private List<String> finnAlleHistoriskeFødselsnummer(String inputIdent) {
+        var request = new HentIdenterQueryRequest();
+        request.setIdent(inputIdent);
+        request.setGrupper(List.of(IdentGruppe.FOLKEREGISTERIDENT));
+        request.setHistorikk(Boolean.TRUE);
+        var projection = new IdentlisteResponseProjection()
+            .identer(new IdentInformasjonResponseProjection().ident());
+
+        try {
+            var identliste = pdlKlient.hentIdenter(request, projection);
+            return identliste.getIdenter().stream().map(IdentInformasjon::getIdent).toList();
+        } catch (VLException v) {
+            if (Persondata.PDL_KLIENT_NOT_FOUND_KODE.equals(v.getKode())) {
+                return List.of();
+            }
+            throw v;
+        } catch (ProcessingException e) {
+            throw e.getCause() instanceof SocketTimeoutException ? new IntegrasjonException("FP-723618", "PDL timeout") : e;
+        }
+    }
+
+    public static class SøkeFeltAbacDataSupplier implements Function<Object, AbacDataAttributter> {
+
+        @Override
+        public AbacDataAttributter apply(Object obj) {
+            var req = (SokefeltDto) obj;
+            var attributter = AbacDataAttributter.opprett();
+            var søkestring = req.getSearchString() != null ? req.getSearchString().trim() : "";
+            if (søkestring.length() == 13 /* guess - aktørId */) {
+                attributter.leggTil(AppAbacAttributtType.AKTØR_ID, søkestring)
+                    .leggTil(AppAbacAttributtType.SAKER_FOR_AKTØR, søkestring);
+            } else if (søkestring.length() == 11 /* guess - FNR */) {
+                attributter.leggTil(AppAbacAttributtType.FNR, søkestring);
+            }
+            return attributter;
+        }
+    }
+
+
+}

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/saksbehandler/InitielleLinksRestTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/saksbehandler/InitielleLinksRestTjeneste.java
@@ -1,6 +1,11 @@
 package no.nav.foreldrepenger.web.app.tjenester.saksbehandler;
 
-import io.swagger.v3.oas.annotations.Operation;
+import static no.nav.foreldrepenger.web.app.rest.ResourceLinks.get;
+import static no.nav.foreldrepenger.web.app.rest.ResourceLinks.post;
+
+import java.util.ArrayList;
+import java.util.List;
+
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
@@ -9,23 +14,20 @@ import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
+
+import io.swagger.v3.oas.annotations.Operation;
 import no.nav.foreldrepenger.produksjonsstyring.behandlingenhet.BehandlendeEnhetTjeneste;
 import no.nav.foreldrepenger.tilganger.TilgangerTjeneste;
 import no.nav.foreldrepenger.web.app.rest.ResourceLink;
 import no.nav.foreldrepenger.web.app.tjenester.dokument.DokumentRestTjeneste;
 import no.nav.foreldrepenger.web.app.tjenester.fagsak.FagsakRestTjeneste;
+import no.nav.foreldrepenger.web.app.tjenester.infotrygd.InfotrygdOppslagRestTjeneste;
 import no.nav.foreldrepenger.web.app.tjenester.kodeverk.KodeverkRestTjeneste;
 import no.nav.foreldrepenger.web.app.tjenester.register.RedirectToRegisterRestTjeneste;
 import no.nav.foreldrepenger.web.app.tjenester.saksbehandler.dto.InitLinksDto;
 import no.nav.vedtak.sikkerhet.abac.BeskyttetRessurs;
 import no.nav.vedtak.sikkerhet.abac.beskyttet.ActionType;
 import no.nav.vedtak.sikkerhet.abac.beskyttet.ResourceType;
-
-import java.util.ArrayList;
-import java.util.List;
-
-import static no.nav.foreldrepenger.web.app.rest.ResourceLinks.get;
-import static no.nav.foreldrepenger.web.app.rest.ResourceLinks.post;
 
 @Path("/init-fetch")
 @ApplicationScoped
@@ -60,6 +62,7 @@ public class InitielleLinksRestTjeneste {
         saklenker.add(post(FagsakRestTjeneste.NOTAT_PATH, "lagre-notat"));
         saklenker.add(get(RedirectToRegisterRestTjeneste.AAREG_REG_PATH, "arbeidstaker-redirect"));
         saklenker.add(get(RedirectToRegisterRestTjeneste.AINNTEKT_REG_PATH, "ainntekt-redirect"));
+        saklenker.add(get(InfotrygdOppslagRestTjeneste.INFOTRYGD_SOK_PATH, "infotrygd-søk"));
         return new InitLinksDto(tilgangerTjeneste.innloggetBruker(), BehandlendeEnhetTjeneste.hentEnhetListe(), lenkene, saklenker);
     }
 

--- a/web/src/main/resources/application-dev-fss.properties
+++ b/web/src/main/resources/application-dev-fss.properties
@@ -37,6 +37,9 @@ arbeid.og.inntekt.base.url=https://arbeid-og-inntekt.dev.adeo.no
 fpsak.it.ps.scopes=api://dev-fss.k9saksbehandling.k9-infotrygd-grunnlag-paaroerende-sykdom/.default
 fpsak.it.sp.scopes=api://dev-fss.infotrygd.infotrygd-sykepenger-fp/.default
 
+fpsak.it.fp.scopes=api://dev-fss.teamforeldrepenger.fp-infotrygd-foreldrepenger/.default
+fpsak.it.sv.scopes=api://dev-fss.teamforeldrepenger.fp-infotrygd-svangerskapspenger/.default
+
 # Kabal
 kabal.api.scopes=api://dev-gcp.klage.kabal-api/.default
 kabal.api.url=https://kabal-api.intern.dev.nav.no/api/oversendelse/v3/sak

--- a/web/src/main/resources/application-prod-fss.properties
+++ b/web/src/main/resources/application-prod-fss.properties
@@ -37,6 +37,9 @@ arbeid.og.inntekt.base.url=https://arbeid-og-inntekt.nais.adeo.no
 fpsak.it.ps.scopes=api://prod-fss.k9saksbehandling.k9-infotrygd-grunnlag-paaroerende-sykdom/.default
 fpsak.it.sp.scopes=api://prod-fss.infotrygd.infotrygd-sykepenger-fp/.default
 
+fpsak.it.fp.scopes=api://prod-fss.teamforeldrepenger.fp-infotrygd-foreldrepenger/.default
+fpsak.it.sv.scopes=api://prod-fss.teamforeldrepenger.fp-infotrygd-svangerskapspenger/.default
+
 # Kabal
 kabal.api.scopes=api://prod-gcp.klage.kabal-api/.default
 kabal.api.url=https://kabal-api.intern.nav.no/api/oversendelse/v3/sak

--- a/web/src/main/resources/application.properties
+++ b/web/src/main/resources/application.properties
@@ -41,6 +41,10 @@ kafka.personoversikt.topic=personoversikt.modia-soknadsstatus-hendelse
 fpsak.it.sp.grunnlag.url=http://infotrygd-sykepenger-fp.infotrygd/grunnlag
 fpsak.it.ps.grunnlag.url=http://k9-infotrygd-grunnlag-paaroerende-sykdom.k9saksbehandling/paaroerendeSykdom/grunnlag
 
+# Oppslag av grunnlag fra infotrygd replika
+fpsak.it.fp.grunnlag.url=http://fp-infotrygd-foreldrepenger/grunnlag
+fpsak.it.sv.grunnlag.url=http://fp-infotrygd-svangerskapspenger/grunnlag
+
 # Kommaseparert liste med systembrukere som skal ha tilgang til ABAC PIP tjenester
 pip.users = srvfplos,srvfpformidling,srvfptilbake,srvfpoppdrag,srvsaf
 


### PR DESCRIPTION
Lenken blir 'infotrygd-søk'.
Tar en input på 11 eller 13 tegn og returnerer liste av grunnlag.
Skal få PL til å teste ut med swagger før vi lander Dtos. 
Grunnlag-klassen ligger i fp-felles.
@mrsladek hjelper du med å få opp fp-infotrygd-foreldrepenger og fp-infotrygd-svangerskapspenger i prod og dev ?
Gjør AzureCC og lener meg på ABAC på søke-endepunktet