### PR TITLE
Spre fagsakavslutning utover noen timer

### DIFF
--- a/domenetjenester/produksjonsstyring/src/main/java/no/nav/foreldrepenger/produksjonsstyring/fagsakstatus/OppdaterFagsakStatusTjeneste.java
+++ b/domenetjenester/produksjonsstyring/src/main/java/no/nav/foreldrepenger/produksjonsstyring/fagsakstatus/OppdaterFagsakStatusTjeneste.java
@@ -1,5 +1,7 @@
 package no.nav.foreldrepenger.produksjonsstyring.fagsakstatus;
 
+import java.util.Objects;
+
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 
@@ -142,6 +144,9 @@ public class OppdaterFagsakStatusTjeneste {
 
     private void oppdaterFagsakStatus(Fagsak fagsak, Long behandlingId, FagsakStatus nyStatus) {
         var gammelStatus = fagsak.getStatus();
+        if (Objects.equals(gammelStatus, nyStatus)) {
+            return;
+        }
         var fagsakId = fagsak.getId();
         fagsakRepository.oppdaterFagsakStatus(fagsakId, nyStatus);
 

--- a/domenetjenester/vedtak/src/main/java/no/nav/foreldrepenger/domene/vedtak/batch/AutomatiskFagsakAvslutningTjeneste.java
+++ b/domenetjenester/vedtak/src/main/java/no/nav/foreldrepenger/domene/vedtak/batch/AutomatiskFagsakAvslutningTjeneste.java
@@ -10,6 +10,8 @@ import no.nav.vedtak.felles.prosesstask.api.ProsessTaskTjeneste;
 import no.nav.vedtak.log.mdc.MDCOperations;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.UUID;
 
 @ApplicationScoped
@@ -35,17 +37,22 @@ public class AutomatiskFagsakAvslutningTjeneste {
         var callId = MDCOperations.getCallId();
         callId = (callId == null ? MDCOperations.generateCallId() : callId) + "_";
 
+        var dato = LocalDate.now();
+        var baseline = LocalTime.now();
+
         for (var fagsak : fagsaker) {
             var nyCallId = callId + fagsak.getId();
-            var task = opprettFagsakAvslutningTask(fagsak, nyCallId);
+            var task = opprettFagsakAvslutningTask(fagsak, nyCallId, dato, baseline, 10799); // Spre kjøring utover 3 timer
             taskTjeneste.lagre(task);
         }
         return batchname + "-" + UUID.randomUUID().toString();
     }
 
-    private ProsessTaskData opprettFagsakAvslutningTask(Fagsak fagsak, String callId) {
+    private ProsessTaskData opprettFagsakAvslutningTask(Fagsak fagsak, String callId, LocalDate dato, LocalTime tid, int spread) {
+        var nesteKjøring = LocalDateTime.of(dato, tid.plusSeconds(Math.abs(System.nanoTime()) % spread));
         var prosessTaskData = ProsessTaskData.forProsessTask(AutomatiskFagsakAvslutningTask.class);
         prosessTaskData.setFagsak(fagsak.getId(), fagsak.getAktørId().getId());
+        prosessTaskData.setNesteKjøringEtter(nesteKjøring);
         prosessTaskData.setPrioritet(100);
         // unik per task da det er ulike tasks for hver behandling
         prosessTaskData.setCallId(callId);

--- a/domenetjenester/vedtak/src/main/java/no/nav/foreldrepenger/domene/vedtak/intern/fp/FpUtledeAvslutningsdato.java
+++ b/domenetjenester/vedtak/src/main/java/no/nav/foreldrepenger/domene/vedtak/intern/fp/FpUtledeAvslutningsdato.java
@@ -140,7 +140,8 @@ public class FpUtledeAvslutningsdato implements UtledeAvslutningsdatoFagsak {
     }
 
     private LocalDate leggPåSøknadsfristMåneder(LocalDate fraDato) {
-        return fraDato.plusMonths(SØKNADSFRIST_I_MÅNEDER).with(TemporalAdjusters.lastDayOfMonth());
+        var padding = System.nanoTime() % 13;
+        return fraDato.plusMonths(SØKNADSFRIST_I_MÅNEDER).with(TemporalAdjusters.lastDayOfMonth()).plusDays(padding);
     }
 
     private static LocalDate leggPåMaksSøknadsfrist(LocalDate fraDato) {

--- a/domenetjenester/vedtak/src/main/java/no/nav/foreldrepenger/domene/vedtak/intern/fp/FpUtledeAvslutningsdato.java
+++ b/domenetjenester/vedtak/src/main/java/no/nav/foreldrepenger/domene/vedtak/intern/fp/FpUtledeAvslutningsdato.java
@@ -32,6 +32,7 @@ import java.util.Optional;
 public class FpUtledeAvslutningsdato implements UtledeAvslutningsdatoFagsak {
 
     private static final int SØKNADSFRIST_I_MÅNEDER = 3;
+    static final int PADDING = 13;
 
     private final FagsakRelasjonTjeneste fagsakRelasjonTjeneste;
     private final BehandlingRepository behandlingRepository;
@@ -140,7 +141,8 @@ public class FpUtledeAvslutningsdato implements UtledeAvslutningsdatoFagsak {
     }
 
     private LocalDate leggPåSøknadsfristMåneder(LocalDate fraDato) {
-        var padding = System.nanoTime() % 13;
+        // Lastbalansering
+        var padding = System.nanoTime() % PADDING;
         return fraDato.plusMonths(SØKNADSFRIST_I_MÅNEDER).with(TemporalAdjusters.lastDayOfMonth()).plusDays(padding);
     }
 

--- a/domenetjenester/vedtak/src/main/java/no/nav/foreldrepenger/domene/vedtak/intern/svp/SvpUtledeAvslutningsdato.java
+++ b/domenetjenester/vedtak/src/main/java/no/nav/foreldrepenger/domene/vedtak/intern/svp/SvpUtledeAvslutningsdato.java
@@ -24,6 +24,8 @@ public class SvpUtledeAvslutningsdato implements UtledeAvslutningsdatoFagsak {
     private BehandlingRepository behandlingRepository;
     private static final int SØKNADSFRIST_I_MÅNEDER = 3;
 
+    static final int PADDING = 13;
+
     private UttakInputTjeneste uttakInputTjeneste;
     private MaksDatoUttakTjeneste maksDatoUttakTjeneste;
 
@@ -66,7 +68,8 @@ public class SvpUtledeAvslutningsdato implements UtledeAvslutningsdatoFagsak {
     }
 
     private LocalDate leggPåSøknadsfrist(LocalDate sisteUttaksdato) {
-        var padding = System.nanoTime() % 13;
+        // Lastbalansering
+        var padding = System.nanoTime() % PADDING;
         return sisteUttaksdato.plusMonths(SØKNADSFRIST_I_MÅNEDER).with(TemporalAdjusters.lastDayOfMonth()).plusDays(padding);
     }
 }

--- a/domenetjenester/vedtak/src/main/java/no/nav/foreldrepenger/domene/vedtak/intern/svp/SvpUtledeAvslutningsdato.java
+++ b/domenetjenester/vedtak/src/main/java/no/nav/foreldrepenger/domene/vedtak/intern/svp/SvpUtledeAvslutningsdato.java
@@ -66,7 +66,8 @@ public class SvpUtledeAvslutningsdato implements UtledeAvslutningsdatoFagsak {
     }
 
     private LocalDate leggPåSøknadsfrist(LocalDate sisteUttaksdato) {
-        return sisteUttaksdato.plusMonths(SØKNADSFRIST_I_MÅNEDER).with(TemporalAdjusters.lastDayOfMonth());
+        var padding = System.nanoTime() % 13;
+        return sisteUttaksdato.plusMonths(SØKNADSFRIST_I_MÅNEDER).with(TemporalAdjusters.lastDayOfMonth()).plusDays(padding);
     }
 }
 

--- a/domenetjenester/vedtak/src/test/java/no/nav/foreldrepenger/domene/vedtak/intern/fp/FpUtledeAvslutningsdatoTest.java
+++ b/domenetjenester/vedtak/src/test/java/no/nav/foreldrepenger/domene/vedtak/intern/fp/FpUtledeAvslutningsdatoTest.java
@@ -39,6 +39,7 @@ import java.time.temporal.TemporalAdjusters;
 import java.util.List;
 import java.util.Optional;
 
+import static no.nav.foreldrepenger.domene.vedtak.intern.fp.FpUtledeAvslutningsdato.PADDING;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -51,7 +52,7 @@ class FpUtledeAvslutningsdatoTest {
     private FpUtledeAvslutningsdato fpUtledeAvslutningsdato;
     private static final int SØKNADSFRIST_I_MÅNEDER = 3;
 
-    @Inject
+    @Mock
     private BehandlingRepositoryProvider repositoryProvider;
 
     @Mock
@@ -85,7 +86,6 @@ class FpUtledeAvslutningsdatoTest {
         var maksDatoUttakTjeneste = new MaksDatoUttakTjenesteImpl(fpUttakRepository,
             stønadskontoSaldoTjeneste);
 
-        repositoryProvider = mock(BehandlingRepositoryProvider.class);
         var fagsakLåsRepository = mock(FagsakLåsRepository.class);
         when(repositoryProvider.getBehandlingRepository()).thenReturn(behandlingRepository);
         when(repositoryProvider.getBehandlingsresultatRepository()).thenReturn(behandlingsresultatRepository);
@@ -145,9 +145,7 @@ class FpUtledeAvslutningsdatoTest {
         var forventetAvslutningsdatoMin = dødsdato.plusDays(1)
             .plusWeeks(UttakParametre.ukerTilgjengeligEtterDødsfall(LocalDate.now()))
             .plusMonths(SØKNADSFRIST_I_MÅNEDER).with(TemporalAdjusters.lastDayOfMonth());
-        var forventetAvslutningsdatoMax = dødsdato.plusDays(1)
-            .plusWeeks(UttakParametre.ukerTilgjengeligEtterDødsfall(LocalDate.now()))
-            .plusMonths(SØKNADSFRIST_I_MÅNEDER).with(TemporalAdjusters.lastDayOfMonth()).plusDays(12);
+        var forventetAvslutningsdatoMax = forventetAvslutningsdatoMin.plusDays(PADDING-1);
 
         // Act and assert
         assertThat(fpUtledeAvslutningsdato.utledAvslutningsdato(fagsak.getId(), fagsakRelasjon)).isBetween(forventetAvslutningsdatoMin, forventetAvslutningsdatoMax);
@@ -209,7 +207,7 @@ class FpUtledeAvslutningsdatoTest {
         when(stønadskontoSaldoTjeneste.finnStønadRest(saldoUtregning)).thenReturn(0);
 
         var forventetAvslutningsdatoMin = VirkedagUtil.tomVirkedag(periodeAvsluttetDato).plusDays(1).plusMonths(SØKNADSFRIST_I_MÅNEDER).with(TemporalAdjusters.lastDayOfMonth());
-        var forventetAvslutningsdatoMax = VirkedagUtil.tomVirkedag(periodeAvsluttetDato).plusDays(1).plusMonths(SØKNADSFRIST_I_MÅNEDER).with(TemporalAdjusters.lastDayOfMonth()).plusDays(12);
+        var forventetAvslutningsdatoMax = forventetAvslutningsdatoMin.plusDays(PADDING-1);
         // Act and assert
         assertThat(fpUtledeAvslutningsdato.utledAvslutningsdato(fagsak.getId(), fagsakRelasjon)).isBetween(forventetAvslutningsdatoMin, forventetAvslutningsdatoMax);
     }
@@ -243,7 +241,7 @@ class FpUtledeAvslutningsdatoTest {
         when(stønadskontoSaldoTjeneste.finnStønadRest(saldoUtregning)).thenReturn(0);
 
         var forventetAvslutningsdatoMin = VirkedagUtil.tomVirkedag(periodeAvsluttetDato).plusDays(1).plusMonths(SØKNADSFRIST_I_MÅNEDER).with(TemporalAdjusters.lastDayOfMonth());
-        var forventetAvslutningsdatoMax = VirkedagUtil.tomVirkedag(periodeAvsluttetDato).plusDays(1).plusMonths(SØKNADSFRIST_I_MÅNEDER).with(TemporalAdjusters.lastDayOfMonth()).plusDays(12);
+        var forventetAvslutningsdatoMax = forventetAvslutningsdatoMin.plusDays(PADDING-1);
         // Act and assert
         assertThat(fpUtledeAvslutningsdato.utledAvslutningsdato(fagsak.getId(), fagsakRelasjon)).isBetween(forventetAvslutningsdatoMin, forventetAvslutningsdatoMax);
     }
@@ -275,7 +273,7 @@ class FpUtledeAvslutningsdatoTest {
         when(stønadskontoSaldoTjeneste.finnStønadRest(saldoUtregning)).thenReturn(0);
 
         var forventetAvslutningsdatoMin = VirkedagUtil.tomVirkedag(periodeAvsluttetDato).plusDays(1).plusMonths(SØKNADSFRIST_I_MÅNEDER).with(TemporalAdjusters.lastDayOfMonth());
-        var forventetAvslutningsdatoMax = VirkedagUtil.tomVirkedag(periodeAvsluttetDato).plusDays(1).plusMonths(SØKNADSFRIST_I_MÅNEDER).with(TemporalAdjusters.lastDayOfMonth()).plusDays(12);
+        var forventetAvslutningsdatoMax = forventetAvslutningsdatoMin.plusDays(PADDING-1);
         // Act and assert
         assertThat(fpUtledeAvslutningsdato.utledAvslutningsdato(fagsak.getId(), fagsakRelasjon)).isBetween(forventetAvslutningsdatoMin, forventetAvslutningsdatoMax);
     }
@@ -353,7 +351,7 @@ class FpUtledeAvslutningsdatoTest {
         when(saldoUtregning.restSaldoEtterNesteStønadsperiode()).thenReturn(trekkdager);
 
         var forventetAvslutningsdatoMin = fødselsdatoNyttBarn.plusMonths(3).with(TemporalAdjusters.lastDayOfMonth()).with(TemporalAdjusters.lastDayOfMonth());
-        var forventetAvslutningsdatoMax = fødselsdatoNyttBarn.plusMonths(3).with(TemporalAdjusters.lastDayOfMonth()).plusDays(12);
+        var forventetAvslutningsdatoMax = forventetAvslutningsdatoMin.plusDays(PADDING-1);
         // Act and assert
         assertThat(fpUtledeAvslutningsdato.utledAvslutningsdato(fagsak.getId(), fagsakRelasjon)).isBetween(forventetAvslutningsdatoMin, forventetAvslutningsdatoMax);
     }

--- a/domenetjenester/vedtak/src/test/java/no/nav/foreldrepenger/domene/vedtak/intern/fp/FpUtledeAvslutningsdatoTest.java
+++ b/domenetjenester/vedtak/src/test/java/no/nav/foreldrepenger/domene/vedtak/intern/fp/FpUtledeAvslutningsdatoTest.java
@@ -142,12 +142,15 @@ class FpUtledeAvslutningsdatoTest {
         when(uttakInputTjeneste.lagInput(any(Behandling.class))).thenReturn(
             new UttakInput(BehandlingReferanse.fra(behandling, stp.build()), null, ytelsespesifiktGrunnlag));
 
-        var forventetAvslutningsdato = dødsdato.plusDays(1)
+        var forventetAvslutningsdatoMin = dødsdato.plusDays(1)
             .plusWeeks(UttakParametre.ukerTilgjengeligEtterDødsfall(LocalDate.now()))
             .plusMonths(SØKNADSFRIST_I_MÅNEDER).with(TemporalAdjusters.lastDayOfMonth());
+        var forventetAvslutningsdatoMax = dødsdato.plusDays(1)
+            .plusWeeks(UttakParametre.ukerTilgjengeligEtterDødsfall(LocalDate.now()))
+            .plusMonths(SØKNADSFRIST_I_MÅNEDER).with(TemporalAdjusters.lastDayOfMonth()).plusDays(12);
 
         // Act and assert
-        assertThat(fpUtledeAvslutningsdato.utledAvslutningsdato(fagsak.getId(), fagsakRelasjon)).isEqualTo(forventetAvslutningsdato);
+        assertThat(fpUtledeAvslutningsdato.utledAvslutningsdato(fagsak.getId(), fagsakRelasjon)).isBetween(forventetAvslutningsdatoMin, forventetAvslutningsdatoMax);
     }
 
     @Test
@@ -205,9 +208,10 @@ class FpUtledeAvslutningsdatoTest {
         when(saldoUtregning.saldo(any(Stønadskontotype.class))).thenReturn(0);
         when(stønadskontoSaldoTjeneste.finnStønadRest(saldoUtregning)).thenReturn(0);
 
-        var forventetAvslutningsdato = VirkedagUtil.tomVirkedag(periodeAvsluttetDato).plusDays(1).plusMonths(SØKNADSFRIST_I_MÅNEDER).with(TemporalAdjusters.lastDayOfMonth());
+        var forventetAvslutningsdatoMin = VirkedagUtil.tomVirkedag(periodeAvsluttetDato).plusDays(1).plusMonths(SØKNADSFRIST_I_MÅNEDER).with(TemporalAdjusters.lastDayOfMonth());
+        var forventetAvslutningsdatoMax = VirkedagUtil.tomVirkedag(periodeAvsluttetDato).plusDays(1).plusMonths(SØKNADSFRIST_I_MÅNEDER).with(TemporalAdjusters.lastDayOfMonth()).plusDays(12);
         // Act and assert
-        assertThat(fpUtledeAvslutningsdato.utledAvslutningsdato(fagsak.getId(), fagsakRelasjon)).isEqualTo(forventetAvslutningsdato);
+        assertThat(fpUtledeAvslutningsdato.utledAvslutningsdato(fagsak.getId(), fagsakRelasjon)).isBetween(forventetAvslutningsdatoMin, forventetAvslutningsdatoMax);
     }
 
     @Test
@@ -238,9 +242,10 @@ class FpUtledeAvslutningsdatoTest {
         when(saldoUtregning.saldo(any(Stønadskontotype.class))).thenReturn(0);
         when(stønadskontoSaldoTjeneste.finnStønadRest(saldoUtregning)).thenReturn(0);
 
-        var forventetAvslutningsdato = VirkedagUtil.tomVirkedag(periodeAvsluttetDato).plusDays(1).plusMonths(SØKNADSFRIST_I_MÅNEDER).with(TemporalAdjusters.lastDayOfMonth());
+        var forventetAvslutningsdatoMin = VirkedagUtil.tomVirkedag(periodeAvsluttetDato).plusDays(1).plusMonths(SØKNADSFRIST_I_MÅNEDER).with(TemporalAdjusters.lastDayOfMonth());
+        var forventetAvslutningsdatoMax = VirkedagUtil.tomVirkedag(periodeAvsluttetDato).plusDays(1).plusMonths(SØKNADSFRIST_I_MÅNEDER).with(TemporalAdjusters.lastDayOfMonth()).plusDays(12);
         // Act and assert
-        assertThat(fpUtledeAvslutningsdato.utledAvslutningsdato(fagsak.getId(), fagsakRelasjon)).isEqualTo(forventetAvslutningsdato);
+        assertThat(fpUtledeAvslutningsdato.utledAvslutningsdato(fagsak.getId(), fagsakRelasjon)).isBetween(forventetAvslutningsdatoMin, forventetAvslutningsdatoMax);
     }
 
     @Test
@@ -269,9 +274,10 @@ class FpUtledeAvslutningsdatoTest {
         when(saldoUtregning.saldo(any(Stønadskontotype.class))).thenReturn(0);
         when(stønadskontoSaldoTjeneste.finnStønadRest(saldoUtregning)).thenReturn(0);
 
-        var forventetAvslutningsdato = VirkedagUtil.tomVirkedag(periodeAvsluttetDato).plusDays(1).plusMonths(SØKNADSFRIST_I_MÅNEDER).with(TemporalAdjusters.lastDayOfMonth());
+        var forventetAvslutningsdatoMin = VirkedagUtil.tomVirkedag(periodeAvsluttetDato).plusDays(1).plusMonths(SØKNADSFRIST_I_MÅNEDER).with(TemporalAdjusters.lastDayOfMonth());
+        var forventetAvslutningsdatoMax = VirkedagUtil.tomVirkedag(periodeAvsluttetDato).plusDays(1).plusMonths(SØKNADSFRIST_I_MÅNEDER).with(TemporalAdjusters.lastDayOfMonth()).plusDays(12);
         // Act and assert
-        assertThat(fpUtledeAvslutningsdato.utledAvslutningsdato(fagsak.getId(), fagsakRelasjon)).isEqualTo(forventetAvslutningsdato);
+        assertThat(fpUtledeAvslutningsdato.utledAvslutningsdato(fagsak.getId(), fagsakRelasjon)).isBetween(forventetAvslutningsdatoMin, forventetAvslutningsdatoMax);
     }
 
     @Test
@@ -346,10 +352,10 @@ class FpUtledeAvslutningsdatoTest {
         var trekkdager = new Trekkdager(0);
         when(saldoUtregning.restSaldoEtterNesteStønadsperiode()).thenReturn(trekkdager);
 
-        var forventetAvslutningsdato = fødselsdatoNyttBarn.plusMonths(3).with(TemporalAdjusters.lastDayOfMonth());
-
-        // Assert and act
-        assertThat(fpUtledeAvslutningsdato.utledAvslutningsdato(fagsak.getId(), fagsakRelasjon)).isEqualTo(forventetAvslutningsdato);
+        var forventetAvslutningsdatoMin = fødselsdatoNyttBarn.plusMonths(3).with(TemporalAdjusters.lastDayOfMonth()).with(TemporalAdjusters.lastDayOfMonth());
+        var forventetAvslutningsdatoMax = fødselsdatoNyttBarn.plusMonths(3).with(TemporalAdjusters.lastDayOfMonth()).plusDays(12);
+        // Act and assert
+        assertThat(fpUtledeAvslutningsdato.utledAvslutningsdato(fagsak.getId(), fagsakRelasjon)).isBetween(forventetAvslutningsdatoMin, forventetAvslutningsdatoMax);
     }
 
     @Test

--- a/domenetjenester/vedtak/src/test/java/no/nav/foreldrepenger/domene/vedtak/intern/svp/SvpUtledeAvslutningsdatoTest.java
+++ b/domenetjenester/vedtak/src/test/java/no/nav/foreldrepenger/domene/vedtak/intern/svp/SvpUtledeAvslutningsdatoTest.java
@@ -90,9 +90,11 @@ class SvpUtledeAvslutningsdatoTest {
 
         // Act
         var avslutningdato = utledeAvslutningsdato.utledAvslutningsdato(fagsak.getId(),fagsakRelasjon);
+        var forventetMin = sisteUttaksdato.plusDays(1).plusMonths(KLAGEFRIST_I_MÅNEDER).with(TemporalAdjusters.lastDayOfMonth());
+        var forventetMax = forventetMin.plusDays(12);
 
         // Assert
-        assertThat(avslutningdato).isEqualTo(sisteUttaksdato.plusDays(1).plusMonths(KLAGEFRIST_I_MÅNEDER).with(TemporalAdjusters.lastDayOfMonth()));
+        assertThat(avslutningdato).isBetween(forventetMin, forventetMax);
 
     }
 

--- a/domenetjenester/vedtak/src/test/java/no/nav/foreldrepenger/domene/vedtak/intern/svp/SvpUtledeAvslutningsdatoTest.java
+++ b/domenetjenester/vedtak/src/test/java/no/nav/foreldrepenger/domene/vedtak/intern/svp/SvpUtledeAvslutningsdatoTest.java
@@ -30,6 +30,7 @@ import java.time.LocalDate;
 import java.time.temporal.TemporalAdjusters;
 import java.util.Optional;
 
+import static no.nav.foreldrepenger.domene.vedtak.intern.svp.SvpUtledeAvslutningsdato.PADDING;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -91,7 +92,7 @@ class SvpUtledeAvslutningsdatoTest {
         // Act
         var avslutningdato = utledeAvslutningsdato.utledAvslutningsdato(fagsak.getId(),fagsakRelasjon);
         var forventetMin = sisteUttaksdato.plusDays(1).plusMonths(KLAGEFRIST_I_MÅNEDER).with(TemporalAdjusters.lastDayOfMonth());
-        var forventetMax = forventetMin.plusDays(12);
+        var forventetMax = forventetMin.plusDays(PADDING-1);
 
         // Assert
         assertThat(avslutningdato).isBetween(forventetMin, forventetMax);


### PR DESCRIPTION
Det opprettes mange tusen tasks første dag i måneden. Denne sprer kjøringen utover flere timer på formiddagen.
Denne sjekken på uendret status kan evt flyttes ned til eventpublisher dersom man er usikker.