### PR TITLE
TFP-5640 ulike klassekoder for feriepenger til bruker

### DIFF
--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/økonomioppdrag/Oppdragslinje150.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/økonomioppdrag/Oppdragslinje150.java
@@ -133,6 +133,11 @@ public class Oppdragslinje150 extends BaseCreateableEntitet {
         return kodeKlassifik;
     }
 
+    // Kun testformål for å sjekke ett tilfelle av migrering
+    public void setKodeKlassifik(KodeKlassifik kodeKlassifik) {
+        this.kodeKlassifik = kodeKlassifik;
+    }
+
     public LocalDate getDatoVedtakFom() {
         return vedtakPeriode.getFomDato();
     }

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/økonomioppdrag/koder/KodeKlassifik.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/økonomioppdrag/koder/KodeKlassifik.java
@@ -14,8 +14,10 @@ public enum KodeKlassifik {
     //Engangsstønad adopsjon
     ES_ADOPSJON("FPENAD-OP"),
 
-    //Feriepenger både FP adopsjon, fødsel og SVP
-    FERIEPENGER_BRUKER("FPATFER"), // Bruker - Feriepenger.
+    //Feriepenger til bruker
+    FERIEPENGER_BRUKER("FPATFER"), // både FP adopsjon, fødsel og SVP for opptjening tom 2022 / utbetaling 2023. Fødsel fom opptjeningsår 2023
+    FPA_FERIEPENGER_BRUKER("FPADATFER"), // Bruker - Feriepenger. Adopsjon fom opptjeningsår 2023
+    SVP_FERIEPENGER_BRUKER("FPSVATFER"), // Bruker - Feriepenger. Adopsjon fom opptjeningsår 2023
 
     //Fødsel
     FPF_ARBEIDSTAKER("FPATORD"), // FP (foreldrepenger), AT - arbeidstaker, ORD - ordinær
@@ -83,8 +85,8 @@ public enum KodeKlassifik {
     }
 
     public boolean gjelderFeriepenger() {
-        return this.equals(FERIEPENGER_BRUKER) || this.equals(FPF_FERIEPENGER_AG) || this.equals(FPA_FERIEPENGER_AG) || this.equals(
-            SVP_FERIEPENGER_AG);
+        return this.equals(FERIEPENGER_BRUKER) || this.equals(FPA_FERIEPENGER_BRUKER) || this.equals(SVP_FERIEPENGER_BRUKER) ||
+            this.equals(FPF_FERIEPENGER_AG) || this.equals(FPA_FERIEPENGER_AG) || this.equals(SVP_FERIEPENGER_AG);
     }
 
     public boolean gjelderArbeidsgiver() {

--- a/domenetjenester/okonomistotte/src/main/java/no/nav/foreldrepenger/økonomistøtte/oppdrag/mapper/KlassekodeUtleder.java
+++ b/domenetjenester/okonomistotte/src/main/java/no/nav/foreldrepenger/økonomistøtte/oppdrag/mapper/KlassekodeUtleder.java
@@ -1,12 +1,18 @@
 package no.nav.foreldrepenger.økonomistøtte.oppdrag.mapper;
 
+import java.time.LocalDate;
+
 import no.nav.foreldrepenger.behandlingslager.behandling.beregning.BeregningsresultatAndel;
 import no.nav.foreldrepenger.behandlingslager.behandling.beregning.Inntektskategori;
 import no.nav.foreldrepenger.behandlingslager.økonomioppdrag.FamilieYtelseType;
 import no.nav.foreldrepenger.behandlingslager.økonomioppdrag.InntektskategoriKlassekodeMapper;
 import no.nav.foreldrepenger.behandlingslager.økonomioppdrag.koder.KodeKlassifik;
+import no.nav.foreldrepenger.konfig.Environment;
 
 public class KlassekodeUtleder {
+
+    private static final boolean ER_PROD = Environment.current().isProd();
+    private static final int FERIEPENGER_NY_MAPPING_OPPTJENINGSÅR = 2023;
 
     private KlassekodeUtleder() {
     }
@@ -27,8 +33,18 @@ public class KlassekodeUtleder {
         return InntektskategoriKlassekodeMapper.mapTilKlassekode(inntektskategori, familieYtelseType);
     }
 
-    public static KodeKlassifik utledForFeriepenger() {
-        return KodeKlassifik.FERIEPENGER_BRUKER;
+    public static KodeKlassifik utledForFeriepenger(FamilieYtelseType familieYtelseType, int opptjeningsår, LocalDate feriepengerDødsdato) {
+        // Bruk gammel mapping for opptjeningsår før 2023 + dødsfallstilfelle i 2023 (1 så langt)
+        if (ER_PROD || opptjeningsår < FERIEPENGER_NY_MAPPING_OPPTJENINGSÅR ||
+            (opptjeningsår == FERIEPENGER_NY_MAPPING_OPPTJENINGSÅR && feriepengerDødsdato != null && feriepengerDødsdato.getYear() == FERIEPENGER_NY_MAPPING_OPPTJENINGSÅR)) {
+            return KodeKlassifik.FERIEPENGER_BRUKER;
+        } else {
+            return switch (familieYtelseType) {
+                case FØDSEL -> KodeKlassifik.FERIEPENGER_BRUKER;
+                case ADOPSJON -> KodeKlassifik.FPA_FERIEPENGER_BRUKER;
+                case SVANGERSKAPSPENGER -> KodeKlassifik.SVP_FERIEPENGER_BRUKER;
+            };
+        }
     }
 
     public static KodeKlassifik utledForFeriepengeRefusjon(FamilieYtelseType familieYtelseType) {

--- a/domenetjenester/okonomistotte/src/main/java/no/nav/foreldrepenger/økonomistøtte/oppdrag/mapper/TilkjentYtelseMapper.java
+++ b/domenetjenester/okonomistotte/src/main/java/no/nav/foreldrepenger/økonomistøtte/oppdrag/mapper/TilkjentYtelseMapper.java
@@ -133,9 +133,10 @@ public class TilkjentYtelseMapper {
     private KjedeNøkkel tilNøkkelFeriepenger(BeregningsresultatAndel andel, int opptjeningsår) {
         var brukferiepengerMaksdato = beregnFeriepengePeriode(opptjeningsår).getTom();
         var tilBruker = andel.skalTilBrukerEllerPrivatperson();
-        return tilBruker ? KjedeNøkkel.lag(KlassekodeUtleder.utledForFeriepenger(), Betalingsmottaker.BRUKER, brukferiepengerMaksdato) :
-            KjedeNøkkel.lag(KlassekodeUtleder.utledForFeriepengeRefusjon(ytelseType),
-                Betalingsmottaker.forArbeidsgiver(andel.getArbeidsgiver().orElseThrow().getOrgnr()), brukferiepengerMaksdato);
+        var klasseKode = tilBruker ? KlassekodeUtleder.utledForFeriepenger(ytelseType, opptjeningsår, feriepengerDødsdato) :
+            KlassekodeUtleder.utledForFeriepengeRefusjon(ytelseType);
+        return tilBruker ? KjedeNøkkel.lag(klasseKode, Betalingsmottaker.BRUKER, brukferiepengerMaksdato) :
+            KjedeNøkkel.lag(klasseKode, Betalingsmottaker.forArbeidsgiver(andel.getArbeidsgiver().orElseThrow().getOrgnr()), brukferiepengerMaksdato);
     }
 
     private Periode beregnFeriepengePeriode(int opptjeningsår) {

--- a/domenetjenester/okonomistotte/src/main/java/no/nav/foreldrepenger/økonomistøtte/oppdrag/util/ØkonomiKodeKlassifikSortering.java
+++ b/domenetjenester/okonomistotte/src/main/java/no/nav/foreldrepenger/økonomistøtte/oppdrag/util/ØkonomiKodeKlassifikSortering.java
@@ -11,7 +11,7 @@ public class ØkonomiKodeKlassifikSortering {
         "ATORD", "ATAL", "ATFRI", "ATSJO",
         "SND-OP", "SNDDM-OP", "SNDJB-OP", "SNDFI",
         "REFAG-IOP",
-        "FER", "FER-IOP",
+        "SVATFER", "ADATFER", "FER", "FER-IOP", // For å skille feriepenger til bruker ifm migrering
         "ENFOD-OP", "ENAD-OP"
     );
 

--- a/domenetjenester/okonomistotte/src/test/java/no/nav/foreldrepenger/økonomistøtte/oppdrag/NyOppdragskontrollTjenesteFeriepengerMedFlereRevurderingerTest.java
+++ b/domenetjenester/okonomistotte/src/test/java/no/nav/foreldrepenger/økonomistøtte/oppdrag/NyOppdragskontrollTjenesteFeriepengerMedFlereRevurderingerTest.java
@@ -8,6 +8,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 import java.time.LocalDate;
 import java.time.temporal.TemporalAdjusters;
+import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
@@ -17,8 +18,12 @@ import org.junit.jupiter.api.Test;
 
 import no.nav.foreldrepenger.behandlingslager.behandling.beregning.BeregningsresultatEntitet;
 import no.nav.foreldrepenger.behandlingslager.økonomioppdrag.FamilieYtelseType;
+import no.nav.foreldrepenger.behandlingslager.økonomioppdrag.Oppdrag110;
 import no.nav.foreldrepenger.behandlingslager.økonomioppdrag.Oppdragslinje150;
 import no.nav.foreldrepenger.behandlingslager.økonomioppdrag.Sats;
+import no.nav.foreldrepenger.behandlingslager.økonomioppdrag.koder.KodeEndringLinje;
+import no.nav.foreldrepenger.behandlingslager.økonomioppdrag.koder.KodeKlassifik;
+import no.nav.foreldrepenger.behandlingslager.økonomioppdrag.koder.KodeStatusLinje;
 import no.nav.foreldrepenger.økonomistøtte.oppdrag.mapper.TilkjentYtelseMapper;
 
 public class NyOppdragskontrollTjenesteFeriepengerMedFlereRevurderingerTest extends NyOppdragskontrollTjenesteTestBase {
@@ -61,7 +66,7 @@ public class NyOppdragskontrollTjenesteFeriepengerMedFlereRevurderingerTest exte
     private BeregningsresultatEntitet oppsettBeregningsresultatForFeriepenger(boolean erOpptjentOverFlereÅr,
                                                                               Long årsbeløp1,
                                                                               Long årsbeløp2) {
-        return buildBeregningsresultatFPForVerifiseringAvOpp150MedFeriepenger(erOpptjentOverFlereÅr, årsbeløp1, årsbeløp2);
+        return buildBeregningsresultatFPForVerifiseringAvOpp150MedFeriepenger(erOpptjentOverFlereÅr, årsbeløp1, årsbeløp2, DAGENS_DATO);
     }
 
     @Test
@@ -805,4 +810,44 @@ public class NyOppdragskontrollTjenesteFeriepengerMedFlereRevurderingerTest exte
         }
     }
 
+    @Test
+    void skalEndreKlassekodeFeriepengerAdopsjonForMigreringOvergangstilfelle() {
+        //Arrange
+        //Førstegangsbehandling
+        //Her vil det være 2 feriepenger til bruker: en med FPATFER til utbetaling i 2023 og en med FPADATFER til utbetaling i 2024
+        var baseDato = LocalDate.of(2022, 7,1);
+        var originaltOppdrag = opprettBeregningsresultatOgFørstegangsoppdragForFeriepenger(true, false, 6000L, 7000L, baseDato);
+
+        // Først sørge for at begge feriepengene er FPATFER - slik som tidligere sendte oppdrag vil være
+        var original150L = originaltOppdrag.getOppdrag110Liste().stream()
+            .map(Oppdrag110::getOppdragslinje150Liste)
+            .flatMap(Collection::stream)
+            .filter(o150 -> o150.getKodeKlassifik().gjelderFeriepenger())
+            .toList();
+        original150L.stream().filter(o150 -> KodeKlassifik.FPA_FERIEPENGER_BRUKER.equals(o150.getKodeKlassifik()))
+            .filter(o150 -> o150.getDatoVedtakFom().isAfter(baseDato.withDayOfYear(1).plusYears(2)))
+            .forEach(o150 -> o150.setKodeKlassifik(KodeKlassifik.FERIEPENGER_BRUKER));
+        assertThat(original150L.stream().filter(o150 -> KodeKlassifik.FERIEPENGER_BRUKER.equals(o150.getKodeKlassifik()))).hasSize(2);
+        assertThat(original150L.stream().filter(o150 -> KodeKlassifik.FPA_FERIEPENGER_BRUKER.equals(o150.getKodeKlassifik()))).hasSize(0);
+
+        //Revurdering #1
+        var beregningsresultatRevurderingFP = buildBeregningsresultatFPForVerifiseringAvOpp150MedFeriepenger(true, 6000L, 7000L, baseDato);
+
+        var mapper = TilkjentYtelseMapper.lagFor(FamilieYtelseType.ADOPSJON);
+        var gruppertYtelse2 = mapper.fordelPåNøkler(beregningsresultatRevurderingFP);
+        var builder2 = getInputStandardBuilder(gruppertYtelse2).medTidligereOppdrag(mapTidligereOppdrag(List.of(originaltOppdrag)));
+
+        var oppdragRevurdering = nyOppdragskontrollTjeneste.opprettOppdrag(builder2.build());
+
+        var ny150L = oppdragRevurdering.orElseThrow().getOppdrag110Liste().stream()
+            .map(Oppdrag110::getOppdragslinje150Liste)
+            .flatMap(Collection::stream)
+            .filter(o150 -> o150.getKodeKlassifik().gjelderFeriepenger())
+            .toList();
+
+        // Validere at eneste endring er opphør av FPATFER og innvilget FPADATFER
+        assertThat(ny150L).hasSize(2);
+        assertThat(ny150L.stream().filter(o150 -> KodeKlassifik.FERIEPENGER_BRUKER.equals(o150.getKodeKlassifik()) && KodeStatusLinje.OPPH.equals(o150.getKodeStatusLinje()))).hasSize(1);
+        assertThat(ny150L.stream().filter(o150 -> KodeKlassifik.FPA_FERIEPENGER_BRUKER.equals(o150.getKodeKlassifik()) && KodeEndringLinje.NY.equals(o150.getKodeEndringLinje()))).hasSize(1);
+    }
 }

--- a/domenetjenester/okonomistotte/src/test/java/no/nav/foreldrepenger/økonomistøtte/oppdrag/NyOppdragskontrollTjenesteFeriepengerTest.java
+++ b/domenetjenester/okonomistotte/src/test/java/no/nav/foreldrepenger/økonomistøtte/oppdrag/NyOppdragskontrollTjenesteFeriepengerTest.java
@@ -10,6 +10,7 @@ import static no.nav.foreldrepenger.økonomistøtte.OppdragskontrollFeriepengerT
 import static no.nav.foreldrepenger.økonomistøtte.OppdragskontrollFeriepengerTestUtil.verifiserOppdr150NårEttFeriepengeårSkalOpphøre;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.time.LocalDate;
 import java.util.List;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -59,7 +60,7 @@ class NyOppdragskontrollTjenesteFeriepengerTest extends NyOppdragskontrollTjenes
 
     private BeregningsresultatEntitet oppsettBeregningsresultatForFeriepenger(boolean erOpptjentOverFlereÅr, Long årsbeløp1, Long årsbeløp2) {
         return buildBeregningsresultatFPForVerifiseringAvOpp150MedFeriepenger(erOpptjentOverFlereÅr, årsbeløp1,
-            årsbeløp2);
+            årsbeløp2, DAGENS_DATO);
     }
 
     /**
@@ -828,7 +829,7 @@ class NyOppdragskontrollTjenesteFeriepengerTest extends NyOppdragskontrollTjenes
     }
 
     @Test
-    void skalSendeOppdragForFeriepengerNårDetGjelderAdopsjon() {
+    void skalSendeOppdragForFeriepengerNårDetGjelderAdopsjonStandard() {
         //Arrange
         //Act
         //Førstegangsbehandling
@@ -844,7 +845,39 @@ class NyOppdragskontrollTjenesteFeriepengerTest extends NyOppdragskontrollTjenes
             .get();
         var opp150FeriepengerBruker = getOppdragslinje150Feriepenger(oppdrag110Bruker);
         assertThat(opp150FeriepengerBruker).isNotEmpty()
-            .allSatisfy(opp150 -> assertThat(opp150.getKodeKlassifik()).isEqualTo(KodeKlassifik.FERIEPENGER_BRUKER));
+            .allSatisfy(opp150 -> assertThat(opp150.getKodeKlassifik()).isEqualTo(KodeKlassifik.FPA_FERIEPENGER_BRUKER));
+        // Arbeidsgiver
+        var oppdrag110Arbeidsgiver = oppdrag.getOppdrag110Liste()
+            .stream()
+            .filter(o110 -> o110.getKodeFagomrade().gjelderRefusjonTilArbeidsgiver())
+            .findFirst()
+            .get();
+        var opp150FeriepengerArbeidsgiver = getOppdragslinje150Feriepenger(oppdrag110Arbeidsgiver);
+        assertThat(opp150FeriepengerArbeidsgiver).isNotEmpty()
+            .allSatisfy(opp150 -> assertThat(opp150.getKodeKlassifik()).isEqualTo(KodeKlassifik.FPA_FERIEPENGER_AG));
+    }
+
+    @Test
+    void skalSendeOppdragForFeriepengerNårDetGjelderAdopsjonStandardOvergang2022() {
+        //Arrange
+        //Act
+        //Førstegangsbehandling
+        var baseDato = LocalDate.of(2022, 7,1);
+        var oppdrag = opprettBeregningsresultatOgFørstegangsoppdragForFeriepenger(true, false, 11000L, 6000L, baseDato);
+
+        //Assert
+        assertThat(oppdrag.getOppdrag110Liste()).hasSize(2);
+        //Bruker
+        var oppdrag110Bruker = oppdrag.getOppdrag110Liste()
+            .stream()
+            .filter(o110 -> !o110.getKodeFagomrade().gjelderRefusjonTilArbeidsgiver())
+            .findFirst()
+            .get();
+        var opp150FeriepengerBruker = getOppdragslinje150Feriepenger(oppdrag110Bruker);
+        assertThat(opp150FeriepengerBruker).isNotEmpty()
+            .satisfiesOnlyOnce(opp150 -> assertThat(opp150.getKodeKlassifik()).isEqualTo(KodeKlassifik.FERIEPENGER_BRUKER)); // Gammel konvensjon for opptjeningsår 2022
+        assertThat(opp150FeriepengerBruker).isNotEmpty()
+            .satisfiesOnlyOnce(opp150 -> assertThat(opp150.getKodeKlassifik()).isEqualTo(KodeKlassifik.FPA_FERIEPENGER_BRUKER)); // Ny konvensjon for opptjeningsår 2023
         // Arbeidsgiver
         var oppdrag110Arbeidsgiver = oppdrag.getOppdrag110Liste()
             .stream()

--- a/domenetjenester/okonomistotte/src/test/java/no/nav/foreldrepenger/økonomistøtte/oppdrag/NyOppdragskontrollTjenesteTestBase.java
+++ b/domenetjenester/okonomistotte/src/test/java/no/nav/foreldrepenger/økonomistøtte/oppdrag/NyOppdragskontrollTjenesteTestBase.java
@@ -509,20 +509,20 @@ public abstract class NyOppdragskontrollTjenesteTestBase {
     }
 
     protected BeregningsresultatEntitet buildBeregningsresultatFPForVerifiseringAvOpp150MedFeriepenger(boolean erOpptjentOverFlereÅr,
-                                                                                                     Long årsbeløp1,
-                                                                                                     Long årsbeløp2) {
+                                                                                                       Long årsbeløp1,
+                                                                                                       Long årsbeløp2, LocalDate brukDato) {
         var builder = BeregningsresultatEntitet.builder()
             .medRegelInput("clob1")
             .medRegelSporing("clob2");
         var beregningsresultat = builder.build();
-        var brPeriode1 = buildBeregningsresultatPeriode(beregningsresultat, 1, 10);
+        var brPeriode1 = buildBeregningsresultatPeriode(beregningsresultat, brukDato, brukDato.plusDays(10));
         var andel1 = buildBeregningsresultatAndel(brPeriode1, true, 1500, BigDecimal.valueOf(100),
             virksomhet);
         var andel2 = buildBeregningsresultatAndel(brPeriode1, false, 1300, BigDecimal.valueOf(100),
             virksomhet);
         var feriepenger = buildBeregningsresultatFeriepenger(beregningsresultat);
-        oppsettFeriepenger(erOpptjentOverFlereÅr, årsbeløp1, årsbeløp2, andel1, feriepenger);
-        oppsettFeriepenger(erOpptjentOverFlereÅr, årsbeløp1, årsbeløp2, andel2, feriepenger);
+        oppsettFeriepenger(erOpptjentOverFlereÅr, årsbeløp1, årsbeløp2, andel1, feriepenger, brukDato);
+        oppsettFeriepenger(erOpptjentOverFlereÅr, årsbeløp1, årsbeløp2, andel2, feriepenger, brukDato);
 
         return beregningsresultat;
     }
@@ -531,12 +531,12 @@ public abstract class NyOppdragskontrollTjenesteTestBase {
                                     Long årsbeløp1,
                                     Long årsbeløp2,
                                     BeregningsresultatAndel andel1,
-                                    BeregningsresultatFeriepenger feriepenger) {
+                                    BeregningsresultatFeriepenger feriepenger, LocalDate brukDato) {
         List<LocalDate> opptjeningsårListe;
         if (erOpptjentOverFlereÅr) {
-            opptjeningsårListe = List.of(DAGENS_DATO, DAGENS_DATO.plusYears(1));
+            opptjeningsårListe = List.of(brukDato, brukDato.plusYears(1));
         } else if (årsbeløp1 > 0 || årsbeløp2 > 0) {
-            opptjeningsårListe = årsbeløp2 > 0 ? List.of(DAGENS_DATO.plusYears(1)) : List.of(DAGENS_DATO);
+            opptjeningsårListe = årsbeløp2 > 0 ? List.of(brukDato.plusYears(1)) : List.of(brukDato);
         } else {
             opptjeningsårListe = Collections.emptyList();
         }
@@ -709,8 +709,16 @@ public abstract class NyOppdragskontrollTjenesteTestBase {
                                                                                            boolean gjelderFødsel,
                                                                                            Long årsbeløp1,
                                                                                            Long årsbeløp2) {
+        return opprettBeregningsresultatOgFørstegangsoppdragForFeriepenger(erOpptjentOverFlereÅr, gjelderFødsel, årsbeløp1, årsbeløp2, DAGENS_DATO);
+    }
+
+    protected Oppdragskontroll opprettBeregningsresultatOgFørstegangsoppdragForFeriepenger(boolean erOpptjentOverFlereÅr,
+                                                                                           boolean gjelderFødsel,
+                                                                                           Long årsbeløp1,
+                                                                                           Long årsbeløp2,
+                                                                                           LocalDate brukDato) {
         var beregningsresultat = buildBeregningsresultatFPForVerifiseringAvOpp150MedFeriepenger(
-            erOpptjentOverFlereÅr, årsbeløp1, årsbeløp2);
+            erOpptjentOverFlereÅr, årsbeløp1, årsbeløp2, brukDato);
 
         if (gjelderFødsel) {
             var mapper = new TilkjentYtelseMapper(FamilieYtelseType.FØDSEL);

--- a/domenetjenester/okonomistotte/src/test/java/no/nav/foreldrepenger/økonomistøtte/oppdrag/OppdragskontrollTjenesteImplSVPTest.java
+++ b/domenetjenester/okonomistotte/src/test/java/no/nav/foreldrepenger/økonomistøtte/oppdrag/OppdragskontrollTjenesteImplSVPTest.java
@@ -5,13 +5,19 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakYtelseType;
 import no.nav.foreldrepenger.behandlingslager.økonomioppdrag.FamilieYtelseType;
+import no.nav.foreldrepenger.behandlingslager.økonomioppdrag.Oppdrag110;
+import no.nav.foreldrepenger.behandlingslager.økonomioppdrag.koder.KodeEndringLinje;
 import no.nav.foreldrepenger.behandlingslager.økonomioppdrag.koder.KodeKlassifik;
+import no.nav.foreldrepenger.behandlingslager.økonomioppdrag.koder.KodeStatusLinje;
+import no.nav.foreldrepenger.økonomistøtte.OppdragMedPositivKvitteringTestUtil;
 import no.nav.foreldrepenger.økonomistøtte.oppdrag.mapper.TilkjentYtelseMapper;
 
 public class OppdragskontrollTjenesteImplSVPTest extends NyOppdragskontrollTjenesteTestBase {
@@ -22,26 +28,23 @@ public class OppdragskontrollTjenesteImplSVPTest extends NyOppdragskontrollTjene
         super.setUp();
     }
 
+
     @Test
     void skal_sende_oppdrag_for_svangerskapspenger() {
         //Arrange
+        var baseDato = LocalDate.now();
         var beregningsresultat = buildEmptyBeregningsresultatFP();
 
-        var brPeriode_1 = buildBeregningsresultatPeriode(beregningsresultat, 1, 10);
+        var brPeriode_1 = buildBeregningsresultatPeriode(beregningsresultat, baseDato.withDayOfMonth(1), baseDato);
         var andelBruker_1 = buildBeregningsresultatAndel(brPeriode_1, true, 1000, BigDecimal.valueOf(100L), virksomhet);
         var andelArbeidsgiver_1 = buildBeregningsresultatAndel(brPeriode_1, false, 1000, BigDecimal.valueOf(100L), virksomhet);
 
-        var brPeriode_2 = buildBeregningsresultatPeriode(beregningsresultat, 11, 20);
-        buildBeregningsresultatAndel(brPeriode_2, true, 1000, BigDecimal.valueOf(100L), virksomhet);
-        buildBeregningsresultatAndel(brPeriode_2, false, 1000, BigDecimal.valueOf(100L), virksomhet);
-
         var feriepenger = buildBeregningsresultatFeriepenger(beregningsresultat);
-        buildBeregningsresultatFeriepengerPrÅr(feriepenger, andelBruker_1, 10000L, LocalDate.of(2018, 12, 31));
-        buildBeregningsresultatFeriepengerPrÅr(feriepenger, andelArbeidsgiver_1, 10000L, LocalDate.of(2018, 12, 31));
+        buildBeregningsresultatFeriepengerPrÅr(feriepenger, andelBruker_1, 100L, baseDato);
+        buildBeregningsresultatFeriepengerPrÅr(feriepenger, andelArbeidsgiver_1, 101L, baseDato);
 
         var mapper = new TilkjentYtelseMapper(FamilieYtelseType.SVANGERSKAPSPENGER);
         var gruppertYtelse = mapper.fordelPåNøkler(beregningsresultat);
-
         var builder = getInputStandardBuilder(gruppertYtelse).medFagsakYtelseType(FagsakYtelseType.SVANGERSKAPSPENGER);
 
         //Act
@@ -65,11 +68,8 @@ public class OppdragskontrollTjenesteImplSVPTest extends NyOppdragskontrollTjene
         assertThat(oppdrag110_Arbeidsgiver).isPresent();
         //Oppdragslinje150 - Bruker
         var opp150List_Bruker = oppdrag110_Bruker.get().getOppdragslinje150Liste();
-        assertThat(opp150List_Bruker).anySatisfy(opp150 ->
-            assertThat(opp150.getKodeKlassifik()).isIn(Arrays.asList(
-                KodeKlassifik.SVP_ARBEDISTAKER,
-                KodeKlassifik.FERIEPENGER_BRUKER.getKode())
-            ));
+        assertThat(opp150List_Bruker.stream().filter(opp150 -> KodeKlassifik.SVP_ARBEDISTAKER.equals(opp150.getKodeKlassifik()))).hasSize(1);
+        assertThat(opp150List_Bruker.stream().filter(opp150 -> KodeKlassifik.SVP_FERIEPENGER_BRUKER.equals(opp150.getKodeKlassifik()))).hasSize(1);
         //Oppdragslinje150 - Arbeidsgiver
         var opp150List_Arbeidsgiver = oppdrag110_Arbeidsgiver.get().getOppdragslinje150Liste();
         assertThat(opp150List_Arbeidsgiver).anySatisfy(opp150 ->
@@ -77,5 +77,123 @@ public class OppdragskontrollTjenesteImplSVPTest extends NyOppdragskontrollTjene
                 KodeKlassifik.SVP_REFUSJON_AG,
                 KodeKlassifik.SVP_FERIEPENGER_AG)
             ));
+    }
+
+    @Test
+    void skal_sende_oppdrag_for_svangerskapspenger_overgang() {
+        //Arrange
+        var baseDato = LocalDate.of(2022, 12, 31);
+        var beregningsresultat = buildEmptyBeregningsresultatFP();
+
+        var brPeriode_1 = buildBeregningsresultatPeriode(beregningsresultat, baseDato.withDayOfMonth(1), baseDato);
+        var andelBruker_1 = buildBeregningsresultatAndel(brPeriode_1, true, 1000, BigDecimal.valueOf(100L), virksomhet);
+        var andelArbeidsgiver_1 = buildBeregningsresultatAndel(brPeriode_1, false, 1000, BigDecimal.valueOf(100L), virksomhet);
+
+        var brPeriode_2 = buildBeregningsresultatPeriode(beregningsresultat, baseDato.plusDays(1), baseDato.plusDays(31));
+        var andelBruker_2 = buildBeregningsresultatAndel(brPeriode_2, true, 1000, BigDecimal.valueOf(100L), virksomhet);
+        var andelArbeidsgiver_2 =buildBeregningsresultatAndel(brPeriode_2, false, 1000, BigDecimal.valueOf(100L), virksomhet);
+
+        var feriepenger = buildBeregningsresultatFeriepenger(beregningsresultat);
+        buildBeregningsresultatFeriepengerPrÅr(feriepenger, andelBruker_1, 100L, baseDato);
+        buildBeregningsresultatFeriepengerPrÅr(feriepenger, andelArbeidsgiver_1, 101L, baseDato);
+        buildBeregningsresultatFeriepengerPrÅr(feriepenger, andelBruker_2, 100L, baseDato.plusYears(1));
+        buildBeregningsresultatFeriepengerPrÅr(feriepenger, andelArbeidsgiver_2, 101L, baseDato.plusYears(1));
+
+        var mapper = new TilkjentYtelseMapper(FamilieYtelseType.SVANGERSKAPSPENGER);
+        var gruppertYtelse = mapper.fordelPåNøkler(beregningsresultat);
+        var builder = getInputStandardBuilder(gruppertYtelse).medFagsakYtelseType(FagsakYtelseType.SVANGERSKAPSPENGER);
+
+        //Act
+        var oppdragskontroll = nyOppdragskontrollTjeneste.opprettOppdrag(builder.build());
+
+        //Assert
+        assertThat(oppdragskontroll).isPresent();
+        var oppdrag = oppdragskontroll.get();
+        assertThat(oppdrag).isNotNull();
+        var oppdrag110List = oppdrag.getOppdrag110Liste();
+        assertThat(oppdrag110List).hasSize(2);
+        //Oppdrag110 - Bruker
+        var oppdrag110_Bruker = oppdrag110List.stream()
+            .filter(o110 -> !o110.getKodeFagomrade().gjelderRefusjonTilArbeidsgiver())
+            .findFirst();
+        assertThat(oppdrag110_Bruker).isPresent();
+        //Oppdrag110 - Arbeidsgiver
+        var oppdrag110_Arbeidsgiver = oppdrag110List.stream()
+            .filter(o110 -> o110.getKodeFagomrade().gjelderRefusjonTilArbeidsgiver())
+            .findFirst();
+        assertThat(oppdrag110_Arbeidsgiver).isPresent();
+        //Oppdragslinje150 - Bruker
+        var opp150List_Bruker = oppdrag110_Bruker.get().getOppdragslinje150Liste();
+        assertThat(opp150List_Bruker.stream().filter(opp150 -> KodeKlassifik.SVP_ARBEDISTAKER.equals(opp150.getKodeKlassifik()))).hasSize(2);
+        assertThat(opp150List_Bruker.stream().filter(opp150 -> KodeKlassifik.FERIEPENGER_BRUKER.equals(opp150.getKodeKlassifik()))).hasSize(1);
+        assertThat(opp150List_Bruker.stream().filter(opp150 -> KodeKlassifik.SVP_FERIEPENGER_BRUKER.equals(opp150.getKodeKlassifik()))).hasSize(1);
+        //Oppdragslinje150 - Arbeidsgiver
+        var opp150List_Arbeidsgiver = oppdrag110_Arbeidsgiver.get().getOppdragslinje150Liste();
+        assertThat(opp150List_Arbeidsgiver).anySatisfy(opp150 ->
+            assertThat(opp150.getKodeKlassifik()).isIn(Arrays.asList(
+                KodeKlassifik.SVP_REFUSJON_AG,
+                KodeKlassifik.SVP_FERIEPENGER_AG)
+            ));
+    }
+
+    @Test
+    void skal_sende_oppdrag_for_svangerskapspenger_migrer() {
+        //Arrange
+        var baseDato = LocalDate.of(2023, 12, 31);
+        var beregningsresultat = buildEmptyBeregningsresultatFP();
+
+        var brPeriode_1 = buildBeregningsresultatPeriode(beregningsresultat, baseDato.withDayOfMonth(1), baseDato);
+        var andelBruker_1 = buildBeregningsresultatAndel(brPeriode_1, true, 1000, BigDecimal.valueOf(100L), virksomhet);
+        var andelArbeidsgiver_1 = buildBeregningsresultatAndel(brPeriode_1, false, 1000, BigDecimal.valueOf(100L), virksomhet);
+
+        var feriepenger = buildBeregningsresultatFeriepenger(beregningsresultat);
+        buildBeregningsresultatFeriepengerPrÅr(feriepenger, andelBruker_1, 100L, baseDato);
+        buildBeregningsresultatFeriepengerPrÅr(feriepenger, andelArbeidsgiver_1, 101L, baseDato);
+
+        var mapper = new TilkjentYtelseMapper(FamilieYtelseType.SVANGERSKAPSPENGER);
+        var gruppertYtelse = mapper.fordelPåNøkler(beregningsresultat);
+        var builder = getInputStandardBuilder(gruppertYtelse).medFagsakYtelseType(FagsakYtelseType.SVANGERSKAPSPENGER);
+
+        //Act
+        var oppdragskontroll = OppdragMedPositivKvitteringTestUtil.opprett(nyOppdragskontrollTjeneste, builder.build());
+
+        // Først sørge for at begge feriepengene er FPATFER - slik som tidligere sendte oppdrag vil være
+        var original150L = oppdragskontroll.getOppdrag110Liste().stream()
+            .map(Oppdrag110::getOppdragslinje150Liste)
+            .flatMap(Collection::stream)
+            .filter(o150 -> o150.getKodeKlassifik().gjelderFeriepenger())
+            .toList();
+        original150L.stream().filter(o150 -> KodeKlassifik.SVP_FERIEPENGER_BRUKER.equals(o150.getKodeKlassifik()))
+            .forEach(o150 -> o150.setKodeKlassifik(KodeKlassifik.FERIEPENGER_BRUKER));
+        assertThat(original150L.stream().filter(o150 -> KodeKlassifik.FERIEPENGER_BRUKER.equals(o150.getKodeKlassifik()))).hasSize(1);
+        assertThat(original150L.stream().filter(o150 -> KodeKlassifik.SVP_FERIEPENGER_BRUKER.equals(o150.getKodeKlassifik()))).hasSize(0);
+
+        //Revurdering #1
+        var rberegningsresultat = buildEmptyBeregningsresultatFP();
+
+        var rbrPeriode_1 = buildBeregningsresultatPeriode(rberegningsresultat, baseDato.withDayOfMonth(1), baseDato);
+        var randelBruker_1 = buildBeregningsresultatAndel(rbrPeriode_1, true, 1000, BigDecimal.valueOf(100L), virksomhet);
+        var randelArbeidsgiver_1 = buildBeregningsresultatAndel(rbrPeriode_1, false, 1000, BigDecimal.valueOf(100L), virksomhet);
+
+        var rferiepenger = buildBeregningsresultatFeriepenger(rberegningsresultat);
+        buildBeregningsresultatFeriepengerPrÅr(rferiepenger, randelBruker_1, 100L, baseDato);
+        buildBeregningsresultatFeriepengerPrÅr(rferiepenger, randelArbeidsgiver_1, 101L, baseDato);
+
+        var gruppertYtelse2 = mapper.fordelPåNøkler(rberegningsresultat);
+        var builder2 = getInputStandardBuilder(gruppertYtelse2).medTidligereOppdrag(mapTidligereOppdrag(List.of(oppdragskontroll)));
+
+        var oppdragRevurdering = nyOppdragskontrollTjeneste.opprettOppdrag(builder2.build());
+
+        var ny150L = oppdragRevurdering.orElseThrow().getOppdrag110Liste().stream()
+            .map(Oppdrag110::getOppdragslinje150Liste)
+            .flatMap(Collection::stream)
+            .filter(o150 -> o150.getKodeKlassifik().gjelderFeriepenger())
+            .toList();
+
+        // Validere at eneste endring er opphør av FPATFER og innvilget FPADATFER
+        assertThat(ny150L).hasSize(2);
+        assertThat(ny150L.stream().filter(o150 -> KodeKlassifik.FERIEPENGER_BRUKER.equals(o150.getKodeKlassifik()) && KodeStatusLinje.OPPH.equals(o150.getKodeStatusLinje()))).hasSize(1);
+        assertThat(ny150L.stream().filter(o150 -> KodeKlassifik.SVP_FERIEPENGER_BRUKER.equals(o150.getKodeKlassifik()) && KodeEndringLinje.NY.equals(o150.getKodeEndringLinje()))).hasSize(1);
+
     }
 }


### PR DESCRIPTION
For opptjeningsår 2023 med utbetaling i 2024 så skal det brukes 3 ulike koder ved feriepenger til bruker.
* Før ble alle feriepenger til bruker postert som FPATFER.
* Vi skal fortsatt bruker FPATFER ved oppdrag som gjelder opptjeningsår før 2023 eller utbetalt 2023 - revurderinger.
* Alle SVP og Adopsjonssaker med framtidig utbetaling i 2024 og senere må kjøre en "reberegn feriepenger" før 1/5-2024