### PR TITLE
Slå sammen sammenhengende oppdragsperioder

### DIFF
--- a/domenetjenester/okonomistotte/src/main/java/no/nav/foreldrepenger/økonomistøtte/oppdrag/domene/Periode.java
+++ b/domenetjenester/okonomistotte/src/main/java/no/nav/foreldrepenger/økonomistøtte/oppdrag/domene/Periode.java
@@ -1,34 +1,16 @@
 package no.nav.foreldrepenger.økonomistøtte.oppdrag.domene;
 
 import java.time.LocalDate;
-import java.time.format.DateTimeFormatter;
 import java.util.Objects;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Embeddable;
+public record Periode(LocalDate fom, LocalDate tom) {
 
-@Embeddable
-public class Periode {
-
-    private static final DateTimeFormatter DATO_FORMAT = DateTimeFormatter.ofPattern("dd.MM.yyyy");
-
-    @Column(name = "fom")
-    private LocalDate fom;
-
-    @Column(name = "tom")
-    private LocalDate tom;
-
-    private Periode() {
-    }
-
-    public Periode(LocalDate fom, LocalDate tom) {
+    public Periode {
         Objects.requireNonNull(fom, "Fra-og-med-dato må være satt");
         Objects.requireNonNull(tom, "Til-og-med-dato må være satt");
         if (tom.isBefore(fom)) {
             throw new IllegalArgumentException("Til-og-med-dato før fra-og-med-dato: " + fom + ">" + tom);
         }
-        this.fom = fom;
-        this.tom = tom;
     }
 
     public static Periode of(LocalDate fom, LocalDate tom) {
@@ -57,25 +39,6 @@ public class Periode {
 
     public static LocalDate min(LocalDate en, LocalDate to) {
         return en.isBefore(to) ? en : to;
-    }
-
-    @Override
-    public String toString() {
-        return fom.format(DATO_FORMAT) + "-" + tom.format(DATO_FORMAT);
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (o instanceof Periode per) {
-            return Objects.equals(getFom(), per.getFom())
-                && Objects.equals(getTom(), per.getTom());
-        }
-        return false;
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(fom, tom);
     }
 
 }

--- a/domenetjenester/okonomistotte/src/test/java/no/nav/foreldrepenger/økonomistøtte/oppdrag/NyOppdragskontrollTjenesteENDRMedFlereBehandlingerMedSammeFagsakTest.java
+++ b/domenetjenester/okonomistotte/src/test/java/no/nav/foreldrepenger/økonomistøtte/oppdrag/NyOppdragskontrollTjenesteENDRMedFlereBehandlingerMedSammeFagsakTest.java
@@ -226,7 +226,7 @@ public class NyOppdragskontrollTjenesteENDRMedFlereBehandlingerMedSammeFagsakTes
         var oppdrag110Liste_1 = originaltOppdrag.getOppdrag110Liste();
         assertThat(oppdrag110Liste_1).hasSize(1);
         verifiserOppdrag110KodeEndring(oppdrag110Liste_1, List.of(KodeEndring.NY));
-        verifiserOppdragslinje150KodeEndring(oppdrag110Liste_1.get(0).getOppdragslinje150Liste(), List.of(KodeEndringLinje.NY, KodeEndringLinje.NY));
+        verifiserOppdragslinje150KodeEndring(oppdrag110Liste_1.get(0).getOppdragslinje150Liste(), List.of(KodeEndringLinje.NY));
 
         // Assert : Revurdering
         var oppdrag110Liste_2 = oppdragRevurdering.getOppdrag110Liste();
@@ -238,8 +238,8 @@ public class NyOppdragskontrollTjenesteENDRMedFlereBehandlingerMedSammeFagsakTes
         var oppdrag110Liste_3 = oppdragRevurdering2.getOppdrag110Liste();
         assertThat(oppdrag110Liste_3).hasSize(2);
         verifiserOppdrag110KodeEndring(oppdrag110Liste_3, List.of(KodeEndring.ENDR, KodeEndring.NY));
-        verifiserOppdragslinje150KodeEndring(OppdragskontrollTestVerktøy.getOpp150ListeForBruker(oppdrag110Liste_3), List.of(KodeEndringLinje.NY, KodeEndringLinje.NY));
-        verifiserOppdragslinje150KodeEndring(OppdragskontrollTestVerktøy.getOpp150ListeForEnVirksomhet(oppdrag110Liste_3, virksomhet), List.of(KodeEndringLinje.NY, KodeEndringLinje.NY));
+        verifiserOppdragslinje150KodeEndring(OppdragskontrollTestVerktøy.getOpp150ListeForBruker(oppdrag110Liste_3), List.of(KodeEndringLinje.NY));
+        verifiserOppdragslinje150KodeEndring(OppdragskontrollTestVerktøy.getOpp150ListeForEnVirksomhet(oppdrag110Liste_3, virksomhet), List.of(KodeEndringLinje.NY));
 
         // Assert : Kjeding
         verifiserKjedingNårDetErFlereBehandlingerMedSammeFagsak(originaltOppdrag, oppdragRevurdering, oppdragRevurdering2, false);
@@ -360,7 +360,7 @@ public class NyOppdragskontrollTjenesteENDRMedFlereBehandlingerMedSammeFagsakTes
         assertThat(oppdrag110ForBruker.getKodeEndring()).isEqualTo(KodeEndring.ENDR);
         //Oppdragslinje150 for Bruker
         var opp150ListeForBruker = oppdrag110ForBruker.getOppdragslinje150Liste();
-        assertThat(opp150ListeForBruker).hasSize(2);
+        assertThat(opp150ListeForBruker).hasSize(1);
         assertThat(opp150ListeForBruker).allSatisfy(opp150 -> {
             assertThat(opp150.getKodeKlassifik()).isEqualTo(KodeKlassifik.FPF_ARBEIDSTAKER);
             assertThat(opp150.gjelderOpphør()).isFalse();

--- a/domenetjenester/okonomistotte/src/test/java/no/nav/foreldrepenger/økonomistøtte/oppdrag/NyOppdragskontrollTjenesteENDRTest.java
+++ b/domenetjenester/okonomistotte/src/test/java/no/nav/foreldrepenger/økonomistøtte/oppdrag/NyOppdragskontrollTjenesteENDRTest.java
@@ -1026,13 +1026,13 @@ public class NyOppdragskontrollTjenesteENDRTest extends NyOppdragskontrollTjenes
         var builder = getInputStandardBuilder(gruppertYtelse);
         var originaltOppdrag = OppdragMedPositivKvitteringTestUtil.opprett(nyOppdragskontrollTjeneste, builder.build());
 
-        // Arrange : Revurdering
+        // Arrange : Revurdering som endrer både klassekoder og perioder etter de første dagene
         var beregningsresultatRevurderingFP = buildEmptyBeregningsresultatFP();
         var b2Periode_1 = buildBeregningsresultatPeriode(beregningsresultatRevurderingFP, 1, 5);
         buildBeregningsresultatAndel(b2Periode_1, true, 1500, BigDecimal.valueOf(100), virksomhet, AktivitetStatus.ARBEIDSTAKER,
             Inntektskategori.ARBEIDSTAKER);
         buildBeregningsresultatAndel(b2Periode_1, true, 1500, BigDecimal.valueOf(100), null, AktivitetStatus.DAGPENGER, Inntektskategori.DAGPENGER);
-        var b2Periode_2 = buildBeregningsresultatPeriode(beregningsresultatRevurderingFP, 6, 20);
+        var b2Periode_2 = buildBeregningsresultatPeriode(beregningsresultatRevurderingFP, 15, 25);
         buildBeregningsresultatAndel(b2Periode_2, true, 1500, BigDecimal.valueOf(100), virksomhet, AktivitetStatus.ARBEIDSTAKER,
             Inntektskategori.ARBEIDSTAKER);
         buildBeregningsresultatAndel(b2Periode_2, true, 1500, BigDecimal.valueOf(100), null, AktivitetStatus.DAGPENGER, Inntektskategori.DAGPENGER);
@@ -1047,7 +1047,7 @@ public class NyOppdragskontrollTjenesteENDRTest extends NyOppdragskontrollTjenes
         var oppdrag110RevurderingListe = oppdragRevurdering.getOppdrag110Liste();
         assertThat(oppdrag110RevurderingListe).hasSize(1);
         var opp150RevurderingListe = oppdrag110RevurderingListe.get(0).getOppdragslinje150Liste();
-        assertThat(opp150RevurderingListe).hasSize(4);
+        assertThat(opp150RevurderingListe).hasSize(6);
         //Opphør for FL
         var opp150OpphForFLListe = getOpp150MedKodeklassifik(opp150RevurderingListe, KodeKlassifik.FPF_FRILANSER);
         assertThat(opp150OpphForFLListe).hasSize(1).allSatisfy(oppdragslinje150 -> assertThat(oppdragslinje150.gjelderOpphør()).isTrue());
@@ -1056,18 +1056,22 @@ public class NyOppdragskontrollTjenesteENDRTest extends NyOppdragskontrollTjenes
         assertThat(opp150OpphForSNListe).hasSize(1).allSatisfy(oppdragslinje150 -> assertThat(oppdragslinje150.gjelderOpphør()).isTrue());
         //Oppdragslinje150 for AT
         var opp150ForATListe = getOpp150MedKodeklassifik(opp150RevurderingListe, KodeKlassifik.FPF_ARBEIDSTAKER);
-        assertThat(opp150ForATListe).hasSize(1).allSatisfy(oppdragslinje150 -> assertThat(oppdragslinje150.gjelderOpphør()).isFalse());
+        assertThat(opp150ForATListe).hasSize(2).allSatisfy(oppdragslinje150 -> assertThat(oppdragslinje150.gjelderOpphør()).isFalse());
         var sortertOpp150OpphForATListe = sortOppdragslinj150Liste(opp150ForATListe);
         var førsteOpp150ForAT = sortertOpp150OpphForATListe.get(0);
         assertThat(førsteOpp150ForAT.getRefFagsystemId()).isNull();
         assertThat(førsteOpp150ForAT.getRefDelytelseId()).isNull();
+        var andreOpp150ForAT = sortertOpp150OpphForATListe.get(1);
+        assertThat(andreOpp150ForAT.getRefDelytelseId()).isEqualTo(førsteOpp150ForAT.getDelytelseId());
         //Oppdragslinje150 for DP
         var opp150OpphForDPListe = getOpp150MedKodeklassifik(opp150RevurderingListe, KodeKlassifik.FPF_DAGPENGER);
-        assertThat(opp150OpphForDPListe).hasSize(1).allSatisfy(oppdragslinje150 -> assertThat(oppdragslinje150.gjelderOpphør()).isFalse());
+        assertThat(opp150OpphForDPListe).hasSize(2).allSatisfy(oppdragslinje150 -> assertThat(oppdragslinje150.gjelderOpphør()).isFalse());
         var sortertOpp150OpphForDPListe = sortOppdragslinj150Liste(opp150OpphForDPListe);
         var førsteOpp150ForDP = sortertOpp150OpphForDPListe.get(0);
         assertThat(førsteOpp150ForDP.getRefFagsystemId()).isNull();
         assertThat(førsteOpp150ForDP.getRefDelytelseId()).isNull();
+        var andreOpp150ForDP = sortertOpp150OpphForDPListe.get(1);
+        assertThat(andreOpp150ForDP.getRefDelytelseId()).isEqualTo(førsteOpp150ForDP.getDelytelseId());
         //Sjekk om delytelseId er unikt for oppdragslinje150
         var delytelseIdList = opp150RevurderingListe.stream().map(Oppdragslinje150::getDelytelseId).toList();
         Set<Long> delytelseIdSet = Sets.newHashSet(delytelseIdList);

--- a/domenetjenester/okonomistotte/src/test/java/no/nav/foreldrepenger/økonomistøtte/oppdrag/NyOppdragskontrollTjenesteENDRTest.java
+++ b/domenetjenester/okonomistotte/src/test/java/no/nav/foreldrepenger/økonomistøtte/oppdrag/NyOppdragskontrollTjenesteENDRTest.java
@@ -905,8 +905,8 @@ public class NyOppdragskontrollTjenesteENDRTest extends NyOppdragskontrollTjenes
         assertThat(oppdrag110Liste).hasSize(1);
         verifiserOppdrag110_ENDR(oppdragRevurdering.getOppdrag110Liste(), originaltOppdrag110Liste, false);
         var opp150Liste = OppdragskontrollTestVerktøy.getOpp150ListeForBruker(oppdrag110Liste);
-        //En Opphør på AT, To for ny AT, To for ny FL
-        assertThat(opp150Liste).hasSize(5);
+        //En Opphør på AT, En ny AT, En ny FL
+        assertThat(opp150Liste).hasSize(3);
         var opp150ForFLListe = OppdragskontrollTestVerktøy.getOppdragslinje150MedKlassekode(opp150Liste, KodeKlassifik.FPF_FRILANSER);
         assertThat(opp150ForFLListe).isNotEmpty().allSatisfy(opp150 -> assertThat(opp150.gjelderOpphør()).isFalse());
         verifiserOppdragslinje150_ENDR(oppdragRevurdering, originaltOppdragslinje150, false, true, 100);
@@ -1047,7 +1047,7 @@ public class NyOppdragskontrollTjenesteENDRTest extends NyOppdragskontrollTjenes
         var oppdrag110RevurderingListe = oppdragRevurdering.getOppdrag110Liste();
         assertThat(oppdrag110RevurderingListe).hasSize(1);
         var opp150RevurderingListe = oppdrag110RevurderingListe.get(0).getOppdragslinje150Liste();
-        assertThat(opp150RevurderingListe).hasSize(6);
+        assertThat(opp150RevurderingListe).hasSize(4);
         //Opphør for FL
         var opp150OpphForFLListe = getOpp150MedKodeklassifik(opp150RevurderingListe, KodeKlassifik.FPF_FRILANSER);
         assertThat(opp150OpphForFLListe).hasSize(1).allSatisfy(oppdragslinje150 -> assertThat(oppdragslinje150.gjelderOpphør()).isTrue());
@@ -1056,22 +1056,18 @@ public class NyOppdragskontrollTjenesteENDRTest extends NyOppdragskontrollTjenes
         assertThat(opp150OpphForSNListe).hasSize(1).allSatisfy(oppdragslinje150 -> assertThat(oppdragslinje150.gjelderOpphør()).isTrue());
         //Oppdragslinje150 for AT
         var opp150ForATListe = getOpp150MedKodeklassifik(opp150RevurderingListe, KodeKlassifik.FPF_ARBEIDSTAKER);
-        assertThat(opp150ForATListe).hasSize(2).allSatisfy(oppdragslinje150 -> assertThat(oppdragslinje150.gjelderOpphør()).isFalse());
+        assertThat(opp150ForATListe).hasSize(1).allSatisfy(oppdragslinje150 -> assertThat(oppdragslinje150.gjelderOpphør()).isFalse());
         var sortertOpp150OpphForATListe = sortOppdragslinj150Liste(opp150ForATListe);
         var førsteOpp150ForAT = sortertOpp150OpphForATListe.get(0);
         assertThat(førsteOpp150ForAT.getRefFagsystemId()).isNull();
         assertThat(førsteOpp150ForAT.getRefDelytelseId()).isNull();
-        var andreOpp150ForAT = sortertOpp150OpphForATListe.get(1);
-        assertThat(andreOpp150ForAT.getRefDelytelseId()).isEqualTo(førsteOpp150ForAT.getDelytelseId());
         //Oppdragslinje150 for DP
         var opp150OpphForDPListe = getOpp150MedKodeklassifik(opp150RevurderingListe, KodeKlassifik.FPF_DAGPENGER);
-        assertThat(opp150OpphForDPListe).hasSize(2).allSatisfy(oppdragslinje150 -> assertThat(oppdragslinje150.gjelderOpphør()).isFalse());
+        assertThat(opp150OpphForDPListe).hasSize(1).allSatisfy(oppdragslinje150 -> assertThat(oppdragslinje150.gjelderOpphør()).isFalse());
         var sortertOpp150OpphForDPListe = sortOppdragslinj150Liste(opp150OpphForDPListe);
         var førsteOpp150ForDP = sortertOpp150OpphForDPListe.get(0);
         assertThat(førsteOpp150ForDP.getRefFagsystemId()).isNull();
         assertThat(førsteOpp150ForDP.getRefDelytelseId()).isNull();
-        var andreOpp150ForDP = sortertOpp150OpphForDPListe.get(1);
-        assertThat(andreOpp150ForDP.getRefDelytelseId()).isEqualTo(førsteOpp150ForDP.getDelytelseId());
         //Sjekk om delytelseId er unikt for oppdragslinje150
         var delytelseIdList = opp150RevurderingListe.stream().map(Oppdragslinje150::getDelytelseId).toList();
         Set<Long> delytelseIdSet = Sets.newHashSet(delytelseIdList);
@@ -1174,7 +1170,7 @@ public class NyOppdragskontrollTjenesteENDRTest extends NyOppdragskontrollTjenes
         var opp150RevurdListe = OppdragskontrollTestVerktøy.getOppdragslinje150Liste(oppdragRevurdering);
         verifiserKodeklassifik(originaltOpp150Liste, opp150RevurdListe);
         var opp150IAndrePeriode = opp150RevurdListe.stream().filter(opp150 -> !opp150.gjelderOpphør()).toList();
-        assertThat(opp150IAndrePeriode).hasSize(3).allSatisfy(opp150 -> assertThat(opp150.getUtbetalingsgrad().getVerdi()).isEqualTo(80));
+        assertThat(opp150IAndrePeriode).hasSize(2).allSatisfy(opp150 -> assertThat(opp150.getUtbetalingsgrad().getVerdi()).isEqualTo(80));
     }
 
     @Test
@@ -1761,7 +1757,7 @@ public class NyOppdragskontrollTjenesteENDRTest extends NyOppdragskontrollTjenes
         assertThat(oppdrag110ListeForBrukerIRevurdering.get(0).getKodeEndring()).isEqualTo(KodeEndring.ENDR);
         //Oppdragslinje150 for bruker i revurdering
         var opp150ListeForBrukerIRevurdering = oppdrag110ListeForBrukerIRevurdering.get(0).getOppdragslinje150Liste();
-        assertThat(opp150ListeForBrukerIRevurdering).hasSize(4);
+        assertThat(opp150ListeForBrukerIRevurdering).hasSize(3);
         assertThat(opp150ListeForBrukerIRevurdering.stream().filter(Oppdragslinje150::gjelderOpphør)).allSatisfy(opp150 -> {
             assertThat(opp150.getDatoStatusFom()).isEqualTo(b1Periode_1.getBeregningsresultatPeriodeFom());
             assertThat(opp150.gjelderOpphør()).isTrue();
@@ -2345,9 +2341,9 @@ public class NyOppdragskontrollTjenesteENDRTest extends NyOppdragskontrollTjenes
         assertThat(oppdra110BrukerList).hasSize(1);
         assertThat(oppdra110BrukerList.get(0).getKodeEndring()).isEqualTo(KodeEndring.ENDR);
         var alleOpp150BrukerListe = oppdra110BrukerList.get(0).getOppdragslinje150Liste();
-        assertThat(alleOpp150BrukerListe).hasSize(3).anySatisfy(opp150 -> assertThat(opp150.gjelderOpphør()).isTrue());
+        assertThat(alleOpp150BrukerListe).hasSize(2).anySatisfy(opp150 -> assertThat(opp150.gjelderOpphør()).isTrue());
         var opp150UtenOpphBrukerListe = alleOpp150BrukerListe.stream().filter(opp150 -> !opp150.gjelderOpphør()).toList();
-        assertThat(opp150UtenOpphBrukerListe).hasSize(2).allSatisfy(opp150 -> {
+        assertThat(opp150UtenOpphBrukerListe).hasSize(1).allSatisfy(opp150 -> {
             assertThat(opp150.getSats()).isEqualTo(Sats.på(2400L));
             assertThat(opp150.getRefDelytelseId()).isNotNull();
             assertThat(opp150.getRefFagsystemId()).isNotNull();
@@ -2399,9 +2395,9 @@ public class NyOppdragskontrollTjenesteENDRTest extends NyOppdragskontrollTjenes
         assertThat(oppdra110BrukerList).hasSize(1);
         assertThat(oppdra110BrukerList.get(0).getKodeEndring()).isEqualTo(KodeEndring.ENDR);
         var alleOpp150BrukerListe = oppdra110BrukerList.get(0).getOppdragslinje150Liste();
-        assertThat(alleOpp150BrukerListe).hasSize(3).anySatisfy(opp150 -> assertThat(opp150.gjelderOpphør()).isTrue());
+        assertThat(alleOpp150BrukerListe).hasSize(2).anySatisfy(opp150 -> assertThat(opp150.gjelderOpphør()).isTrue());
         var opp150UtenOpphBrukerListe = alleOpp150BrukerListe.stream().filter(opp150 -> !opp150.gjelderOpphør()).toList();
-        assertThat(opp150UtenOpphBrukerListe).hasSize(2).allSatisfy(opp150 -> {
+        assertThat(opp150UtenOpphBrukerListe).hasSize(1).allSatisfy(opp150 -> {
             assertThat(opp150.getSats()).isEqualTo(Sats.på(3700L));
             assertThat(opp150.getRefDelytelseId()).isNotNull();
             assertThat(opp150.getRefFagsystemId()).isNotNull();
@@ -2499,7 +2495,7 @@ public class NyOppdragskontrollTjenesteENDRTest extends NyOppdragskontrollTjenes
         assertThat(oppdrag110ForPrivatArbgvr.getKodeEndring()).isEqualTo(KodeEndring.NY);
         //Oppdragslinje150 privat arbgvr
         var opp150PrivatArbgvrListe = oppdrag110ForPrivatArbgvr.getOppdragslinje150Liste();
-        assertThat(opp150PrivatArbgvrListe).hasSize(2).allSatisfy(opp150 -> {
+        assertThat(opp150PrivatArbgvrListe).hasSize(1).allSatisfy(opp150 -> {
             assertThat(opp150.getSats()).isEqualTo(Sats.på(1000));
             assertThat(opp150.gjelderOpphør()).isFalse();
         });
@@ -2744,7 +2740,7 @@ public class NyOppdragskontrollTjenesteENDRTest extends NyOppdragskontrollTjenes
             .toList();
 
         // Bruker + FP
-        assertThat(opp150RevurderingListe).hasSize(8).anySatisfy(linje -> assertThat(linje.gjelderOpphør()).isTrue());
+        assertThat(opp150RevurderingListe).hasSize(6).anySatisfy(linje -> assertThat(linje.gjelderOpphør()).isTrue());
 
 
         // Arrange 3 - tredje revurdering med omfordeling av andre ag til bruker

--- a/domenetjenester/okonomistotte/src/test/java/no/nav/foreldrepenger/økonomistøtte/oppdrag/NyOppdragskontrollTjenesteImplTest.java
+++ b/domenetjenester/okonomistotte/src/test/java/no/nav/foreldrepenger/økonomistøtte/oppdrag/NyOppdragskontrollTjenesteImplTest.java
@@ -324,7 +324,7 @@ class NyOppdragskontrollTjenesteImplTest extends NyOppdragskontrollTjenesteTestB
             assertThat(oppdrag110List).hasSize(1);
             assertThat(oppdrag110List.get(0).getOmpostering116()).isNotPresent();
             var oppdragslinje150List = oppdrag110List.get(0).getOppdragslinje150Liste();
-            assertThat(oppdragslinje150List).hasSize(2);
+            assertThat(oppdragslinje150List).hasSize(1);
             assertThat(oppdragslinje150List).allSatisfy(opp150 -> {
                 assertThat(opp150.getSats()).isEqualTo(Sats.på(1500L));
                 assertThat(opp150.getKodeKlassifik()).isEqualTo(KodeKlassifik.FPF_ARBEIDSTAKER);
@@ -339,7 +339,7 @@ class NyOppdragskontrollTjenesteImplTest extends NyOppdragskontrollTjenesteTestB
         var brPeriode_1 = buildBeregningsresultatPeriode(beregningsresultat, 1, 10);
         buildBeregningsresultatAndel(brPeriode_1, true, 0, BigDecimal.valueOf(100L), null);
         buildBeregningsresultatAndel(brPeriode_1, false, 1000, BigDecimal.valueOf(100L), null);
-        var brPeriode_2 = buildBeregningsresultatPeriode(beregningsresultat, 11, 20);
+        var brPeriode_2 = buildBeregningsresultatPeriode(beregningsresultat, 20, 28);
         buildBeregningsresultatAndel(brPeriode_2, true, 0, BigDecimal.valueOf(100L), null);
         buildBeregningsresultatAndel(brPeriode_2, false, 1000, BigDecimal.valueOf(100L), null);
 
@@ -390,7 +390,7 @@ class NyOppdragskontrollTjenesteImplTest extends NyOppdragskontrollTjenesteTestB
             var oppdrag110List = ok.getOppdrag110Liste();
             assertThat(oppdrag110List).hasSize(1);
             var oppdragslinje150List = oppdrag110List.get(0).getOppdragslinje150Liste();
-            assertThat(oppdragslinje150List).hasSize(2);
+            assertThat(oppdragslinje150List).hasSize(1);
             assertThat(oppdragslinje150List).allSatisfy(opp150 -> {
                 assertThat(opp150.getSats()).isEqualTo(Sats.på(1000L));
                 assertThat(opp150.getKodeKlassifik()).isEqualTo(KodeKlassifik.FPF_ARBEIDSTAKER);
@@ -427,7 +427,7 @@ class NyOppdragskontrollTjenesteImplTest extends NyOppdragskontrollTjenesteTestB
             var oppdrag110List = ok.getOppdrag110Liste();
             assertThat(oppdrag110List).hasSize(1);
             var oppdragslinje150List = oppdrag110List.get(0).getOppdragslinje150Liste();
-            assertThat(oppdragslinje150List).hasSize(2);
+            assertThat(oppdragslinje150List).hasSize(1);
             assertThat(oppdragslinje150List).allSatisfy(opp150 -> {
                 assertThat(opp150.getSats()).isEqualTo(Sats.på(1000L));
                 assertThat(opp150.getKodeKlassifik()).isEqualTo(KodeKlassifik.FPF_ARBEIDSTAKER);
@@ -444,7 +444,7 @@ class NyOppdragskontrollTjenesteImplTest extends NyOppdragskontrollTjenesteTestB
         buildBeregningsresultatAndel(brPeriode_1, true, 0, BigDecimal.valueOf(100L), virksomhet);
         buildBeregningsresultatAndel(brPeriode_1, false, 500, BigDecimal.valueOf(100L), null);
         buildBeregningsresultatAndel(brPeriode_1, false, 500, BigDecimal.valueOf(100L), virksomhet);
-        var brPeriode_2 = buildBeregningsresultatPeriode(beregningsresultat, 11, 20);
+        var brPeriode_2 = buildBeregningsresultatPeriode(beregningsresultat, 20, 28);
         buildBeregningsresultatAndel(brPeriode_2, true, 0, BigDecimal.valueOf(100L), null);
         buildBeregningsresultatAndel(brPeriode_2, true, 0, BigDecimal.valueOf(100L), virksomhet);
         buildBeregningsresultatAndel(brPeriode_2, false, 500, BigDecimal.valueOf(100L), null);
@@ -520,14 +520,14 @@ class NyOppdragskontrollTjenesteImplTest extends NyOppdragskontrollTjenesteTestB
             assertThat(oppdrag110Virksomhet).isNotNull();
             //Oppdragslinj150 for bruker/privat arbeidsgiver
             var opp150ListPrivatArbgvr = OppdragskontrollTestVerktøy.getOpp150ListeForBruker(oppdrag110List);
-            assertThat(opp150ListPrivatArbgvr).hasSize(2);
+            assertThat(opp150ListPrivatArbgvr).hasSize(1);
             assertThat(opp150ListPrivatArbgvr).allSatisfy(opp150 -> {
                 assertThat(opp150.getSats()).isEqualTo(Sats.på(1500L));
                 assertThat(opp150.getKodeKlassifik()).isEqualTo(KodeKlassifik.FPF_ARBEIDSTAKER);
             });
             //Oppdragslinj150 for arbeidsgiver
             var opp150ListVirksomhet = OppdragskontrollTestVerktøy.getOpp150ListeForEnVirksomhet(oppdrag110List, virksomhet);
-            assertThat(opp150ListVirksomhet).hasSize(2);
+            assertThat(opp150ListVirksomhet).hasSize(1);
             assertThat(opp150ListVirksomhet).allSatisfy(opp150 -> {
                 assertThat(opp150.getSats()).isEqualTo(Sats.på(500L));
                 assertThat(opp150.getKodeKlassifik()).isEqualTo(KodeKlassifik.FPF_REFUSJON_AG);

--- a/domenetjenester/okonomistotte/src/test/java/no/nav/foreldrepenger/økonomistøtte/oppdrag/OppdragskontrollTjenesteImplSVPTest.java
+++ b/domenetjenester/okonomistotte/src/test/java/no/nav/foreldrepenger/økonomistøtte/oppdrag/OppdragskontrollTjenesteImplSVPTest.java
@@ -124,7 +124,7 @@ public class OppdragskontrollTjenesteImplSVPTest extends NyOppdragskontrollTjene
         assertThat(oppdrag110_Arbeidsgiver).isPresent();
         //Oppdragslinje150 - Bruker
         var opp150List_Bruker = oppdrag110_Bruker.get().getOppdragslinje150Liste();
-        assertThat(opp150List_Bruker.stream().filter(opp150 -> KodeKlassifik.SVP_ARBEDISTAKER.equals(opp150.getKodeKlassifik()))).hasSize(2);
+        assertThat(opp150List_Bruker.stream().filter(opp150 -> KodeKlassifik.SVP_ARBEDISTAKER.equals(opp150.getKodeKlassifik()))).hasSize(1);
         assertThat(opp150List_Bruker.stream().filter(opp150 -> KodeKlassifik.FERIEPENGER_BRUKER.equals(opp150.getKodeKlassifik()))).hasSize(1);
         assertThat(opp150List_Bruker.stream().filter(opp150 -> KodeKlassifik.SVP_FERIEPENGER_BRUKER.equals(opp150.getKodeKlassifik()))).hasSize(1);
         //Oppdragslinje150 - Arbeidsgiver

--- a/domenetjenester/okonomistotte/src/test/java/no/nav/foreldrepenger/økonomistøtte/oppdrag/mapper/TilkjentYtelseMapperTest.java
+++ b/domenetjenester/okonomistotte/src/test/java/no/nav/foreldrepenger/økonomistøtte/oppdrag/mapper/TilkjentYtelseMapperTest.java
@@ -28,9 +28,9 @@ class TilkjentYtelseMapperTest {
 
     private static final LocalDate JAN_1 = LocalDate.of(2020, 1, 1);
     private static final LocalDate JAN_2 = LocalDate.of(2020, 1, 2);
-    private static final LocalDate JAN_3 = LocalDate.of(2020, 1, 3);
+    private static final LocalDate JAN_3 = LocalDate.of(2020, 1, 3); // Fredag
     private static final LocalDate JAN_4 = LocalDate.of(2020, 1, 4);
-    private static final LocalDate JAN_6 = LocalDate.of(2020, 1, 6);
+    private static final LocalDate JAN_6 = LocalDate.of(2020, 1, 6); // Mandag
     private static final LocalDate JAN_7 = LocalDate.of(2020, 1, 7);
 
     private static final LocalDate NESTE_MAI_1 = LocalDate.of(2021, 5, 1);
@@ -200,8 +200,54 @@ class TilkjentYtelseMapperTest {
     }
 
     @Test
-    void skal_mappe_andeler_fra_private_arbeidsgivere_til_bruker() {
+    void skal_slå_sammen_perioder_som_er_tidsnaboer_med_like_verdier() {
+        var periode1 = BeregningsresultatPeriode.builder().medBeregningsresultatPeriodeFomOgTom(JAN_1, JAN_2).build(ENTITET);
+        lagAndelTilBruker(Inntektskategori.ARBEIDSTAKER, 1000, periode1);
+        var periode2 = BeregningsresultatPeriode.builder().medBeregningsresultatPeriodeFomOgTom(JAN_3, JAN_4).build(ENTITET);
+        lagAndelTilBruker(Inntektskategori.ARBEIDSTAKER, 1000, periode2);
+        var perioder = List.of(periode1, periode2);
+
+        var resultat = MAPPER.fordelPåNøkler(perioder).getYtelsePrNøkkel();
+
+        //assert
+        var forventetNøkkelYtelse = KjedeNøkkel.lag(KodeKlassifik.FPF_ARBEIDSTAKER, Betalingsmottaker.BRUKER);
+        Assertions.assertThat(resultat).containsOnlyKeys(forventetNøkkelYtelse);
+
+        var ytelse = resultat.get(forventetNøkkelYtelse);
+        // Skal være komprimert til 1 sammenhengende periode
+        Assertions.assertThat(ytelse.getPerioder()).hasSize(1);
+        var ytelsePeriode1 = ytelse.getPerioder().get(0);
+        Assertions.assertThat(ytelsePeriode1.getSats()).isEqualTo(Satsen.dagsats(1000));
+        Assertions.assertThat(ytelsePeriode1.getPeriode()).isEqualTo(Periode.of(JAN_1, JAN_4));
+        Assertions.assertThat(ytelsePeriode1.getUtbetalingsgrad()).isEqualTo(new Utbetalingsgrad(100));
+    }
+
+    @Test
+    void skal_slå_sammen_perioder_som_er_tidsnaboer__fredag_mandag_med_like_verdier() {
         var periode1 = BeregningsresultatPeriode.builder().medBeregningsresultatPeriodeFomOgTom(JAN_1, JAN_3).build(ENTITET);
+        lagAndelTilBruker(Inntektskategori.ARBEIDSTAKER, 1000, periode1);
+        var periode2 = BeregningsresultatPeriode.builder().medBeregningsresultatPeriodeFomOgTom(JAN_6, JAN_7).build(ENTITET);
+        lagAndelTilBruker(Inntektskategori.ARBEIDSTAKER, 1000, periode2);
+        var perioder = List.of(periode1, periode2);
+
+        var resultat = MAPPER.fordelPåNøkler(perioder).getYtelsePrNøkkel();
+
+        //assert
+        var forventetNøkkelYtelse = KjedeNøkkel.lag(KodeKlassifik.FPF_ARBEIDSTAKER, Betalingsmottaker.BRUKER);
+        Assertions.assertThat(resultat).containsOnlyKeys(forventetNøkkelYtelse);
+
+        var ytelse = resultat.get(forventetNøkkelYtelse);
+        // Skal være komprimert til 1 sammenhengende periode
+        Assertions.assertThat(ytelse.getPerioder()).hasSize(1);
+        var ytelsePeriode1 = ytelse.getPerioder().get(0);
+        Assertions.assertThat(ytelsePeriode1.getSats()).isEqualTo(Satsen.dagsats(1000));
+        Assertions.assertThat(ytelsePeriode1.getPeriode()).isEqualTo(Periode.of(JAN_1, JAN_7));
+        Assertions.assertThat(ytelsePeriode1.getUtbetalingsgrad()).isEqualTo(new Utbetalingsgrad(100));
+    }
+
+    @Test
+    void skal_mappe_andeler_fra_private_arbeidsgivere_til_bruker() {
+        var periode1 = BeregningsresultatPeriode.builder().medBeregningsresultatPeriodeFomOgTom(JAN_1, JAN_2).build(ENTITET);
         lagAndelTilBruker(Inntektskategori.ARBEIDSTAKER, 1000, periode1);
         lagAndelTilOrg(Arbeidsgiver.person(new AktørId(1234567891234L)), 500, periode1);
         var periode2 = BeregningsresultatPeriode.builder().medBeregningsresultatPeriodeFomOgTom(JAN_6, JAN_7).build(ENTITET);
@@ -217,11 +263,16 @@ class TilkjentYtelseMapperTest {
 
         var ytelse = resultat.get(forventetNøkkelYtelse);
         // Skal være komprimert til 1 sammenhengende periode
-        Assertions.assertThat(ytelse.getPerioder()).hasSize(1);
+        Assertions.assertThat(ytelse.getPerioder()).hasSize(2);
         var ytelsePeriode1 = ytelse.getPerioder().get(0);
         Assertions.assertThat(ytelsePeriode1.getSats()).isEqualTo(Satsen.dagsats(1500));
-        Assertions.assertThat(ytelsePeriode1.getPeriode()).isEqualTo(Periode.of(JAN_1, JAN_7));
+        Assertions.assertThat(ytelsePeriode1.getPeriode()).isEqualTo(Periode.of(JAN_1, JAN_2));
         Assertions.assertThat(ytelsePeriode1.getUtbetalingsgrad()).isEqualTo(new Utbetalingsgrad(100));
+
+        var ytelsePeriode2 = ytelse.getPerioder().get(1);
+        Assertions.assertThat(ytelsePeriode2.getSats()).isEqualTo(Satsen.dagsats(1500));
+        Assertions.assertThat(ytelsePeriode2.getPeriode()).isEqualTo(Periode.of(JAN_6, JAN_7));
+        Assertions.assertThat(ytelsePeriode2.getUtbetalingsgrad()).isEqualTo(new Utbetalingsgrad(100));
     }
 
     private static BeregningsresultatAndel lagAndelTilBruker(Inntektskategori inntektskategori, int dagsats, BeregningsresultatPeriode periode) {

--- a/domenetjenester/okonomistotte/src/test/java/no/nav/foreldrepenger/økonomistøtte/oppdrag/mapper/TilkjentYtelseMapperTest.java
+++ b/domenetjenester/okonomistotte/src/test/java/no/nav/foreldrepenger/økonomistøtte/oppdrag/mapper/TilkjentYtelseMapperTest.java
@@ -30,6 +30,8 @@ class TilkjentYtelseMapperTest {
     private static final LocalDate JAN_2 = LocalDate.of(2020, 1, 2);
     private static final LocalDate JAN_3 = LocalDate.of(2020, 1, 3);
     private static final LocalDate JAN_4 = LocalDate.of(2020, 1, 4);
+    private static final LocalDate JAN_6 = LocalDate.of(2020, 1, 6);
+    private static final LocalDate JAN_7 = LocalDate.of(2020, 1, 7);
 
     private static final LocalDate NESTE_MAI_1 = LocalDate.of(2021, 5, 1);
     private static final LocalDate NESTE_MAI_31 = LocalDate.of(2021, 5, 31);
@@ -199,10 +201,10 @@ class TilkjentYtelseMapperTest {
 
     @Test
     void skal_mappe_andeler_fra_private_arbeidsgivere_til_bruker() {
-        var periode1 = BeregningsresultatPeriode.builder().medBeregningsresultatPeriodeFomOgTom(JAN_1, JAN_2).build(ENTITET);
+        var periode1 = BeregningsresultatPeriode.builder().medBeregningsresultatPeriodeFomOgTom(JAN_1, JAN_3).build(ENTITET);
         lagAndelTilBruker(Inntektskategori.ARBEIDSTAKER, 1000, periode1);
         lagAndelTilOrg(Arbeidsgiver.person(new AktørId(1234567891234L)), 500, periode1);
-        var periode2 = BeregningsresultatPeriode.builder().medBeregningsresultatPeriodeFomOgTom(JAN_3, JAN_4).build(ENTITET);
+        var periode2 = BeregningsresultatPeriode.builder().medBeregningsresultatPeriodeFomOgTom(JAN_6, JAN_7).build(ENTITET);
         lagAndelTilBruker(Inntektskategori.ARBEIDSTAKER, 1000, periode2);
         lagAndelTilOrg(Arbeidsgiver.person(new AktørId(1234567891234L)), 500, periode2);
         var perioder = List.of(periode1, periode2);
@@ -214,16 +216,12 @@ class TilkjentYtelseMapperTest {
         Assertions.assertThat(resultat).containsOnlyKeys(forventetNøkkelYtelse);
 
         var ytelse = resultat.get(forventetNøkkelYtelse);
-        Assertions.assertThat(ytelse.getPerioder()).hasSize(2);
+        // Skal være komprimert til 1 sammenhengende periode
+        Assertions.assertThat(ytelse.getPerioder()).hasSize(1);
         var ytelsePeriode1 = ytelse.getPerioder().get(0);
         Assertions.assertThat(ytelsePeriode1.getSats()).isEqualTo(Satsen.dagsats(1500));
-        Assertions.assertThat(ytelsePeriode1.getPeriode()).isEqualTo(Periode.of(JAN_1, JAN_2));
+        Assertions.assertThat(ytelsePeriode1.getPeriode()).isEqualTo(Periode.of(JAN_1, JAN_7));
         Assertions.assertThat(ytelsePeriode1.getUtbetalingsgrad()).isEqualTo(new Utbetalingsgrad(100));
-
-        var ytelsePeriode2 = ytelse.getPerioder().get(1);
-        Assertions.assertThat(ytelsePeriode2.getSats()).isEqualTo(Satsen.dagsats(1500));
-        Assertions.assertThat(ytelsePeriode2.getPeriode()).isEqualTo(Periode.of(JAN_3, JAN_4));
-        Assertions.assertThat(ytelsePeriode2.getUtbetalingsgrad()).isEqualTo(new Utbetalingsgrad(100));
     }
 
     private static BeregningsresultatAndel lagAndelTilBruker(Inntektskategori inntektskategori, int dagsats, BeregningsresultatPeriode periode) {


### PR DESCRIPTION
Denne vil slå sammen oppdragsperioder for samme kjedenøkkel gitt at periodene ligger inntil hverandre (dag-dag eller fra-man) og at de har lik verdi (sats, beløp, utbetgrad)
@tendestad dere har kanskje gjort dette allerede gitt at dere har mange perioder man-fre + påfølgende man-fre ?