### PR TITLE
TFP-5005: Fjern ompostering og la økonomi å utlede det selv automatisk.

### DIFF
--- a/domenetjenester/okonomistotte/src/main/java/no/nav/foreldrepenger/økonomistøtte/oppdrag/mapper/OppdragMapper.java
+++ b/domenetjenester/okonomistotte/src/main/java/no/nav/foreldrepenger/økonomistøtte/oppdrag/mapper/OppdragMapper.java
@@ -60,13 +60,13 @@ public class OppdragMapper {
         // - det er ikke en utbetaling til ny mottaker
         // - mottaker har gjeldende utbetalinger fra tidligere
         // - gjeldende oppdrag fører ikke til full opphør for mottaker
-        var tidligerOppdragForMottaker = tidligereOppdrag.filter(oppdrag.getBetalingsmottaker());
-        if (oppdrag.getBetalingsmottaker() == Betalingsmottaker.BRUKER
-            && !oppdragErTilNyMottaker(oppdrag.getBetalingsmottaker())
-            && harGjeldendeUtbetalingerFraTidligere(tidligerOppdragForMottaker)
-            && !erOpphørForMottaker(tidligerOppdragForMottaker.utvidMed(oppdrag))) {
-            builder.medOmpostering116(opprettOmpostering116(oppdrag, input.brukInntrekk()));
-        }
+//        var tidligerOppdragForMottaker = tidligereOppdrag.filter(oppdrag.getBetalingsmottaker());
+//        if (oppdrag.getBetalingsmottaker() == Betalingsmottaker.BRUKER
+//            && !oppdragErTilNyMottaker(oppdrag.getBetalingsmottaker())
+//            && harGjeldendeUtbetalingerFraTidligere(tidligerOppdragForMottaker)
+//            && !erOpphørForMottaker(tidligerOppdragForMottaker.utvidMed(oppdrag))) {
+//            builder.medOmpostering116(opprettOmpostering116(oppdrag, input.brukInntrekk()));
+//        }
 
         var oppdrag110 = builder.build();
 

--- a/domenetjenester/okonomistotte/src/test/java/no/nav/foreldrepenger/økonomistøtte/oppdrag/NyOppdragskontrollTjenesteENDRTest.java
+++ b/domenetjenester/okonomistotte/src/test/java/no/nav/foreldrepenger/økonomistøtte/oppdrag/NyOppdragskontrollTjenesteENDRTest.java
@@ -94,13 +94,14 @@ public class NyOppdragskontrollTjenesteENDRTest extends NyOppdragskontrollTjenes
         assertThat(oppdragRevurdering).isNotNull();
         var oppdrag110 = OppdragskontrollTestVerktøy.getOppdrag110ForBruker(oppdragRevurdering.getOppdrag110Liste());
         assertThat(oppdrag110.getKodeEndring()).isEqualTo(KodeEndring.ENDR);
-        assertThat(oppdrag110.getOmpostering116()).isPresent();
-        var ompostering116 = oppdrag110.getOmpostering116().get();
-        assertThat(ompostering116.getOmPostering()).isFalse();
-        assertThat(ompostering116.getDatoOmposterFom()).isNull();
+       // assertThat(oppdrag110.getOmpostering116()).isPresent();
+       // var ompostering116 = oppdrag110.getOmpostering116().get();
+       // assertThat(ompostering116.getOmPostering()).isFalse();
+       // assertThat(ompostering116.getDatoOmposterFom()).isNull();
     }
 
     @Test
+    @Disabled(value = "Midlertidig slått av Ompostering siden økonomi klarer å utlede selv den beste datoen for ompostering.")
     void skalSendeOppdragMedOmpostering116HvisIkkeAvslåttInntrekkOgDetFinnesForrigeOppdrag() {
         // Arrange
         var beregningsresultat = buildEmptyBeregningsresultatFP();
@@ -144,6 +145,7 @@ public class NyOppdragskontrollTjenesteENDRTest extends NyOppdragskontrollTjenes
 
     @Test
     @DisplayName("Tester tilfeller hvor ompostering116 ble ikke sendt fordi bruker har fått opphør på feriepenger men ikke selve ytelsen.")
+    @Disabled(value = "Midlertidig slått av Ompostering siden økonomi klarer å utlede selv den beste datoen for ompostering.")
     void test_manglende_inntrekk_tfp_5130() {
         // Arrange
         // Arrange : Førstegangsbehandling
@@ -355,10 +357,10 @@ public class NyOppdragskontrollTjenesteENDRTest extends NyOppdragskontrollTjenes
 
         //Assert
         var oppdrag110Bruker = OppdragskontrollTestVerktøy.getOppdrag110ForBruker(oppdragRevurdering.getOppdrag110Liste());
-        assertThat(oppdrag110Bruker.getOmpostering116()).isPresent();
-        var ompostering116 = oppdrag110Bruker.getOmpostering116().get();
-        assertThat(ompostering116.getOmPostering()).isTrue();
-        assertThat(ompostering116.getDatoOmposterFom()).isEqualTo(b1Periode.getBeregningsresultatPeriodeFom());
+        // assertThat(oppdrag110Bruker.getOmpostering116()).isPresent();
+        // var ompostering116 = oppdrag110Bruker.getOmpostering116().get();
+        // assertThat(ompostering116.getOmPostering()).isTrue();
+        // assertThat(ompostering116.getDatoOmposterFom()).isEqualTo(b1Periode.getBeregningsresultatPeriodeFom());
     }
 
     /**


### PR DESCRIPTION
Basert på denne tråden [her](https://nav-it.slack.com/archives/CKZADNFBP/p1701842681456999), ser det ut til at økonomi kan fastslå en optimal OmposteringsdatoFom selv. Ompostering116-objektet ser ut til å være ment for at en saksbehandler kan "overstyre" systemet. Det er likevel verdt å merke seg at vi ikke har gitt saksbehandlere muligheten til å overstyre Ompostering - dette håndteres automatisk av systemet.