### PR TITLE
Stønadsstatistikk div feilrettinger

### DIFF
--- a/domenetjenester/datavarehus/src/main/java/no/nav/foreldrepenger/datavarehus/v2/StønadsstatistikkTjeneste.java
+++ b/domenetjenester/datavarehus/src/main/java/no/nav/foreldrepenger/datavarehus/v2/StønadsstatistikkTjeneste.java
@@ -13,6 +13,7 @@ import static no.nav.foreldrepenger.datavarehus.v2.StønadsstatistikkVedtak.Utla
 import static no.nav.foreldrepenger.datavarehus.v2.StønadsstatistikkVedtak.VedtakResultat;
 import static no.nav.foreldrepenger.datavarehus.v2.StønadsstatistikkVedtak.YtelseType;
 
+import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.Period;
@@ -413,8 +414,10 @@ public class StønadsstatistikkTjeneste {
             case FORELDREPENGER -> Stønadskontotype.FORELDREPENGER;
             case FLERBARNSDAGER, UDEFINERT -> throw new IllegalStateException("Ukjent " + stønadskonto.getStønadskontoType());
             case FORELDREPENGER_FØR_FØDSEL -> Stønadskontotype.FORELDREPENGER_FØR_FØDSEL;
-        }).decimalValue();
-        return new ForeldrepengerRettigheter.Stønadskonto(stønadskontoType, maksdager, new ForeldrepengerRettigheter.Trekkdager(restdager),
+        });
+        //Kan være trukket i minus
+        var restdagerDto = new ForeldrepengerRettigheter.Trekkdager(restdager.mindreEnn0() ? BigDecimal.ZERO : restdager.decimalValue());
+        return new ForeldrepengerRettigheter.Stønadskonto(stønadskontoType, maksdager, restdagerDto,
             new ForeldrepengerRettigheter.Trekkdager(minsterett));
     }
 

--- a/domenetjenester/datavarehus/src/main/java/no/nav/foreldrepenger/datavarehus/v2/StønadsstatistikkVedtak.java
+++ b/domenetjenester/datavarehus/src/main/java/no/nav/foreldrepenger/datavarehus/v2/StønadsstatistikkVedtak.java
@@ -11,7 +11,6 @@ import java.util.UUID;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
-import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Positive;
@@ -182,7 +181,7 @@ public class StønadsstatistikkVedtak {
     record FamilieHendelse(LocalDate termindato,
                            LocalDate adopsjonsdato,
                            @NotNull @Positive Integer antallBarn,
-                           @NotEmpty @Valid List<Barn> barn, // AktørId setter ikke ved adopsjon og utenlandsfødte barn
+                           List<@Valid Barn> barn, // AktørId setter ikke ved adopsjon og utenlandsfødte barn
                            @NotNull HendelseType hendelseType) {
 
         record Barn(AktørId aktørId, @NotNull LocalDate fødselsdato, LocalDate dødsdato) {}
@@ -218,7 +217,7 @@ public class StønadsstatistikkVedtak {
 
     record ForeldrepengerRettigheter(@NotNull Integer dekningsgrad,
                                      @NotNull RettighetType rettighetType,
-                                     @NotNull @NotEmpty @Valid Set<Stønadskonto> stønadskonti,
+                                     @NotNull Set<@Valid Stønadskonto> stønadskonti,
                                      @Valid Trekkdager flerbarnsdager) {
 
         record Stønadskonto(@NotNull StønadskontoType type,


### PR DESCRIPTION
Ser ut til at valideringen fungerte i dev. Får en del feil

restdager - Setter 0 restdager hvis bruker er trukket i minus. Catchet av Min(0) validering
barn - Barn listen kan være tom
kontiliste - kan være tom hvis feks avslag der stønadskonti aldri er beregnet