### PR TITLE
FAGSYSTEM-314625 endringsdato utleder og uttak aksjonspunkt utleder b…

### DIFF
--- a/domenetjenester/behandling-revurdering/src/main/java/no/nav/foreldrepenger/behandling/revurdering/ytelse/UttakInputTjeneste.java
+++ b/domenetjenester/behandling-revurdering/src/main/java/no/nav/foreldrepenger/behandling/revurdering/ytelse/UttakInputTjeneste.java
@@ -28,7 +28,6 @@ import no.nav.foreldrepenger.domene.entiteter.BeregningsgrunnlagPrStatusOgAndel;
 import no.nav.foreldrepenger.domene.iay.modell.InntektArbeidYtelseGrunnlag;
 import no.nav.foreldrepenger.domene.mappers.til_kalkulus.BehandlingslagerTilKalkulusMapper;
 import no.nav.foreldrepenger.domene.medlem.MedlemTjeneste;
-import no.nav.foreldrepenger.domene.personopplysning.PersonopplysningGrunnlagDiff;
 import no.nav.foreldrepenger.domene.prosess.HentOgLagreBeregningsgrunnlagTjeneste;
 import no.nav.foreldrepenger.domene.uttak.input.BeregningsgrunnlagStatus;
 import no.nav.foreldrepenger.domene.uttak.input.UttakInput;
@@ -97,8 +96,7 @@ public class UttakInputTjeneste {
             .medMedlemskapOpphørsdato(medlemskapOpphørsdato)
             .medSøknadOpprettetTidspunkt(søknadOpprettetTidspunkt)
             .medBehandlingÅrsaker(map(årsaker))
-            .medBehandlingManueltOpprettet(erManueltOpprettet(årsaker))
-            .medErOpplysningerOmDødEndret(erOpplysningerOmDødEndret(ref));
+            .medBehandlingManueltOpprettet(erManueltOpprettet(årsaker));
         var beregningsgrunnlag = beregningsgrunnlagTjeneste.hentBeregningsgrunnlagEntitetForBehandling(ref.behandlingId());
         if (beregningsgrunnlag.isPresent()) {
             var bgStatuser = lagBeregningsgrunnlagStatuser(beregningsgrunnlag.get());
@@ -155,17 +153,5 @@ public class UttakInputTjeneste {
             case SVANGERSKAPSPENGER -> svpUttakGrunnlagTjeneste.grunnlag(ref);
             default -> throw new IllegalStateException("Finner ikke tjeneste for å lage ytelsesspesifikt grunnlag for ytelsetype " + ytelseType);
         };
-    }
-
-    private boolean erOpplysningerOmDødEndret(BehandlingReferanse ref) {
-        var behandlingId = ref.behandlingId();
-        var originaltGrunnlag = personopplysningRepository.hentFørsteVersjonAvPersonopplysninger(behandlingId);
-        var nåværendeGrunnlag = personopplysningRepository.hentPersonopplysninger(behandlingId);
-        var poDiff = new PersonopplysningGrunnlagDiff(ref.aktørId(), nåværendeGrunnlag, originaltGrunnlag);
-
-        var barnDødt = poDiff.erBarnDødsdatoEndret();
-        var foreldreDød = poDiff.erForeldreDødsdatoEndret();
-
-        return barnDødt || foreldreDød;
     }
 }

--- a/domenetjenester/behandling-revurdering/src/test/java/no/nav/foreldrepenger/behandling/revurdering/ytelse/UttakInputTjenesteTest.java
+++ b/domenetjenester/behandling-revurdering/src/test/java/no/nav/foreldrepenger/behandling/revurdering/ytelse/UttakInputTjenesteTest.java
@@ -10,8 +10,6 @@ import jakarta.inject.Inject;
 import org.junit.jupiter.api.Test;
 
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingÅrsakType;
-import no.nav.foreldrepenger.behandlingslager.behandling.personopplysning.PersonInformasjonBuilder;
-import no.nav.foreldrepenger.behandlingslager.behandling.personopplysning.PersonopplysningVersjonType;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepositoryProvider;
 import no.nav.foreldrepenger.behandlingslager.testutilities.behandling.ScenarioMorSøkerForeldrepenger;
 import no.nav.foreldrepenger.dbstoette.CdiDbAwareTest;
@@ -52,35 +50,5 @@ class UttakInputTjenesteTest {
         var resultat = tjeneste.lagInput(revurdering);
 
         assertThat(resultat.isBehandlingManueltOpprettet()).isTrue();
-    }
-
-    @Test
-    void skal_sette_om_opplysninger_om_død_er_endret_hvis_det_er_endringer() {
-        var behandlingMedEndretOpplysningerOmDød = ScenarioMorSøkerForeldrepenger.forFødsel()
-                .medDefaultSøknadTerminbekreftelse().medDefaultFordeling(LocalDate.of(2019, 1, 1))
-                .lagre(repositoryProvider);
-        var personopplysningRepository = repositoryProvider.getPersonopplysningRepository();
-        var registerVersjon = personopplysningRepository
-                .hentPersonopplysninger(behandlingMedEndretOpplysningerOmDød.getId()).getRegisterVersjon();
-        var builder = PersonInformasjonBuilder
-                .oppdater(registerVersjon, PersonopplysningVersjonType.REGISTRERT);
-        builder.leggTil(builder.getPersonopplysningBuilder(behandlingMedEndretOpplysningerOmDød.getAktørId())
-                .medDødsdato(LocalDate.now()));
-        personopplysningRepository.lagre(behandlingMedEndretOpplysningerOmDød.getId(), builder);
-
-        var resultat = tjeneste.lagInput(behandlingMedEndretOpplysningerOmDød.getId());
-
-        assertThat(resultat.isOpplysningerOmDødEndret()).isTrue();
-    }
-
-    @Test
-    void skal_sette_om_opplysninger_om_død_er_endret_hvis_det_er_ingen_endringer() {
-        var behandlingUtenEndringIOpplysninger = ScenarioMorSøkerForeldrepenger.forFødsel()
-                .medDefaultSøknadTerminbekreftelse().medDefaultFordeling(LocalDate.of(2019, 1, 1))
-                .lagre(repositoryProvider);
-
-        var resultat = tjeneste.lagInput(behandlingUtenEndringIOpplysninger.getId());
-
-        assertThat(resultat.isOpplysningerOmDødEndret()).isFalse();
     }
 }

--- a/domenetjenester/behandling-revurdering/src/test/java/no/nav/foreldrepenger/behandling/revurdering/ytelse/fp/UttakGrunnlagTjenesteTest.java
+++ b/domenetjenester/behandling-revurdering/src/test/java/no/nav/foreldrepenger/behandling/revurdering/ytelse/fp/UttakGrunnlagTjenesteTest.java
@@ -14,9 +14,12 @@ import no.nav.foreldrepenger.behandling.BehandlingReferanse;
 import no.nav.foreldrepenger.behandling.RelatertBehandlingTjeneste;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingÅrsakType;
 import no.nav.foreldrepenger.behandlingslager.behandling.familiehendelse.FamilieHendelseRepository;
+import no.nav.foreldrepenger.behandlingslager.behandling.personopplysning.PersonInformasjonBuilder;
+import no.nav.foreldrepenger.behandlingslager.behandling.personopplysning.PersonopplysningVersjonType;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingGrunnlagRepositoryProvider;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepositoryProvider;
 import no.nav.foreldrepenger.behandlingslager.testutilities.behandling.ScenarioMorSøkerEngangsstønad;
+import no.nav.foreldrepenger.behandlingslager.testutilities.behandling.ScenarioMorSøkerForeldrepenger;
 import no.nav.foreldrepenger.dbstoette.JpaExtension;
 import no.nav.foreldrepenger.familiehendelse.FamilieHendelseTjeneste;
 
@@ -24,14 +27,13 @@ import no.nav.foreldrepenger.familiehendelse.FamilieHendelseTjeneste;
 class UttakGrunnlagTjenesteTest {
 
     private BehandlingRepositoryProvider repositoryProvider;
-    private BehandlingGrunnlagRepositoryProvider grunnlagRepositoryProvider;
 
     private UttakGrunnlagTjeneste tjeneste;
 
     @BeforeEach
     void setUp(EntityManager entityManager) {
         repositoryProvider = new BehandlingRepositoryProvider(entityManager);
-        grunnlagRepositoryProvider = new BehandlingGrunnlagRepositoryProvider(entityManager);
+        var grunnlagRepositoryProvider = new BehandlingGrunnlagRepositoryProvider(entityManager);
         var relatertBehandlingTjeneste = new RelatertBehandlingTjeneste(repositoryProvider);
         var familieHendelseRepository = new FamilieHendelseRepository(entityManager);
         var familieHendelseTjeneste = new FamilieHendelseTjeneste(null, familieHendelseRepository);
@@ -61,5 +63,51 @@ class UttakGrunnlagTjenesteTest {
         var førstegangsBehandlingFamilieHendelser = grunnlagFørstegangsBehandling.getFamilieHendelser();
         assertThat(førstegangsBehandlingFamilieHendelser.getOverstyrtFamilieHendelse()).isEmpty();
         assertThat(førstegangsBehandlingFamilieHendelser.getGjeldendeFamilieHendelse().getFamilieHendelseDato()).isEqualTo(fødselsDato);
+    }
+
+    @Test
+    void skal_sette_dødsfall_hvis_det_er_endringer_om_død() {
+        var behandlingMedEndretOpplysningerOmDød = ScenarioMorSøkerForeldrepenger.forFødsel()
+            .medDefaultSøknadTerminbekreftelse().medDefaultFordeling(LocalDate.of(2019, 1, 1))
+            .lagre(repositoryProvider);
+        var personopplysningRepository = repositoryProvider.getPersonopplysningRepository();
+        var registerVersjon = personopplysningRepository
+            .hentPersonopplysninger(behandlingMedEndretOpplysningerOmDød.getId()).getRegisterVersjon();
+        var builder = PersonInformasjonBuilder
+            .oppdater(registerVersjon, PersonopplysningVersjonType.REGISTRERT);
+        builder.leggTil(builder.getPersonopplysningBuilder(behandlingMedEndretOpplysningerOmDød.getAktørId())
+            .medDødsdato(LocalDate.now()));
+        personopplysningRepository.lagre(behandlingMedEndretOpplysningerOmDød.getId(), builder);
+
+        var resultat = tjeneste.grunnlag(BehandlingReferanse.fra(behandlingMedEndretOpplysningerOmDød));
+
+        assertThat(resultat.isDødsfall()).isTrue();
+    }
+
+    @Test
+    void skal_sette_dødsfall_hvis_det_er_ingen_endringer_om_død() {
+        var behandlingUtenEndringIOpplysninger = ScenarioMorSøkerForeldrepenger.forFødsel()
+            .medDefaultSøknadTerminbekreftelse().medDefaultFordeling(LocalDate.of(2019, 1, 1))
+            .lagre(repositoryProvider);
+
+        var resultat = tjeneste.grunnlag(BehandlingReferanse.fra(behandlingUtenEndringIOpplysninger));
+
+        assertThat(resultat.isDødsfall()).isFalse();
+    }
+
+    @Test
+    void skal_sette_dødsfall_hvis_behandlingårsak_død() {
+        var fom = LocalDate.of(2019, 1, 1);
+        var originalBehandling = ScenarioMorSøkerForeldrepenger.forFødsel()
+            .medDefaultBekreftetTerminbekreftelse().medDefaultFordeling(fom)
+            .lagre(repositoryProvider);
+        var behandlingUtenEndringIOpplysninger = ScenarioMorSøkerForeldrepenger.forFødsel()
+            .medOriginalBehandling(originalBehandling, BehandlingÅrsakType.RE_HENDELSE_DØD_BARN)
+            .medDefaultSøknadTerminbekreftelse().medDefaultFordeling(fom)
+            .lagre(repositoryProvider);
+
+        var resultat = tjeneste.grunnlag(BehandlingReferanse.fra(behandlingUtenEndringIOpplysninger));
+
+        assertThat(resultat.isDødsfall()).isTrue();
     }
 }

--- a/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/SkalKopiereUttakTjeneste.java
+++ b/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/SkalKopiereUttakTjeneste.java
@@ -41,13 +41,14 @@ public class SkalKopiereUttakTjeneste {
         if (arbeidEndret) {
             return false;
         }
-        if (uttakInput.isOpplysningerOmDødEndret() || uttakInput.harBehandlingÅrsakRelatertTilDød()) {
+        var fpGrunnlag = (ForeldrepengerGrunnlag) uttakInput.getYtelsespesifiktGrunnlag();
+        if (fpGrunnlag.isDødsfall()) {
             return false;
         }
         if (saksbehandlerHarManueltAvklartStartdato(uttakInput)) {
             return false;
         }
-        if (familiehendelseEndret(uttakInput)) {
+        if (familiehendelseEndret(fpGrunnlag)) {
             return false;
         }
         var årsaker = uttakInput.getBehandlingÅrsaker();
@@ -56,8 +57,7 @@ public class SkalKopiereUttakTjeneste {
                 BehandlingÅrsakType.RE_ENDRET_INNTEKTSMELDING));
     }
 
-    private boolean familiehendelseEndret(UttakInput uttakInput) {
-        ForeldrepengerGrunnlag fpGrunnlag = uttakInput.getYtelsespesifiktGrunnlag();
+    private boolean familiehendelseEndret(ForeldrepengerGrunnlag fpGrunnlag) {
         var originalBehandling = fpGrunnlag.getOriginalBehandling();
         if (originalBehandling.isEmpty()) {
             return false;

--- a/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/fastsetteperioder/FastsettUttakManueltAksjonspunktUtleder.java
+++ b/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/fastsetteperioder/FastsettUttakManueltAksjonspunktUtleder.java
@@ -60,13 +60,13 @@ public class FastsettUttakManueltAksjonspunktUtleder {
         utledAksjonspunktForManuellBehandlingFraRegler(behandlingId).ifPresent(aksjonspunkter::add);
         utledAksjonspunktForStortingsrepresentant(input).ifPresent(aksjonspunkter::add);
         utledAksjonspunktForTetteFødsler(input).ifPresent(aksjonspunkter::add);
-        utledAksjonspunktForDødtBarn(input.getYtelsespesifiktGrunnlag()).ifPresent(aksjonspunkter::add);
         utledAksjonspunktForAnnenpartEØS(behandlingId).ifPresent(aksjonspunkter::add);
         if (input.harBehandlingÅrsak(BehandlingÅrsakType.RE_KLAGE_UTEN_END_INNTEKT)
             || input.harBehandlingÅrsak(BehandlingÅrsakType.RE_KLAGE_MED_END_INNTEKT)) {
             aksjonspunkter.add(AksjonspunktDefinisjon.KONTROLLER_REALITETSBEHANDLING_ELLER_KLAGE);
         }
-        if (input.harBehandlingÅrsakRelatertTilDød() || input.isOpplysningerOmDødEndret()) {
+        var fpGrunnlag = (ForeldrepengerGrunnlag) input.getYtelsespesifiktGrunnlag();
+        if (fpGrunnlag.isDødsfall()) {
             aksjonspunkter.add(AksjonspunktDefinisjon.KONTROLLER_OPPLYSNINGER_OM_DØD);
         }
         if (input.harBehandlingÅrsak(BehandlingÅrsakType.RE_OPPLYSNINGER_OM_SØKNAD_FRIST)) {
@@ -123,25 +123,10 @@ public class FastsettUttakManueltAksjonspunktUtleder {
         return uttakEtterNesteStartdato ? Optional.of(AksjonspunktDefinisjon.FASTSETT_UTTAK_ETTER_NESTE_SAK) : Optional.empty();
     }
 
-    private Optional<AksjonspunktDefinisjon> utledAksjonspunktForDødtBarn(ForeldrepengerGrunnlag foreldrepengerGrunnlag) {
-        if (finnesDødsdatoIRegistertEllerOverstyrtVersjon(foreldrepengerGrunnlag)) {
-            return Optional.of(AksjonspunktDefinisjon.KONTROLLER_OPPLYSNINGER_OM_DØD);
-        }
-        return Optional.empty();
-    }
-
     private Optional<AksjonspunktDefinisjon> utledAksjonspunktForAnnenpartEØS(Long behandlingId) {
         return ytelsesFordelingRepository.hentAggregatHvisEksisterer(behandlingId)
             .filter(UttakOmsorgUtil::avklartAnnenForelderHarRettEØS)
             .map(yfa -> AksjonspunktDefinisjon.KONTROLLER_ANNENPART_EØS);
-    }
-
-    private boolean finnesDødsdatoIRegistertEllerOverstyrtVersjon(ForeldrepengerGrunnlag foreldrepengerGrunnlag) {
-        var familieHendelser = foreldrepengerGrunnlag.getFamilieHendelser();
-        var barna = familieHendelser.getGjeldendeFamilieHendelse().getBarna();
-
-        return barna.stream()
-            .anyMatch(barn -> barn.getDødsdato().isPresent());
     }
 
     private AksjonspunktDefinisjon fastsettUttakAksjonspunkt() {

--- a/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/input/ForeldrepengerGrunnlag.java
+++ b/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/input/ForeldrepengerGrunnlag.java
@@ -17,6 +17,7 @@ public class ForeldrepengerGrunnlag implements YtelsespesifiktGrunnlag {
     private boolean oppdagetPleiepengerOverlappendeUtbetaling;
     private UføretrygdGrunnlagEntitet uføretrygdGrunnlag;
     private NesteSakGrunnlagEntitet nesteSakGrunnlag;
+    private boolean dødsfall;
 
     public ForeldrepengerGrunnlag() {
 
@@ -32,6 +33,7 @@ public class ForeldrepengerGrunnlag implements YtelsespesifiktGrunnlag {
         this.oppdagetPleiepengerOverlappendeUtbetaling = foreldrepengerGrunnlag.oppdagetPleiepengerOverlappendeUtbetaling;
         this.uføretrygdGrunnlag = foreldrepengerGrunnlag.uføretrygdGrunnlag;
         this.nesteSakGrunnlag = foreldrepengerGrunnlag.nesteSakGrunnlag;
+        this.dødsfall = foreldrepengerGrunnlag.dødsfall;
     }
 
     public boolean isBerørtBehandling() {
@@ -68,6 +70,10 @@ public class ForeldrepengerGrunnlag implements YtelsespesifiktGrunnlag {
 
     public Optional<NesteSakGrunnlagEntitet> getNesteSakGrunnlag() {
         return Optional.ofNullable(nesteSakGrunnlag);
+    }
+
+    public boolean isDødsfall() {
+        return dødsfall;
     }
 
     public ForeldrepengerGrunnlag medErBerørtBehandling(boolean berørtBehandling) {
@@ -121,6 +127,12 @@ public class ForeldrepengerGrunnlag implements YtelsespesifiktGrunnlag {
     public ForeldrepengerGrunnlag medNesteSakGrunnlag(NesteSakGrunnlagEntitet nesteSakGrunnlag) {
         var nyttGrunnlag = new ForeldrepengerGrunnlag(this);
         nyttGrunnlag.nesteSakGrunnlag = nesteSakGrunnlag;
+        return nyttGrunnlag;
+    }
+
+    public ForeldrepengerGrunnlag medDødsfall(boolean dødsfall) {
+        var nyttGrunnlag = new ForeldrepengerGrunnlag(this);
+        nyttGrunnlag.dødsfall = dødsfall;
         return nyttGrunnlag;
     }
 }

--- a/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/input/UttakInput.java
+++ b/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/input/UttakInput.java
@@ -22,7 +22,6 @@ public class UttakInput {
     private LocalDate medlemskapOpphørsdato;
     private Set<BehandlingÅrsakType> behandlingÅrsaker = Set.of();
     private boolean behandlingManueltOpprettet;
-    private boolean opplysningerOmDødEndret;
     private boolean finnesAndelerMedGraderingUtenBeregningsgrunnlag;
 
     public UttakInput(BehandlingReferanse behandlingReferanse,
@@ -40,7 +39,6 @@ public class UttakInput {
         this.medlemskapOpphørsdato = input.medlemskapOpphørsdato;
         this.behandlingÅrsaker = input.behandlingÅrsaker;
         this.behandlingManueltOpprettet = input.behandlingManueltOpprettet;
-        this.opplysningerOmDødEndret = input.opplysningerOmDødEndret;
         this.finnesAndelerMedGraderingUtenBeregningsgrunnlag = input.finnesAndelerMedGraderingUtenBeregningsgrunnlag;
     }
 
@@ -78,16 +76,8 @@ public class UttakInput {
         return behandlingÅrsaker.stream().anyMatch(årsak -> årsak.equals(behandlingÅrsakType));
     }
 
-    public boolean harBehandlingÅrsakRelatertTilDød() {
-        return behandlingÅrsaker.stream().anyMatch(årsak -> BehandlingÅrsakType.årsakerRelatertTilDød().contains(årsak));
-    }
-
     public boolean isBehandlingManueltOpprettet() {
         return behandlingManueltOpprettet;
-    }
-
-    public boolean isOpplysningerOmDødEndret() {
-        return opplysningerOmDødEndret;
     }
 
     public LocalDateTime getSøknadOpprettetTidspunkt() {
@@ -129,12 +119,6 @@ public class UttakInput {
     public UttakInput medBehandlingManueltOpprettet(boolean behandlingManueltOpprettet) {
         var newInput = new UttakInput(this);
         newInput.behandlingManueltOpprettet = behandlingManueltOpprettet;
-        return newInput;
-    }
-
-    public UttakInput medErOpplysningerOmDødEndret(boolean opplysningerOmDødEndret) {
-        var newInput = new UttakInput(this);
-        newInput.opplysningerOmDødEndret = opplysningerOmDødEndret;
         return newInput;
     }
 

--- a/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/uttaksgrunnlag/fp/EndringsdatoRevurderingUtlederImpl.java
+++ b/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/uttaksgrunnlag/fp/EndringsdatoRevurderingUtlederImpl.java
@@ -185,7 +185,8 @@ public class EndringsdatoRevurderingUtlederImpl implements EndringsdatoRevurderi
 
     private Optional<EndringsdatoType> førsteUttaksdatoGjeldendeVedtakEndringsdato(UttakInput input) {
         var ref = input.getBehandlingReferanse();
-        if (input.isBehandlingManueltOpprettet() || input.isOpplysningerOmDødEndret()
+        var fpGrunnlag = (ForeldrepengerGrunnlag) input.getYtelsespesifiktGrunnlag();
+        if (input.isBehandlingManueltOpprettet() || fpGrunnlag.isDødsfall()
             || arbeidsforholdRelevantForUttakErEndret(input) || endretDekningsgrad(ref)) {
 
             return Optional.of(EndringsdatoType.FØRSTE_UTTAKSDATO_GJELDENDE_VEDTAK);

--- a/domenetjenester/uttak/src/test/java/no/nav/foreldrepenger/domene/uttak/SkalKopiereUttakTjenesteTest.java
+++ b/domenetjenester/uttak/src/test/java/no/nav/foreldrepenger/domene/uttak/SkalKopiereUttakTjenesteTest.java
@@ -55,7 +55,7 @@ class SkalKopiereUttakTjenesteTest {
     }
 
     @Test
-    void endret_inntektsmelding_men_opplysninger_om_død_endret_skal_ikke_kopiere() {
+    void endret_inntektsmelding_men_med_dødsfall_skal_ikke_kopiere() {
         assertThat(skalKopiereStegResultat(Set.of(RE_ENDRET_INNTEKTSMELDING), false, true, true)).isFalse();
     }
 
@@ -138,8 +138,8 @@ class SkalKopiereUttakTjenesteTest {
     private boolean skalKopiereStegResultat(Set<BehandlingÅrsakType> årsaker,
                                             boolean arbeidEndret,
                                             boolean erRevurdering,
-                                            boolean opplysningerOmDødEndret) {
-        var input = lagInput(årsaker, erRevurdering, opplysningerOmDødEndret);
+                                            boolean dødsfall) {
+        var input = lagInput(årsaker, erRevurdering, dødsfall);
         var tjeneste = opprettTjeneste(arbeidEndret);
         return tjeneste.skalKopiereStegResultat(input);
     }
@@ -154,15 +154,14 @@ class SkalKopiereUttakTjenesteTest {
 
     private UttakInput lagInput(Set<BehandlingÅrsakType> årsaker,
                                 boolean erRevurdering,
-                                boolean opplysningerOmDødEndret) {
+                                boolean dødsfall) {
         var scenario = ScenarioMorSøkerForeldrepenger.forFødsel();
         if (erRevurdering) {
             scenario.medOriginalBehandling(ScenarioMorSøkerForeldrepenger.forFødsel().lagre(repositoryProvider),
                 årsaker);
         }
         var behandling = scenario.lagre(repositoryProvider);
-        return new UttakInput(BehandlingReferanse.fra(behandling), null, new ForeldrepengerGrunnlag())
-            .medErOpplysningerOmDødEndret(opplysningerOmDødEndret)
+        return new UttakInput(BehandlingReferanse.fra(behandling), null, new ForeldrepengerGrunnlag().medDødsfall(dødsfall))
             .medBehandlingÅrsaker(årsaker);
     }
 }

--- a/domenetjenester/uttak/src/test/java/no/nav/foreldrepenger/domene/uttak/fastsetteperioder/FastsettUttakManueltAksjonspunktUtlederTest.java
+++ b/domenetjenester/uttak/src/test/java/no/nav/foreldrepenger/domene/uttak/fastsetteperioder/FastsettUttakManueltAksjonspunktUtlederTest.java
@@ -56,16 +56,21 @@ class FastsettUttakManueltAksjonspunktUtlederTest {
     }
 
     private UttakInput lagInput(Behandling behandling) {
-        return new UttakInput(BehandlingReferanse.fra(behandling), iayTjeneste.hentGrunnlag(behandling.getId()),
-            new ForeldrepengerGrunnlag().medFamilieHendelser(new FamilieHendelser().medBekreftetHendelse(FamilieHendelse.forFødsel(LocalDate.now(),
-                null, List.of(), 1))));
+        return lagInput(behandling, false);
+    }
+
+    private UttakInput lagInput(Behandling behandling, boolean dødsfall) {
+        var ytelsespesifiktGrunnlag = new ForeldrepengerGrunnlag().medDødsfall(dødsfall).medFamilieHendelser(
+            new FamilieHendelser().medBekreftetHendelse(FamilieHendelse.forFødsel(LocalDate.now(), null, List.of(), 1)));
+        return new UttakInput(BehandlingReferanse.fra(behandling), iayTjeneste.hentGrunnlag(behandling.getId()), ytelsespesifiktGrunnlag);
     }
 
     @Test
     void skal_utlede_aksjonspunkt_for_død_når_behandling_er_manuelt_opprettet_med_dødsårsak() {
         var revurdering = testUtil.opprettRevurdering(BehandlingÅrsakType.RE_HENDELSE_FØDSEL);
         lagreUttak(revurdering.getId());
-        var input = lagInput(revurdering).medBehandlingÅrsaker(Set.of(BehandlingÅrsakType.RE_OPPLYSNINGER_OM_DØD))
+        var input = lagInput(revurdering, true)
+            .medBehandlingÅrsaker(Set.of(BehandlingÅrsakType.RE_OPPLYSNINGER_OM_DØD))
             .medBehandlingManueltOpprettet(true);
 
         var aksjonspunkter = utleder.utledAksjonspunkterFor(input);
@@ -77,19 +82,7 @@ class FastsettUttakManueltAksjonspunktUtlederTest {
     void skal_utlede_aksjonspunkt_for_død_når_grunnlaget_har_opplysninger_om_død() {
         var revurdering = testUtil.opprettRevurdering(BehandlingÅrsakType.RE_HENDELSE_FØDSEL);
         lagreUttak(revurdering.getId());
-        var input = lagInput(revurdering).medErOpplysningerOmDødEndret(true);
-
-        var aksjonspunkter = utleder.utledAksjonspunkterFor(input);
-
-        assertThat(aksjonspunkter).contains(AksjonspunktDefinisjon.KONTROLLER_OPPLYSNINGER_OM_DØD);
-    }
-
-    @Test
-    void skal_utlede_aksjonspunkt_for_død_når_behandlingen_har_en_årsak_relatert_til_hendelse_død() {
-        var revurdering = testUtil.opprettRevurdering(BehandlingÅrsakType.RE_HENDELSE_DØD_FORELDER);
-        lagreUttak(revurdering.getId());
-        var input = lagInput(revurdering).medErOpplysningerOmDødEndret(false)
-            .medBehandlingÅrsaker(Set.of(BehandlingÅrsakType.RE_HENDELSE_DØD_FORELDER));
+        var input = lagInput(revurdering, true);
 
         var aksjonspunkter = utleder.utledAksjonspunkterFor(input);
 

--- a/domenetjenester/uttak/src/test/java/no/nav/foreldrepenger/domene/uttak/uttaksgrunnlag/fp/EndringsdatoRevurderingUtlederImplTest.java
+++ b/domenetjenester/uttak/src/test/java/no/nav/foreldrepenger/domene/uttak/uttaksgrunnlag/fp/EndringsdatoRevurderingUtlederImplTest.java
@@ -193,7 +193,7 @@ class EndringsdatoRevurderingUtlederImplTest {
     }
 
     @Test // #1.1
-    public void skal_utlede_at_endringsdato_er_fødselsdato_når_fødsel_har_forekommet_før_første_uttaksdato() {
+    void skal_utlede_at_endringsdato_er_fødselsdato_når_fødsel_har_forekommet_før_første_uttaksdato() {
         // Arrange
         var revurdering = testUtil.opprettRevurdering(RE_HENDELSE_FØDSEL);
         var bekreftetHendelse = FamilieHendelse.forFødsel(FØDSELSDATO, FØDSELSDATO, List.of(new Barn()), 1);
@@ -219,7 +219,7 @@ class EndringsdatoRevurderingUtlederImplTest {
     }
 
     @Test // #1.2
-    public void skal_utlede_at_endringsdato_er_første_uttaksdato_fra_vedtak_når_fødsel_har_forekommet_etter_første_uttaksdato() {
+    void skal_utlede_at_endringsdato_er_første_uttaksdato_fra_vedtak_når_fødsel_har_forekommet_etter_første_uttaksdato() {
         // Arrange
         var revurdering = testUtil.opprettRevurdering(RE_HENDELSE_FØDSEL);
         var bekreftetHendelse = FamilieHendelse.forFødsel(FØDSELSDATO, FØRSTE_UTTAKSDATO_GJELDENDE_VEDTAK,
@@ -240,7 +240,7 @@ class EndringsdatoRevurderingUtlederImplTest {
     }
 
     @Test // #2
-    public void skal_utlede_at_endringsdato_er_første_uttaksdato_fra_søknad_når_endringssøknad_er_mottatt() {
+    void skal_utlede_at_endringsdato_er_første_uttaksdato_fra_søknad_når_endringssøknad_er_mottatt() {
         // Arrange
         var revurdering = testUtil.opprettRevurdering(RE_ENDRING_FRA_BRUKER);
         testUtil.byggOgLagreOppgittFordelingForMorFPFF(revurdering);
@@ -254,7 +254,7 @@ class EndringsdatoRevurderingUtlederImplTest {
     }
 
     @Test // #2
-    public void skal_utlede_at_endringsdato_er_første_uttaksdato_fra_søknad_når_endringssøknad_er_mottatt_selv_om_mottatt_dato_før_vedtaksdato_på_original_behandling() {
+    void skal_utlede_at_endringsdato_er_første_uttaksdato_fra_søknad_når_endringssøknad_er_mottatt_selv_om_mottatt_dato_før_vedtaksdato_på_original_behandling() {
         var originalScenario = ScenarioMorSøkerForeldrepenger.forFødsel();
 
         var oppgittPeriode = OppgittPeriodeBuilder.ny()
@@ -296,7 +296,7 @@ class EndringsdatoRevurderingUtlederImplTest {
     }
 
     @Test // #2
-    public void skal_utlede_at_endringsdato_er_siste_uttaksdato_pluss_1_virkedag_fra_original_behandling_når_første_uttaksdato_fra_søknad_er_senere() {
+    void skal_utlede_at_endringsdato_er_siste_uttaksdato_pluss_1_virkedag_fra_original_behandling_når_første_uttaksdato_fra_søknad_er_senere() {
         var originalScenario = ScenarioMorSøkerForeldrepenger.forFødsel();
 
         var originalOppgittPeriode = OppgittPeriodeBuilder.ny()
@@ -337,7 +337,7 @@ class EndringsdatoRevurderingUtlederImplTest {
     }
 
     @Test // #3
-    public void skal_utlede_at_endringsdato_er_første_uttaksdato_fra_vedtak_når_revurdering_er_manuelt_opprettet() {
+    void skal_utlede_at_endringsdato_er_første_uttaksdato_fra_vedtak_når_revurdering_er_manuelt_opprettet() {
         // Arrange
         var revurdering = testUtil.opprettRevurdering(RE_HENDELSE_FØDSEL);
         var input = lagInput(revurdering).medBehandlingÅrsaker(Set.of(RE_HENDELSE_FØDSEL))
@@ -351,7 +351,7 @@ class EndringsdatoRevurderingUtlederImplTest {
     }
 
     @Test // #4.1
-    public void skal_utlede_at_endringsdato_på_mors_berørte_behandling_er_lik_fars_første_uttaksdag() {
+    void skal_utlede_at_endringsdato_på_mors_berørte_behandling_er_lik_fars_første_uttaksdag() {
         // Arrange førstegangsbehandling mor
         var behandling = testUtil.byggFørstegangsbehandlingForRevurderingBerørtSak(AKTØR_ID_MOR,
             testUtil.uttaksresultatBerørtSak(FØRSTE_UTTAKSDATO_GJELDENDE_VEDTAK), testUtil.søknadsAggregatBerørtSak(FØRSTE_UTTAKSDATO_GJELDENDE_VEDTAK));
@@ -386,7 +386,7 @@ class EndringsdatoRevurderingUtlederImplTest {
     }
 
     @Test // #4.2
-    public void skal_utlede_at_endringsdato_på_mors_berørte_behandling_er_første_uttaksdag_fra_vedtaket_når_fars_endringsdato_er_tidligere() {
+    void skal_utlede_at_endringsdato_på_mors_berørte_behandling_er_første_uttaksdag_fra_vedtaket_når_fars_endringsdato_er_tidligere() {
         // Arrange førstegangsbehandling mor
         var behandling = testUtil.byggFørstegangsbehandlingForRevurderingBerørtSak(AKTØR_ID_MOR,
             testUtil.uttaksresultatBerørtSak(FØRSTE_UTTAKSDATO_GJELDENDE_VEDTAK), testUtil.søknadsAggregatBerørtSak(FØRSTE_UTTAKSDATO_GJELDENDE_VEDTAK));
@@ -421,7 +421,7 @@ class EndringsdatoRevurderingUtlederImplTest {
     }
 
     @Test // #5
-    public void skal_utlede_at_endringsdato_er_manuelt_satt_første_uttaksdato() {
+    void skal_utlede_at_endringsdato_er_manuelt_satt_første_uttaksdato() {
         // Arrange
         var revurdering = testUtil.opprettRevurdering(RE_HENDELSE_FØDSEL);
         var entitet = new AvklarteUttakDatoerEntitet.Builder().medFørsteUttaksdato(
@@ -439,7 +439,7 @@ class EndringsdatoRevurderingUtlederImplTest {
     }
 
     @Test // #2 + #5
-    public void skal_utlede_at_endringsdato_er_første_uttaksdag_fra_søknad_når_denne_er_tidligere_enn_manuelt_satt_første_uttaksdato() {
+    void skal_utlede_at_endringsdato_er_første_uttaksdag_fra_søknad_når_denne_er_tidligere_enn_manuelt_satt_første_uttaksdato() {
         // Arrange
         var revurdering = testUtil.opprettRevurdering(RE_ENDRING_FRA_BRUKER);
         testUtil.byggOgLagreOppgittFordelingForMorFPFF(revurdering);
@@ -460,7 +460,7 @@ class EndringsdatoRevurderingUtlederImplTest {
     }
 
     @Test // #6
-    public void skal_utlede_at_endringsdato_er_første_uttaksdato_fra_vedtaket_når_inntektsmelding_endrer_uttak() {
+    void skal_utlede_at_endringsdato_er_første_uttaksdato_fra_vedtaket_når_inntektsmelding_endrer_uttak() {
         // Arrange
         var revurdering = testUtil.opprettRevurdering(AKTØR_ID_MOR, RE_ENDRET_INNTEKTSMELDING);
         testUtil.opprettInntektsmelding(revurdering);
@@ -473,12 +473,22 @@ class EndringsdatoRevurderingUtlederImplTest {
     }
 
     @Test // #7
-    public void skal_utlede_at_endringsdato_er_første_uttaksdato_fra_vedtaket_ved_opplysninger_om_død() {
+    void skal_utlede_at_endringsdato_er_første_uttaksdato_fra_vedtaket_ved_opplysninger_om_død() {
         // Arrange
         var revurdering = testUtil.opprettRevurdering(RE_HENDELSE_FØDSEL);
+        var bekreftetHendelse = FamilieHendelse.forFødsel(null, FØDSELSDATO, List.of(new Barn()), 1);
+        var ref = BehandlingReferanse.fra(revurdering, Skjæringstidspunkt.builder().medUtledetSkjæringstidspunkt(bekreftetHendelse.getFamilieHendelseDato()).build());
+        var iayGrunnlag = iayTjeneste.hentGrunnlag(ref.behandlingId());
+        var familiehendelser = new FamilieHendelser().medBekreftetHendelse(bekreftetHendelse);
+        var ytelsespesifiktGrunnlag = new ForeldrepengerGrunnlag()
+            .medFamilieHendelser(familiehendelser)
+            .medDødsfall(true)
+            .medOriginalBehandling(new OriginalBehandling(revurdering.getOriginalBehandlingId().orElseThrow(),
+                new FamilieHendelser().medBekreftetHendelse(bekreftetHendelse)));
+        var input = new UttakInput(ref, iayGrunnlag, ytelsespesifiktGrunnlag).medBeregningsgrunnlagStatuser(
+            uttakBeregningsandelTjeneste.hentStatuser());
 
         // Act
-        var input = lagInput(revurdering).medErOpplysningerOmDødEndret(true);
         var endringsdato = utleder.utledEndringsdato(input);
 
         // Assert
@@ -521,7 +531,7 @@ class EndringsdatoRevurderingUtlederImplTest {
     }
 
     @Test // Adopsjon.1
-    public void skal_utlede_at_endringsdato_er_omsorgsovertakelsedato_ved_adopsjon_uten_ankomstdato() {
+    void skal_utlede_at_endringsdato_er_omsorgsovertakelsedato_ved_adopsjon_uten_ankomstdato() {
         // Arrange
         var revurdering = testUtil.opprettRevurderingAdopsjon();
         var ref = BehandlingReferanse.fra(revurdering);
@@ -544,7 +554,7 @@ class EndringsdatoRevurderingUtlederImplTest {
     }
 
     @Test // Adopsjon.2
-    public void skal_utlede_at_endringsdato_er_ankomstdato_ved_adopsjon_når_ankomstdatoen_er_satt() {
+    void skal_utlede_at_endringsdato_er_ankomstdato_ved_adopsjon_når_ankomstdatoen_er_satt() {
         // Arrange
         var revurdering = testUtil.opprettRevurderingAdopsjon();
         var ref = BehandlingReferanse.fra(revurdering);


### PR DESCRIPTION
…ruker samme definisjon av dødsfall. Gjør at endringsdato settes til første uttaksdag i revurdering etter saken først har fått opphør pga død

Flyttet død fra uttakinput til foreldrepengergrunnlag ettersom det bare er FP som bryr seg.
Tidligere så endringsdatoutleder bare på "endring i opplysninger om død", men uttak AP så på om det fantes et dødt barn. Ble i usynk i revurdering etter opphør