### PR TITLE
Stønad og beregning forenkling

### DIFF
--- a/domenetjenester/datavarehus/src/main/java/no/nav/foreldrepenger/datavarehus/v2/StønadsstatistikkBeregningMapper.java
+++ b/domenetjenester/datavarehus/src/main/java/no/nav/foreldrepenger/datavarehus/v2/StønadsstatistikkBeregningMapper.java
@@ -1,13 +1,16 @@
 package no.nav.foreldrepenger.datavarehus.v2;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakYtelseType;
 import no.nav.foreldrepenger.behandlingslager.virksomhet.Arbeidsgiver;
 import no.nav.foreldrepenger.domene.entiteter.BeregningsgrunnlagEntitet;
+import no.nav.foreldrepenger.domene.entiteter.BeregningsgrunnlagPeriode;
 import no.nav.foreldrepenger.domene.entiteter.BeregningsgrunnlagPrStatusOgAndel;
 import no.nav.foreldrepenger.domene.iay.modell.InntektArbeidYtelseGrunnlag;
 import no.nav.foreldrepenger.domene.iay.modell.OppgittEgenNæring;
@@ -19,7 +22,8 @@ class StønadsstatistikkBeregningMapper {
     private StønadsstatistikkBeregningMapper() {
     }
 
-    static StønadsstatistikkVedtak.Beregning mapBeregning(BeregningsgrunnlagEntitet beregningsgrunnlag, InntektArbeidYtelseGrunnlag iaygrunnlag) {
+    static StønadsstatistikkVedtak.Beregning mapBeregning(FagsakYtelseType ytelseType,
+                                                          BeregningsgrunnlagEntitet beregningsgrunnlag, InntektArbeidYtelseGrunnlag iaygrunnlag) {
         if (beregningsgrunnlag == null) {
             return null;
         }
@@ -31,15 +35,18 @@ class StønadsstatistikkBeregningMapper {
             .findFirst()
             .orElseThrow();
         var grunnbeløp = beregningsgrunnlag.getGrunnbeløp().getVerdi();
+        var avkortet = FagsakYtelseType.FORELDREPENGER.equals(ytelseType) ? periodePåStp.getAvkortetPrÅr() :
+            utledAvkortetÅrsbeløp(periodePåStp, grunnbeløp);
+        var redusert = FagsakYtelseType.FORELDREPENGER.equals(ytelseType) ? periodePåStp.getRedusertPrÅr() : avkortet;
+        var dagsats = FagsakYtelseType.FORELDREPENGER.equals(ytelseType) ? periodePåStp.getDagsats() : utledDagsats(avkortet);
 
-        var årsbeløp = new StønadsstatistikkVedtak.BeregningÅrsbeløp(periodePåStp.getBruttoPrÅr(), periodePåStp.getAvkortetPrÅr(),
-            periodePåStp.getRedusertPrÅr(), periodePåStp.getDagsats());
+        var årsbeløp = new StønadsstatistikkVedtak.BeregningÅrsbeløp(periodePåStp.getBruttoPrÅr(), avkortet, redusert, dagsats);
 
         var andeler = periodePåStp.getBeregningsgrunnlagPrStatusOgAndelList().stream()
             .collect(Collectors.groupingBy(Gruppering::new))
             .entrySet().stream()
             .filter(e -> e.getValue().stream().anyMatch(b -> b.getBruttoPrÅr() != null || b.getAvkortetPrÅr() != null || b.getRedusertPrÅr() != null || b.getDagsats() != null))
-            .map(e -> mapAndeler(e.getKey(), e.getValue()))
+            .map(e -> mapAndeler(e.getKey(), e.getValue(), ytelseType))
             .toList();
 
         var næringOrgNr = Optional.ofNullable(iaygrunnlag)
@@ -53,6 +60,26 @@ class StønadsstatistikkBeregningMapper {
         return new StønadsstatistikkVedtak.Beregning(grunnbeløp, årsbeløp, andeler, næringOrgNr);
     }
 
+    private static Long utledDagsats(BigDecimal avkortet) {
+        if (avkortet == null) {
+            return null;
+        }
+        return avkortet.divide(new BigDecimal(260), 0, RoundingMode.HALF_EVEN).longValue();
+    }
+
+    private static BigDecimal utledAvkortetÅrsbeløp(BeregningsgrunnlagPeriode periodePåStp, BigDecimal grunnbeløp) {
+        var bruttoInkludertBortfaltNaturalytelsePrAar = periodePåStp.getBeregningsgrunnlagPrStatusOgAndelList().stream()
+            .map(BeregningsgrunnlagPrStatusOgAndel::getBruttoInkludertNaturalYtelser)
+            .filter(Objects::nonNull)
+            .reduce(BigDecimal::add)
+            .orElse(null);
+        if (bruttoInkludertBortfaltNaturalytelsePrAar == null) {
+            return null;
+        }
+        BigDecimal seksG = grunnbeløp.multiply(new BigDecimal(6));
+        return bruttoInkludertBortfaltNaturalytelsePrAar.compareTo(seksG) > 0 ? seksG : bruttoInkludertBortfaltNaturalytelsePrAar;
+    }
+
     private record Gruppering(StønadsstatistikkVedtak.AndelType andelType, String arbeidsgiver) {
         Gruppering(BeregningsgrunnlagPrStatusOgAndel andel) {
             this(mapAktivitetStatus(andel.getAktivitetStatus()), andel.getArbeidsgiver().map(Arbeidsgiver::getIdentifikator).orElse(null));
@@ -60,13 +87,32 @@ class StønadsstatistikkBeregningMapper {
 
     }
 
-    private static StønadsstatistikkVedtak.BeregningAndel mapAndeler(Gruppering gruppering, List<BeregningsgrunnlagPrStatusOgAndel> andeler) {
-        var bruttoÅr = andeler.stream().map(BeregningsgrunnlagPrStatusOgAndel::getBruttoPrÅr).filter(Objects::nonNull).reduce(BigDecimal.ZERO, BigDecimal::add);
-        var avkortetÅr = andeler.stream().map(BeregningsgrunnlagPrStatusOgAndel::getAvkortetPrÅr).filter(Objects::nonNull).reduce(BigDecimal.ZERO, BigDecimal::add);
-        var redusertÅr = andeler.stream().map(BeregningsgrunnlagPrStatusOgAndel::getRedusertPrÅr).filter(Objects::nonNull).reduce(BigDecimal.ZERO, BigDecimal::add);
-        var dagsats = andeler.stream().map(BeregningsgrunnlagPrStatusOgAndel::getDagsats).filter(Objects::nonNull).reduce(0L, Long::sum);
-        var årsbeløp = new StønadsstatistikkVedtak.BeregningÅrsbeløp(bruttoÅr, avkortetÅr, redusertÅr, dagsats);
-        return new StønadsstatistikkVedtak.BeregningAndel(gruppering.andelType(), gruppering.arbeidsgiver(), årsbeløp);
+    private static StønadsstatistikkVedtak.BeregningAndel mapAndeler(Gruppering gruppering, List<BeregningsgrunnlagPrStatusOgAndel> andeler,
+                                                                     FagsakYtelseType ytelseType) {
+        if (FagsakYtelseType.FORELDREPENGER.equals(ytelseType)) {
+            var bruttoÅr = andeler.stream()
+                .map(BeregningsgrunnlagPrStatusOgAndel::getBruttoPrÅr)
+                .filter(Objects::nonNull)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+            var avkortetÅr = andeler.stream()
+                .map(BeregningsgrunnlagPrStatusOgAndel::getAvkortetPrÅr)
+                .filter(Objects::nonNull)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+            var redusertÅr = andeler.stream()
+                .map(BeregningsgrunnlagPrStatusOgAndel::getRedusertPrÅr)
+                .filter(Objects::nonNull)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+            var dagsats = andeler.stream().map(BeregningsgrunnlagPrStatusOgAndel::getDagsats).filter(Objects::nonNull).reduce(0L, Long::sum);
+            var årsbeløp = new StønadsstatistikkVedtak.BeregningÅrsbeløp(bruttoÅr, avkortetÅr, redusertÅr, dagsats);
+            return new StønadsstatistikkVedtak.BeregningAndel(gruppering.andelType(), gruppering.arbeidsgiver(), årsbeløp);
+        } else {
+            var bruttoÅr = andeler.stream()
+                .map(BeregningsgrunnlagPrStatusOgAndel::getBruttoPrÅr)
+                .filter(Objects::nonNull)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+            var årsbeløp = new StønadsstatistikkVedtak.BeregningÅrsbeløp(bruttoÅr, null, null, null);
+            return new StønadsstatistikkVedtak.BeregningAndel(gruppering.andelType(), gruppering.arbeidsgiver(), årsbeløp);
+        }
     }
 
     private static StønadsstatistikkVedtak.AndelType mapAktivitetStatus(AktivitetStatus aktivitetStatus) {

--- a/domenetjenester/datavarehus/src/main/java/no/nav/foreldrepenger/datavarehus/v2/StønadsstatistikkTjeneste.java
+++ b/domenetjenester/datavarehus/src/main/java/no/nav/foreldrepenger/datavarehus/v2/StønadsstatistikkTjeneste.java
@@ -224,7 +224,7 @@ public class StønadsstatistikkTjeneste {
             return null;
         }
         var iayGrunnlag = inntektArbeidYtelseTjeneste.finnGrunnlag(behandling.getId()).orElse(null);
-        return StønadsstatistikkBeregningMapper.mapBeregning(beregningsgrunnlag, iayGrunnlag);
+        return StønadsstatistikkBeregningMapper.mapBeregning(behandling.getFagsakYtelseType(), beregningsgrunnlag, iayGrunnlag);
     }
 
     private Long utledTilkjentEngangsstønad(Long behandlingId) {

--- a/domenetjenester/datavarehus/src/main/java/no/nav/foreldrepenger/datavarehus/v2/StønadsstatistikkUtbetalingPeriode.java
+++ b/domenetjenester/datavarehus/src/main/java/no/nav/foreldrepenger/datavarehus/v2/StønadsstatistikkUtbetalingPeriode.java
@@ -10,8 +10,7 @@ record StønadsstatistikkUtbetalingPeriode(@NotNull LocalDate fom,
                                           @NotNull Inntektskategori inntektskategori,
                                           String arbeidsgiver,  // Orgnummer eller aktørId
                                           @NotNull Mottaker mottaker,
-                                          @NotNull Integer dagsats, //dagsatsFraBeregningsgrunnlag * utbetalingsgrad
-                                          @NotNull Integer dagsatsFraBeregningsgrunnlag, //TODO kan vi unngå?
+                                          @NotNull Integer dagsats,
                                           @NotNull BigDecimal utbetalingsgrad) {
 
     //Feriepenger ikke interessant - sier konsumenten

--- a/domenetjenester/datavarehus/src/main/java/no/nav/foreldrepenger/datavarehus/v2/StønadsstatistikkUtbetalingPeriodeMapper.java
+++ b/domenetjenester/datavarehus/src/main/java/no/nav/foreldrepenger/datavarehus/v2/StønadsstatistikkUtbetalingPeriodeMapper.java
@@ -33,7 +33,7 @@ class StønadsstatistikkUtbetalingPeriodeMapper {
             .map(ldt -> ldt.compress(LocalDateInterval::abutsWorkdays, StønadsstatistikkUtbetalingPeriodeMapper::likeNaboer, StandardCombinators::leftOnly))
             .flatMap(LocalDateTimeline::stream)
             .map(s -> new StønadsstatistikkUtbetalingPeriode(s.getFom(), s.getTom(), s.getValue().inntektskategori(), s.getValue().arbeidsgiver(),
-                s.getValue().mottaker(), s.getValue().dagsats(), s.getValue().dagsatsFraBeregningsgrunnlag(), s.getValue().utbetalingsgrad()))
+                s.getValue().mottaker(), s.getValue().dagsats(), s.getValue().utbetalingsgrad()))
             .toList();
     }
 
@@ -52,14 +52,13 @@ class StønadsstatistikkUtbetalingPeriodeMapper {
                                                                              List<UtbetalingSammenlign> utbetalinger) {
         var any = utbetalinger.stream().findFirst().orElseThrow();
         var sumDagsats = utbetalinger.stream().map(UtbetalingSammenlign::dagsats).reduce(0, Integer::sum);
-        var sumDagsatsFraBeregningsgrunnlag = utbetalinger.stream().map(UtbetalingSammenlign::dagsatsFraBeregningsgrunnlag).reduce(0, Integer::sum);
         return new LocalDateSegment<>(periode.getBeregningsresultatPeriodeFom(), periode.getBeregningsresultatPeriodeTom(),
-            new UtbetalingSammenlign(any, sumDagsats, sumDagsatsFraBeregningsgrunnlag));
+            new UtbetalingSammenlign(any, sumDagsats));
     }
 
     private static UtbetalingSammenlign mapTilkjentAndel(BeregningsresultatAndel andel) {
         return new UtbetalingSammenlign(mapInntektskategori(andel), andel.getArbeidsgiver().map(Arbeidsgiver::getIdentifikator).orElse(null),
-            mapMottaker(andel), andel.getDagsats(), andel.getDagsatsFraBg(), andel.getUtbetalingsgrad());
+            mapMottaker(andel), andel.getDagsats(), andel.getUtbetalingsgrad());
     }
 
     // Bruker int for å slippe hash-problematikk rundt BigDecimal
@@ -72,9 +71,9 @@ class StønadsstatistikkUtbetalingPeriodeMapper {
     }
 
     private record UtbetalingSammenlign(StønadsstatistikkUtbetalingPeriode.Inntektskategori inntektskategori, String arbeidsgiver,
-                                        StønadsstatistikkUtbetalingPeriode.Mottaker mottaker, int dagsats, int dagsatsFraBeregningsgrunnlag, BigDecimal utbetalingsgrad) {
-        UtbetalingSammenlign(UtbetalingSammenlign utbetaling, int dagsats, int dagsatsFraBeregningsgrunnlag) {
-            this(utbetaling.inntektskategori(), utbetaling.arbeidsgiver(), utbetaling.mottaker(), dagsats, dagsatsFraBeregningsgrunnlag, utbetaling.utbetalingsgrad());
+                                        StønadsstatistikkUtbetalingPeriode.Mottaker mottaker, int dagsats, BigDecimal utbetalingsgrad) {
+        UtbetalingSammenlign(UtbetalingSammenlign utbetaling, int dagsats) {
+            this(utbetaling.inntektskategori(), utbetaling.arbeidsgiver(), utbetaling.mottaker(), dagsats, utbetaling.utbetalingsgrad());
         }
     }
 

--- a/domenetjenester/datavarehus/src/main/java/no/nav/foreldrepenger/datavarehus/v2/StønadsstatistikkUtbetalingSVPLegacyMapper.java
+++ b/domenetjenester/datavarehus/src/main/java/no/nav/foreldrepenger/datavarehus/v2/StønadsstatistikkUtbetalingSVPLegacyMapper.java
@@ -39,7 +39,7 @@ class StønadsstatistikkUtbetalingSVPLegacyMapper {
                 StandardCombinators::leftOnly))
             .flatMap(LocalDateTimeline::stream)
             .map(s -> new StønadsstatistikkUtbetalingPeriode(s.getFom(), s.getTom(), s.getValue().inntektskategori(), s.getValue().arbeidsgiver(),
-                s.getValue().mottaker(), s.getValue().dagsats(), s.getValue().dagsatsFraBeregningsgrunnlag(), s.getValue().utbetalingsgrad()))
+                s.getValue().mottaker(), s.getValue().dagsats(), s.getValue().utbetalingsgrad()))
             .toList();
     }
 
@@ -61,9 +61,8 @@ class StønadsstatistikkUtbetalingSVPLegacyMapper {
                                                                              List<UtbetalingSammenlign> utbetalinger) {
         var any = utbetalinger.stream().findFirst().orElseThrow();
         var sumDagsats = utbetalinger.stream().map(UtbetalingSammenlign::dagsats).reduce(0, Integer::sum);
-        var sumDagsatsFraBeregningsgrunnlag = utbetalinger.stream().map(UtbetalingSammenlign::dagsatsFraBeregningsgrunnlag).reduce(0, Integer::sum);
         return new LocalDateSegment<>(periode.getBeregningsresultatPeriodeFom(), periode.getBeregningsresultatPeriodeTom(),
-            new UtbetalingSammenlign(any, sumDagsats, sumDagsatsFraBeregningsgrunnlag));
+            new UtbetalingSammenlign(any, sumDagsats));
     }
 
     private static UtbetalingSammenlign mapTilkjentAndel(BeregningsresultatAndel andel, SvangerskapspengerUttakResultatEntitet uttak) {
@@ -79,7 +78,7 @@ class StønadsstatistikkUtbetalingSVPLegacyMapper {
             .orElseThrow();
 
         return new UtbetalingSammenlign(mapInntektskategori(andel), andel.getArbeidsgiver().map(Arbeidsgiver::getIdentifikator).orElse(null),
-            mapMottaker(andel), andel.getDagsats(), andel.getDagsatsFraBg(), aktuellUttakPeriode.getUtbetalingsgrad().decimalValue() );
+            mapMottaker(andel), andel.getDagsats(), aktuellUttakPeriode.getUtbetalingsgrad().decimalValue() );
     }
 
     public static AktivitetStatus map(UttakArbeidType uttakArbeidType) {
@@ -127,11 +126,9 @@ class StønadsstatistikkUtbetalingSVPLegacyMapper {
     }
 
     private record UtbetalingSammenlign(StønadsstatistikkUtbetalingPeriode.Inntektskategori inntektskategori, String arbeidsgiver,
-                                        StønadsstatistikkUtbetalingPeriode.Mottaker mottaker, int dagsats, int dagsatsFraBeregningsgrunnlag,
-                                        BigDecimal utbetalingsgrad) {
-        UtbetalingSammenlign(UtbetalingSammenlign utbetaling, int dagsats, int dagsatsFraBeregningsgrunnlag) {
-            this(utbetaling.inntektskategori(), utbetaling.arbeidsgiver(), utbetaling.mottaker(), dagsats, dagsatsFraBeregningsgrunnlag,
-                utbetaling.utbetalingsgrad());
+                                        StønadsstatistikkUtbetalingPeriode.Mottaker mottaker, int dagsats, BigDecimal utbetalingsgrad) {
+        UtbetalingSammenlign(UtbetalingSammenlign utbetaling, int dagsats) {
+            this(utbetaling.inntektskategori(), utbetaling.arbeidsgiver(), utbetaling.mottaker(), dagsats, utbetaling.utbetalingsgrad());
         }
     }
 

--- a/domenetjenester/datavarehus/src/test/java/no/nav/foreldrepenger/datavarehus/v2/StønadsstatistikkUtbetalingPeriodeMapperTest.java
+++ b/domenetjenester/datavarehus/src/test/java/no/nav/foreldrepenger/datavarehus/v2/StønadsstatistikkUtbetalingPeriodeMapperTest.java
@@ -52,7 +52,6 @@ class StønadsstatistikkUtbetalingPeriodeMapperTest {
         assertThat(stønadsstatistikkUtbetalingPeriode.arbeidsgiver()).isEqualTo(orgnr);
         assertThat(stønadsstatistikkUtbetalingPeriode.mottaker()).isEqualTo(StønadsstatistikkUtbetalingPeriode.Mottaker.ARBEIDSGIVER);
         assertThat(stønadsstatistikkUtbetalingPeriode.dagsats()).isEqualTo(andel2.getDagsats());
-        assertThat(stønadsstatistikkUtbetalingPeriode.dagsatsFraBeregningsgrunnlag()).isEqualTo(andel2.getDagsatsFraBg());
         assertThat(stønadsstatistikkUtbetalingPeriode.utbetalingsgrad()).isEqualTo(andel2.getUtbetalingsgrad());
 
     }
@@ -95,7 +94,6 @@ class StønadsstatistikkUtbetalingPeriodeMapperTest {
         assertThat(stønadsstatistikkUtbetalingPeriode.arbeidsgiver()).isEqualTo(orgnr);
         assertThat(stønadsstatistikkUtbetalingPeriode.mottaker()).isEqualTo(StønadsstatistikkUtbetalingPeriode.Mottaker.BRUKER);
         assertThat(stønadsstatistikkUtbetalingPeriode.dagsats()).isEqualTo(andel2.getDagsats());
-        assertThat(stønadsstatistikkUtbetalingPeriode.dagsatsFraBeregningsgrunnlag()).isEqualTo(andel2.getDagsatsFraBg());
         assertThat(stønadsstatistikkUtbetalingPeriode.utbetalingsgrad()).isEqualTo(andel2.getUtbetalingsgrad());
 
     }


### PR DESCRIPTION
Fjerner dagsatsfrabg i Utbetalingsperiode - ble ikke sendt tidligere.
SVP total beregning: Setter avkortet = min(6G, bruttoMedNatural) og setter redusert = avkortet og dagsats = avkortet/260
SVP pr andel: Setter kun bruttobeløp og null for de andre.
Tidligere ble det sendt alle detaljer i beregning med perioder og andeler - vi viser vi bare situasjon på STP.