### PR TITLE
Bedre konfig av overlappsavstemming

### DIFF
--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/vedtak/avstemming/VedtakAvstemPeriodeTask.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/vedtak/avstemming/VedtakAvstemPeriodeTask.java
@@ -27,6 +27,7 @@ public class VedtakAvstemPeriodeTask extends GenerellProsessTask {
 
     public static final String LOG_FOM_KEY = "logfom";
     public static final String LOG_TOM_KEY = "logtom";
+    public static final String LOG_TIDSROM = "logtidsrom";
 
 
     private InformasjonssakRepository informasjonssakRepository;
@@ -48,6 +49,7 @@ public class VedtakAvstemPeriodeTask extends GenerellProsessTask {
     public void prosesser(ProsessTaskData prosessTaskData, Long fagsakId, Long behandlingId) {
         var fom = LocalDate.parse(prosessTaskData.getPropertyValue(LOG_FOM_KEY), DateTimeFormatter.ISO_LOCAL_DATE);
         var tom = LocalDate.parse(prosessTaskData.getPropertyValue(LOG_TOM_KEY), DateTimeFormatter.ISO_LOCAL_DATE);
+        var tidsrom = Integer.parseInt(prosessTaskData.getPropertyValue(LOG_TIDSROM));
         var baseline = LocalDateTime.now();
         if (MDCOperations.getCallId() == null) MDCOperations.putCallId();
         var callId = MDCOperations.getCallId();
@@ -57,7 +59,7 @@ public class VedtakAvstemPeriodeTask extends GenerellProsessTask {
             var task = ProsessTaskDataBuilder.forProsessTask(VedtakOverlappAvstemSakTask.class)
                 .medProperty(VedtakOverlappAvstemSakTask.LOG_SAKSNUMMER_KEY, f.getSaksnummer().getVerdi())
                 .medProperty(VedtakOverlappAvstemSakTask.LOG_HENDELSE_KEY, OverlappVedtak.HENDELSE_AVSTEM_PERIODE)
-                .medNesteKjøringEtter(baseline.plusSeconds(Math.abs(System.nanoTime()) % 239))
+                .medNesteKjøringEtter(baseline.plusSeconds(Math.abs(System.nanoTime()) % tidsrom))
                 .medCallId(callId + "_" + f.getSaksnummer().getVerdi())
                 .medPrioritet(100)
                 .build();

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/forvaltning/ForvaltningUttrekkRestTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/forvaltning/ForvaltningUttrekkRestTjeneste.java
@@ -211,7 +211,8 @@ public class ForvaltningUttrekkRestTjeneste {
             var prosessTaskData = ProsessTaskDataBuilder.forProsessTask(VedtakAvstemPeriodeTask.class)
                 .medProperty(VedtakAvstemPeriodeTask.LOG_FOM_KEY, betweendays.toString())
                 .medProperty(VedtakAvstemPeriodeTask.LOG_TOM_KEY, betweendays.toString())
-                .medNesteKjøringEtter(baseline.plusSeconds(suffix * 240))
+                .medProperty(VedtakAvstemPeriodeTask.LOG_TIDSROM, String.valueOf(dto.getTidsrom() - 1))
+                .medNesteKjøringEtter(baseline.plusSeconds(suffix * dto.getTidsrom()))
                 .medCallId(callId + "_" + suffix)
                 .medPrioritet(100)
                 .build();

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/forvaltning/dto/AvstemmingPeriodeDto.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/forvaltning/dto/AvstemmingPeriodeDto.java
@@ -35,10 +35,16 @@ public class AvstemmingPeriodeDto implements AbacDto {
     @Pattern(regexp = DATO_PATTERN)
     private String tom;
 
-    public AvstemmingPeriodeDto(@NotNull String key, @NotNull String fom, @NotNull String tom) {
+    @NotNull
+    @Parameter(description = "tidsrom for kjøring (sekunder)")
+    @QueryParam("tidsrom")
+    private int tidsrom;
+
+    public AvstemmingPeriodeDto(@NotNull String key, @NotNull String fom, @NotNull String tom, int tidsrom) {
         this.key = key;
         this.fom = fom;
         this.tom = tom;
+        this.tidsrom = tidsrom;
     }
 
     public AvstemmingPeriodeDto() {
@@ -59,5 +65,9 @@ public class AvstemmingPeriodeDto implements AbacDto {
 
     public LocalDate getTom() {
         return LocalDate.parse(tom, DateTimeFormatter.ISO_LOCAL_DATE);
+    }
+
+    public int getTidsrom() {
+        return tidsrom;
     }
 }

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/forvaltning/dto/AvstemmingPeriodeDto.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/forvaltning/dto/AvstemmingPeriodeDto.java
@@ -6,6 +6,8 @@ import static no.nav.vedtak.util.InputValideringRegex.FRITEKST;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import jakarta.ws.rs.FormParam;
@@ -35,9 +37,12 @@ public class AvstemmingPeriodeDto implements AbacDto {
     @Pattern(regexp = DATO_PATTERN)
     private String tom;
 
+    // Tidsrom mellom dager. Det er opp til 900 saker/dag - færre i helg/ferie. Tidsbruk 0,2-10s pr sak
     @NotNull
-    @Parameter(description = "tidsrom for kjøring (sekunder)")
+    @Parameter(description = "tidsrom for avstemming av 1 dag (sekunder)")
     @QueryParam("tidsrom")
+    @Min(0)
+    @Max(3600)
     private int tidsrom;
 
     public AvstemmingPeriodeDto(@NotNull String key, @NotNull String fom, @NotNull String tom, int tidsrom) {


### PR DESCRIPTION
Konfigurerbar kjøretids-mellomrom. Man sender inn et datointervall, det opprettes en periodetask for hver dag i intervallet.
Hver periodetask (1 dag) oppretter en saksstask pr fagsak med vedtak. Det er max 840 saker opprettet på en dag.
Det tar 0,2 - 10s å kjøre en saksstask pga ustabil svartid fra spøkelse