### PR TITLE
Fix: Utleder ENDRING_UTBETALING dokument type hvis fritekst mal brukes

### DIFF
--- a/domenetjenester/dokumentbestiller/src/main/java/no/nav/foreldrepenger/dokumentbestiller/DokumentBestillerTjeneste.java
+++ b/domenetjenester/dokumentbestiller/src/main/java/no/nav/foreldrepenger/dokumentbestiller/DokumentBestillerTjeneste.java
@@ -44,7 +44,7 @@ public class DokumentBestillerTjeneste {
         var dokumentMal = velgDokumentMalForVedtak(behandling, behandlingsresultat.getBehandlingResultatType(), behandlingVedtak.getVedtakResultatType(), behandlingVedtak.isBeslutningsvedtak(), klageRepository);
 
         if (Vedtaksbrev.FRITEKST.equals(behandlingsresultat.getVedtaksbrev())) {
-            opprinneligDokumentMal = erVedtakMedEndringIYtelse(behandlingsresultat) ? DokumentMalType.ENDRING_UTBETALING : dokumentMal;
+            opprinneligDokumentMal = endretVedtakOgKunEndringIFordeling(behandlingsresultat) ? DokumentMalType.ENDRING_UTBETALING : dokumentMal;
             dokumentMal = DokumentMalType.FRITEKSTBREV;
         }
 
@@ -59,7 +59,7 @@ public class DokumentBestillerTjeneste {
         dokumentBestiller.bestillVedtak(brevBestilling, opprinneligDokumentMal, aktør);
     }
 
-    private boolean erVedtakMedEndringIYtelse(Behandlingsresultat behandlingsresultat) {
+    private boolean endretVedtakOgKunEndringIFordeling(Behandlingsresultat behandlingsresultat) {
         return BehandlingResultatType.FORELDREPENGER_ENDRET.equals(behandlingsresultat.getBehandlingResultatType())
             && erKunEndringIFordelingAvYtelsen(behandlingsresultat);
     }

--- a/domenetjenester/dokumentbestiller/src/main/java/no/nav/foreldrepenger/dokumentbestiller/formidling/DokumentBestillerTask.java
+++ b/domenetjenester/dokumentbestiller/src/main/java/no/nav/foreldrepenger/dokumentbestiller/formidling/DokumentBestillerTask.java
@@ -10,7 +10,6 @@ import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakProsesstaskRekkefølg
 import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakYtelseType;
 import no.nav.foreldrepenger.kontrakter.formidling.kodeverk.YtelseType;
 import no.nav.foreldrepenger.kontrakter.formidling.v1.DokumentbestillingV2Dto;
-import no.nav.foreldrepenger.kontrakter.formidling.v3.DokumentBestillingDto;
 import no.nav.vedtak.exception.TekniskException;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTask;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTaskData;

--- a/domenetjenester/dokumentbestiller/src/main/java/no/nav/foreldrepenger/dokumentbestiller/formidling/DokumentBestillerTask.java
+++ b/domenetjenester/dokumentbestiller/src/main/java/no/nav/foreldrepenger/dokumentbestiller/formidling/DokumentBestillerTask.java
@@ -10,6 +10,7 @@ import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakProsesstaskRekkefølg
 import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakYtelseType;
 import no.nav.foreldrepenger.kontrakter.formidling.kodeverk.YtelseType;
 import no.nav.foreldrepenger.kontrakter.formidling.v1.DokumentbestillingV2Dto;
+import no.nav.foreldrepenger.kontrakter.formidling.v3.DokumentBestillingDto;
 import no.nav.vedtak.exception.TekniskException;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTask;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTaskData;
@@ -45,6 +46,7 @@ public class DokumentBestillerTask implements ProsessTaskHandler {
 
     private DokumentbestillingV2Dto mapDokumentbestilling(ProsessTaskData prosessTaskData) {
         var behandling = behandlingRepository.hentBehandling(prosessTaskData.getBehandlingUuid());
+
         return new DokumentbestillingV2Dto(
             behandling.getUuid(),
             UUID.fromString(prosessTaskData.getPropertyValue(BESTILLING_UUID)),

--- a/domenetjenester/dokumentbestiller/src/main/java/no/nav/foreldrepenger/dokumentbestiller/vedtak/VedtaksbrevUtleder.java
+++ b/domenetjenester/dokumentbestiller/src/main/java/no/nav/foreldrepenger/dokumentbestiller/vedtak/VedtaksbrevUtleder.java
@@ -47,8 +47,7 @@ public class VedtaksbrevUtleder {
     static DokumentMalType velgNegativVedtaksmal(Behandling behandling, BehandlingResultatType behandlingResultatType) {
         return switch (behandling.getFagsakYtelseType()) {
             case ENGANGSTØNAD -> DokumentMalType.ENGANGSSTØNAD_AVSLAG;
-            case FORELDREPENGER ->
-                erOpphør(behandlingResultatType) ? DokumentMalType.FORELDREPENGER_OPPHØR : DokumentMalType.FORELDREPENGER_AVSLAG;
+            case FORELDREPENGER -> erOpphør(behandlingResultatType) ? DokumentMalType.FORELDREPENGER_OPPHØR : DokumentMalType.FORELDREPENGER_AVSLAG;
             case SVANGERSKAPSPENGER ->
                 erOpphør(behandlingResultatType) ? DokumentMalType.SVANGERSKAPSPENGER_OPPHØR : DokumentMalType.SVANGERSKAPSPENGER_AVSLAG;
             case null, default -> null;
@@ -61,8 +60,8 @@ public class VedtaksbrevUtleder {
 
     static DokumentMalType velgPositivtVedtaksmal(Behandling behandling, BehandlingResultatType behandlingResultatType) {
         return switch (behandling.getFagsakYtelseType()) {
-            case FORELDREPENGER -> erUtsettelse(behandlingResultatType) ?
-                DokumentMalType.FORELDREPENGER_ANNULLERT : DokumentMalType.FORELDREPENGER_INNVILGELSE;
+            case FORELDREPENGER ->
+                erUtsettelse(behandlingResultatType) ? DokumentMalType.FORELDREPENGER_ANNULLERT : DokumentMalType.FORELDREPENGER_INNVILGELSE;
             case SVANGERSKAPSPENGER -> DokumentMalType.SVANGERSKAPSPENGER_INNVILGELSE;
             case ENGANGSTØNAD -> DokumentMalType.ENGANGSSTØNAD_INNVILGELSE;
             case null, default -> null;

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/brev/BrevRestTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/brev/BrevRestTjeneste.java
@@ -16,10 +16,6 @@ import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 
-import no.nav.foreldrepenger.dokumentbestiller.DokumentKvittering;
-import no.nav.foreldrepenger.kontrakter.formidling.v1.DokumentProdusertDto;
-import no.nav.foreldrepenger.kontrakter.formidling.v3.DokumentKvitteringDto;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -32,9 +28,11 @@ import no.nav.foreldrepenger.dokumentbestiller.BrevBestilling;
 import no.nav.foreldrepenger.dokumentbestiller.DokumentBehandlingTjeneste;
 import no.nav.foreldrepenger.dokumentbestiller.DokumentBestillerTjeneste;
 import no.nav.foreldrepenger.dokumentbestiller.DokumentForhåndsvisningTjeneste;
+import no.nav.foreldrepenger.dokumentbestiller.DokumentKvittering;
 import no.nav.foreldrepenger.dokumentbestiller.DokumentMalType;
 import no.nav.foreldrepenger.dokumentbestiller.dto.BestillBrevDto;
 import no.nav.foreldrepenger.kontrakter.formidling.v1.DokumentbestillingDto;
+import no.nav.foreldrepenger.kontrakter.formidling.v3.DokumentKvitteringDto;
 import no.nav.foreldrepenger.web.app.tjenester.behandling.dto.BehandlingAbacSuppliers;
 import no.nav.foreldrepenger.web.app.tjenester.behandling.dto.UuidDto;
 import no.nav.foreldrepenger.web.server.abac.AppAbacAttributtType;
@@ -137,25 +135,13 @@ public class BrevRestTjeneste {
     }
 
     @POST
-    @Path("/kvittering")
-    @Produces(MediaType.APPLICATION_JSON)
-    @Operation(description = "Kvitterer at brevet ble produsert og sendt. BREV_SENT historikk blir lagt og behandling dokument blir oppdatert med journalpostId.", tags = "brev")
-    @BeskyttetRessurs(actionType = ActionType.UPDATE, resourceType = ResourceType.FAGSAK)
-    public void kvittering(@TilpassetAbacAttributt(supplierClass = DokumentProdusertDataSupplier.class) @Valid DokumentProdusertDto kvittering) {
-        dokumentBehandlingTjeneste.kvitterSendtBrev(new DokumentKvittering(kvittering.behandlingUuid(),
-            kvittering.dokumentbestillingUuid(),
-            DokumentMalType.fraKode(kvittering.dokumentMal()),
-            kvittering.journalpostId(),
-            kvittering.dokumentId()));
-    }
-
-    @POST
     @Path("/kvittering/v3")
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(description = "Kvitterer at brevet ble produsert og sendt. BREV_SENT historikk blir lagt og behandling dokument blir oppdatert med journalpostId.", tags = "brev")
     @BeskyttetRessurs(actionType = ActionType.UPDATE, resourceType = ResourceType.FAGSAK)
     public void kvitteringV3(@TilpassetAbacAttributt(supplierClass = DokumentKvitteringDataSupplier.class) @Valid DokumentKvitteringDto kvitto) {
-        dokumentBehandlingTjeneste.kvitterSendtBrev(new DokumentKvittering(kvitto.behandlingUuid(), kvitto.dokumentbestillingUuid(), null, kvitto.journalpostId(), kvitto.dokumentId()));
+        dokumentBehandlingTjeneste.kvitterSendtBrev(
+            new DokumentKvittering(kvitto.behandlingUuid(), kvitto.dokumentbestillingUuid(), null, kvitto.journalpostId(), kvitto.dokumentId()));
     }
 
     @GET
@@ -173,15 +159,6 @@ public class BrevRestTjeneste {
         @Override
         public AbacDataAttributter apply(Object obj) {
             var req = (BestillBrevDto) obj;
-            return AbacDataAttributter.opprett().leggTil(AppAbacAttributtType.BEHANDLING_UUID, req.behandlingUuid());
-        }
-    }
-
-    public static class DokumentProdusertDataSupplier implements Function<Object, AbacDataAttributter> {
-
-        @Override
-        public AbacDataAttributter apply(Object obj) {
-            var req = (DokumentProdusertDto) obj;
             return AbacDataAttributter.opprett().leggTil(AppAbacAttributtType.BEHANDLING_UUID, req.behandlingUuid());
         }
     }


### PR DESCRIPTION
Skal flyttes fra formidling til fpsak på sikt om da er det greit å ha samme logikk begge steder.

Fjerner det gamle kvittering endepunktet som ikke lenger brukes.