### PR TITLE
Håndtere tilfelle der forrige uttak er tomt. Da er start=yf

### DIFF
--- a/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/ForeldrepengerUttak.java
+++ b/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/ForeldrepengerUttak.java
@@ -4,6 +4,7 @@ import java.time.LocalDate;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 
 public class ForeldrepengerUttak {
 
@@ -39,6 +40,10 @@ public class ForeldrepengerUttak {
 
     public LocalDate finnFørsteUttaksdato() {
         return getGjeldendePerioder().stream().map(p -> p.getTidsperiode().getFomDato()).min(LocalDate::compareTo).orElseThrow();
+    }
+
+    public Optional<LocalDate> finnFørsteUttaksdatoHvisFinnes() {
+        return getGjeldendePerioder().stream().map(p -> p.getTidsperiode().getFomDato()).min(LocalDate::compareTo);
     }
 
     public LocalDate sistDagMedTrekkdager() {

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/ytelsefordeling/YtelseFordelingDtoTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/ytelsefordeling/YtelseFordelingDtoTjeneste.java
@@ -16,11 +16,10 @@ import no.nav.foreldrepenger.domene.uttak.ForeldrepengerUttak;
 import no.nav.foreldrepenger.domene.uttak.ForeldrepengerUttakTjeneste;
 import no.nav.foreldrepenger.domene.uttak.UttakOmsorgUtil;
 import no.nav.foreldrepenger.domene.ytelsefordeling.YtelseFordelingTjeneste;
+import no.nav.vedtak.konfig.Tid;
 
 @ApplicationScoped
 public class YtelseFordelingDtoTjeneste {
-
-    private static final LocalDate DATO_FOR_TOMT_UTTAK = LocalDate.of(2199, 12, 31);
 
     private YtelseFordelingTjeneste ytelseFordelingTjeneste;
     private FagsakRelasjonRepository fagsakRelasjonRepository;
@@ -86,7 +85,7 @@ public class YtelseFordelingDtoTjeneste {
             .orElseThrow(() -> new IllegalStateException("Utviklerfeil: Original behandling mangler på revurdering - skal ikke skje"));
         var uttakOriginal = uttakTjeneste.hentUttakHvisEksisterer(originalBehandling);
         var førsteUttakOriginal = uttakOriginal.flatMap(ForeldrepengerUttak::finnFørsteUttaksdatoHvisFinnes);
-        var førsteUttaksdatoTidligereBehandling = førsteUttakOriginal.orElse(DATO_FOR_TOMT_UTTAK);
+        var førsteUttaksdatoTidligereBehandling = førsteUttakOriginal.orElse(Tid.TIDENES_ENDE);
 
         var førsteUttaksdatoSøkt = ytelseFordelingTjeneste.hentAggregat(behandling.getId())
             .getOppgittFordeling()


### PR DESCRIPTION
Feil i spesialtilfelle av revurdering etter at forrige behandling har tomt uttak. Bruker da dato fra nåværende behandling.