### PR TITLE
Opprett vurder konsekvens på pleiepengerenhet ved overlapp

### DIFF
--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/vedtak/OverlappVedtak.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/vedtak/OverlappVedtak.java
@@ -15,6 +15,7 @@ import jakarta.persistence.Transient;
 import jakarta.persistence.Version;
 
 import no.nav.foreldrepenger.behandlingslager.BaseEntitet;
+import no.nav.foreldrepenger.behandlingslager.kodeverk.Fagsystem;
 import no.nav.foreldrepenger.domene.tid.ÅpenDatoIntervallEntitet;
 import no.nav.foreldrepenger.domene.typer.Saksnummer;
 
@@ -93,12 +94,16 @@ public class OverlappVedtak extends BaseEntitet {
         return hendelse;
     }
 
-    public String getFagsystem() {
-        return fagsystem;
+    public Fagsystem getFagsystem() {
+        return Fagsystem.fraKode(fagsystem);
     }
 
-    public String getYtelse() {
-        return ytelse;
+    public OverlappYtelseType getYtelse() {
+        return switch (ytelse) {
+            case "PSB", "PPN" -> OverlappYtelseType.PLEIEPENGER;
+            case "OMP" -> OverlappYtelseType.OMSORGSPENGER;
+            default -> OverlappYtelseType.valueOf(ytelse);
+        };
     }
 
     public String getReferanse() {
@@ -111,6 +116,8 @@ public class OverlappVedtak extends BaseEntitet {
     public long getFpsakUtbetalingsprosent() {
         return fpsakUtbetalingsprosent;
     }
+
+    public enum OverlappYtelseType { SP, BS, PLEIEPENGER, OMSORGSPENGER, OPPLÆRINGSPENGER, FRISINN }
 
 
     @Override
@@ -165,13 +172,13 @@ public class OverlappVedtak extends BaseEntitet {
             return this;
         }
 
-        public Builder medFagsystem(String fagsystem) {
-            this.kladd.fagsystem = fagsystem;
+        public Builder medFagsystem(Fagsystem fagsystem) {
+            this.kladd.fagsystem = fagsystem.getKode();
             return this;
         }
 
-        public Builder medYtelse(String ytelse) {
-            this.kladd.ytelse = ytelse;
+        public Builder medYtelse(OverlappYtelseType ytelse) {
+            this.kladd.ytelse = ytelse.name();
             return this;
         }
 

--- a/behandlingslager/domene/src/test/java/no/nav/foreldrepenger/behandlingslager/behandling/vedtak/OverlappVedtakRepositoryTest.java
+++ b/behandlingslager/domene/src/test/java/no/nav/foreldrepenger/behandlingslager/behandling/vedtak/OverlappVedtakRepositoryTest.java
@@ -32,14 +32,14 @@ class OverlappVedtakRepositoryTest extends EntityManagerAwareTest {
         var behandling = behandlingBuilder.opprettOgLagreFørstegangssøknad(FagsakYtelseType.FORELDREPENGER);
         var periodeVL = ÅpenDatoIntervallEntitet.fraOgMedTilOgMed(LocalDate.of(2019, 1, 1),
             LocalDate.of(2019, 5, 1));
-        var ytelseInfotrygd = "BS";
+        var ytelseInfotrygd = OverlappVedtak.OverlappYtelseType.BS;
         var builder = OverlappVedtak.builder()
             .medSaksnummer(behandling.getFagsak().getSaksnummer())
             .medBehandlingId(behandling.getId())
             .medPeriode(periodeVL)
             .medHendelse("TEST")
             .medUtbetalingsprosent(100L)
-            .medFagsystem(Fagsystem.INFOTRYGD.getKode())
+            .medFagsystem(Fagsystem.INFOTRYGD)
             .medYtelse(ytelseInfotrygd);
 
         // Act

--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/vedtak/overlapp/LoggOverlappEksterneYtelserTjeneste.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/vedtak/overlapp/LoggOverlappEksterneYtelserTjeneste.java
@@ -8,7 +8,6 @@ import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
@@ -19,7 +18,6 @@ import jakarta.inject.Inject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import no.nav.abakus.iaygrunnlag.kodeverk.Fagsystem;
 import no.nav.abakus.vedtak.ytelse.Desimaltall;
 import no.nav.abakus.vedtak.ytelse.Kildesystem;
 import no.nav.abakus.vedtak.ytelse.Ytelser;
@@ -33,6 +31,7 @@ import no.nav.foreldrepenger.behandlingslager.behandling.vedtak.OverlappVedtak;
 import no.nav.foreldrepenger.behandlingslager.behandling.vedtak.OverlappVedtakRepository;
 import no.nav.foreldrepenger.behandlingslager.fagsak.Fagsak;
 import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakYtelseType;
+import no.nav.foreldrepenger.behandlingslager.kodeverk.Fagsystem;
 import no.nav.foreldrepenger.domene.abakus.AbakusTjeneste;
 import no.nav.foreldrepenger.domene.modell.BeregningsgrunnlagGrunnlag;
 import no.nav.foreldrepenger.domene.modell.BeregningsgrunnlagPeriode;
@@ -44,7 +43,6 @@ import no.nav.foreldrepenger.domene.typer.PersonIdent;
 import no.nav.foreldrepenger.konfig.Environment;
 import no.nav.foreldrepenger.mottak.vedtak.rest.InfotrygdPSGrunnlag;
 import no.nav.foreldrepenger.mottak.vedtak.rest.InfotrygdSPGrunnlag;
-import no.nav.foreldrepenger.produksjonsstyring.oppgavebehandling.OppgaveTjeneste;
 import no.nav.fpsak.tidsserie.LocalDateInterval;
 import no.nav.fpsak.tidsserie.LocalDateSegment;
 import no.nav.fpsak.tidsserie.LocalDateTimeline;
@@ -55,11 +53,11 @@ import no.nav.vedtak.felles.integrasjon.spokelse.Spøkelse;
 import no.nav.vedtak.felles.integrasjon.spokelse.SykepengeVedtak;
 
 /*
-Når Foreldrepenger-sak, enten førstegang eller revurdering, innvilges sjekker vi for overlapp med pleiepenger eller sykepenger i Infortrygd på personen.
-Overlapp er tilstede dersom noen av de vedtatte periodende i Infotrygd overlapper med noen av utbetalingsperiodene på iverksatt foreldrepenge-behandling
-Ved overlapp lagres informasjonen til databasetabellen BEHANDLING_OVERLAPP_INFOTRYGD
-Det er manuell håndtering av funnene videre.
-Håndtering av overlapp av Foreldrepenger-foreldrepenger håndteres av klassen VurderOpphørAvYtelser som trigges av en prosesstask.
+ * Når Foreldrepenger-sak, enten førstegang eller revurdering, innvilges sjekker vi for overlapp med pleiepenger eller sykepenger i Infortrygd på personen.
+ * Overlapp er tilstede dersom noen av de vedtatte periodende i Infotrygd overlapper med noen av utbetalingsperiodene på iverksatt foreldrepenge-behandling
+ * Ved overlapp lagres informasjonen til databasetabellen BEHANDLING_OVERLAPP_INFOTRYGD
+ * Det er manuell håndtering av funnene videre.
+ * Håndtering av overlapp av Foreldrepenger-foreldrepenger håndteres av klassen VurderOpphørAvYtelser som trigges av en prosesstask.
  */
 @ApplicationScoped
 public class LoggOverlappEksterneYtelserTjeneste {
@@ -69,11 +67,6 @@ public class LoggOverlappEksterneYtelserTjeneste {
 
     private static final List<Duration> SPOKELSE_TIMEOUTS = List.of(Duration.ofMillis(100), Duration.ofMillis(500), Duration.ofMillis(2500),
         Duration.ofMillis(12), Duration.ofSeconds(60));
-
-    private static final String BS_PLEIEPENGER_BARN = "PSB";
-    private static final String BS_PLEIEPENGER_NÆR = "PPN";
-
-    private static final Set<String> BS_YTELSER_OPPGAVE = Set.of(BS_PLEIEPENGER_BARN, BS_PLEIEPENGER_NÆR);
 
     private static final boolean IS_PROD = Environment.current().isProd();
 
@@ -86,7 +79,7 @@ public class LoggOverlappEksterneYtelserTjeneste {
     private AbakusTjeneste abakusTjeneste;
     private Spøkelse spøkelse;
     private OverlappVedtakRepository overlappRepository;
-    private OppgaveTjeneste oppgaveTjeneste;
+    private OverlappOppgaveTjeneste oppgaveTjeneste;
 
 
     @Inject
@@ -98,7 +91,8 @@ public class LoggOverlappEksterneYtelserTjeneste {
                                                AbakusTjeneste abakusTjeneste,
                                                Spøkelse spøkelse,
                                                OverlappVedtakRepository overlappRepository,
-                                               BehandlingRepository behandlingRepository, OppgaveTjeneste oppgaveTjeneste) {
+                                               BehandlingRepository behandlingRepository,
+                                               OverlappOppgaveTjeneste oppgaveTjeneste) {
         this.beregningTjeneste = beregningTjeneste;
         this.beregningsresultatRepository = beregningsresultatRepository;
         this.behandlingRepository = behandlingRepository;
@@ -122,59 +116,9 @@ public class LoggOverlappEksterneYtelserTjeneste {
 
         overlappListe.forEach(overlappRepository::lagre);
 
-        håndterOverlapp(overlappListe, behandling);
+        oppgaveTjeneste.håndterOverlapp(overlappListe, behandling);
     }
 
-    private void håndterOverlapp(List<OverlappVedtak> overlappListe, Behandling behandling) {
-        håndterOverlappVLSP(overlappListe, behandling);
-        håndterOverlappVLBSkunPSB(overlappListe, behandling);
-    }
-
-    private void håndterOverlappVLSP(List<OverlappVedtak> overlappListe, Behandling behandling) {
-        var sykepengerOverlapp = overlappListe.stream()
-            .filter(overlappVedtak -> Fagsystem.VLSP.getKode().equals(overlappVedtak.getFagsystem()))
-            .toList();
-        if (sykepengerOverlapp.isEmpty()) {
-            return;
-        }
-        var minFom = sykepengerOverlapp.stream()
-            .map(periode -> periode.getPeriode().getFomDato())
-            .min(Comparator.naturalOrder()).orElseThrow();
-        var maxTom = sykepengerOverlapp.stream()
-            .map(periode -> periode.getPeriode().getTomDato())
-            .max(Comparator.naturalOrder()).orElseThrow();
-        var ytelse = behandling.getFagsakYtelseType().getNavn().toLowerCase();
-        var maxUtbetalingsprosent = sykepengerOverlapp.stream()
-            .map(OverlappVedtak::getFpsakUtbetalingsprosent)
-            .max(Comparator.naturalOrder()).orElse(100L);
-
-        var beskrivelse = String.format("Det er innvilget %s (%s%%) som overlapper med sykepenger i periode %s - %s i Speil. Vurder konsekvens for ytelse.", ytelse, maxUtbetalingsprosent, minFom, maxTom );
-        oppgaveTjeneste.opprettVurderKonsekvensHosSykepenger(behandling.getBehandlendeEnhet(), beskrivelse, behandling.getAktørId());
-
-    }
-
-    private void håndterOverlappVLBSkunPSB(List<OverlappVedtak> overlappListe, Behandling behandling) {
-        var pleiepengerOverlapp = overlappListe.stream()
-            .filter(overlappVedtak -> Fagsystem.K9SAK.getKode().equals(overlappVedtak.getFagsystem()))
-            .filter(overlappVedtak -> BS_YTELSER_OPPGAVE.contains(overlappVedtak.getYtelse()))
-            .toList();
-        if (pleiepengerOverlapp.isEmpty()) {
-            return;
-        }
-        var minFom = pleiepengerOverlapp.stream()
-            .map(periode -> periode.getPeriode().getFomDato())
-            .min(Comparator.naturalOrder()).orElseThrow();
-        var maxTom = pleiepengerOverlapp.stream()
-            .map(periode -> periode.getPeriode().getTomDato())
-            .max(Comparator.naturalOrder()).orElseThrow();
-        var ytelse = behandling.getFagsakYtelseType().getNavn().toLowerCase();
-        var maxUtbetalingsprosent = pleiepengerOverlapp.stream()
-            .map(OverlappVedtak::getFpsakUtbetalingsprosent)
-            .max(Comparator.naturalOrder()).orElse(100L);
-
-        var beskrivelse = String.format("Det er innvilget %s (%s%%) som overlapper med pleiepenger i periode %s - %s i K9-sak. Vurder konsekvens for ytelse.", ytelse, maxUtbetalingsprosent, minFom, maxTom );
-        oppgaveTjeneste.opprettVurderKonsekvensHosPleiepenger(behandling.getBehandlendeEnhet(), beskrivelse, behandling.getAktørId());
-    }
 
     public void loggOverlappForAvstemming(String hendelse, Behandling behandling) {
         loggOverlappendeYtelser(behandling).stream()
@@ -190,7 +134,7 @@ public class LoggOverlappEksterneYtelserTjeneste {
             .flatMap(f -> behandlingRepository.finnSisteAvsluttedeIkkeHenlagteBehandling(f.getId()).stream())
             .forEach(b -> {
                 var fpTimeline = getTidslinjeForBehandling(b.getId(), b.getFagsakYtelseType());
-                var overlapp = finnGradertOverlapp(fpTimeline, Fagsystem.K9SAK.getKode(), mapAbakusYtelseType(ytelse),
+                var overlapp = finnGradertOverlapp(fpTimeline, Fagsystem.K9SAK, mapAbakusYtelseType(ytelse),
                     ytelse.getSaksnummer(), ytelseTidslinje);
                 overlapp.stream()
                     .map(builder -> builder.medSaksnummer(b.getFagsak().getSaksnummer())
@@ -201,14 +145,13 @@ public class LoggOverlappEksterneYtelserTjeneste {
             });
     }
 
-    private String mapAbakusYtelseType(YtelseV1 ytelse) {
-        if (ytelse.getYtelse() == null) {
-            return "UKJENT";
-        }
+    private OverlappVedtak.OverlappYtelseType mapAbakusYtelseType(YtelseV1 ytelse) {
         return switch (ytelse.getYtelse()) {
-            case PLEIEPENGER_SYKT_BARN -> BS_PLEIEPENGER_BARN;
-            case PLEIEPENGER_NÆRSTÅENDE -> BS_PLEIEPENGER_NÆR;
-            default -> ytelse.getYtelse().name();
+            case PLEIEPENGER_SYKT_BARN, PLEIEPENGER_NÆRSTÅENDE -> OverlappVedtak.OverlappYtelseType.PLEIEPENGER;
+            case OMSORGSPENGER -> OverlappVedtak.OverlappYtelseType.OMSORGSPENGER;
+            case OPPLÆRINGSPENGER -> OverlappVedtak.OverlappYtelseType.OPPLÆRINGSPENGER;
+            case FRISINN -> OverlappVedtak.OverlappYtelseType.FRISINN;
+            case null, default -> throw new IllegalArgumentException("Ukjent ytelse " + ytelse.getYtelse());
         };
     }
 
@@ -321,13 +264,13 @@ public class LoggOverlappEksterneYtelserTjeneste {
         //sjekker om noen av vedtaksperiodene i Infotrygd på sykepenger eller pleiepenger overlapper med perioderFp
         var infotrygdPSGrunnlag = infotrygdPSGrTjeneste.hentGrunnlag(ident.getIdent(),
             førsteUttaksDatoFP.minusMonths(1), førsteUttaksDatoFP.plusYears(3));
-        overlappene.addAll(finnGradertOverlapp(perioderFp, Fagsystem.INFOTRYGD.getKode(), "BS", null,
+        overlappene.addAll(finnGradertOverlapp(perioderFp, Fagsystem.INFOTRYGD, OverlappVedtak.OverlappYtelseType.BS, null,
             finnTidslinjeFraGrunnlagene(infotrygdPSGrunnlag)));
 
         var infotrygdSPGrunnlag = infotrygdSPGrTjeneste.hentGrunnlag(ident.getIdent(),
             førsteUttaksDatoFP.minusMonths(1), førsteUttaksDatoFP.plusYears(3));
         overlappene.addAll(
-            finnGradertOverlapp(perioderFp, Fagsystem.INFOTRYGD.getKode(), "SP", null,
+            finnGradertOverlapp(perioderFp, Fagsystem.INFOTRYGD, OverlappVedtak.OverlappYtelseType.SP, null,
                 finnTidslinjeFraGrunnlagene(infotrygdSPGrunnlag)));
     }
 
@@ -344,7 +287,7 @@ public class LoggOverlappEksterneYtelserTjeneste {
                 .filter(y -> Kildesystem.K9SAK.equals(y.getKildesystem()))
                 .forEach(y -> {
                     var ytelseTidslinje = lagTidslinjeforYtelseV1(y);
-                    overlappene.addAll(finnGradertOverlapp(perioderFp, Fagsystem.K9SAK.getKode(),  mapAbakusYtelseType(y),
+                    overlappene.addAll(finnGradertOverlapp(perioderFp, Fagsystem.K9SAK,  mapAbakusYtelseType(y),
                         y.getSaksnummer(), ytelseTidslinje));
                 });
         } catch (Exception e) {
@@ -369,7 +312,7 @@ public class LoggOverlappEksterneYtelserTjeneste {
             var ytelseTidslinje = new LocalDateTimeline<>(graderteSegments,
                 LoggOverlappEksterneYtelserTjeneste::max).compress(this::like, this::kombiner);
             overlappene.addAll(
-                finnGradertOverlapp(perioderFp, Fagsystem.VLSP.getKode(), "SP",
+                finnGradertOverlapp(perioderFp, Fagsystem.VLSP, OverlappVedtak.OverlappYtelseType.SP,
                     y.vedtaksreferanse(), ytelseTidslinje));
         });
 
@@ -404,8 +347,8 @@ public class LoggOverlappEksterneYtelserTjeneste {
     }
 
     private List<OverlappVedtak.Builder> finnGradertOverlapp(LocalDateTimeline<BigDecimal> perioderFP,
-                                                             String fagsystem,
-                                                             String ytelseType,
+                                                             Fagsystem fagsystem,
+                                                             OverlappVedtak.OverlappYtelseType ytelseType,
                                                              String referanse,
                                                              LocalDateTimeline<BigDecimal> tlGrunnlag) {
         var filter = perioderFP.intersection(tlGrunnlag, StandardCombinators::sum)

--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/vedtak/overlapp/OverlappOppgaveTjeneste.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/vedtak/overlapp/OverlappOppgaveTjeneste.java
@@ -1,0 +1,119 @@
+package no.nav.foreldrepenger.mottak.vedtak.overlapp;
+
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
+import no.nav.foreldrepenger.behandlingslager.behandling.vedtak.OverlappVedtak;
+import no.nav.foreldrepenger.behandlingslager.kodeverk.Fagsystem;
+import no.nav.foreldrepenger.produksjonsstyring.oppgavebehandling.OppgaveTjeneste;
+
+/*
+ * Tjeneste for å opprette samshandlingsoppgaver dersom nylig vedtak i fpsak overlapper andre ytelser
+ * - Sykepenger i SPeil
+ * - Pleiepenger i K9-sak
+ * - Pleiepenger i Infotrygd
+ * - Omsorgspenger i K9-sak (hovedsaklig om høsten)
+ * - Opplæringspenger i K9-sak (behandles i Infotrygd inntil videre)
+ * - FRISINN i K9-sak (venter ikke mye aktivitet)
+ *
+ * TBD
+ * - Sykepenger i Infotrygd
+ * - Ta inn ting fra VurderOmArenaYtelseSkalOpphøre (flytt fra vedtak til mottak)
+ */
+@ApplicationScoped
+public class OverlappOppgaveTjeneste {
+
+    private OppgaveTjeneste oppgaveTjeneste;
+
+
+    @Inject
+    public OverlappOppgaveTjeneste(OppgaveTjeneste oppgaveTjeneste) {
+        this.oppgaveTjeneste = oppgaveTjeneste;
+    }
+
+    OverlappOppgaveTjeneste() {
+        // for CDI
+    }
+
+    public void håndterOverlapp(List<OverlappVedtak> overlappListe, Behandling behandling) {
+        var grupperteOverlapp = overlappListe.stream()
+            .collect(Collectors.groupingBy(Gruppering::new));
+        grupperteOverlapp.entrySet().stream()
+            .filter(e -> OverlappVedtak.OverlappYtelseType.SP.equals(e.getKey().ytelseType()))
+            .forEach(e -> håndterOverlappSykepenger(e.getKey(), e.getValue(), behandling));
+        grupperteOverlapp.entrySet().stream()
+            .filter(e -> OverlappVedtak.OverlappYtelseType.BS.equals(e.getKey().ytelseType()) || Fagsystem.K9SAK.equals(e.getKey().fagsystem()))
+            .forEach(e -> håndterOverlappPleieOmsorg(e.getKey(), e.getValue(), behandling));
+    }
+
+    private void håndterOverlappSykepenger(Gruppering gruppering, List<OverlappVedtak> overlappListe, Behandling behandling) {
+        if (Fagsystem.INFOTRYGD.equals(gruppering.fagsystem()) || overlappListe.isEmpty()) { // Utelat Infotrygd inntil det er avtalt
+            return;
+        }
+        var minFom = overlappListe.stream()
+            .map(periode -> periode.getPeriode().getFomDato())
+            .min(Comparator.naturalOrder()).orElseThrow();
+        var maxTom = overlappListe.stream()
+            .map(periode -> periode.getPeriode().getTomDato())
+            .max(Comparator.naturalOrder()).orElseThrow();
+        var foreldrepengerYtelse = behandling.getFagsakYtelseType().getNavn().toLowerCase();
+        var maxUtbetalingsprosent = overlappListe.stream()
+            .map(OverlappVedtak::getFpsakUtbetalingsprosent)
+            .max(Comparator.naturalOrder()).orElse(100L);
+
+        // Beskrivelse må tilpasses dersom / når det skal opprettes oppgaver ved overlapp mot Infotrygd
+        var beskrivelse = String.format("Det er innvilget %s (%s%%) som overlapper med sykepenger i periode %s - %s i Speil. Vurder konsekvens for ytelse.",
+            foreldrepengerYtelse, maxUtbetalingsprosent, minFom, maxTom );
+        oppgaveTjeneste.opprettVurderKonsekvensHosSykepenger(behandling.getBehandlendeEnhet(), beskrivelse, behandling.getAktørId());
+
+    }
+
+    private void håndterOverlappPleieOmsorg(Gruppering gruppering, List<OverlappVedtak> overlappListe, Behandling behandling) {
+        if (overlappListe.isEmpty()) {
+            return;
+        }
+        var minFom = overlappListe.stream()
+            .map(periode -> periode.getPeriode().getFomDato())
+            .min(Comparator.naturalOrder()).orElseThrow();
+        var maxTom = overlappListe.stream()
+            .map(periode -> periode.getPeriode().getTomDato())
+            .max(Comparator.naturalOrder()).orElseThrow();
+        var foreldrepengerYtelse = behandling.getFagsakYtelseType().getNavn().toLowerCase();
+        var maxUtbetalingsprosent = overlappListe.stream()
+            .map(OverlappVedtak::getFpsakUtbetalingsprosent)
+            .max(Comparator.naturalOrder()).orElse(100L);
+        var omsorgspengerYtelse = omsorgspengerYtelse(gruppering);
+
+        if (Fagsystem.K9SAK.equals(gruppering.fagsystem())) {
+            var beskrivelse = String.format("Det er innvilget %s (%s%%) som overlapper med %s sak %s i periode %s - %s i K9-sak. Vurder konsekvens for ytelse.",
+                    foreldrepengerYtelse, maxUtbetalingsprosent, omsorgspengerYtelse, gruppering.saksnummer(), minFom, maxTom );
+            oppgaveTjeneste.opprettVurderKonsekvensHosPleiepenger(behandling.getBehandlendeEnhet(), beskrivelse, behandling.getAktørId());
+        } else {
+            var beskrivelse = String.format("Det er innvilget %s (%s%%) som overlapper med pleiepenger i periode %s - %s i Infotrygd. Vurder konsekvens for ytelse.",
+                    foreldrepengerYtelse, maxUtbetalingsprosent, minFom, maxTom );
+            oppgaveTjeneste.opprettVurderKonsekvensHosPleiepenger(behandling.getBehandlendeEnhet(), beskrivelse, behandling.getAktørId());
+        }
+    }
+
+    private static String omsorgspengerYtelse(Gruppering gruppering) {
+        return switch (gruppering.ytelseType()) {
+            case SP -> "sykepenger";
+            case BS -> "pleiepenger";
+            case PLEIEPENGER, OMSORGSPENGER, OPPLÆRINGSPENGER, FRISINN -> gruppering.ytelseType().name().toLowerCase();
+        };
+    }
+
+    private record Gruppering(Fagsystem fagsystem, OverlappVedtak.OverlappYtelseType ytelseType, String saksnummer) {
+        Gruppering(OverlappVedtak vedtak) {
+            this(vedtak.getFagsystem(), vedtak.getYtelse(), Fagsystem.K9SAK.equals(vedtak.getFagsystem()) ? vedtak.getReferanse() : "");
+        }
+
+    }
+
+}

--- a/domenetjenester/mottak/src/test/java/no/nav/foreldrepenger/mottak/vedtak/kafka/VedtaksHendelseHåndtererTest.java
+++ b/domenetjenester/mottak/src/test/java/no/nav/foreldrepenger/mottak/vedtak/kafka/VedtaksHendelseHåndtererTest.java
@@ -16,8 +16,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
-import no.nav.foreldrepenger.produksjonsstyring.oppgavebehandling.OppgaveTjeneste;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -70,6 +68,8 @@ import no.nav.foreldrepenger.domene.tid.ÅpenDatoIntervallEntitet;
 import no.nav.foreldrepenger.domene.typer.InternArbeidsforholdRef;
 import no.nav.foreldrepenger.mottak.vedtak.overlapp.HåndterOverlappPleiepengerTask;
 import no.nav.foreldrepenger.mottak.vedtak.overlapp.LoggOverlappEksterneYtelserTjeneste;
+import no.nav.foreldrepenger.mottak.vedtak.overlapp.OverlappOppgaveTjeneste;
+import no.nav.foreldrepenger.produksjonsstyring.oppgavebehandling.OppgaveTjeneste;
 import no.nav.fpsak.tidsserie.LocalDateInterval;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTaskData;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTaskTjeneste;
@@ -101,9 +101,10 @@ class VedtaksHendelseHåndtererTest extends EntityManagerAwareTest {
         var behandlingRepository = new BehandlingRepository(getEntityManager());
         var fagsakTjeneste = new FagsakTjeneste(new FagsakRepository(getEntityManager()),
             new SøknadRepository(getEntityManager(), behandlingRepository), null);
+        var overlappOppgaveTjeneste = new OverlappOppgaveTjeneste(oppgaveTjenesteMock);
         var overlappTjeneste = new LoggOverlappEksterneYtelserTjeneste(beregningTjeneste, beregningsresultatRepository, null,
             null, null, null, null,
-            overlappInfotrygdRepository, behandlingRepository, oppgaveTjenesteMock);
+            overlappInfotrygdRepository, behandlingRepository, overlappOppgaveTjeneste);
         lenient().when(mottakRepository.hendelseErNy(any())).thenReturn(true);
         vedtaksHendelseHåndterer = new VedtaksHendelseHåndterer(fagsakTjeneste, beregningsresultatRepository, behandlingRepository, overlappTjeneste,
             taskTjeneste, mottakRepository);

--- a/domenetjenester/produksjonsstyring/src/main/java/no/nav/foreldrepenger/produksjonsstyring/oppgavebehandling/OppgaveTjeneste.java
+++ b/domenetjenester/produksjonsstyring/src/main/java/no/nav/foreldrepenger/produksjonsstyring/oppgavebehandling/OppgaveTjeneste.java
@@ -37,7 +37,7 @@ public class OppgaveTjeneste {
     private static final String NØS_ANSVARLIG_ENHETID = "4151";
     private static final String NØS_BEH_TEMA = "ab0273";
     private static final String NØS_TEMA = "STO";
-    private static final String SAMHANDLING_BA_FA_SP = "ae0119";
+    private static final String SAMHANDLING_BS_FA_SP = "ae0119";
     private static final String SYK_TEMA = "SYK";
     private static final String SYK_ANSVARLIG_ENHETID = "4488";
     private static final String OMS_TEMA = "OMS";
@@ -126,7 +126,7 @@ public class OppgaveTjeneste {
     public void opprettVurderKonsekvensHosSykepenger(String enhetsId, String beskrivelse, AktørId aktørId) {
         var orequest = createRestRequestBuilder(Oppgavetype.VURDER_KONSEKVENS_YTELSE, null, aktørId, enhetsId, beskrivelse,
             Prioritet.HOY, DEFAULT_OPPGAVEFRIST_DAGER)
-            .medBehandlingstype(SAMHANDLING_BA_FA_SP)
+            .medBehandlingstype(SAMHANDLING_BS_FA_SP)
             .medTema(SYK_TEMA)
             .medTildeltEnhetsnr(SYK_ANSVARLIG_ENHETID);
         var oppgave = restKlient.opprettetOppgave(orequest.build());
@@ -136,7 +136,7 @@ public class OppgaveTjeneste {
     public void opprettVurderKonsekvensHosPleiepenger(String enhetsId, String beskrivelse, AktørId aktørId) {
         var orequest = createRestRequestBuilder(Oppgavetype.VURDER_KONSEKVENS_YTELSE, null, aktørId, enhetsId, beskrivelse,
             Prioritet.HOY, DEFAULT_OPPGAVEFRIST_DAGER)
-            .medBehandlingstype(SAMHANDLING_BA_FA_SP)
+            .medBehandlingstype(SAMHANDLING_BS_FA_SP)
             .medTema(OMS_TEMA)
             .medTildeltEnhetsnr(OMS_ANSVARLIG_ENHETID);
         var oppgave = restKlient.opprettetOppgave(orequest.build());

--- a/domenetjenester/produksjonsstyring/src/main/java/no/nav/foreldrepenger/produksjonsstyring/oppgavebehandling/OppgaveTjeneste.java
+++ b/domenetjenester/produksjonsstyring/src/main/java/no/nav/foreldrepenger/produksjonsstyring/oppgavebehandling/OppgaveTjeneste.java
@@ -40,6 +40,8 @@ public class OppgaveTjeneste {
     private static final String SAMHANDLING_BA_FA_SP = "ae0119";
     private static final String SYK_TEMA = "SYK";
     private static final String SYK_ANSVARLIG_ENHETID = "4488";
+    private static final String OMS_TEMA = "OMS";
+    private static final String OMS_ANSVARLIG_ENHETID = "4487";
     private static final String FEILMELDING = "Feil ved henting av oppgaver for oppgavetype=";
 
     private FagsakRepository fagsakRepository;
@@ -129,6 +131,16 @@ public class OppgaveTjeneste {
             .medTildeltEnhetsnr(SYK_ANSVARLIG_ENHETID);
         var oppgave = restKlient.opprettetOppgave(orequest.build());
         LOG.info("FPSAK GOSYS opprettet SYK oppgave {}", oppgave.id());
+    }
+
+    public void opprettVurderKonsekvensHosPleiepenger(String enhetsId, String beskrivelse, AktørId aktørId) {
+        var orequest = createRestRequestBuilder(Oppgavetype.VURDER_KONSEKVENS_YTELSE, null, aktørId, enhetsId, beskrivelse,
+            Prioritet.HOY, DEFAULT_OPPGAVEFRIST_DAGER)
+            .medBehandlingstype(SAMHANDLING_BA_FA_SP)
+            .medTema(OMS_TEMA)
+            .medTildeltEnhetsnr(OMS_ANSVARLIG_ENHETID);
+        var oppgave = restKlient.opprettetOppgave(orequest.build());
+        LOG.info("FPSAK GOSYS opprettet OMS oppgave {}", oppgave.id());
     }
 
     public String opprettOppgaveStopUtbetalingAvARENAYtelse(long behandlingId, LocalDate førsteUttaksdato) {


### PR DESCRIPTION
@AnjaAalerud det er avklart at vi oppretter oppgaver når vi fatter vedtak som overlapper pleiepenger i K9 eller Infotrygd.
Det som gjenstår er å avklare om vi skal opprette oppgaver når våre ferske vedtak overlapper sykepenger i Infotrygd.
Se gjerne godt gjennom koden