### PR TITLE
TFP-5716: Utvider fpsak DTO ut mot fpoversikt med avslagsårsaker for tap av dager

### DIFF
--- a/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/ForeldrepengerUttakPeriode.java
+++ b/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/ForeldrepengerUttakPeriode.java
@@ -167,6 +167,9 @@ public class ForeldrepengerUttakPeriode {
     public boolean harUtbetaling() {
         return getAktiviteter().stream().anyMatch(aktivitet -> aktivitet.getUtbetalingsgrad().harUtbetaling());
     }
+    public boolean harRedusertUtbetaling() {
+        return getAktiviteter().stream().anyMatch(aktivitet -> aktivitet.getUtbetalingsgrad().erRedusert());
+    }
 
     public boolean harTrekkdager() {
         return getAktiviteter().stream().anyMatch(aktivitet -> aktivitet.getTrekkdager().merEnn0());

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/fpoversikt/FpSak.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/fpoversikt/FpSak.java
@@ -41,6 +41,8 @@ record FpSak(String saksnummer,
             enum Årsak {
                 ANNET,
                 AVSLAG_HULL_I_UTTAKSPLAN,
+                AVSLAG_UTSETTELSE_TILBAKE_I_TID,
+                INNVILGET_UTTAK_AVSLÅTT_GRADERING_TILBAKE_I_TID,
                 AVSLAG_FRATREKK_PLEIEPENGER
             }
         }


### PR DESCRIPTION
Følgende avslagsårsaker sendes til FPOVERSIKT:
```
                AVSLAG_HULL_I_UTTAKSPLAN,
                AVSLAG_UTSETTELSE_TILBAKE_I_TID,
                INNVILGET_UTTAK_AVSLÅTT_GRADERING_TILBAKE_I_TID,
```

**AVSLAG_HULL_I_UTTAKSPLAN:**
Utledes basert på PeriodeResultatÅrsakene HULL_MELLOM_FORELDRENES_PERIODER og BARE_FAR_RETT_IKKE_SØKT (slikt som tidligere)

**AVSLAG_UTSETTELSE_TILBAKE_I_TID:**
Utledes basert på PeriodeResultatÅrsakene AVSLAG_UTSETTELSE_PGA_ARBEID_TILBAKE_I_TID og AVSLAG_UTSETTELSE_PGA_FERIE_TILBAKE_I_TID. Gjelder alle periode med denne avslagsårsaken?


**INNVILGET_UTTAK_AVSLÅTT_GRADERING_TILBAKE_I_TID:**
For avslagsårsaken INNVILGET_UTTAK_AVSLÅTT_GRADERING_TILBAKE_I_TID utledes basert på graderingsårsak som er FOR_SEN_SØKNAD("4501", "§14-16: Ikke gradering pga. for sen søknad"...). 
Skal vi gjøre det BARE for innvilgede perioder, men avslått gradering? Eller skal vi gjøre det for alle tilfellen som har følgende graderingsårsak? @jolarsen @palfi 




