### PR TITLE
Utlede refusjonskrav kun når alle IM har refusjon

### DIFF
--- a/domenetjenester/datavarehus/src/main/java/no/nav/foreldrepenger/datavarehus/v2/StønadsstatistikkBeregningMapper.java
+++ b/domenetjenester/datavarehus/src/main/java/no/nav/foreldrepenger/datavarehus/v2/StønadsstatistikkBeregningMapper.java
@@ -151,7 +151,7 @@ class StønadsstatistikkBeregningMapper {
             if (hjemler.contains(Hjemmel.F_14_7_8_49) || statuser.contains(AktivitetStatus.DAGPENGER)) {
                 var besteberegnet = beregningsgrunnlag.getBesteberegninggrunnlag().isPresent() ||
                     beregningsgrunnlag.getFaktaOmBeregningTilfeller().stream().anyMatch(BESTEBEREGNING_FAKTA::contains);
-                return besteberegnet ? StønadsstatistikkVedtak.BeregningHjemmel.MOR_DAGPENGER_BESTEBEREGNING : StønadsstatistikkVedtak.BeregningHjemmel.DAGPENGER;
+                return besteberegnet ? StønadsstatistikkVedtak.BeregningHjemmel.BESTEBEREGNING : StønadsstatistikkVedtak.BeregningHjemmel.DAGPENGER;
             }
             if (statuser.contains(AktivitetStatus.ARBEIDSAVKLARINGSPENGER)) {
                 return StønadsstatistikkVedtak.BeregningHjemmel.ARBEIDSAVKLARINGSPENGER;

--- a/domenetjenester/datavarehus/src/main/java/no/nav/foreldrepenger/datavarehus/v2/StønadsstatistikkVedtak.java
+++ b/domenetjenester/datavarehus/src/main/java/no/nav/foreldrepenger/datavarehus/v2/StønadsstatistikkVedtak.java
@@ -242,7 +242,7 @@ public class StønadsstatistikkVedtak {
         ARBEID_NÆRING_FRILANS, // Ftl 14-7 første ledd, jf Ftl 8-43
         DAGPENGER, // Ftl 14-7 første ledd, jf Ftl 8-49
         ARBEIDSAVKLARINGSPENGER, // Ftl 14-7 andre ledd
-        MOR_DAGPENGER_BESTEBEREGNING, // Ftl 14-7 tredje ledd
+        BESTEBEREGNING, // Ftl 14-7 tredje ledd
         MILITÆR_SIVIL, // Ftl 14-7 fjerde ledd
         ANNEN // Annet innenfor Ftl 14-7, 14-4, 8
     }

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/los/LosBehandlingDtoTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/los/LosBehandlingDtoTjeneste.java
@@ -250,11 +250,14 @@ public class LosBehandlingDtoTjeneste {
     }
 
     private boolean harRefusjonskrav(Behandling behandling) {
-        return !FagsakYtelseType.ENGANGSTØNAD.equals(behandling.getFagsakYtelseType()) && behandling.erYtelseBehandling() &&
-            inntektsmeldingTjeneste.hentAlleInntektsmeldingerForAngitteBehandlinger(Set.of(behandling.getId())).stream()
+        if (FagsakYtelseType.ENGANGSTØNAD.equals(behandling.getFagsakYtelseType()) || !behandling.erYtelseBehandling() || behandling.harÅpentAksjonspunktMedType(AksjonspunktDefinisjon.VURDER_ARBEIDSFORHOLD_INNTEKTSMELDING)) {
+            return false;
+        }
+        var inntektsmeldinger = inntektsmeldingTjeneste.hentAlleInntektsmeldingerForAngitteBehandlinger(Set.of(behandling.getId()));
+        return !inntektsmeldinger.isEmpty() && inntektsmeldinger.stream()
             .map(Inntektsmelding::getRefusjonBeløpPerMnd)
             .filter(Objects::nonNull)
-            .anyMatch(beløp -> beløp.compareTo(Beløp.ZERO) > 0);
+            .allMatch(beløp -> beløp.compareTo(Beløp.ZERO) > 0);
     }
 
     public LosFagsakEgenskaperDto lagFagsakEgenskaper(Fagsak fagsak) {

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/los/LosBehandlingDtoTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/los/LosBehandlingDtoTjeneste.java
@@ -256,8 +256,7 @@ public class LosBehandlingDtoTjeneste {
         var inntektsmeldinger = inntektsmeldingTjeneste.hentAlleInntektsmeldingerForAngitteBehandlinger(Set.of(behandling.getId()));
         return !inntektsmeldinger.isEmpty() && inntektsmeldinger.stream()
             .map(Inntektsmelding::getRefusjonBeløpPerMnd)
-            .filter(Objects::nonNull)
-            .allMatch(beløp -> beløp.compareTo(Beløp.ZERO) > 0);
+            .allMatch(beløp -> beløp != null && beløp.compareTo(Beløp.ZERO) > 0);
     }
 
     public LosFagsakEgenskaperDto lagFagsakEgenskaper(Fagsak fagsak) {


### PR DESCRIPTION
Man ønsker fokus på de med direkte utbetaling, ikke refusjon.
Som første steg sier vi refusjon når 5085 er passert og alle mottatte inntektsmeldinger har refusjon.
Neste steg er å innføre kriterie Direkteutbetaling - i frontend, kontrakter, LOS, ...