### PR TITLE
TFP-5714 Håndtere at bekreftet opptjening arbeid ikke matcher ansettelse

### DIFF
--- a/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/iay/modell/Yrkesaktivitet.java
+++ b/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/iay/modell/Yrkesaktivitet.java
@@ -220,8 +220,8 @@ public class Yrkesaktivitet implements IndexKey {
                 '}';
     }
 
-    void fjernPeriode(DatoIntervallEntitet aktivitetsPeriode) {
-        aktivitetsAvtale.removeIf(aa -> aa.matcherPeriode(aktivitetsPeriode));
+    void fjernAnsettelsesPeriode(DatoIntervallEntitet aktivitetsPeriode) {
+        aktivitetsAvtale.removeIf(aa -> aa.erAnsettelsesPeriode() && aa.matcherPeriode(aktivitetsPeriode));
     }
 
 }


### PR DESCRIPTION
Dette er en gammel og litt subtil feil som typisk gjelder tilfelle av 0%-arbeidsforhold.
Dersom avklart periode ikke matchet ansettelsesperioden så ble det liggende 2 ansettelsesperioder - en avkortet og en lang.

Her fjerner vi YA sine ansettelsesperioder som overlapper bekreftede (godkjente/avslåtte) perioder for Fakta opptjening. Så blir de godkjente lagt til.  
* Først lager vi en kompakt tidslinje over alle bekreftede perioder - så fjernes ansettelsesperioder som overlapper
* Algoritmen er å fjerne ansettelsesperioder som er omsluttet av bekreftetperiode, deretter splitte overlappende (før/etter)
* Repeat until ingen overlapp