### PR TITLE
TFP-5693: Rydder i fylling av oppståtte hull og bruker mottattidspunk…

### DIFF
--- a/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/uttaksgrunnlag/fp/JusterFordelingTjeneste.java
+++ b/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/uttaksgrunnlag/fp/JusterFordelingTjeneste.java
@@ -94,7 +94,7 @@ final class JusterFordelingTjeneste {
     private static List<OppgittPeriodeEntitet> fjernHelgerFraStartOgSlutt(List<OppgittPeriodeEntitet> oppgittePerioder) {
         return oppgittePerioder.stream()
             .filter(p -> !erHelg(p))
-            .map(p -> kopier(p, flyttFraHelgTilMandag(p.getFom()), flyttFraHelgTilFredag(p.getTom())))
+            .map(p -> kopier(p, p.getFom(), p.getTom()))
             .toList();
     }
 

--- a/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/uttaksgrunnlag/fp/OppgittPeriodeUtil.java
+++ b/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/uttaksgrunnlag/fp/OppgittPeriodeUtil.java
@@ -1,5 +1,8 @@
 package no.nav.foreldrepenger.domene.uttak.uttaksgrunnlag.fp;
 
+import static no.nav.foreldrepenger.domene.uttak.uttaksgrunnlag.fp.JusterFordelingTjeneste.flyttFraHelgTilFredag;
+import static no.nav.foreldrepenger.domene.uttak.uttaksgrunnlag.fp.JusterFordelingTjeneste.flyttFraHelgTilMandag;
+
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -114,8 +117,7 @@ public class OppgittPeriodeUtil {
 
     static OppgittPeriodeEntitet kopier(OppgittPeriodeEntitet oppgittPeriode, LocalDate nyFom, LocalDate nyTom) {
         return OppgittPeriodeBuilder.fraEksisterende(oppgittPeriode)
-            .medPeriode(nyFom, nyTom)
+            .medPeriode(flyttFraHelgTilMandag(nyFom), flyttFraHelgTilFredag(nyTom))
             .build();
     }
-
 }

--- a/domenetjenester/uttak/src/test/java/no/nav/foreldrepenger/domene/uttak/uttaksgrunnlag/fp/JusterFordelingTjenesteTest.java
+++ b/domenetjenester/uttak/src/test/java/no/nav/foreldrepenger/domene/uttak/uttaksgrunnlag/fp/JusterFordelingTjenesteTest.java
@@ -320,6 +320,20 @@ class JusterFordelingTjenesteTest {
     }
 
     @Test
+    void ingen_flyttbare_perioder_fører_til_hull_og_skal_ikke_fylles_ved_fødsel_før_termin() {
+        var termin = LocalDate.of(2019, 8, 20);
+        var gradering = lagGradering(MØDREKVOTE, termin, termin.plusWeeks(15).minusDays(1), BigDecimal.TEN);
+
+        var oppgittePerioder = List.of(gradering);
+
+        var fødsel = termin.minusWeeks(1);
+        var justertePerioder = juster(oppgittePerioder, termin, fødsel);
+
+        assertThat(justertePerioder).hasSize(1);
+        assertThat(justertePerioder.getFirst()).isEqualTo(gradering);
+    }
+
+    @Test
     void skal_ikke_lage_hull_hvis_fødsel_før_termin_og_de_to_siste_periodene_ikke_er_flyttbare() {
         var mødrekvote = lagPeriode(MØDREKVOTE, LocalDate.of(2019, 8, 19), LocalDate.of(2019, 8, 23));
         var utsettelse1 = lagUtsettelse(LocalDate.of(2019, 8, 26), LocalDate.of(2019, 8, 26), ARBEID);
@@ -1136,9 +1150,8 @@ class JusterFordelingTjenesteTest {
 
         var justertePerioder = juster(oppgittePerioder, fødselsdato, fødselsdato.plusWeeks(1));
 
-        assertThat(justertePerioder).hasSize(2);
-        assertThat(justertePerioder.get(1).getFom()).isEqualTo(mk.getFom().plusWeeks(1));
-        assertThat(justertePerioder.get(1).getTom()).isEqualTo(mk.getTom());
+        assertThat(justertePerioder).hasSize(1);
+        assertThat(justertePerioder.getFirst()).isEqualTo(oppgittePerioder.getFirst());
     }
 
     @Test //Unntak: Skal justere mødrekvote

--- a/domenetjenester/uttak/src/test/java/no/nav/foreldrepenger/domene/uttak/uttaksgrunnlag/fp/PleiepengerJusteringTest.java
+++ b/domenetjenester/uttak/src/test/java/no/nav/foreldrepenger/domene/uttak/uttaksgrunnlag/fp/PleiepengerJusteringTest.java
@@ -3,6 +3,7 @@ package no.nav.foreldrepenger.domene.uttak.uttaksgrunnlag.fp;
 import static java.time.LocalDate.of;
 import static no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.periode.UttakPeriodeType.MØDREKVOTE;
 import static no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.årsak.UtsettelseÅrsak.INSTITUSJON_BARN;
+import static no.nav.foreldrepenger.domene.uttak.uttaksgrunnlag.fp.JusterFordelingTjeneste.flyttFraHelgTilFredag;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.math.BigDecimal;
@@ -272,7 +273,7 @@ class PleiepengerJusteringTest {
         assertThat(resultat).hasSize(1);
         assertThat(resultat.get(0).isUtsettelse()).isTrue();
         assertThat(resultat.get(0).getFom()).isEqualTo(pleiepengerInterval.getFomDato());
-        assertThat(resultat.get(0).getTom()).isEqualTo(pleiepengerInterval.getTomDato());
+        assertThat(resultat.get(0).getTom()).isEqualTo(flyttFraHelgTilFredag(pleiepengerInterval.getTomDato()));
     }
 
     @Test


### PR DESCRIPTION
…t fra perioden og ikke første/siste flyttbare periode

Lagt til litt smartere og generell fylling av hull:
1. Hull som oppstår før fødsel fylles med fellesperioden eller foreldrepenger
2. Hull som oppstår etter fødsel og frem til 6 uker etter fødsel (eller frem til termin hvis det er lenger) fylles med mødrekvote eller foreldrepenger
4. Hull som oppstår etter dette fylles med siste flyttbare periode

Ellers så arver alle hullene mottattdato og tidligstmottattdato fra den opprinnelige perioden og ikke siste flyttbare periode.