### PR TITLE
TFP-5680 Opprett gosys-vky-oppgave ved overlapp Sykepenger / Infotrygd

### DIFF
--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/vedtak/overlapp/OverlappOppgaveTjeneste.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/vedtak/overlapp/OverlappOppgaveTjeneste.java
@@ -53,9 +53,10 @@ public class OverlappOppgaveTjeneste {
     }
 
     private void håndterOverlappSykepenger(Gruppering gruppering, List<OverlappVedtak> overlappListe, Behandling behandling) {
-        if (Fagsystem.INFOTRYGD.equals(gruppering.fagsystem()) || overlappListe.isEmpty()) { // Utelat Infotrygd inntil det er avtalt
+        if (overlappListe.isEmpty()) { // Utelat Infotrygd inntil det er avtalt
             return;
         }
+        var system = Fagsystem.INFOTRYGD.equals(gruppering.fagsystem()) ? "Infotrygd" : "Speil";
         var minFom = overlappListe.stream()
             .map(periode -> periode.getPeriode().getFomDato())
             .min(Comparator.naturalOrder()).orElseThrow();
@@ -68,8 +69,8 @@ public class OverlappOppgaveTjeneste {
             .max(Comparator.naturalOrder()).orElse(100L);
 
         // Beskrivelse må tilpasses dersom / når det skal opprettes oppgaver ved overlapp mot Infotrygd
-        var beskrivelse = String.format("Det er innvilget %s (%s%%) som overlapper med sykepenger i periode %s - %s i Speil. Vurder konsekvens for ytelse.",
-            foreldrepengerYtelse, maxUtbetalingsprosent, minFom, maxTom );
+        var beskrivelse = String.format("Det er innvilget %s (%s%%) som overlapper med sykepenger i periode %s - %s i %s. Vurder konsekvens for ytelse.",
+            foreldrepengerYtelse, maxUtbetalingsprosent, minFom, maxTom, system );
         oppgaveTjeneste.opprettVurderKonsekvensHosSykepenger(behandling.getBehandlendeEnhet(), beskrivelse, behandling.getAktørId());
 
     }

--- a/domenetjenester/mottak/src/test/java/no/nav/foreldrepenger/mottak/vedtak/overlapp/LoggOverlappEksterneYtelserTjenesteTest.java
+++ b/domenetjenester/mottak/src/test/java/no/nav/foreldrepenger/mottak/vedtak/overlapp/LoggOverlappEksterneYtelserTjenesteTest.java
@@ -222,6 +222,7 @@ class LoggOverlappEksterneYtelserTjenesteTest extends EntityManagerAwareTest {
         var overlappIT = overlappRepository.hentForSaksnummer(behandlingFP.getFagsak().getSaksnummer());
         assertThat(overlappIT).hasSize(2);
         verify(oppgaveTjenesteMock, times(1)).opprettVurderKonsekvensHosPleiepenger(any(), any(), any());
+        verify(oppgaveTjenesteMock, times(1)).opprettVurderKonsekvensHosSykepenger(any(), any(), any());
         verifyNoMoreInteractions(oppgaveTjenesteMock);
     }
 
@@ -245,7 +246,7 @@ class LoggOverlappEksterneYtelserTjenesteTest extends EntityManagerAwareTest {
 
         utbetalingsperioderSyk.add(new SykepengeVedtak.SykepengeUtbetaling(førsteUttaksdatoFp.minusWeeks(3), førsteUttaksdatoFp, BigDecimal.valueOf(100)));
         utbetalingsperioderSyk.add(new SykepengeVedtak.SykepengeUtbetaling(førsteUttaksdatoFp.plusWeeks(1), førsteUttaksdatoFp.plusWeeks(2), BigDecimal.valueOf(100)));
-        var sykepengerVedtak  = (lagSykVedtak(utbetalingsperioderSyk, LocalDateTime.now()));
+        var sykepengerVedtak  = lagSykVedtak(utbetalingsperioderSyk, LocalDateTime.now());
 
         when(infotrygdPSGrTjenesteMock.hentGrunnlag(any())).thenReturn(Collections.emptyList());
         when(infotrygdSPGrTjenesteMock.hentGrunnlag(any())).thenReturn(List.of(infotrygSPGrunnlag));
@@ -260,7 +261,7 @@ class LoggOverlappEksterneYtelserTjenesteTest extends EntityManagerAwareTest {
         // Assert
         var overlappIT = overlappRepository.hentForSaksnummer(behandlingFP.getFagsak().getSaksnummer());
         assertThat(overlappIT).hasSize(3);
-        verify(oppgaveTjenesteMock, times(1)).opprettVurderKonsekvensHosSykepenger(any(), any(), any());
+        verify(oppgaveTjenesteMock, times(2)).opprettVurderKonsekvensHosSykepenger(any(), any(), any());
         verifyNoMoreInteractions(oppgaveTjenesteMock);
     }
 


### PR DESCRIPTION
Siste håndterbare tilfelle av overlapp BS eller SP i Infotrygd, Speil eller K9-sak.
Arena+P4 gjenstår