### PR TITLE
TFP-5760 Retter feil for SVP og ELYSIM

### DIFF
--- a/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/arbeidsforhold/impl/InntektsmeldingRegisterTjeneste.java
+++ b/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/arbeidsforhold/impl/InntektsmeldingRegisterTjeneste.java
@@ -129,7 +129,8 @@ public class InntektsmeldingRegisterTjeneste {
         Objects.requireNonNull(referanse, VALID_REF);
         var inntektArbeidYtelseGrunnlag = inntektArbeidYtelseTjeneste.finnGrunnlag(referanse.behandlingId());
         var påkrevdeInntektsmeldinger = utledPåkrevdeInntektsmeldingerFraGrunnlag(referanse, inntektArbeidYtelseGrunnlag);
-        return filtrerInntektsmeldingerForYtelseUtvidet(referanse, inntektArbeidYtelseGrunnlag, påkrevdeInntektsmeldinger, false);
+        var filtrertHvisSvp = filtrerInntektsmeldingerForYtelse(referanse, påkrevdeInntektsmeldinger);
+        return filtrerInntektsmeldingerForYtelseUtvidet(referanse, inntektArbeidYtelseGrunnlag, filtrertHvisSvp, false);
     }
 
     /**

--- a/domenetjenester/arbeidsforhold/src/test/java/no/nav/foreldrepenger/domene/arbeidsforhold/impl/InaktiveArbeidsforholdUtlederTest.java
+++ b/domenetjenester/arbeidsforhold/src/test/java/no/nav/foreldrepenger/domene/arbeidsforhold/impl/InaktiveArbeidsforholdUtlederTest.java
@@ -229,7 +229,7 @@ class InaktiveArbeidsforholdUtlederTest {
     }
 
     @Test
-    void Skal_ikke_ta_hensynt_til_at_alle_arbeidsforhold_er_inaktive_pga_permisjon() {
+    void Skal_ikke_ta_hensynt_til_at_arbeidsforhold_er_inaktive_pga_permisjon() {
         // Arrange
         var arbeidsgiver = arbeidsgiver("999999999");
         var internRef1MedPermisjon = InternArbeidsforholdRef.nyRef();


### PR DESCRIPTION
Retter at arbeidsforhold det ikke var søkt svangerskapspenger for ble vurdert om manglet inntektsmelding, og ble listet som et arbeidsforhold det var mottatt IM for.