### PR TITLE
Rydder bort bruk av ANNET som periodetype for oppholdsperioder

### DIFF
--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/ytelsefordeling/periode/OppgittPeriodeEntitet.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/ytelsefordeling/periode/OppgittPeriodeEntitet.java
@@ -139,11 +139,15 @@ public class OppgittPeriodeEntitet extends BaseEntitet implements IndexKey {
     }
 
     public UttakPeriodeType getPeriodeType() {
-        return uttakPeriodeType;
+        return UttakPeriodeType.ANNET.equals(uttakPeriodeType) ? UttakPeriodeType.UDEFINERT : uttakPeriodeType;
     }
 
     void setPeriodeType(UttakPeriodeType uttakPeriodeType) {
-        this.uttakPeriodeType = uttakPeriodeType == null ? UttakPeriodeType.UDEFINERT : uttakPeriodeType;
+        if (UttakPeriodeType.ANNET.equals(uttakPeriodeType) || uttakPeriodeType == null) {
+            this.uttakPeriodeType = UttakPeriodeType.UDEFINERT;
+        } else {
+            this.uttakPeriodeType = uttakPeriodeType;
+        }
     }
 
     void setOppgittFordeling(OppgittFordelingEntitet oppgittFordeling) {

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/ytelsefordeling/periode/UttakPeriodeType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/ytelsefordeling/periode/UttakPeriodeType.java
@@ -3,7 +3,6 @@ package no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.period
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.Set;
 
 import jakarta.persistence.AttributeConverter;
 import jakarta.persistence.Converter;
@@ -23,7 +22,6 @@ public enum UttakPeriodeType implements Kodeverdi {
     ANNET("ANNET", "Andre typer som f.eks utsettelse"),
     UDEFINERT("-", "Ikke satt eller valgt kode"),
     ;
-    public static final Set<UttakPeriodeType> STØNADSPERIODETYPER = Set.of(FORELDREPENGER_FØR_FØDSEL, MØDREKVOTE, FEDREKVOTE, FELLESPERIODE, FORELDREPENGER, UDEFINERT);
     private static final Map<String, UttakPeriodeType> KODER = new LinkedHashMap<>();
 
     public static final String KODEVERK = "UTTAK_PERIODE_TYPE";

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/uttak/fp/UttakResultatPeriodeSøknadEntitet.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/uttak/fp/UttakResultatPeriodeSøknadEntitet.java
@@ -65,7 +65,7 @@ public class UttakResultatPeriodeSøknadEntitet extends BaseEntitet {
     }
 
     public UttakPeriodeType getUttakPeriodeType() {
-        return uttakPeriodeType;
+        return UttakPeriodeType.ANNET.equals(uttakPeriodeType) ? UttakPeriodeType.UDEFINERT : uttakPeriodeType;
     }
 
     public BigDecimal getGraderingArbeidsprosent() {

--- a/behandlingslager/domene/src/test/java/no/nav/foreldrepenger/behandlingslager/behandling/ytelsefordeling/YtelsesFordelingRepositoryTest.java
+++ b/behandlingslager/domene/src/test/java/no/nav/foreldrepenger/behandlingslager/behandling/ytelsefordeling/YtelsesFordelingRepositoryTest.java
@@ -82,7 +82,7 @@ class YtelsesFordelingRepositoryTest extends EntityManagerAwareTest {
         var periode_2 = lagOppgittPeriode(LocalDate.now().minusDays(20), LocalDate.now().minusDays(20),
             UttakPeriodeType.FORELDREPENGER);
         var periode_3 = lagOppgittPeriode(LocalDate.now().minusDays(20), LocalDate.now().minusDays(20),
-            UttakPeriodeType.ANNET);
+            UttakPeriodeType.FEDREKVOTE);
 
         var yf = repository.opprettBuilder(behandling.getId())
             .medOppgittRettighet(OppgittRettighetEntitet.beggeRett())

--- a/domenetjenester/datavarehus/src/main/java/no/nav/foreldrepenger/datavarehus/xml/fp/UttakXmlTjeneste.java
+++ b/domenetjenester/datavarehus/src/main/java/no/nav/foreldrepenger/datavarehus/xml/fp/UttakXmlTjeneste.java
@@ -14,6 +14,7 @@ import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepositoryProvider;
 import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.YtelsesFordelingRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.periode.OppgittPeriodeEntitet;
+import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.periode.UttakPeriodeType;
 import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakYtelseType;
 import no.nav.foreldrepenger.behandlingslager.uttak.Uttaksperiodegrense;
 import no.nav.foreldrepenger.behandlingslager.uttak.UttaksperiodegrenseRepository;
@@ -101,7 +102,8 @@ public class UttakXmlTjeneste {
         var kontrakt = new FordelingPeriode();
         kontrakt.setMorsAktivitet(VedtakXmlUtil.lagKodeverksOpplysning(periodeDomene.getMorsAktivitet()));
         kontrakt.setPeriode(VedtakXmlUtil.lagPeriodeOpplysning(periodeDomene.getFom(), periodeDomene.getTom()));
-        kontrakt.setPeriodetype(VedtakXmlUtil.lagKodeverksOpplysning(periodeDomene.getPeriodeType()));
+        kontrakt.setPeriodetype(periodeDomene.isOpphold() ? VedtakXmlUtil.lagKodeverksOpplysning(UttakPeriodeType.ANNET)
+            : VedtakXmlUtil.lagKodeverksOpplysning(periodeDomene.getPeriodeType()));
         return kontrakt;
     }
 

--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/dokumentpersiterer/impl/søknad/v3/SøknadOversetter.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/dokumentpersiterer/impl/søknad/v3/SøknadOversetter.java
@@ -644,19 +644,15 @@ public class SøknadOversetter implements MottattDokumentOversetter<SøknadWrapp
     }
 
     private OppgittPeriodeEntitet oversettPeriode(LukketPeriodeMedVedlegg lukketPeriode) {
-        var oppgittPeriodeBuilder = OppgittPeriodeBuilder.ny()
-            .medPeriode(lukketPeriode.getFom(), lukketPeriode.getTom());
+        var oppgittPeriodeBuilder = OppgittPeriodeBuilder.ny().medPeriode(lukketPeriode.getFom(), lukketPeriode.getTom());
         if (lukketPeriode instanceof final Uttaksperiode periode) {
             oversettUttakperiode(oppgittPeriodeBuilder, periode);
         } else if (lukketPeriode instanceof Oppholdsperiode oppholdsperiode) {
-            oppgittPeriodeBuilder.medÅrsak(
-                OppholdÅrsak.fraKode(oppholdsperiode.getAarsak().getKode()));
-            oppgittPeriodeBuilder.medPeriodeType(UttakPeriodeType.fraKode(UttakPeriodeType.ANNET.getKode()));
+            oppgittPeriodeBuilder.medÅrsak(OppholdÅrsak.fraKode(oppholdsperiode.getAarsak().getKode()));
+            oppgittPeriodeBuilder.medPeriodeType(UttakPeriodeType.UDEFINERT);
         } else if (lukketPeriode instanceof Overfoeringsperiode overfoeringsperiode) {
-            oppgittPeriodeBuilder.medÅrsak(
-                OverføringÅrsak.fraKode(overfoeringsperiode.getAarsak().getKode()));
-            oppgittPeriodeBuilder.medPeriodeType(
-                UttakPeriodeType.fraKode(((Overfoeringsperiode) lukketPeriode).getOverfoeringAv().getKode()));
+            oppgittPeriodeBuilder.medÅrsak(OverføringÅrsak.fraKode(overfoeringsperiode.getAarsak().getKode()));
+            oppgittPeriodeBuilder.medPeriodeType(UttakPeriodeType.fraKode(overfoeringsperiode.getOverfoeringAv().getKode()));
         } else if (lukketPeriode instanceof Utsettelsesperiode utsettelsesperiode) {
             oversettUtsettelsesperiode(oppgittPeriodeBuilder, utsettelsesperiode);
         } else {

--- a/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/fastsetteperioder/grunnlagbyggere/SøknadGrunnlagBygger.java
+++ b/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/fastsetteperioder/grunnlagbyggere/SøknadGrunnlagBygger.java
@@ -17,7 +17,6 @@ import jakarta.inject.Inject;
 import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.YtelseFordelingAggregat;
 import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.YtelsesFordelingRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.periode.OppgittPeriodeEntitet;
-import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.periode.UttakPeriodeType;
 import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.årsak.OppholdÅrsak;
 import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.årsak.OverføringÅrsak;
 import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.årsak.UtsettelseÅrsak;
@@ -73,16 +72,14 @@ public class SøknadGrunnlagBygger {
         var stønadskontotype = map(oppgittPeriodeType);
 
         final OppgittPeriode periode;
-        if (UttakPeriodeType.STØNADSPERIODETYPER.contains(oppgittPeriodeType)) {
-            if (oppgittPeriode.isUtsettelse()) {
-                periode = byggUtsettelseperiode(oppgittPeriode);
-            } else if (oppgittPeriode.isOverføring()) {
-                periode = byggOverføringPeriode(oppgittPeriode, stønadskontotype);
-            } else {
-                periode = byggStønadsperiode(oppgittPeriode, stønadskontotype, aktiviteter);
-            }
-        } else if (UttakPeriodeType.ANNET.equals(oppgittPeriodeType)) {
+        if (oppgittPeriode.isUtsettelse()) {
+            periode = byggUtsettelseperiode(oppgittPeriode);
+        } else if (oppgittPeriode.isOverføring()) {
+            periode = byggOverføringPeriode(oppgittPeriode, stønadskontotype);
+        } else if (oppgittPeriode.isOpphold()){
             periode = byggTilOppholdPeriode(oppgittPeriode);
+        } else if (stønadskontotype != null) {
+            periode = byggStønadsperiode(oppgittPeriode, stønadskontotype, aktiviteter);
         } else {
             throw new IllegalArgumentException("Ikke-støttet UttakPeriodeType: " + oppgittPeriodeType);
         }

--- a/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/uttaksgrunnlag/fp/VedtaksperioderHelper.java
+++ b/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/uttaksgrunnlag/fp/VedtaksperioderHelper.java
@@ -207,7 +207,7 @@ public class VedtaksperioderHelper {
     private static UttakPeriodeType finnPeriodetype(UttakResultatPeriodeEntitet uttakResultatPeriode) {
         //Oppholdsperiode har ingen aktiviteter
         if (uttakResultatPeriode.isOpphold()) {
-            return UttakPeriodeType.ANNET;
+            return UttakPeriodeType.UDEFINERT;
         }
         var harTrekkdager = uttakResultatPeriode.getAktiviteter().stream()
             .map(UttakResultatPeriodeAktivitetEntitet::getTrekkdager)

--- a/domenetjenester/uttak/src/test/java/no/nav/foreldrepenger/domene/uttak/fastsetteperioder/FastsettePerioderRegelAdapterTest.java
+++ b/domenetjenester/uttak/src/test/java/no/nav/foreldrepenger/domene/uttak/fastsetteperioder/FastsettePerioderRegelAdapterTest.java
@@ -549,7 +549,7 @@ class FastsettePerioderRegelAdapterTest {
 
         // Angitt periode for annen forelder
         var opphold = OppgittPeriodeBuilder.ny()
-            .medPeriodeType(UttakPeriodeType.ANNET)
+            .medPeriodeType(UttakPeriodeType.UDEFINERT)
             .medÅrsak(KVOTE_FELLESPERIODE_ANNEN_FORELDER)
             .medPeriode(startDatoOpphold, sluttDatoOpphold)
             .build();
@@ -632,7 +632,7 @@ class FastsettePerioderRegelAdapterTest {
 
         // Angitt periode for annen forelder
         var opphold = OppgittPeriodeBuilder.ny()
-            .medPeriodeType(UttakPeriodeType.ANNET)
+            .medPeriodeType(UttakPeriodeType.UDEFINERT)
             .medÅrsak(FEDREKVOTE_ANNEN_FORELDER)
             .medPeriode(startDatoOpphold, sluttDatoOpphold)
             .build();

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/uttak/fakta/FaktaUttakFellesTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/uttak/fakta/FaktaUttakFellesTjeneste.java
@@ -197,7 +197,7 @@ class FaktaUttakFellesTjeneste {
             builder = builder.medÅrsak(dto.overføringÅrsak());
         } else if (dto.oppholdÅrsak() != null) {
             builder = builder.medÅrsak(dto.oppholdÅrsak());
-            builder = builder.medPeriodeType(UttakPeriodeType.ANNET);
+            builder = builder.medPeriodeType(UttakPeriodeType.UDEFINERT);
         } else if (erGradering(dto)) {
             builder = builder.medArbeidsgiver(mapArbeidsgiver(dto.arbeidsforhold()))
                 .medGraderingAktivitetType(mapAktivitetType(dto.arbeidsforhold()))

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/uttak/fakta/FaktaUttakHistorikkinnslagTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/uttak/fakta/FaktaUttakHistorikkinnslagTjeneste.java
@@ -169,7 +169,7 @@ public class FaktaUttakHistorikkinnslagTjeneste {
 
     private Optional<String> uttakPeriodeTypeTekst(OppgittPeriodeEntitet periode) {
         return Optional.ofNullable(periode.getPeriodeType())
-            .filter(t -> !UttakPeriodeType.UDEFINERT.equals(t) && !UttakPeriodeType.ANNET.equals(t))
+            .filter(t -> !UttakPeriodeType.UDEFINERT.equals(t))
             .map(UttakPeriodeType::getNavn);
     }
 

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/uttak/fakta/FaktaUttakPeriodeDtoTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/uttak/fakta/FaktaUttakPeriodeDtoTjeneste.java
@@ -5,7 +5,6 @@ import static no.nav.foreldrepenger.domene.uttak.uttaksgrunnlag.fp.OppgittPeriod
 import java.time.LocalDate;
 import java.util.Comparator;
 import java.util.List;
-import java.util.Set;
 import java.util.stream.Stream;
 
 import jakarta.enterprise.context.ApplicationScoped;
@@ -97,8 +96,7 @@ public class FaktaUttakPeriodeDtoTjeneste {
         var overføringÅrsak = periode.isOverføring() ? (OverføringÅrsak) periode.getÅrsak() : null;
         var arbeidsprosent = periode.getArbeidsprosent();
         var arbeidsforhold = arbeidsprosent != null ? mapArbeidsforhold(periode) : null;
-        var periodeType = periode.getPeriodeType() == null || Set.of(UttakPeriodeType.ANNET, UttakPeriodeType.UDEFINERT).contains(
-            periode.getPeriodeType()) ? null : periode.getPeriodeType();
+        var periodeType = periode.getPeriodeType() == null || UttakPeriodeType.UDEFINERT.equals(periode.getPeriodeType()) ? null : periode.getPeriodeType();
         var morsAktivitet = periode.getMorsAktivitet() == null || MorsAktivitet.UDEFINERT.equals(periode.getMorsAktivitet()) ? null : periode.getMorsAktivitet();
         return new FaktaUttakPeriodeDto(periode.getFom(), periode.getTom(),
             periodeType, utsettelseÅrsak, overføringÅrsak, oppholdÅrsak, arbeidsprosent, arbeidsforhold,

--- a/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/uttak/fakta/FaktaUttakFellesTjenesteTest.java
+++ b/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/uttak/fakta/FaktaUttakFellesTjenesteTest.java
@@ -4,7 +4,6 @@ import static no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.
 import static no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.periode.FordelingPeriodeKilde.SAKSBEHANDLER;
 import static no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.periode.FordelingPeriodeKilde.SØKNAD;
 import static no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.periode.FordelingPeriodeKilde.TIDLIGERE_VEDTAK;
-import static no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.periode.UttakPeriodeType.ANNET;
 import static no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.periode.UttakPeriodeType.FEDREKVOTE;
 import static no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.periode.UttakPeriodeType.FELLESPERIODE;
 import static no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.periode.UttakPeriodeType.MØDREKVOTE;
@@ -148,7 +147,7 @@ class FaktaUttakFellesTjenesteTest {
         assertThat(lagretPerioder.get(3).getArbeidsgiver()).isNull();
         assertThat(lagretPerioder.get(3).getPeriodeKilde()).isEqualTo(SAKSBEHANDLER);
         assertThat(lagretPerioder.get(3).getSamtidigUttaksprosent()).isNull();
-        assertThat(lagretPerioder.get(3).getPeriodeType()).isEqualTo(ANNET);
+        assertThat(lagretPerioder.get(3).getPeriodeType()).isEqualTo(UDEFINERT);
         assertThat(lagretPerioder.get(3).isFlerbarnsdager()).isEqualTo(oppholdDto.flerbarnsdager());
         assertThat(lagretPerioder.get(3).getÅrsak()).isEqualTo(oppholdDto.oppholdÅrsak());
 


### PR DESCRIPTION
Starter med ANNET, udef er litt mer jobb. Så tror vi utsetter den.

Bestiller en patch som setter alle ANNET til '-' før jeg fjerner ANNET fra selve enumen