### PR TITLE
Bruk nye kode 6/7 tilganger i frontend.

### DIFF
--- a/domenetjenester/beregningsgrunnlag/src/main/java/no/nav/foreldrepenger/domene/mappers/fra_kalkulus/BesteberegningMapper.java
+++ b/domenetjenester/beregningsgrunnlag/src/main/java/no/nav/foreldrepenger/domene/mappers/fra_kalkulus/BesteberegningMapper.java
@@ -1,6 +1,5 @@
 package no.nav.foreldrepenger.domene.mappers.fra_kalkulus;
 
-import java.math.BigDecimal;
 import java.util.Optional;
 
 import no.nav.folketrygdloven.kalkulator.modell.beregningsgrunnlag.BeregningsgrunnlagDto;

--- a/web/src/main/resources/application.properties
+++ b/web/src/main/resources/application.properties
@@ -49,13 +49,13 @@ fpsak.it.fp.sak.url=http://fp-infotrygd-foreldrepenger/sak
 fpsak.it.sv.sak.url=http://fp-infotrygd-svangerskapspenger/sak
 
 # Kommaseparert liste med systembrukere som skal ha tilgang til ABAC PIP tjenester
-pip.users = srvfplos,srvfpformidling,srvfptilbake,srvfpoppdrag,srvsaf
+pip.users = srvfplos,srvfpformidling,srvfptilbake,srvfpoppdrag
 
 # Gruppenavn for roller fra Active Directory
 bruker.gruppenavn.beslutter = 0000-GA-fpsak-beslutter
 bruker.gruppenavn.egenansatt = 0000-GA-GOSYS_UTVIDET
-bruker.gruppenavn.kode6 = 0000-GA-GOSYS_KODE6
-bruker.gruppenavn.kode7 = 0000-GA-GOSYS_KODE7
+bruker.gruppenavn.kode6 = 0000-ga-strengt_fortrolig_adresse
+bruker.gruppenavn.kode7 = 0000-ga-fortrolig_adresse
 bruker.gruppenavn.overstyrer = 0000-GA-fpsak-manuelt-overstyrer
 bruker.gruppenavn.saksbehandler = 0000-GA-fpsak-saksbehandler
 bruker.gruppenavn.veileder = 0000-GA-fpsak-veileder


### PR DESCRIPTION
Frontend får en vurdering basert på `GOSYS` tilganger mens abac sjekker mot `fortrolig_adresse` tilganger. Er ikke et problem en så lenge SBH har begge tilganger, men greit å gjøre alt mot de nye tilganger.

Må finne ut hva med 0000-GA-GOSYS_UTVIDET siden det finnes et tilsvarende 0000-GA-egen-ansatt men hverken abac eller frontend bruker den