### PR TITLE
Fjerner ubrukt uttakperiodetype ANNET

### DIFF
--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/ytelsefordeling/periode/OppgittPeriodeEntitet.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/ytelsefordeling/periode/OppgittPeriodeEntitet.java
@@ -139,15 +139,11 @@ public class OppgittPeriodeEntitet extends BaseEntitet implements IndexKey {
     }
 
     public UttakPeriodeType getPeriodeType() {
-        return UttakPeriodeType.ANNET.equals(uttakPeriodeType) ? UttakPeriodeType.UDEFINERT : uttakPeriodeType;
+        return uttakPeriodeType;
     }
 
     void setPeriodeType(UttakPeriodeType uttakPeriodeType) {
-        if (UttakPeriodeType.ANNET.equals(uttakPeriodeType) || uttakPeriodeType == null) {
-            this.uttakPeriodeType = UttakPeriodeType.UDEFINERT;
-        } else {
-            this.uttakPeriodeType = uttakPeriodeType;
-        }
+        this.uttakPeriodeType = uttakPeriodeType == null ? UttakPeriodeType.UDEFINERT : uttakPeriodeType;
     }
 
     void setOppgittFordeling(OppgittFordelingEntitet oppgittFordeling) {

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/ytelsefordeling/periode/UttakPeriodeType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/ytelsefordeling/periode/UttakPeriodeType.java
@@ -19,7 +19,6 @@ public enum UttakPeriodeType implements Kodeverdi {
     FEDREKVOTE("FEDREKVOTE", "Fedrekvoten"),
     FORELDREPENGER("FORELDREPENGER", "Foreldrepenger"),
     FORELDREPENGER_FØR_FØDSEL("FORELDREPENGER_FØR_FØDSEL", "Foreldrepenger før fødsel"),
-    ANNET("ANNET", "Andre typer som f.eks utsettelse"),
     UDEFINERT("-", "Ikke satt eller valgt kode"),
     ;
     private static final Map<String, UttakPeriodeType> KODER = new LinkedHashMap<>();

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/uttak/fp/UttakResultatPeriodeSøknadEntitet.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/uttak/fp/UttakResultatPeriodeSøknadEntitet.java
@@ -65,7 +65,7 @@ public class UttakResultatPeriodeSøknadEntitet extends BaseEntitet {
     }
 
     public UttakPeriodeType getUttakPeriodeType() {
-        return UttakPeriodeType.ANNET.equals(uttakPeriodeType) ? UttakPeriodeType.UDEFINERT : uttakPeriodeType;
+        return uttakPeriodeType;
     }
 
     public BigDecimal getGraderingArbeidsprosent() {

--- a/domenetjenester/datavarehus/src/main/java/no/nav/foreldrepenger/datavarehus/xml/VedtakXmlUtil.java
+++ b/domenetjenester/datavarehus/src/main/java/no/nav/foreldrepenger/datavarehus/xml/VedtakXmlUtil.java
@@ -128,7 +128,7 @@ public class VedtakXmlUtil {
 
     public static KodeverksOpplysning lagOppholdPeriodeTypeKodeverkOpplysning() {
         var kodeverksOpplysning = fellesObjectFactory.createKodeverksOpplysning();
-        //Annet er fjernet fra enum
+        // Annet er fjernet fra enum
         kodeverksOpplysning.setKode("ANNET");
         kodeverksOpplysning.setValue("Andre typer som f.eks utsettelse");
         kodeverksOpplysning.setKodeverk(UttakPeriodeType.KODEVERK);

--- a/domenetjenester/datavarehus/src/main/java/no/nav/foreldrepenger/datavarehus/xml/VedtakXmlUtil.java
+++ b/domenetjenester/datavarehus/src/main/java/no/nav/foreldrepenger/datavarehus/xml/VedtakXmlUtil.java
@@ -8,6 +8,7 @@ import java.util.Objects;
 import java.util.Optional;
 
 import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.AksjonspunktDefinisjon;
+import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.periode.UttakPeriodeType;
 import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
 import no.nav.foreldrepenger.xmlutils.DateUtil;
 import no.nav.vedtak.felles.xml.felles.v2.BooleanOpplysning;
@@ -122,6 +123,15 @@ public class VedtakXmlUtil {
         kodeverksOpplysning.setValue(aksjonspunktDefinisjon.getNavn());
         kodeverksOpplysning.setKode(aksjonspunktDefinisjon.getKode());
         kodeverksOpplysning.setKodeverk("AKSJONSPUNKT_DEF");
+        return kodeverksOpplysning;
+    }
+
+    public static KodeverksOpplysning lagOppholdPeriodeTypeKodeverkOpplysning() {
+        var kodeverksOpplysning = fellesObjectFactory.createKodeverksOpplysning();
+        //Annet er fjernet fra enum
+        kodeverksOpplysning.setKode("ANNET");
+        kodeverksOpplysning.setValue("Andre typer som f.eks utsettelse");
+        kodeverksOpplysning.setKodeverk(UttakPeriodeType.KODEVERK);
         return kodeverksOpplysning;
     }
 }

--- a/domenetjenester/datavarehus/src/main/java/no/nav/foreldrepenger/datavarehus/xml/fp/UttakXmlTjeneste.java
+++ b/domenetjenester/datavarehus/src/main/java/no/nav/foreldrepenger/datavarehus/xml/fp/UttakXmlTjeneste.java
@@ -14,7 +14,6 @@ import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepositoryProvider;
 import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.YtelsesFordelingRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.periode.OppgittPeriodeEntitet;
-import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.periode.UttakPeriodeType;
 import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakYtelseType;
 import no.nav.foreldrepenger.behandlingslager.uttak.Uttaksperiodegrense;
 import no.nav.foreldrepenger.behandlingslager.uttak.UttaksperiodegrenseRepository;
@@ -102,7 +101,7 @@ public class UttakXmlTjeneste {
         var kontrakt = new FordelingPeriode();
         kontrakt.setMorsAktivitet(VedtakXmlUtil.lagKodeverksOpplysning(periodeDomene.getMorsAktivitet()));
         kontrakt.setPeriode(VedtakXmlUtil.lagPeriodeOpplysning(periodeDomene.getFom(), periodeDomene.getTom()));
-        kontrakt.setPeriodetype(periodeDomene.isOpphold() ? VedtakXmlUtil.lagKodeverksOpplysning(UttakPeriodeType.ANNET)
+        kontrakt.setPeriodetype(periodeDomene.isOpphold() ? VedtakXmlUtil.lagOppholdPeriodeTypeKodeverkOpplysning()
             : VedtakXmlUtil.lagKodeverksOpplysning(periodeDomene.getPeriodeType()));
         return kontrakt;
     }

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/fpoversikt/FpDtoTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/fpoversikt/FpDtoTjeneste.java
@@ -190,7 +190,7 @@ public class FpDtoTjeneste {
             case FEDREKVOTE -> Konto.FEDREKVOTE;
             case FORELDREPENGER -> Konto.FORELDREPENGER;
             case FORELDREPENGER_FØR_FØDSEL -> Konto.FORELDREPENGER_FØR_FØDSEL;
-            case ANNET, UDEFINERT -> null;
+            case UDEFINERT -> null;
         };
         var utsettelseÅrsak = finnUtsettelseÅrsak(periode.getÅrsak());
         var oppholdÅrsak = finnOppholdÅrsak(periode.getÅrsak());

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/kodeverk/app/HentKodeverkTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/kodeverk/app/HentKodeverkTjeneste.java
@@ -152,7 +152,7 @@ public class HentKodeverkTjeneste {
         map.put(OverføringÅrsak.class.getSimpleName(), OverføringÅrsak.kodeMap().values());
         map.put(UtsettelseÅrsak.class.getSimpleName(), UtsettelseÅrsak.kodeMap().values());
         map.put(UttakArbeidType.class.getSimpleName(), UttakArbeidType.kodeMap().values());
-        map.put(UttakPeriodeType.class.getSimpleName(), UttakPeriodeType.kodeMap().values().stream().filter(k -> k != UttakPeriodeType.ANNET).toList());
+        map.put(UttakPeriodeType.class.getSimpleName(), UttakPeriodeType.kodeMap().values());
         map.put(MorsAktivitet.class.getSimpleName(), MorsAktivitet.kodeMap().values());
         map.put(ManuellBehandlingÅrsak.class.getSimpleName(), ManuellBehandlingÅrsak.kodeMap().values());
         map.put(FaresignalVurdering.class.getSimpleName(), FaresignalVurdering.kodeMap().values());


### PR DESCRIPTION
ANNET er patchet bort fra databasen. Setter fortsatt samme verdier i dvh xml.
Neste blir å bruke UttakPeriodeType på uttaksperiodene, erstatte StønadskontoType