### PR TITLE
Slå av sammenligning mot MS Graph og innfører en toggle.

### DIFF
--- a/.deploy/naiserator.yaml
+++ b/.deploy/naiserator.yaml
@@ -43,6 +43,9 @@ spec:
     requests:
       cpu: "{{requests.cpu}}"
       memory: "{{requests.mem}}"
+  env:
+    - name: MS_GRAPH_CHECK
+      value: "false"
   kafka:
       pool: {{kafkaPool}}
   vault:

--- a/web/src/main/java/no/nav/foreldrepenger/tilganger/TilgangerTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/tilganger/TilgangerTjeneste.java
@@ -57,11 +57,13 @@ public class TilgangerTjeneste {
         var ident = KontekstHolder.getKontekst().getUid();
         var ldapBruker = new LdapBrukeroppslag().hentBrukerinformasjon(ident);
         var ldapBrukerInfo = getInnloggetBruker(ident, ldapBruker);
-        sammenlignMenAzureGraphFailSoft(ldapBrukerInfo);
+        if (!Environment.current().isProd() || Boolean.TRUE.equals(Environment.current().getProperty("MS_GRAPH_CHECK", Boolean.class, Boolean.FALSE))) {
+            sammenlignMedAzureGraphFailSoft(ldapBrukerInfo);
+        }
         return ldapBrukerInfo;
     }
 
-    private static void sammenlignMenAzureGraphFailSoft(InnloggetNavAnsattDto ldapBrukerInfo) {
+    private static void sammenlignMedAzureGraphFailSoft(InnloggetNavAnsattDto ldapBrukerInfo) {
         LOG.info("TILGANGER Azure. Henter fra azure.");
         try {
             var azureBrukerInfo = new TilgangKlient().brukerInfo();


### PR DESCRIPTION
Slår av i prod.

Virker i dev siden dev-fss er flyttet til Azure og det ikke trenges en proxy til å komme seg ut mot Microsoft Azure.

Prod er fortsatt in-house og trenger en proxy - dette fikses om ikke lenge.