### PR TITLE
TFP-5769 sanere aksjonspunkt for 2 tette

### DIFF
--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/aksjonspunkt/AksjonspunktDefinisjon.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/aksjonspunkt/AksjonspunktDefinisjon.java
@@ -224,9 +224,6 @@ public enum AksjonspunktDefinisjon implements Kodeverdi {
             SkjermlenkeType.UTTAK, TOTRINN, EnumSet.of(FP)),
     FASTSETT_UTTAK_STORTINGSREPRESENTANT(AksjonspunktKodeDefinisjon.VURDER_UTTAK_STORTINGSREPRESENTANT_KODE, AksjonspunktType.MANUELL, "Søker er stortingsrepresentant",
         BehandlingStegType.VURDER_UTTAK, VurderingspunktType.UT, UTEN_VILKÅR, SkjermlenkeType.UTTAK, TOTRINN, EnumSet.of(FP)),
-    FASTSETT_UTTAK_ETTER_NESTE_SAK(AksjonspunktKodeDefinisjon.VURDER_UTTAK_ETTER_NESTE_SAK_KODE, AksjonspunktType.MANUELL,
-        "Bruker har minsterett ifm tette saker og uttak etter start av ny sak", BehandlingStegType.VURDER_UTTAK,
-        VurderingspunktType.UT, UTEN_VILKÅR, SkjermlenkeType.UTTAK, TOTRINN, EnumSet.of(FP)),
     KONTROLLER_ANNENPART_EØS(AksjonspunktKodeDefinisjon.KONTROLLER_ANNENPART_EØS_KODE, AksjonspunktType.MANUELL, "Kontroller annen forelders uttak i EØS",
         BehandlingStegType.VURDER_UTTAK, VurderingspunktType.UT, UTEN_VILKÅR, SkjermlenkeType.UTTAK, TOTRINN, EnumSet.of(FP)),
     KONTROLLER_REALITETSBEHANDLING_ELLER_KLAGE(
@@ -394,6 +391,8 @@ public enum AksjonspunktDefinisjon implements Kodeverdi {
     UTGÅTT_5048("5048", AksjonspunktType.MANUELL, "Kontroller den automatiske besteberegningen."),
     @Deprecated
     UTGÅTT_5050("5050", AksjonspunktType.MANUELL, "Vurder gradering på andel uten beregningsgrunnlag"),
+    @Deprecated
+    UTGÅTT_5067("5067", AksjonspunktType.MANUELL, "Bruker har minsterett ifm tette saker og uttak etter start av ny sak"),
     @Deprecated
     UTGÅTT_5070("5070", AksjonspunktType.MANUELL, "Kontrollerer søknadsperioder"),
     @Deprecated

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/aksjonspunkt/AksjonspunktKodeDefinisjon.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/aksjonspunkt/AksjonspunktKodeDefinisjon.java
@@ -119,7 +119,6 @@ public class AksjonspunktKodeDefinisjon {
 
     public static final String KONTROLLER_ANNENPART_EØS_KODE = "5069";
     public static final String VURDER_UTTAK_STORTINGSREPRESENTANT_KODE = "5072";
-    public static final String VURDER_UTTAK_ETTER_NESTE_SAK_KODE = "5067";
     public static final String KONTROLLER_REALITETSBEHANDLING_ELLER_KLAGE_KODE = "5073";
     public static final String KONTROLLER_OPPLYSNINGER_OM_DØD_KODE = "5076";
     public static final String KONTROLLER_OPPLYSNINGER_OM_SØKNADSFRIST_KODE = "5077";
@@ -158,6 +157,7 @@ public class AksjonspunktKodeDefinisjon {
     //  "5036"
     //  "5042"  "5044"  "5045"  "5048"
     //  "5050"
+    //  "5067"
     //  "5070"  "5075"  "5078"  "5079"
     //  "5080"  "5081"  "5083"  "5088"
     //  "5090"  "5093"  "5094"  "5097" "5098"  "5099"

--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/vedtak/observer/VedtaksHendelseObserver.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/vedtak/observer/VedtaksHendelseObserver.java
@@ -10,6 +10,7 @@ import jakarta.inject.Inject;
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingType;
 import no.nav.foreldrepenger.behandlingslager.behandling.events.BehandlingVedtakEvent;
+import no.nav.foreldrepenger.behandlingslager.behandling.vedtak.VedtakResultatType;
 import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakYtelseType;
 import no.nav.foreldrepenger.konfig.Environment;
 import no.nav.foreldrepenger.mottak.vedtak.StartBerørtBehandlingTask;
@@ -56,7 +57,10 @@ public class VedtaksHendelseObserver {
         if (FagsakYtelseType.FORELDREPENGER.equals(fagsakYtelseType)) {
             lagreProsesstaskFor(behandling, TaskType.forProsessTask(StartBerørtBehandlingTask.class), ENV.isLocal() ? 1 : 5);
         }
-        lagreProsesstaskFor(behandling, TaskType.forProsessTask(VurderOpphørAvYtelserTask.class), ENV.isLocal() ? 2 : 40); // Kafka kan ta litt tid
+        // Se bort fra avslagsvedtak - de skal ikke føre til opphør av eksisterende ytelse
+        if (!VedtakResultatType.AVSLAG.equals(event.vedtak().getVedtakResultatType())) {
+            lagreProsesstaskFor(behandling, TaskType.forProsessTask(VurderOpphørAvYtelserTask.class), ENV.isLocal() ? 2 : 40); // Kafka kan ta tid
+        }
     }
 
     void lagreProsesstaskFor(Behandling behandling, TaskType taskType, int delaysecs) {

--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/vedtak/overlapp/VurderOpphørAvYtelser.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/vedtak/overlapp/VurderOpphørAvYtelser.java
@@ -117,8 +117,8 @@ public class VurderOpphørAvYtelser {
         var prosessTaskData = ProsessTaskData.forProsessTask(HåndterOpphørAvYtelserTask.class);
 
         //dersom to tette fødsler skal vi opprette VKY for at SB må ta stilling til eventuelt gjenstående minsterett ellers ikke
-        if (toTetteFødsler(sakOpphør, iverksattBehandling )) {
-            prosessTaskData.setProperty(HåndterOpphørAvYtelserTask.BESKRIVELSE_KEY, String.format("Overlapp på sak med minsterett(to tette) identifisert: Vurder om sak %s har brukt opp minsteretten, og skal opphøres pga ny sak %s", sakOpphør.getSaksnummer(), iverksattBehandling.getFagsak().getSaksnummer()));
+        if (toTetteFødsler(sakOpphør, iverksattBehandling) && overlappendeYtelse(sakOpphør, iverksattBehandling)) {
+            prosessTaskData.setProperty(HåndterOpphørAvYtelserTask.BESKRIVELSE_KEY, String.format("Overlapp på sak med minsterett ved tette fødsler identifisert: Vurder om sak %s har brukt opp minsteretten, og skal opphøres pga ny sak %s", sakOpphør.getSaksnummer(), iverksattBehandling.getFagsak().getSaksnummer()));
         } else {
             prosessTaskData.setProperty(HåndterOpphørAvYtelserTask.BESKRIVELSE_KEY, null);
         }
@@ -154,6 +154,11 @@ public class VurderOpphørAvYtelser {
         }
         var grenseToTette = tidligsteFH.plus(TO_TETTE_GRENSE).plusDays(1);
         return grenseToTette.isAfter(senesteFH);
+    }
+
+    private boolean overlappendeYtelse(Fagsak sakOpphør, Behandling iverksattBehandling) {
+        return !stønadsperiodeTjeneste.utbetalingsTidslinjeEnkeltSak(sakOpphør)
+            .intersection(stønadsperiodeTjeneste.utbetalingsTidslinjeEnkeltSak(iverksattBehandling)).isEmpty();
     }
 
     private boolean beggeSakerErForeldrepenger(Fagsak sakOpphør, Behandling iverksattBehandling) {

--- a/domenetjenester/mottak/src/test/java/no/nav/foreldrepenger/mottak/vedtak/overlapp/VurderOpphørAvYtelserTest.java
+++ b/domenetjenester/mottak/src/test/java/no/nav/foreldrepenger/mottak/vedtak/overlapp/VurderOpphørAvYtelserTest.java
@@ -11,6 +11,8 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Optional;
 
+import no.nav.fpsak.tidsserie.LocalDateTimeline;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -281,9 +283,13 @@ class VurderOpphørAvYtelserTest extends EntityManagerAwareTest {
         var avsluttetBehMor = lagBehandlingMor(LocalDate.now(), AKTØR_ID_MOR, null);
         when(stønadsperiodeTjeneste.stønadsperiodeSluttdatoEnkeltSak(avsluttetBehMor.getFagsak())).thenReturn(Optional.of(
             SISTE_PERIODEDAG_LØPENDE_BEHANDLING));
+        when(stønadsperiodeTjeneste.utbetalingsTidslinjeEnkeltSak(avsluttetBehMor.getFagsak()))
+            .thenReturn(new LocalDateTimeline<>(SISTE_PERIODEDAG_LØPENDE_BEHANDLING.minusWeeks(1), SISTE_PERIODEDAG_LØPENDE_BEHANDLING, Boolean.TRUE));
 
         var nyAvsBehandlingMor = lagBehandlingMor(LocalDate.now().plusWeeks(20), AKTØR_ID_MOR, null);
         when(stønadsperiodeTjeneste.stønadsperiodeStartdato(nyAvsBehandlingMor)).thenReturn(Optional.of(SISTE_PERIODEDAG_LØPENDE_BEHANDLING));
+        when(stønadsperiodeTjeneste.utbetalingsTidslinjeEnkeltSak(nyAvsBehandlingMor))
+            .thenReturn(new LocalDateTimeline<>(SISTE_PERIODEDAG_LØPENDE_BEHANDLING, SISTE_PERIODEDAG_LØPENDE_BEHANDLING.plusWeeks(1), Boolean.TRUE));
 
         //første barn
         when(familieHendelseRepository.hentAggregat(avsluttetBehMor.getId())).thenReturn(familieHendelseGrunnlagEntitet);
@@ -597,7 +603,7 @@ class VurderOpphørAvYtelserTest extends EntityManagerAwareTest {
             .findFirst()
             .orElse(null);
         assertThat(håndterOpphør.getFagsakId()).isEqualTo(fagsak.getId());
-        assertThat(håndterOpphør.getPropertyValue(HåndterOpphørAvYtelserTask.BESKRIVELSE_KEY)).contains("Overlapp på sak med minsterett(to tette) identifisert");
+        assertThat(håndterOpphør.getPropertyValue(HåndterOpphørAvYtelserTask.BESKRIVELSE_KEY)).contains("Overlapp på sak med minsterett ved tette fødsler identifisert");
     }
 
     private void verifiserAtProsesstaskForHåndteringAvOpphørIkkeErOpprettet() {

--- a/domenetjenester/registerinnhenting/src/test/java/no/nav/foreldrepenger/domene/registerinnhenting/StønadsperiodeInnhenterTest.java
+++ b/domenetjenester/registerinnhenting/src/test/java/no/nav/foreldrepenger/domene/registerinnhenting/StønadsperiodeInnhenterTest.java
@@ -9,6 +9,8 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Optional;
 
+import no.nav.fpsak.tidsserie.LocalDateTimeline;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -107,6 +109,8 @@ class StønadsperiodeInnhenterTest extends EntityManagerAwareTest {
         Mockito.lenient().when(fhGrunnlagAnnenMock.getGjeldendeVersjon()).thenReturn(familieHendelseAnnenMock);
         Mockito.lenient().when(familieHendelseAnnenMock.getSkjæringstidspunkt()).thenReturn(FH_DATO_ELDRE);
         when(stønadsperiodeTjeneste.stønadsperiodeStartdato(eldreBehandling.getFagsak())).thenReturn(Optional.of(FH_DATO_ELDRE.minusWeeks(2)));
+        when(stønadsperiodeTjeneste.utbetalingsTidslinjeEnkeltSak(eldreBehandling.getFagsak()))
+            .thenReturn(new LocalDateTimeline<>(FH_DATO_ELDRE.minusWeeks(2), FH_DATO_ELDRE.plusWeeks(6), Boolean.TRUE));
         avsluttBehandling(eldreBehandling);
 
         var behandling = lagBehandlingMor(FH_DATO, AKTØR_ID_MOR, null);
@@ -128,6 +132,8 @@ class StønadsperiodeInnhenterTest extends EntityManagerAwareTest {
         Mockito.lenient().when(fhGrunnlagAnnenMock.getGjeldendeVersjon()).thenReturn(familieHendelseAnnenMock);
         Mockito.lenient().when(familieHendelseAnnenMock.getSkjæringstidspunkt()).thenReturn(FH_DATO_YNGRE);
         when(stønadsperiodeTjeneste.stønadsperiodeStartdato(nyereBehandling.getFagsak())).thenReturn(Optional.of(FH_DATO_YNGRE));
+        when(stønadsperiodeTjeneste.utbetalingsTidslinjeEnkeltSak(nyereBehandling.getFagsak()))
+            .thenReturn(new LocalDateTimeline<>(FH_DATO_YNGRE, FH_DATO_YNGRE.plusWeeks(6), Boolean.TRUE));
         avsluttBehandling(nyereBehandling);
 
         var behandling = lagBehandlingMor(FH_DATO, AKTØR_ID_MOR, null);
@@ -152,6 +158,8 @@ class StønadsperiodeInnhenterTest extends EntityManagerAwareTest {
         Mockito.lenient().when(fhGrunnlagAnnenMock.getGjeldendeVersjon()).thenReturn(familieHendelseAnnenMock);
         Mockito.lenient().when(familieHendelseAnnenMock.getSkjæringstidspunkt()).thenReturn(FH_DATO.minusWeeks(1));
         when(stønadsperiodeTjeneste.utbetalingsperiodeEnkeltSak(avsluttetFPBehMor.getFagsak())).thenReturn(Optional.of(new LocalDateInterval(STP_NORMAL, STP_NORMAL)));
+        when(stønadsperiodeTjeneste.utbetalingsTidslinjeEnkeltSak(avsluttetFPBehMor.getFagsak()))
+            .thenReturn(new LocalDateTimeline<>(STP_NORMAL, STP_NORMAL, Boolean.TRUE));
         avsluttetFPBehMor.avsluttBehandling();
 
         var nyBehSVPOverlapper = lagBehandlingSVP(AKTØR_ID_MOR);
@@ -175,6 +183,8 @@ class StønadsperiodeInnhenterTest extends EntityManagerAwareTest {
         Mockito.lenient().when(fhGrunnlagAnnenMock.getGjeldendeVersjon()).thenReturn(familieHendelseAnnenMock);
         Mockito.lenient().when(familieHendelseAnnenMock.getSkjæringstidspunkt()).thenReturn(FH_DATO_YNGRE);
         when(stønadsperiodeTjeneste.stønadsperiodeStartdato(nyereBehandling.getFagsak())).thenReturn(Optional.of(FH_DATO_YNGRE.minusWeeks(3)));
+        when(stønadsperiodeTjeneste.utbetalingsTidslinjeEnkeltSak(nyereBehandling.getFagsak()))
+            .thenReturn(new LocalDateTimeline<>(FH_DATO_YNGRE.minusWeeks(3), FH_DATO_YNGRE.plusWeeks(6), Boolean.TRUE));
         avsluttBehandling(nyereBehandling);
 
         var behandling = lagBehandlingFar(FH_DATO, MEDF_AKTØR_ID, AKTØR_ID_MOR);
@@ -201,6 +211,8 @@ class StønadsperiodeInnhenterTest extends EntityManagerAwareTest {
         Mockito.lenient().when(fhGrunnlagAnnenMock.getGjeldendeVersjon()).thenReturn(familieHendelseAnnenMock);
         Mockito.lenient().when(familieHendelseAnnenMock.getSkjæringstidspunkt()).thenReturn(FH_DATO_YNGRE);
         when(stønadsperiodeTjeneste.stønadsperiodeStartdato(nyereBehandling.getFagsak())).thenReturn(Optional.of(FH_DATO_YNGRE.minusWeeks(3)));
+        when(stønadsperiodeTjeneste.utbetalingsTidslinjeEnkeltSak(nyereBehandling.getFagsak()))
+            .thenReturn(new LocalDateTimeline<>(FH_DATO_YNGRE.minusWeeks(3), FH_DATO_YNGRE.plusWeeks(6), Boolean.TRUE));
         avsluttBehandling(nyereBehandling);
 
         var behandling = lagBehandlingFar(FH_DATO, MEDF_AKTØR_ID, AKTØR_ID_MOR);
@@ -226,6 +238,8 @@ class StønadsperiodeInnhenterTest extends EntityManagerAwareTest {
         Mockito.lenient().when(fhGrunnlagAnnenMock.getGjeldendeVersjon()).thenReturn(familieHendelseAnnenMock);
         Mockito.lenient().when(familieHendelseAnnenMock.getSkjæringstidspunkt()).thenReturn(FH_DATO_YNGRE);
         when(stønadsperiodeTjeneste.stønadsperiodeStartdato(nyereBehandling.getFagsak())).thenReturn(Optional.of(FH_DATO_YNGRE.minusWeeks(3)));
+        when(stønadsperiodeTjeneste.utbetalingsTidslinjeEnkeltSak(nyereBehandling.getFagsak()))
+            .thenReturn(new LocalDateTimeline<>(FH_DATO_YNGRE.minusWeeks(3), FH_DATO_YNGRE.plusWeeks(6), Boolean.TRUE));
         avsluttBehandling(nyereBehandling);
 
         var nyereÅpenBehandlingFar = lagBehandlingFar(FH_DATO_YNGRE, MEDF_AKTØR_ID, AKTØR_ID_MOR);
@@ -233,6 +247,8 @@ class StønadsperiodeInnhenterTest extends EntityManagerAwareTest {
         Mockito.lenient().when(fhGrunnlagAnnenMock.getGjeldendeVersjon()).thenReturn(familieHendelseAnnenMock);
         Mockito.lenient().when(familieHendelseAnnenMock.getSkjæringstidspunkt()).thenReturn(FH_DATO_YNGRE.plusMonths(2));
         lenient().when(stønadsperiodeTjeneste.stønadsperiodeStartdato(nyereÅpenBehandlingFar.getFagsak())).thenReturn(Optional.empty());
+        when(stønadsperiodeTjeneste.utbetalingsTidslinjeEnkeltSak(nyereÅpenBehandlingFar.getFagsak()))
+            .thenReturn(LocalDateTimeline.empty());
 
         var gammelBehandlingMor = lagBehandlingFar(FH_DATO, AKTØR_ID_MOR, MEDF_AKTØR_ID);
         Mockito.lenient().when(familieHendelseTjeneste.finnAggregat(gammelBehandlingMor.getId())).thenReturn(Optional.of(fhGrunnlagAktuellMock));
@@ -241,6 +257,8 @@ class StønadsperiodeInnhenterTest extends EntityManagerAwareTest {
         when(skjæringstidspunktTjeneste.getSkjæringstidspunkter(any())).thenReturn(skjæringstidspunkt);
         lenient().when(skjæringstidspunkt.getUtledetSkjæringstidspunkt()).thenReturn(FH_DATO.plusWeeks(34));
         lenient().when(stønadsperiodeTjeneste.stønadsperiodeStartdato(gammelBehandlingMor.getFagsak())).thenReturn(Optional.of(FH_DATO.minusWeeks(3)));
+        lenient().when(stønadsperiodeTjeneste.utbetalingsTidslinjeEnkeltSak(gammelBehandlingMor.getFagsak()))
+            .thenReturn(new LocalDateTimeline<>(FH_DATO.minusWeeks(3), FH_DATO.plusWeeks(6), Boolean.TRUE));
 
         var behandling = lagBehandlingFar(FH_DATO, MEDF_AKTØR_ID, AKTØR_ID_MOR);
         Mockito.lenient().when(familieHendelseTjeneste.finnAggregat(behandling.getId())).thenReturn(Optional.of(fhGrunnlagAktuellMock));
@@ -272,6 +290,8 @@ class StønadsperiodeInnhenterTest extends EntityManagerAwareTest {
         Mockito.lenient().when(fhGrunnlagAnnenMock.getGjeldendeVersjon()).thenReturn(familieHendelseAnnenMock);
         Mockito.lenient().when(familieHendelseAnnenMock.getSkjæringstidspunkt()).thenReturn(FH_DATO.plusWeeks(1));
         when(stønadsperiodeTjeneste.utbetalingsperiodeEnkeltSak(avsluttetFPBehMor.getFagsak())).thenReturn(Optional.of(new LocalDateInterval(FH_DATO.minusWeeks(15), FH_DATO)));
+        when(stønadsperiodeTjeneste.utbetalingsTidslinjeEnkeltSak(avsluttetFPBehMor.getFagsak()))
+            .thenReturn(new LocalDateTimeline<>(FH_DATO.minusWeeks(15), FH_DATO.plusWeeks(6), Boolean.TRUE));
         avsluttetFPBehMor.avsluttBehandling();
 
         var nyBehSVPOverlapper = lagBehandlingSVP(AKTØR_ID_MOR);

--- a/domenetjenester/registerinnhenting/src/test/java/no/nav/foreldrepenger/domene/registerinnhenting/StønadsperiodeInnhenterTest.java
+++ b/domenetjenester/registerinnhenting/src/test/java/no/nav/foreldrepenger/domene/registerinnhenting/StønadsperiodeInnhenterTest.java
@@ -9,8 +9,6 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Optional;
 
-import no.nav.fpsak.tidsserie.LocalDateTimeline;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -109,8 +107,6 @@ class StønadsperiodeInnhenterTest extends EntityManagerAwareTest {
         Mockito.lenient().when(fhGrunnlagAnnenMock.getGjeldendeVersjon()).thenReturn(familieHendelseAnnenMock);
         Mockito.lenient().when(familieHendelseAnnenMock.getSkjæringstidspunkt()).thenReturn(FH_DATO_ELDRE);
         when(stønadsperiodeTjeneste.stønadsperiodeStartdato(eldreBehandling.getFagsak())).thenReturn(Optional.of(FH_DATO_ELDRE.minusWeeks(2)));
-        when(stønadsperiodeTjeneste.utbetalingsTidslinjeEnkeltSak(eldreBehandling.getFagsak()))
-            .thenReturn(new LocalDateTimeline<>(FH_DATO_ELDRE.minusWeeks(2), FH_DATO_ELDRE.plusWeeks(6), Boolean.TRUE));
         avsluttBehandling(eldreBehandling);
 
         var behandling = lagBehandlingMor(FH_DATO, AKTØR_ID_MOR, null);
@@ -132,8 +128,6 @@ class StønadsperiodeInnhenterTest extends EntityManagerAwareTest {
         Mockito.lenient().when(fhGrunnlagAnnenMock.getGjeldendeVersjon()).thenReturn(familieHendelseAnnenMock);
         Mockito.lenient().when(familieHendelseAnnenMock.getSkjæringstidspunkt()).thenReturn(FH_DATO_YNGRE);
         when(stønadsperiodeTjeneste.stønadsperiodeStartdato(nyereBehandling.getFagsak())).thenReturn(Optional.of(FH_DATO_YNGRE));
-        when(stønadsperiodeTjeneste.utbetalingsTidslinjeEnkeltSak(nyereBehandling.getFagsak()))
-            .thenReturn(new LocalDateTimeline<>(FH_DATO_YNGRE, FH_DATO_YNGRE.plusWeeks(6), Boolean.TRUE));
         avsluttBehandling(nyereBehandling);
 
         var behandling = lagBehandlingMor(FH_DATO, AKTØR_ID_MOR, null);
@@ -158,8 +152,6 @@ class StønadsperiodeInnhenterTest extends EntityManagerAwareTest {
         Mockito.lenient().when(fhGrunnlagAnnenMock.getGjeldendeVersjon()).thenReturn(familieHendelseAnnenMock);
         Mockito.lenient().when(familieHendelseAnnenMock.getSkjæringstidspunkt()).thenReturn(FH_DATO.minusWeeks(1));
         when(stønadsperiodeTjeneste.utbetalingsperiodeEnkeltSak(avsluttetFPBehMor.getFagsak())).thenReturn(Optional.of(new LocalDateInterval(STP_NORMAL, STP_NORMAL)));
-        when(stønadsperiodeTjeneste.utbetalingsTidslinjeEnkeltSak(avsluttetFPBehMor.getFagsak()))
-            .thenReturn(new LocalDateTimeline<>(STP_NORMAL, STP_NORMAL, Boolean.TRUE));
         avsluttetFPBehMor.avsluttBehandling();
 
         var nyBehSVPOverlapper = lagBehandlingSVP(AKTØR_ID_MOR);
@@ -183,8 +175,6 @@ class StønadsperiodeInnhenterTest extends EntityManagerAwareTest {
         Mockito.lenient().when(fhGrunnlagAnnenMock.getGjeldendeVersjon()).thenReturn(familieHendelseAnnenMock);
         Mockito.lenient().when(familieHendelseAnnenMock.getSkjæringstidspunkt()).thenReturn(FH_DATO_YNGRE);
         when(stønadsperiodeTjeneste.stønadsperiodeStartdato(nyereBehandling.getFagsak())).thenReturn(Optional.of(FH_DATO_YNGRE.minusWeeks(3)));
-        when(stønadsperiodeTjeneste.utbetalingsTidslinjeEnkeltSak(nyereBehandling.getFagsak()))
-            .thenReturn(new LocalDateTimeline<>(FH_DATO_YNGRE.minusWeeks(3), FH_DATO_YNGRE.plusWeeks(6), Boolean.TRUE));
         avsluttBehandling(nyereBehandling);
 
         var behandling = lagBehandlingFar(FH_DATO, MEDF_AKTØR_ID, AKTØR_ID_MOR);
@@ -211,8 +201,6 @@ class StønadsperiodeInnhenterTest extends EntityManagerAwareTest {
         Mockito.lenient().when(fhGrunnlagAnnenMock.getGjeldendeVersjon()).thenReturn(familieHendelseAnnenMock);
         Mockito.lenient().when(familieHendelseAnnenMock.getSkjæringstidspunkt()).thenReturn(FH_DATO_YNGRE);
         when(stønadsperiodeTjeneste.stønadsperiodeStartdato(nyereBehandling.getFagsak())).thenReturn(Optional.of(FH_DATO_YNGRE.minusWeeks(3)));
-        when(stønadsperiodeTjeneste.utbetalingsTidslinjeEnkeltSak(nyereBehandling.getFagsak()))
-            .thenReturn(new LocalDateTimeline<>(FH_DATO_YNGRE.minusWeeks(3), FH_DATO_YNGRE.plusWeeks(6), Boolean.TRUE));
         avsluttBehandling(nyereBehandling);
 
         var behandling = lagBehandlingFar(FH_DATO, MEDF_AKTØR_ID, AKTØR_ID_MOR);
@@ -238,8 +226,6 @@ class StønadsperiodeInnhenterTest extends EntityManagerAwareTest {
         Mockito.lenient().when(fhGrunnlagAnnenMock.getGjeldendeVersjon()).thenReturn(familieHendelseAnnenMock);
         Mockito.lenient().when(familieHendelseAnnenMock.getSkjæringstidspunkt()).thenReturn(FH_DATO_YNGRE);
         when(stønadsperiodeTjeneste.stønadsperiodeStartdato(nyereBehandling.getFagsak())).thenReturn(Optional.of(FH_DATO_YNGRE.minusWeeks(3)));
-        when(stønadsperiodeTjeneste.utbetalingsTidslinjeEnkeltSak(nyereBehandling.getFagsak()))
-            .thenReturn(new LocalDateTimeline<>(FH_DATO_YNGRE.minusWeeks(3), FH_DATO_YNGRE.plusWeeks(6), Boolean.TRUE));
         avsluttBehandling(nyereBehandling);
 
         var nyereÅpenBehandlingFar = lagBehandlingFar(FH_DATO_YNGRE, MEDF_AKTØR_ID, AKTØR_ID_MOR);
@@ -247,8 +233,6 @@ class StønadsperiodeInnhenterTest extends EntityManagerAwareTest {
         Mockito.lenient().when(fhGrunnlagAnnenMock.getGjeldendeVersjon()).thenReturn(familieHendelseAnnenMock);
         Mockito.lenient().when(familieHendelseAnnenMock.getSkjæringstidspunkt()).thenReturn(FH_DATO_YNGRE.plusMonths(2));
         lenient().when(stønadsperiodeTjeneste.stønadsperiodeStartdato(nyereÅpenBehandlingFar.getFagsak())).thenReturn(Optional.empty());
-        when(stønadsperiodeTjeneste.utbetalingsTidslinjeEnkeltSak(nyereÅpenBehandlingFar.getFagsak()))
-            .thenReturn(LocalDateTimeline.empty());
 
         var gammelBehandlingMor = lagBehandlingFar(FH_DATO, AKTØR_ID_MOR, MEDF_AKTØR_ID);
         Mockito.lenient().when(familieHendelseTjeneste.finnAggregat(gammelBehandlingMor.getId())).thenReturn(Optional.of(fhGrunnlagAktuellMock));
@@ -257,8 +241,6 @@ class StønadsperiodeInnhenterTest extends EntityManagerAwareTest {
         when(skjæringstidspunktTjeneste.getSkjæringstidspunkter(any())).thenReturn(skjæringstidspunkt);
         lenient().when(skjæringstidspunkt.getUtledetSkjæringstidspunkt()).thenReturn(FH_DATO.plusWeeks(34));
         lenient().when(stønadsperiodeTjeneste.stønadsperiodeStartdato(gammelBehandlingMor.getFagsak())).thenReturn(Optional.of(FH_DATO.minusWeeks(3)));
-        lenient().when(stønadsperiodeTjeneste.utbetalingsTidslinjeEnkeltSak(gammelBehandlingMor.getFagsak()))
-            .thenReturn(new LocalDateTimeline<>(FH_DATO.minusWeeks(3), FH_DATO.plusWeeks(6), Boolean.TRUE));
 
         var behandling = lagBehandlingFar(FH_DATO, MEDF_AKTØR_ID, AKTØR_ID_MOR);
         Mockito.lenient().when(familieHendelseTjeneste.finnAggregat(behandling.getId())).thenReturn(Optional.of(fhGrunnlagAktuellMock));
@@ -290,8 +272,6 @@ class StønadsperiodeInnhenterTest extends EntityManagerAwareTest {
         Mockito.lenient().when(fhGrunnlagAnnenMock.getGjeldendeVersjon()).thenReturn(familieHendelseAnnenMock);
         Mockito.lenient().when(familieHendelseAnnenMock.getSkjæringstidspunkt()).thenReturn(FH_DATO.plusWeeks(1));
         when(stønadsperiodeTjeneste.utbetalingsperiodeEnkeltSak(avsluttetFPBehMor.getFagsak())).thenReturn(Optional.of(new LocalDateInterval(FH_DATO.minusWeeks(15), FH_DATO)));
-        when(stønadsperiodeTjeneste.utbetalingsTidslinjeEnkeltSak(avsluttetFPBehMor.getFagsak()))
-            .thenReturn(new LocalDateTimeline<>(FH_DATO.minusWeeks(15), FH_DATO.plusWeeks(6), Boolean.TRUE));
         avsluttetFPBehMor.avsluttBehandling();
 
         var nyBehSVPOverlapper = lagBehandlingSVP(AKTØR_ID_MOR);

--- a/domenetjenester/uttak/src/test/java/no/nav/foreldrepenger/domene/uttak/fastsetteperioder/FastsettUttakManueltAksjonspunktUtlederTest.java
+++ b/domenetjenester/uttak/src/test/java/no/nav/foreldrepenger/domene/uttak/fastsetteperioder/FastsettUttakManueltAksjonspunktUtlederTest.java
@@ -9,8 +9,6 @@ import java.util.Set;
 import org.junit.jupiter.api.Test;
 
 import no.nav.foreldrepenger.behandling.BehandlingReferanse;
-import no.nav.foreldrepenger.behandling.DekningsgradTjeneste;
-import no.nav.foreldrepenger.behandling.FagsakRelasjonTjeneste;
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingÅrsakType;
 import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.AksjonspunktDefinisjon;
@@ -19,10 +17,7 @@ import no.nav.foreldrepenger.behandlingslager.uttak.fp.PeriodeResultatÅrsak;
 import no.nav.foreldrepenger.behandlingslager.uttak.fp.UttakResultatPeriodeEntitet;
 import no.nav.foreldrepenger.behandlingslager.uttak.fp.UttakResultatPerioderEntitet;
 import no.nav.foreldrepenger.domene.abakus.AbakusInMemoryInntektArbeidYtelseTjeneste;
-import no.nav.foreldrepenger.domene.uttak.ForeldrepengerUttakTjeneste;
 import no.nav.foreldrepenger.domene.uttak.UttakRevurderingTestUtil;
-import no.nav.foreldrepenger.domene.uttak.fastsetteperioder.grunnlagbyggere.KontoerGrunnlagBygger;
-import no.nav.foreldrepenger.domene.uttak.fastsetteperioder.grunnlagbyggere.RettOgOmsorgGrunnlagBygger;
 import no.nav.foreldrepenger.domene.uttak.input.FamilieHendelse;
 import no.nav.foreldrepenger.domene.uttak.input.FamilieHendelser;
 import no.nav.foreldrepenger.domene.uttak.input.ForeldrepengerGrunnlag;
@@ -34,19 +29,8 @@ class FastsettUttakManueltAksjonspunktUtlederTest {
     private final UttakRepositoryStubProvider repositoryProvider = new UttakRepositoryStubProvider();
     private final AbakusInMemoryInntektArbeidYtelseTjeneste iayTjeneste = new AbakusInMemoryInntektArbeidYtelseTjeneste();
     private final UttakRevurderingTestUtil testUtil = new UttakRevurderingTestUtil(repositoryProvider, iayTjeneste);
-    private final RettOgOmsorgGrunnlagBygger rettOgOmsorgGrunnlagBygger = new RettOgOmsorgGrunnlagBygger(repositoryProvider,
-        new ForeldrepengerUttakTjeneste(repositoryProvider.getFpUttakRepository()));
-    private final KontoerGrunnlagBygger kontoerGrunnlagBygger;
 
-    {
-        var fagsakRelasjonTjeneste = new FagsakRelasjonTjeneste(repositoryProvider.getFagsakRepository(), null,
-            repositoryProvider.getFagsakRelasjonRepository());
-        kontoerGrunnlagBygger = new KontoerGrunnlagBygger(fagsakRelasjonTjeneste,
-            rettOgOmsorgGrunnlagBygger, new DekningsgradTjeneste(fagsakRelasjonTjeneste, repositoryProvider.getBehandlingsresultatRepository()));
-    }
-
-    private final FastsettUttakManueltAksjonspunktUtleder utleder = new FastsettUttakManueltAksjonspunktUtleder(repositoryProvider,
-        kontoerGrunnlagBygger);
+    private final FastsettUttakManueltAksjonspunktUtleder utleder = new FastsettUttakManueltAksjonspunktUtleder(repositoryProvider);
 
 
     @Test

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/uttak/dto/FastsetteUttakDto.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/uttak/dto/FastsetteUttakDto.java
@@ -58,20 +58,6 @@ public abstract class FastsetteUttakDto extends BekreftetAksjonspunktDto {
 
     }
 
-    @JsonTypeName(AksjonspunktKodeDefinisjon.VURDER_UTTAK_ETTER_NESTE_SAK_KODE)
-    public static class FastsetteUttakEtterNesteSakDto extends FastsetteUttakDto {
-
-        @SuppressWarnings("unused")
-        private FastsetteUttakEtterNesteSakDto() {
-            // For Jackson
-        }
-
-        public FastsetteUttakEtterNesteSakDto(List<UttakResultatPeriodeLagreDto> perioder) {
-            super(perioder);
-        }
-
-    }
-
     @JsonTypeName(AksjonspunktKodeDefinisjon.KONTROLLER_ANNENPART_EØS_KODE)
     public static class FastsetteUttakKontrollerAnnenpartEØSDto extends FastsetteUttakDto {
 

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/vedtak/app/UttakPeriodeEndringDtoTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/vedtak/app/UttakPeriodeEndringDtoTjeneste.java
@@ -21,7 +21,7 @@ import no.nav.foreldrepenger.web.app.tjenester.behandling.uttak.fakta.FaktaUttak
 public class UttakPeriodeEndringDtoTjeneste {
 
     private static final Set<AksjonspunktDefinisjon> PROSESS_UTTAK = Set.of(AksjonspunktDefinisjon.FASTSETT_UTTAKPERIODER,
-        AksjonspunktDefinisjon.FASTSETT_UTTAK_STORTINGSREPRESENTANT, AksjonspunktDefinisjon.FASTSETT_UTTAK_ETTER_NESTE_SAK,
+        AksjonspunktDefinisjon.FASTSETT_UTTAK_STORTINGSREPRESENTANT,
         AksjonspunktDefinisjon.KONTROLLER_ANNENPART_EØS,
         AksjonspunktDefinisjon.KONTROLLER_REALITETSBEHANDLING_ELLER_KLAGE, AksjonspunktDefinisjon.KONTROLLER_OPPLYSNINGER_OM_SØKNADSFRIST,
         AksjonspunktDefinisjon.KONTROLLER_OPPLYSNINGER_OM_DØD,


### PR DESCRIPTION
Det er svært få forekomster av aksjonspunkt ved to tette og vi kan tillate dersom det ikke er overlapp i utbetaling.
* Forbedret innhenting av nestesak - bare tilfelle med utbetalte perioder (unngår avslag)
* Fjerner eget aksjonspunkt i uttak for totette
* Beholde Gosys-oppgave/aksjonspunkt dersom vedtak i ny sak, to tette og det er utbetaling som overlapper med tidl sak