### PR TITLE
Fikse tredelt 80-prosent og aleneomsorgstilfelle

### DIFF
--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/ytelsefordeling/OppgittRettighetEntitet.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/ytelsefordeling/OppgittRettighetEntitet.java
@@ -103,12 +103,12 @@ public class OppgittRettighetEntitet extends BaseEntitet {
         return annenForelderOppholdEØS;
     }
 
-    public static OppgittRettighetEntitet kopiAleneomsorg(OppgittRettighetEntitet rett, Boolean aleneomsorg) {
+    public static OppgittRettighetEntitet kopiIkkeAleneomsorg(OppgittRettighetEntitet rett) {
         if (rett == null) {
-            return new OppgittRettighetEntitet(null, aleneomsorg, null, null, null);
+            return new OppgittRettighetEntitet(null, false, null, null, null);
         }
-        return Objects.equals(aleneomsorg, rett.harAleneomsorgForBarnet) ? rett :
-            new OppgittRettighetEntitet(rett.harAnnenForeldreRett, aleneomsorg, rett.morMottarUføretrygd, rett.annenForelderRettEØS,
+        return Objects.equals(false, rett.harAleneomsorgForBarnet) ? rett :
+            new OppgittRettighetEntitet(rett.harAnnenForeldreRett, false, rett.morMottarUføretrygd, rett.annenForelderRettEØS,
                 rett.annenForelderOppholdEØS);
     }
 
@@ -120,7 +120,10 @@ public class OppgittRettighetEntitet extends BaseEntitet {
             new OppgittRettighetEntitet(false, true, rett.morMottarUføretrygd, rett.annenForelderRettEØS, rett.annenForelderOppholdEØS);
     }
 
-    public static OppgittRettighetEntitet kopiAnnenForelderRett(OppgittRettighetEntitet rett, Boolean annenForelderRett) {
+    public static OppgittRettighetEntitet kopiAnnenForelderRett(OppgittRettighetEntitet rett, boolean annenForelderRett) {
+        // Kan velge å sette aleneomsorg = false dersom annenForelder rett her og for Boolean EØS.
+        // Nå er dette implisitt gjennom avklaringsrekkefølge i KontrollerOmsorgRett (Alene, AnnenRett, AnnenRettEØS). null = ikke eksplisitt avklart
+        // Krever antagelig fortsatt robustAleneomsorg pga ny 1g-søknad
         if (rett == null) {
             return new OppgittRettighetEntitet(annenForelderRett, null, null, null, null);
         }

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/ytelsefordeling/YtelseFordelingAggregat.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/ytelsefordeling/YtelseFordelingAggregat.java
@@ -6,6 +6,7 @@ import java.time.LocalDate;
 import java.util.Objects;
 import java.util.Optional;
 
+import no.nav.foreldrepenger.behandlingslager.behandling.personopplysning.RelasjonsRolleType;
 import no.nav.foreldrepenger.behandlingslager.behandling.ufore.UføretrygdGrunnlagEntitet;
 import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.periode.OppgittFordelingEntitet;
 import no.nav.foreldrepenger.behandlingslager.fagsak.Dekningsgrad;
@@ -24,6 +25,11 @@ public class YtelseFordelingAggregat {
     private Boolean overstyrtOmsorg;
 
     protected YtelseFordelingAggregat() {
+    }
+
+    // Brukes i tilfelle og steder der aleneomsorg ventes å ha vært manuelt/maskinelt avklart. OBS på nye førstegangssøknader
+    public boolean robustHarAleneomsorg(RelasjonsRolleType relasjonsRolleType) {
+        return RelasjonsRolleType.erMor(relasjonsRolleType) ? harAleneomsorg() : TRUE.equals(getAleneomsorgAvklaring());
     }
 
     public boolean harAleneomsorg() {

--- a/domenetjenester/datavarehus/src/main/java/no/nav/foreldrepenger/datavarehus/v2/StønadsstatistikkTjeneste.java
+++ b/domenetjenester/datavarehus/src/main/java/no/nav/foreldrepenger/datavarehus/v2/StønadsstatistikkTjeneste.java
@@ -422,7 +422,7 @@ public class StønadsstatistikkTjeneste {
 
 
             var yfa = ytelseFordelingTjeneste.hentAggregat(behandling.getId());
-            var rettighetType = utledRettighetType(yfa, konti);
+            var rettighetType = utledRettighetType(behandling.getRelasjonsRolleType(), yfa, konti);
             var dekningsgrad = fagsakRelasjon.getGjeldendeDekningsgrad(); //TODO: Erstatt med å hente dekningsgrad fra behandling etter at dekningsgrad migreres til behandling
             var dekningsgradEkstradager = dekningsgrad.isÅtti() ? Dekningsgrad.DEKNINGSGRAD_80 : Dekningsgrad.DEKNINGSGRAD_100;
             var ekstradager = new HashSet<ForeldrepengerRettigheter.Stønadsutvidelse>();
@@ -441,9 +441,9 @@ public class StønadsstatistikkTjeneste {
         });
     }
 
-    private static RettighetType utledRettighetType(YtelseFordelingAggregat yfa, Set<ForeldrepengerRettigheter.Stønadskonto> konti) {
+    private static RettighetType utledRettighetType(RelasjonsRolleType relasjonsRolleType, YtelseFordelingAggregat yfa, Set<ForeldrepengerRettigheter.Stønadskonto> konti) {
         if (konti.stream().anyMatch(k -> k.type().equals(StønadsstatistikkVedtak.StønadskontoType.FORELDREPENGER))) {
-            return yfa.harAleneomsorg() ? RettighetType.ALENEOMSORG : RettighetType.BARE_SØKER_RETT;
+            return yfa.robustHarAleneomsorg(relasjonsRolleType) ? RettighetType.ALENEOMSORG : RettighetType.BARE_SØKER_RETT;
         }
         return yfa.avklartAnnenForelderHarRettEØS() ? RettighetType.BEGGE_RETT_EØS : RettighetType.BEGGE_RETT;
     }

--- a/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/beregnkontoer/StønadskontoRegelOversetter.java
+++ b/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/beregnkontoer/StønadskontoRegelOversetter.java
@@ -3,12 +3,14 @@ package no.nav.foreldrepenger.domene.uttak.beregnkontoer;
 import static no.nav.foreldrepenger.domene.uttak.UttakEnumMapper.map;
 
 import java.time.LocalDate;
+import java.time.Month;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
 import no.nav.foreldrepenger.behandling.BehandlingReferanse;
 import no.nav.foreldrepenger.behandlingslager.behandling.nestesak.NesteSakGrunnlagEntitet;
+import no.nav.foreldrepenger.behandlingslager.behandling.personopplysning.RelasjonsRolleType;
 import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.YtelseFordelingAggregat;
 import no.nav.foreldrepenger.behandlingslager.fagsak.Dekningsgrad;
 import no.nav.foreldrepenger.behandlingslager.uttak.fp.StønadskontoType;
@@ -21,6 +23,8 @@ import no.nav.foreldrepenger.stønadskonto.regelmodell.grunnlag.BeregnKontoerGru
 import no.nav.foreldrepenger.stønadskonto.regelmodell.grunnlag.Rettighetstype;
 
 public class StønadskontoRegelOversetter {
+
+    private static final LocalDate START_FPSAK = LocalDate.of(2019, Month.JANUARY, 1);
 
     public BeregnKontoerGrunnlag tilRegelmodell(YtelseFordelingAggregat ytelseFordelingAggregat,
                                                 Dekningsgrad dekningsgrad,
@@ -36,14 +40,14 @@ public class StønadskontoRegelOversetter {
             .antallBarn(familieHendelse.getAntallBarn())
             .dekningsgrad(map(dekningsgrad))
             .brukerRolle(UttakEnumMapper.mapTilBeregning(ref.relasjonRolle()))
-            .rettighetType(mapRettighet(ytelseFordelingAggregat, annenForeldreHarRett))
+            .rettighetType(mapRettighet(ref.relasjonRolle(), ytelseFordelingAggregat, annenForeldreHarRett))
             .tidligereUtregning(mapTilStønadskontoBeregning(tidligereUtregning))
             .morHarUføretrygd(ytelseFordelingAggregat.morMottarUføretrygd(fpGrunnlag.getUføretrygdGrunnlag().orElse(null)))
             .familieHendelseDatoNesteSak(familieHendelseNesteSak(fpGrunnlag).orElse(null));
 
 
         leggTilFamileHendelseDatoer(grunnlagBuilder, familieHendelse, fpGrunnlag.getFamilieHendelser().gjelderTerminFødsel());
-
+        utledRegelvalgsdato(ref, dekningsgrad, familieHendelse).ifPresent(grunnlagBuilder::regelvalgsdato);
         return grunnlagBuilder
             .build();
     }
@@ -59,8 +63,9 @@ public class StønadskontoRegelOversetter {
         }
     }
 
-    private static Rettighetstype mapRettighet(YtelseFordelingAggregat ytelseFordelingAggregat, boolean annenForeldreHarRett) {
-        if (ytelseFordelingAggregat.harAleneomsorg()) {
+    private static Rettighetstype mapRettighet(RelasjonsRolleType relasjonsRolleType, YtelseFordelingAggregat ytelseFordelingAggregat, boolean annenForeldreHarRett) {
+        // Skal være avklart på dette tidspunktet - forsiktig med metoder som har fallback til oppgitt rettighet pga nyere førstegangssøknader.
+        if (ytelseFordelingAggregat.robustHarAleneomsorg(relasjonsRolleType)) {
             return Rettighetstype.ALENEOMSORG;
         } else if (annenForeldreHarRett) {
             return Rettighetstype.BEGGE_RETT;
@@ -77,6 +82,21 @@ public class StønadskontoRegelOversetter {
         return gjeldende.entrySet().stream()
             .collect(Collectors.toMap(e -> UttakEnumMapper.mapTilBeregning(e.getKey()), Map.Entry::getValue));
     }
+
+    /*
+     * Normalt er ikrafttredelse lagt til fødsel eller omsorgsovertakelse etter en gitt dato. Unntak:
+     * - LOV-2018-12-07-90 om tredeling av 80% uttak - gjelder for tilfelle der uttaket begynner etter 1/1-2019
+     *
+     * Ikrafttredelsesmekanismer kan også foreligge her
+     */
+    private static Optional<LocalDate> utledRegelvalgsdato(BehandlingReferanse ref, Dekningsgrad dekningsgrad, FamilieHendelse familieHendelse) {
+        if (familieHendelse.getFamilieHendelseDato().isBefore(START_FPSAK) && dekningsgrad.isÅtti()) {
+            return ref.getUtledetSkjæringstidspunktHvisUtledet().filter(stp -> !stp.isBefore(START_FPSAK));
+        }
+        return Optional.empty();
+    }
+
+
 
 
 }

--- a/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/fakta/uttak/AktivitetskravDokumentasjonUtleder.java
+++ b/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/fakta/uttak/AktivitetskravDokumentasjonUtleder.java
@@ -48,7 +48,7 @@ public class AktivitetskravDokumentasjonUtleder {
         var behandlingReferanse = input.getBehandlingReferanse();
         ForeldrepengerGrunnlag fpGrunnlag = input.getYtelsespesifiktGrunnlag();
         var familieHendelse = fpGrunnlag.getFamilieHendelser().getGjeldendeFamilieHendelse();
-        if (helePeriodenErHelg(periode) || RelasjonsRolleType.erMor(behandlingReferanse.relasjonRolle()) || ytelseFordelingAggregat.harAleneomsorg()
+        if (helePeriodenErHelg(periode) || RelasjonsRolleType.erMor(behandlingReferanse.relasjonRolle()) || ytelseFordelingAggregat.robustHarAleneomsorg(input.getBehandlingReferanse().relasjonRolle())
             || familieHendelse.erStebarnsadopsjon() || MorsAktivitet.UFØRE.equals(periode.getMorsAktivitet()) || MorsAktivitet.IKKE_OPPGITT.equals(periode.getMorsAktivitet())) {
             return Optional.empty();
         }

--- a/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/fakta/uttak/TidligOppstartFarDokumentasjonUtleder.java
+++ b/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/fakta/uttak/TidligOppstartFarDokumentasjonUtleder.java
@@ -43,7 +43,7 @@ final class TidligOppstartFarDokumentasjonUtleder {
 
     private static boolean behandlingKanIkkeHaTidligOppstart(UttakInput input, YtelseFordelingAggregat ytelseFordelingAggregat, FamilieHendelse familieHendelse) {
         return !familieHendelse.gjelderFødsel() || RelasjonsRolleType.erMor(input.getBehandlingReferanse().relasjonRolle())
-            || ytelseFordelingAggregat.harAleneomsorg();
+            || ytelseFordelingAggregat.robustHarAleneomsorg(input.getBehandlingReferanse().relasjonRolle());
     }
 
     private static boolean erBalansertUttakRundtFødsel(OppgittPeriodeEntitet søknadsperiode, UttakInput input) {

--- a/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/fastsetteperioder/grunnlagbyggere/RettOgOmsorgGrunnlagBygger.java
+++ b/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/fastsetteperioder/grunnlagbyggere/RettOgOmsorgGrunnlagBygger.java
@@ -41,7 +41,7 @@ public class RettOgOmsorgGrunnlagBygger {
         var annenpartsUttaksplan = hentAnnenpartsUttak(uttakInput);
         var samtykke = samtykke(ytelseFordelingAggregat);
         return new RettOgOmsorg.Builder()
-                .aleneomsorg(ytelseFordelingAggregat.harAleneomsorg())
+                .aleneomsorg(ytelseFordelingAggregat.robustHarAleneomsorg(uttakInput.getBehandlingReferanse().relasjonRolle()))
                 .farHarRett(farHarRett(ref, ytelseFordelingAggregat, annenpartsUttaksplan))
                 .morHarRett(morHarRett(ref, ytelseFordelingAggregat, annenpartsUttaksplan))
                 .morUføretrygd(morUføretrygd(uttakInput, ytelseFordelingAggregat))

--- a/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/ytelsefordeling/YtelseFordelingTjeneste.java
+++ b/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/ytelsefordeling/YtelseFordelingTjeneste.java
@@ -54,7 +54,7 @@ public class YtelseFordelingTjeneste {
         if (aleneomsorg) {
             overstyrtRett = OppgittRettighetEntitet.kopiAleneomsorgIkkeRettAnnenForelder(overstyrtRett);
         } else {
-            overstyrtRett = OppgittRettighetEntitet.kopiAleneomsorg(overstyrtRett, aleneomsorg);
+            overstyrtRett = OppgittRettighetEntitet.kopiIkkeAleneomsorg(overstyrtRett);
         }
         ytelseFordelingBuilder.medOverstyrtRettighet(overstyrtRett);
         ytelsesFordelingRepository.lagre(behandlingId, ytelseFordelingBuilder.build());
@@ -115,7 +115,7 @@ public class YtelseFordelingTjeneste {
         ytelsesFordelingRepository.lagre(behandlingId, builder.build());
     }
 
-    public void bekreftAnnenforelderHarRett(Long behandlingId, Boolean annenforelderHarRett, Boolean annenForelderHarRettEØS, Boolean annenforelderMottarUføretrygd) {
+    public void bekreftAnnenforelderHarRett(Long behandlingId, boolean annenforelderHarRett, Boolean annenForelderHarRettEØS, Boolean annenforelderMottarUføretrygd) {
         var overstyrtRett = ytelsesFordelingRepository.hentAggregatHvisEksisterer(behandlingId)
             .flatMap(YtelseFordelingAggregat::getOverstyrtRettighet).orElse(null);
         overstyrtRett = OppgittRettighetEntitet.kopiAnnenForelderRett(overstyrtRett, annenforelderHarRett);

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/uttak/app/UttakPerioderDtoTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/uttak/app/UttakPerioderDtoTjeneste.java
@@ -84,7 +84,7 @@ public class UttakPerioderDtoTjeneste {
         var filter = new UttakResultatPerioderDto.FilterDto(kreverSammenhengendeUttak, utenMinsterett,
             RelasjonsRolleType.erMor(behandling.getRelasjonsRolleType()));
         var annenForelderHarRett = ytelseFordeling.filter(yf -> yf.harAnnenForelderRett(annenpartUttak.filter(ForeldrepengerUttak::harUtbetaling).isPresent())).isPresent();
-        var aleneomsorg = ytelseFordeling.map(YtelseFordelingAggregat::harAleneomsorg).orElse(false);
+        var aleneomsorg = ytelseFordeling.map(a -> a.robustHarAleneomsorg(behandling.getRelasjonsRolleType())).orElse(false);
         var annenForelderRettEØS = ytelseFordeling.map(YtelseFordelingAggregat::avklartAnnenForelderHarRettEØS).orElse(false);
         var oppgittAnnenForelderRettEØS = ytelseFordeling.map(YtelseFordelingAggregat::oppgittAnnenForelderRettEØS).orElse(false);
         return new UttakResultatPerioderDto(perioderSøker,


### PR DESCRIPTION
Fikser to problem observert ved tørrkjøring
- tredeling for 80 prosent hadde ikrafttredelse for uttak fom 2019 - familiehendelsedato uten betydning. Ser på STP
- mer robust sjekk for aleneomsorg - mor blir maskinelt avklart mens far skal manuelt avklares - men far kan søke N så J

Jobber videre med siste 60 avvik fra dryrun