### PR TITLE
VedtakObserver sjekker kun overlapp med tidligere saker

### DIFF
--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/vedtak/overlapp/VurderOpphørAvYtelser.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/vedtak/overlapp/VurderOpphørAvYtelser.java
@@ -226,9 +226,7 @@ public class VurderOpphørAvYtelser {
     private boolean erMaxDatoPåLøpendeSakEtterStartDatoNysak(Fagsak fagsak, LocalDate startdatoIVB) {
         var startdato = stønadsperiodeTjeneste.stønadsperiodeStartdato(fagsak).orElse(Tid.TIDENES_ENDE);
         var sluttdato = stønadsperiodeTjeneste.stønadsperiodeSluttdatoEnkeltSak(fagsak).orElse(Tid.TIDENES_BEGYNNELSE);
-        var startintervallIVB = new LocalDateInterval(startdatoIVB.minus(MATCH_INTERVALL_HENDELSE), startdatoIVB.plus(MATCH_INTERVALL_HENDELSE));
-        var startintervall = new LocalDateInterval(startdato.minus(MATCH_INTERVALL_HENDELSE), startdato.plus(MATCH_INTERVALL_HENDELSE));
-        return startintervall.compareTo(startintervallIVB) < 0 && (sluttdato.equals(startdatoIVB) || sluttdato.isAfter(startdatoIVB));
+        return startdato.minus(MATCH_INTERVALL_HENDELSE).isBefore(startdatoIVB.plusWeeks(6)) && (sluttdato.equals(startdatoIVB) || sluttdato.isAfter(startdatoIVB));
     }
 
 }

--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/vedtak/overlapp/VurderOpphørAvYtelser.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/vedtak/overlapp/VurderOpphørAvYtelser.java
@@ -42,6 +42,8 @@ public class VurderOpphørAvYtelser {
 
     private static final Set<FagsakYtelseType> VURDER_OVERLAPP = Set.of(FagsakYtelseType.FORELDREPENGER, FagsakYtelseType.SVANGERSKAPSPENGER);
 
+    private static final Period MATCH_INTERVALL_HENDELSE = Period.parse("P6W");
+
     private FagsakRelasjonTjeneste fagsakRelasjonTjeneste;
     private FagsakRepository fagsakRepository;
     private PersonopplysningRepository personopplysningRepository;
@@ -222,8 +224,11 @@ public class VurderOpphørAvYtelser {
     }
 
     private boolean erMaxDatoPåLøpendeSakEtterStartDatoNysak(Fagsak fagsak, LocalDate startdatoIVB) {
+        var startdato = stønadsperiodeTjeneste.stønadsperiodeStartdato(fagsak).orElse(Tid.TIDENES_ENDE);
         var sluttdato = stønadsperiodeTjeneste.stønadsperiodeSluttdatoEnkeltSak(fagsak).orElse(Tid.TIDENES_BEGYNNELSE);
-        return sluttdato.equals(startdatoIVB) || sluttdato.isAfter(startdatoIVB);
+        var startintervallIVB = new LocalDateInterval(startdatoIVB.minus(MATCH_INTERVALL_HENDELSE), startdatoIVB.plus(MATCH_INTERVALL_HENDELSE));
+        var startintervall = new LocalDateInterval(startdato.minus(MATCH_INTERVALL_HENDELSE), startdato.plus(MATCH_INTERVALL_HENDELSE));
+        return startintervall.compareTo(startintervallIVB) < 0 && (sluttdato.equals(startdatoIVB) || sluttdato.isAfter(startdatoIVB));
     }
 
 }

--- a/domenetjenester/mottak/src/test/java/no/nav/foreldrepenger/mottak/vedtak/overlapp/VurderOpphørAvYtelserTest.java
+++ b/domenetjenester/mottak/src/test/java/no/nav/foreldrepenger/mottak/vedtak/overlapp/VurderOpphørAvYtelserTest.java
@@ -395,14 +395,10 @@ class VurderOpphørAvYtelserTest extends EntityManagerAwareTest {
     void opprettHåndteringNårOverlappMedFPNårInnvilgerSVPPåNyttBarn() {
         var løpendeFPMor = lagBehandlingMor(START_PERIODEDAG_LØPENDE_BEHANDLING, AKTØR_ID_MOR, null);
         // PGA sjekk gradering
-        when(stønadsperiodeTjeneste.stønadsperiodeStartdato(løpendeFPMor.getFagsak())).thenReturn(Optional.of(START_PERIODEDAG_LØPENDE_BEHANDLING));
-        when(stønadsperiodeTjeneste.stønadsperiodeSluttdatoEnkeltSak(løpendeFPMor.getFagsak())).thenReturn(Optional.of(SISTE_PERIODEDAG_LØPENDE_BEHANDLING));
         when(stønadsperiodeTjeneste.utbetalingsperiodeEnkeltSak(løpendeFPMor.getFagsak())).thenReturn(Optional.of(new LocalDateInterval(START_PERIODEDAG_LØPENDE_BEHANDLING,SISTE_PERIODEDAG_LØPENDE_BEHANDLING)));
         lenient().when(stønadsperiodeTjeneste.fullUtbetalingSisteUtbetalingsperiode(løpendeFPMor.getFagsak())).thenReturn(true);
 
         var nySVPNyttBarnOverlapperFP = lagBehandlingSVP(AKTØR_ID_MOR);
-        when(stønadsperiodeTjeneste.stønadsperiodeStartdato(nySVPNyttBarnOverlapperFP.getFagsak())).thenReturn(Optional.of(START_PERIODEDAG_OVERLAPP));
-        when(stønadsperiodeTjeneste.stønadsperiodeSluttdatoEnkeltSak(nySVPNyttBarnOverlapperFP.getFagsak())).thenReturn(Optional.of(SISTE_PERIODEDAG_OVERLAPP));
         when(stønadsperiodeTjeneste.stønadsperiode(nySVPNyttBarnOverlapperFP)).thenReturn(Optional.of(new LocalDateInterval(START_PERIODEDAG_OVERLAPP, SISTE_PERIODEDAG_OVERLAPP)));
 
         vurderOpphørAvYtelser.vurderOpphørAvYtelser(nySVPNyttBarnOverlapperFP);


### PR DESCRIPTION
Før i tiden så sjekket man kun overlapp med eldre saker dersom det kom vedtak for førstegang.
Så åpnet vi for sjekk dersom vedtak i revurderinger og da har autotest avdekket en mulig loop.
Legger inn filter på saker med tidligere startdato enn den som nylig er iverksatt (med slingringsmonn på 6 uker).
Fant også en mangel i en test som sjekket med løpende FP fulgt av SVP-vedtak 49 uker senere - vil nå opphøre FP, ikke SVP