### PR TITLE
TFP-4846 sett konto i fagsakrel ved avslutt behandling

### DIFF
--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/Behandlingsresultat.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/Behandlingsresultat.java
@@ -81,6 +81,8 @@ public class Behandlingsresultat extends BaseEntitet {
     @Column(name = "endret_dekningsgrad", nullable = false)
     private boolean endretDekningsgrad;
 
+
+    // TODO post konto og dekningsgrad: Unmap herfra og setUnused
     @Convert(converter = BooleanToStringConverter.class)
     @Column(name = "endret_stoenadskonto", nullable = false)
     private boolean endretStønadskonto;
@@ -169,10 +171,6 @@ public class Behandlingsresultat extends BaseEntitet {
 
     public boolean isEndretDekningsgrad() {
         return endretDekningsgrad;
-    }
-
-    public boolean isEndretStønadskonto() {
-        return endretStønadskonto;
     }
 
     @Override
@@ -302,12 +300,6 @@ public class Behandlingsresultat extends BaseEntitet {
         public Builder medEndretDekningsgrad(boolean endretDekningsgrad) {
             validerKanModifisere();
             this.behandlingsresultat.endretDekningsgrad = endretDekningsgrad;
-            return this;
-        }
-
-        public Builder medEndretStønadskonto(boolean endretStønadskonto) {
-            validerKanModifisere();
-            this.behandlingsresultat.endretStønadskonto = endretStønadskonto;
             return this;
         }
 

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/fagsak/FagsakRelasjon.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/fagsak/FagsakRelasjon.java
@@ -131,7 +131,7 @@ public class FagsakRelasjon extends BaseEntitet {
     }
 
     public Optional<Stønadskontoberegning> getGjeldendeStønadskontoberegning() {
-        return getOverstyrtStønadskontoberegning().isPresent() ? getOverstyrtStønadskontoberegning() : getStønadskontoberegning();
+        return getOverstyrtStønadskontoberegning().or(this::getStønadskontoberegning);
     }
 
     public Dekningsgrad getGjeldendeDekningsgrad() {

--- a/behandlingsprosess/src/main/java/no/nav/foreldrepenger/behandling/steg/uttak/fp/UttakStegBeregnStønadskontoTjeneste.java
+++ b/behandlingsprosess/src/main/java/no/nav/foreldrepenger/behandling/steg/uttak/fp/UttakStegBeregnStønadskontoTjeneste.java
@@ -1,48 +1,31 @@
 package no.nav.foreldrepenger.behandling.steg.uttak.fp;
 
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.Objects;
-import java.util.Set;
-import java.util.stream.Collectors;
+import java.util.Map;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import no.nav.foreldrepenger.behandling.DekningsgradTjeneste;
 import no.nav.foreldrepenger.behandling.FagsakRelasjonTjeneste;
 import no.nav.foreldrepenger.behandlingslager.fagsak.Dekningsgrad;
-import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakRelasjon;
-import no.nav.foreldrepenger.behandlingslager.uttak.fp.StønadskontoType;
 import no.nav.foreldrepenger.behandlingslager.uttak.fp.Stønadskontoberegning;
-import no.nav.foreldrepenger.domene.uttak.ForeldrepengerUttakPeriode;
-import no.nav.foreldrepenger.domene.uttak.ForeldrepengerUttakTjeneste;
 import no.nav.foreldrepenger.domene.uttak.beregnkontoer.BeregnStønadskontoerTjeneste;
-import no.nav.foreldrepenger.domene.uttak.input.ForeldrepengerGrunnlag;
 import no.nav.foreldrepenger.domene.uttak.input.UttakInput;
 
 
 @ApplicationScoped
 public class UttakStegBeregnStønadskontoTjeneste {
 
-    private static final Logger LOG = LoggerFactory.getLogger(UttakStegBeregnStønadskontoTjeneste.class);
-
     private BeregnStønadskontoerTjeneste beregnStønadskontoerTjeneste;
     private DekningsgradTjeneste dekningsgradTjeneste;
     private FagsakRelasjonTjeneste fagsakRelasjonTjeneste;
-    private ForeldrepengerUttakTjeneste uttakTjeneste;
 
     @Inject
     public UttakStegBeregnStønadskontoTjeneste(BeregnStønadskontoerTjeneste beregnStønadskontoerTjeneste,
                                                DekningsgradTjeneste dekningsgradTjeneste,
-                                               ForeldrepengerUttakTjeneste uttakTjeneste,
                                                FagsakRelasjonTjeneste fagsakRelasjonTjeneste) {
         this.beregnStønadskontoerTjeneste = beregnStønadskontoerTjeneste;
         this.fagsakRelasjonTjeneste = fagsakRelasjonTjeneste;
-        this.uttakTjeneste = uttakTjeneste;
         this.dekningsgradTjeneste = dekningsgradTjeneste;
     }
 
@@ -50,101 +33,17 @@ public class UttakStegBeregnStønadskontoTjeneste {
         // CDI
     }
 
-    /**
-     * Beregner og lagrer stønadskontoer hvis preconditions er oppfylt
-     */
-    BeregningingAvStønadskontoResultat beregnStønadskontoer(UttakInput input) {
-        var ref = input.getBehandlingReferanse();
-        var fagsakRelasjon = fagsakRelasjonTjeneste.finnRelasjonFor(ref.saksnummer());
-        ForeldrepengerGrunnlag fpGrunnlag = input.getYtelsespesifiktGrunnlag();
-
-        // Trenger ikke behandlingslås siden stønadskontoer lagres på fagsakrelasjon.
-        if (fagsakRelasjon.getStønadskontoberegning().isEmpty() || !finnesLøpendeInnvilgetFP(fpGrunnlag)) {
-            beregnStønadskontoerTjeneste.opprettStønadskontoer(input);
-            return BeregningingAvStønadskontoResultat.BEREGNET;
-        }
-        // Default er beregning relativt til eksisterende kontoberegning.
-        // Endring fra 80 til 100% DG krever full omregning ettersom antall dager reduseres
-        var endretDekningsgrad = dekningsgradTjeneste.behandlingHarEndretDekningsgrad(ref);
-        if (endretDekningsgrad) {
-            var fullBeregning = Dekningsgrad._100.equals(dekningsgradTjeneste.finnGjeldendeDekningsgrad(ref));
-            beregnStønadskontoerTjeneste.overstyrStønadskontoberegning(input, !fullBeregning);
-            return BeregningingAvStønadskontoResultat.OVERSTYRT;
-        }
-
-        // Mulig hver behandling skal regne ut stønadskontoer på nytt. Logger her for å
-        // samle data på hvor mye endringer det fører til
-        logEvtEndring(input, fagsakRelasjon);
-
-        return BeregningingAvStønadskontoResultat.INGEN_BEREGNING;
-    }
-
     public Stønadskontoberegning fastsettStønadskontoerForBehandling(UttakInput input) {
+        var ref = input.getBehandlingReferanse();
         var gjeldendeStønadskontoberegning = fagsakRelasjonTjeneste.finnRelasjonFor(input.getBehandlingReferanse().saksnummer())
             .getGjeldendeStønadskontoberegning();
-        return beregnStønadskontoerTjeneste.beregnForBehandling(input, gjeldendeStønadskontoberegning.orElseThrow().getStønadskontoutregning())
-            .or(() -> gjeldendeStønadskontoberegning)
+        var kreverNyBeregning = gjeldendeStønadskontoberegning.isPresent() && dekningsgradTjeneste.behandlingHarEndretDekningsgrad(ref) &&
+            Dekningsgrad._100.equals(dekningsgradTjeneste.finnGjeldendeDekningsgrad(ref));
+        var tidligereStønadskontoberegning = gjeldendeStønadskontoberegning.filter(sb -> !kreverNyBeregning);
+        var gjeldendeKontoutregning = tidligereStønadskontoberegning.map(Stønadskontoberegning::getStønadskontoutregning).orElse(Map.of());
+        return beregnStønadskontoerTjeneste.beregnForBehandling(input, gjeldendeKontoutregning)
+            .or(() -> tidligereStønadskontoberegning)
             .orElseThrow();
     }
 
-    private void logEvtEndring(UttakInput input, FagsakRelasjon fagsakRelasjon) {
-        var nyeKontoer = beregnStønadskontoerTjeneste.beregn(input, false);
-
-        var eksiterendeKontoer = fagsakRelasjon.getStønadskontoberegning().orElseThrow();
-        var endringerVedReberegning = utledEndringer(eksiterendeKontoer, nyeKontoer);
-        if (!endringerVedReberegning.isEmpty()) {
-            var saksnummer1 = fagsakRelasjon.getFagsakNrEn().getSaksnummer().getVerdi();
-            var saksnummer2 = fagsakRelasjon.getFagsakNrTo().map(fr -> fr.getSaksnummer().getVerdi()).orElse("");
-            LOG.info("Behandling ville ha endret stønadskontoer {} {} {} {} {}", saksnummer1, saksnummer2,
-                endringerVedReberegning, eksiterendeKontoer.getRegelInput(), nyeKontoer.getRegelInput());
-        }
-    }
-
-    private static Set<KontoEndring> utledEndringer(Stønadskontoberegning eksiterendeKonti, Stønadskontoberegning nyeKonti) {
-        HashSet<StønadskontoType> alleTyper = new HashSet<>(Arrays.stream(StønadskontoType.values()).filter(StønadskontoType::erStønadsdager).toList());
-
-        return alleTyper.stream().map(type -> {
-            var dagerEksisterende = finnMaksdagerForType(eksiterendeKonti, type);
-            var dagerNye = finnMaksdagerForType(nyeKonti, type);
-            return dagerNye.equals(dagerEksisterende) ? null : new KontoEndring(type, dagerEksisterende, dagerNye);
-        }).filter(Objects::nonNull).collect(Collectors.toSet());
-    }
-
-    private static Integer finnMaksdagerForType(Stønadskontoberegning eksiterendeKonti, StønadskontoType type) {
-        return eksiterendeKonti.getStønadskontoutregning().getOrDefault(type, 0);
-    }
-
-    private boolean finnesLøpendeInnvilgetFP(ForeldrepengerGrunnlag foreldrepengerGrunnlag) {
-        var originalBehandling = foreldrepengerGrunnlag.getOriginalBehandling();
-        if (originalBehandling.isPresent() && erLøpendeInnvilgetFP(originalBehandling.get().getId())) {
-            return true;
-        }
-
-        return foreldrepengerGrunnlag.getAnnenpart().filter(ap -> erLøpendeInnvilgetFP(ap.gjeldendeVedtakBehandlingId())).isPresent();
-    }
-
-    private boolean erLøpendeInnvilgetFP(Long behandlingId) {
-        var uttak = uttakTjeneste.hentUttakHvisEksisterer(behandlingId);
-        if (uttak.isEmpty()) {
-            return false;
-        }
-        return uttak.get().getGjeldendePerioder()
-                .stream()
-                .anyMatch(this::harTrekkdagerEllerUtbetaling);
-    }
-
-    private boolean harTrekkdagerEllerUtbetaling(ForeldrepengerUttakPeriode periode) {
-        return periode.getAktiviteter()
-                .stream()
-                .anyMatch(aktivitet -> aktivitet.getTrekkdager().merEnn0() || aktivitet.getUtbetalingsgrad().harUtbetaling());
-    }
-
-    enum BeregningingAvStønadskontoResultat {
-        BEREGNET,
-        OVERSTYRT,
-        INGEN_BEREGNING
-    }
-
-    private record KontoEndring(StønadskontoType type, Integer dagerEksisterende, Integer dagerNye) {
-    }
 }

--- a/behandlingsprosess/src/main/java/no/nav/foreldrepenger/behandling/steg/uttak/fp/UttakStegImpl.java
+++ b/behandlingsprosess/src/main/java/no/nav/foreldrepenger/behandling/steg/uttak/fp/UttakStegImpl.java
@@ -8,7 +8,6 @@ import jakarta.inject.Inject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import no.nav.foreldrepenger.behandling.FagsakRelasjonTjeneste;
 import no.nav.foreldrepenger.behandling.revurdering.ytelse.UttakInputTjeneste;
 import no.nav.foreldrepenger.behandling.steg.uttak.UttakSteg;
 import no.nav.foreldrepenger.behandlingskontroll.AksjonspunktResultat;
@@ -19,11 +18,9 @@ import no.nav.foreldrepenger.behandlingskontroll.BehandlingTypeRef;
 import no.nav.foreldrepenger.behandlingskontroll.BehandlingskontrollKontekst;
 import no.nav.foreldrepenger.behandlingskontroll.FagsakYtelseTypeRef;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingStegType;
-import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingsresultatRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepositoryProvider;
 import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.MorsAktivitet;
 import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.periode.DokumentasjonVurdering;
-import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakRepository;
 import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakYtelseType;
 import no.nav.foreldrepenger.behandlingslager.uttak.fp.FpUttakRepository;
 import no.nav.foreldrepenger.domene.uttak.KopierForeldrepengerUttaktjeneste;
@@ -41,14 +38,11 @@ import no.nav.foreldrepenger.domene.ytelsefordeling.YtelseFordelingTjeneste;
 public class UttakStegImpl implements UttakSteg {
 
     private static final Logger LOG = LoggerFactory.getLogger(UttakStegImpl.class);
-    private final BehandlingsresultatRepository behandlingsresultatRepository;
     private final FastsettePerioderTjeneste fastsettePerioderTjeneste;
     private final FastsettUttakManueltAksjonspunktUtleder fastsettUttakManueltAksjonspunktUtleder;
-    private final FagsakRelasjonTjeneste fagsakRelasjonTjeneste;
     private final FpUttakRepository fpUttakRepository;
     private final UttakInputTjeneste uttakInputTjeneste;
     private final UttakStegBeregnStønadskontoTjeneste beregnStønadskontoTjeneste;
-    private final FagsakRepository fagsakRepository;
     private final SkalKopiereUttakTjeneste skalKopiereUttakTjeneste;
     private final KopierForeldrepengerUttaktjeneste kopierUttaktjeneste;
     private final LoggInfoOmArbeidsforholdAktivitetskrav loggArbeidsforholdInfo;
@@ -60,19 +54,14 @@ public class UttakStegImpl implements UttakSteg {
                          FastsettUttakManueltAksjonspunktUtleder fastsettUttakManueltAksjonspunktUtleder,
                          UttakInputTjeneste uttakInputTjeneste,
                          UttakStegBeregnStønadskontoTjeneste beregnStønadskontoTjeneste,
-                         SkalKopiereUttakTjeneste skalKopiereUttakTjeneste,
-                         FagsakRelasjonTjeneste fagsakRelasjonTjeneste,
-                         KopierForeldrepengerUttaktjeneste kopierUttaktjeneste,
+                         SkalKopiereUttakTjeneste skalKopiereUttakTjeneste, KopierForeldrepengerUttaktjeneste kopierUttaktjeneste,
                          LoggInfoOmArbeidsforholdAktivitetskrav loggArbeidsforholdInfo,
                          YtelseFordelingTjeneste ytelseFordelingTjeneste) {
         this.fastsettUttakManueltAksjonspunktUtleder = fastsettUttakManueltAksjonspunktUtleder;
         this.fastsettePerioderTjeneste = fastsettePerioderTjeneste;
         this.uttakInputTjeneste = uttakInputTjeneste;
-        this.behandlingsresultatRepository = repositoryProvider.getBehandlingsresultatRepository();
-        this.fagsakRelasjonTjeneste = fagsakRelasjonTjeneste;
         this.fpUttakRepository = repositoryProvider.getFpUttakRepository();
         this.beregnStønadskontoTjeneste = beregnStønadskontoTjeneste;
-        this.fagsakRepository = repositoryProvider.getFagsakRepository();
         this.skalKopiereUttakTjeneste = skalKopiereUttakTjeneste;
         this.kopierUttaktjeneste = kopierUttaktjeneste;
         this.loggArbeidsforholdInfo = loggArbeidsforholdInfo;

--- a/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/uttak/fp/UttakStegBeregnStønadskontoTjenesteTest.java
+++ b/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/uttak/fp/UttakStegBeregnStønadskontoTjenesteTest.java
@@ -14,7 +14,6 @@ import org.junit.jupiter.api.Test;
 import no.nav.foreldrepenger.behandling.BehandlingReferanse;
 import no.nav.foreldrepenger.behandling.DekningsgradTjeneste;
 import no.nav.foreldrepenger.behandling.FagsakRelasjonTjeneste;
-import no.nav.foreldrepenger.behandling.steg.uttak.fp.UttakStegBeregnStønadskontoTjeneste.BeregningingAvStønadskontoResultat;
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingÅrsakType;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepositoryProvider;
@@ -60,8 +59,7 @@ class UttakStegBeregnStønadskontoTjenesteTest extends EntityManagerAwareTest {
         var dekningsgradTjeneste = new DekningsgradTjeneste(fagsakRelasjonTjeneste, uttakRepositoryProvider.getBehandlingsresultatRepository());
         var beregnStønadskontoerTjeneste = new BeregnStønadskontoerTjeneste(uttakRepositoryProvider, fagsakRelasjonTjeneste, uttakTjeneste,
             dekningsgradTjeneste);
-        tjeneste = new UttakStegBeregnStønadskontoTjeneste(beregnStønadskontoerTjeneste, dekningsgradTjeneste,
-                uttakTjeneste, fagsakRelasjonTjeneste);
+        tjeneste = new UttakStegBeregnStønadskontoTjeneste(beregnStønadskontoerTjeneste, dekningsgradTjeneste, fagsakRelasjonTjeneste);
     }
 
     @Test
@@ -79,9 +77,9 @@ class UttakStegBeregnStønadskontoTjenesteTest extends EntityManagerAwareTest {
 
         var ytelsespesifiktGrunnlag = familieHendelser(FamilieHendelse.forFødsel(null, LocalDate.now(), List.of(), 1));
         var input = new UttakInput(BehandlingReferanse.fra(revurdering), null, ytelsespesifiktGrunnlag);
-        var resultat = tjeneste.beregnStønadskontoer(input);
+        var resultat = tjeneste.fastsettStønadskontoerForBehandling(input);
 
-        assertThat(resultat).isEqualTo(BeregningingAvStønadskontoResultat.BEREGNET);
+        assertThat(resultat.getStønadskontoutregning()).containsKey(StønadskontoType.FELLESPERIODE);
     }
 
     @Test
@@ -100,9 +98,9 @@ class UttakStegBeregnStønadskontoTjenesteTest extends EntityManagerAwareTest {
 
         var ytelsespesifiktGrunnlag = familieHendelser(FamilieHendelse.forFødsel(null, LocalDate.now(), List.of(), 1));
         var input = new UttakInput(BehandlingReferanse.fra(revurdering), null, ytelsespesifiktGrunnlag);
-        var resultat = tjeneste.beregnStønadskontoer(input);
+        var resultat = tjeneste.fastsettStønadskontoerForBehandling(input);
 
-        assertThat(resultat).isEqualTo(BeregningingAvStønadskontoResultat.BEREGNET);
+        assertThat(resultat.getStønadskontoutregning()).containsKey(StønadskontoType.FELLESPERIODE);
     }
 
     @Test
@@ -135,9 +133,9 @@ class UttakStegBeregnStønadskontoTjenesteTest extends EntityManagerAwareTest {
         var ytelsespesifiktGrunnlag = familieHendelser(FamilieHendelse.forFødsel(null, LocalDate.now(), List.of(), 1))
                 .medAnnenpart(new Annenpart(førsteBehandling.getId(), LocalDateTime.now()));
         var input = new UttakInput(BehandlingReferanse.fra(revurdering), null, ytelsespesifiktGrunnlag);
-        var resultat = tjeneste.beregnStønadskontoer(input);
+        var resultat = tjeneste.fastsettStønadskontoerForBehandling(input);
 
-        assertThat(resultat).isEqualTo(BeregningingAvStønadskontoResultat.INGEN_BEREGNING);
+        assertThat(resultat.getStønadskontoutregning()).containsKey(StønadskontoType.FELLESPERIODE);
     }
 
     @Test
@@ -158,9 +156,9 @@ class UttakStegBeregnStønadskontoTjenesteTest extends EntityManagerAwareTest {
         var ytelsespesifiktGrunnlag = familieHendelser(FamilieHendelse.forFødsel(null, LocalDate.now(), List.of(), 1))
                 .medAnnenpart(new Annenpart(morBehandling.getId(), LocalDateTime.now()));
         var input = new UttakInput(BehandlingReferanse.fra(farBehandling), null, ytelsespesifiktGrunnlag);
-        var resultat = tjeneste.beregnStønadskontoer(input);
+        var resultat = tjeneste.fastsettStønadskontoerForBehandling(input);
 
-        assertThat(resultat).isEqualTo(BeregningingAvStønadskontoResultat.INGEN_BEREGNING);
+        assertThat(resultat.getStønadskontoutregning()).containsKey(StønadskontoType.FELLESPERIODE);
     }
 
     private ForeldrepengerGrunnlag familieHendelser(FamilieHendelse søknadFamilieHendelse) {
@@ -183,9 +181,9 @@ class UttakStegBeregnStønadskontoTjenesteTest extends EntityManagerAwareTest {
 
         var ytelsespesifiktGrunnlag = familieHendelser(FamilieHendelse.forFødsel(null, LocalDate.now(), List.of(), 1));
         var input = new UttakInput(BehandlingReferanse.fra(farBehandling), null, ytelsespesifiktGrunnlag);
-        var resultat = tjeneste.beregnStønadskontoer(input);
+        var resultat = tjeneste.fastsettStønadskontoerForBehandling(input);
 
-        assertThat(resultat).isEqualTo(BeregningingAvStønadskontoResultat.BEREGNET);
+        assertThat(resultat.getStønadskontoutregning()).containsKey(StønadskontoType.FELLESPERIODE);
     }
 
     @Test
@@ -204,9 +202,9 @@ class UttakStegBeregnStønadskontoTjenesteTest extends EntityManagerAwareTest {
 
         var ytelsespesifiktGrunnlag = familieHendelser(FamilieHendelse.forFødsel(null, LocalDate.now(), List.of(), 1));
         var input = new UttakInput(BehandlingReferanse.fra(farBehandling), null, ytelsespesifiktGrunnlag);
-        var resultat = tjeneste.beregnStønadskontoer(input);
+        var resultat = tjeneste.fastsettStønadskontoerForBehandling(input);
 
-        assertThat(resultat).isEqualTo(BeregningingAvStønadskontoResultat.BEREGNET);
+        assertThat(resultat.getStønadskontoutregning()).containsKey(StønadskontoType.FELLESPERIODE);
     }
 
     private void lagreUttak(Behandling førsteBehandling, UttakResultatPerioderEntitet opprinneligPerioder) {

--- a/domenetjenester/behandling-revurdering/src/main/java/no/nav/foreldrepenger/behandling/revurdering/BerørtBehandlingTjeneste.java
+++ b/domenetjenester/behandling-revurdering/src/main/java/no/nav/foreldrepenger/behandling/revurdering/BerørtBehandlingTjeneste.java
@@ -17,6 +17,7 @@ import no.nav.foreldrepenger.behandlingslager.behandling.SpesialBehandling;
 import no.nav.foreldrepenger.domene.uttak.ForeldrepengerUttak;
 import no.nav.foreldrepenger.domene.uttak.ForeldrepengerUttakPeriode;
 import no.nav.foreldrepenger.domene.uttak.ForeldrepengerUttakTjeneste;
+import no.nav.foreldrepenger.domene.uttak.beregnkontoer.UtregnetStønadskontoTjeneste;
 import no.nav.foreldrepenger.domene.uttak.saldo.StønadskontoSaldoTjeneste;
 import no.nav.foreldrepenger.domene.uttak.uttaksgrunnlag.fp.EndringsdatoBerørtUtleder;
 import no.nav.foreldrepenger.domene.ytelsefordeling.YtelseFordelingTjeneste;
@@ -79,7 +80,8 @@ public class BerørtBehandlingTjeneste {
     }
 
     private BerørtÅrsak utledÅrsak(ForeldrepengerUttak brukersUttak, ForeldrepengerUttak annenpartsUttak) {
-        var harEndretStrukturEllerRedusertAntallStønadsdager = EndringsdatoBerørtUtleder.harEndretStrukturEllerRedusertAntallStønadsdager(brukersUttak, annenpartsUttak);
+        var harEndretStrukturEllerRedusertAntallStønadsdager = UtregnetStønadskontoTjeneste
+            .harEndretStrukturEllerRedusertAntallStønadsdager(annenpartsUttak.getStønadskontoBeregning(), brukersUttak.getStønadskontoBeregning());
         return harEndretStrukturEllerRedusertAntallStønadsdager ? BerørtÅrsak.KONTO_REDUSERT : BerørtÅrsak.ORDINÆR;
     }
 

--- a/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/beregnkontoer/StønadskontoRegelAdapter.java
+++ b/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/beregnkontoer/StønadskontoRegelAdapter.java
@@ -44,7 +44,7 @@ public class StønadskontoRegelAdapter {
         return endretUtregning(tidligereUtregning, resultat) ? Optional.of(konverterTilStønadskontoberegning(resultat)) : Optional.empty();
     }
 
-    public StønadskontoResultat beregnKontoerMedResultat(BehandlingReferanse ref,
+    private StønadskontoResultat beregnKontoerMedResultat(BehandlingReferanse ref,
                                                          YtelseFordelingAggregat ytelseFordelingAggregat,
                                                          Dekningsgrad dekningsgrad,
                                                          Optional<ForeldrepengerUttak> annenpartsGjeldendeUttaksplan,
@@ -74,10 +74,6 @@ public class StønadskontoRegelAdapter {
 
     private boolean endretUtregning(Map<StønadskontoType, Integer> tidligereUtregning, StønadskontoResultat resultat) {
         var nyUtregning = resultat.getStønadskontoer().entrySet().stream()
-            .filter(e -> e.getValue() > 0)
-            .collect(Collectors.toMap(e -> map(e.getKey()), Map.Entry::getValue));
-        // Dersom man vil ha uflettet resultat
-        var nyUtregningBeholdkontoer = resultat.getStønadskontoerBeholdStønadsdager().entrySet().stream()
             .filter(e -> e.getValue() > 0)
             .collect(Collectors.toMap(e -> map(e.getKey()), Map.Entry::getValue));
         return !nyUtregning.equals(tidligereUtregning);

--- a/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/beregnkontoer/UtregnetStønadskontoTjeneste.java
+++ b/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/beregnkontoer/UtregnetStønadskontoTjeneste.java
@@ -2,6 +2,7 @@ package no.nav.foreldrepenger.domene.uttak.beregnkontoer;
 
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -50,4 +51,33 @@ public class UtregnetStønadskontoTjeneste {
                 .map(Stønadskontoberegning::getStønadskontoutregning))
             .orElseGet(Map::of);
     }
+
+    public static boolean harSammeAntallStønadsdager(Map<StønadskontoType, Integer> forrigeUtregning, Map<StønadskontoType, Integer> nyUtregning) {
+        var forrigeDager = forrigeUtregning.entrySet().stream()
+            .filter(e -> e.getKey().erStønadsdager())
+            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+        var nyeDager = nyUtregning.entrySet().stream()
+            .filter(e -> e.getKey().erStønadsdager())
+            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+        return forrigeDager.equals(nyeDager);
+    }
+
+    public static boolean harEndretStrukturEllerRedusertAntallStønadsdager(Map<StønadskontoType, Integer> forrigeUtregning,
+                                                                           Map<StønadskontoType, Integer> nyUtregning) {
+        var nyutregnetForeldrepenger = nyUtregning.getOrDefault(StønadskontoType.FORELDREPENGER, 0);
+        var eksisterendeForeldrepenger = forrigeUtregning.getOrDefault(StønadskontoType.FORELDREPENGER, 0);
+        if (nyutregnetForeldrepenger > 0 && eksisterendeForeldrepenger > 0) {
+            return nyutregnetForeldrepenger < eksisterendeForeldrepenger;
+        }
+        var nyutregnetFellesperiode = nyUtregning.getOrDefault(StønadskontoType.FELLESPERIODE, 0);
+        var eksisterendeFellesperiode = forrigeUtregning.getOrDefault(StønadskontoType.FELLESPERIODE, 0);
+        if (nyutregnetFellesperiode > 0 && eksisterendeFellesperiode > 0) {
+            return nyutregnetFellesperiode < eksisterendeFellesperiode;
+        } else {
+            // Endret fra Foreldrepenger til Kvoter eller omvendt
+            return (nyutregnetForeldrepenger > 0 && eksisterendeFellesperiode > 0) ||  (nyutregnetFellesperiode > 0 && eksisterendeForeldrepenger > 0);
+        }
+    }
+
+
 }

--- a/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/uttaksgrunnlag/fp/EndringsdatoRevurderingUtleder.java
+++ b/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/uttaksgrunnlag/fp/EndringsdatoRevurderingUtleder.java
@@ -5,6 +5,7 @@ import java.util.Comparator;
 import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -38,6 +39,7 @@ import no.nav.foreldrepenger.domene.uttak.ForeldrepengerUttak;
 import no.nav.foreldrepenger.domene.uttak.ForeldrepengerUttakTjeneste;
 import no.nav.foreldrepenger.domene.uttak.RelevanteArbeidsforholdTjeneste;
 import no.nav.foreldrepenger.domene.uttak.UttakRepositoryProvider;
+import no.nav.foreldrepenger.domene.uttak.beregnkontoer.UtregnetStønadskontoTjeneste;
 import no.nav.foreldrepenger.domene.uttak.input.FamilieHendelse;
 import no.nav.foreldrepenger.domene.uttak.input.ForeldrepengerGrunnlag;
 import no.nav.foreldrepenger.domene.uttak.input.UttakInput;
@@ -150,7 +152,8 @@ public class EndringsdatoRevurderingUtleder {
         var annenpartBehandling = annenpartsBehandling(fpGrunnlag);
         var utløsendeUttak = hentUttak(annenpartBehandling);
         var berørtUttak = hentUttak(input.getBehandlingReferanse().originalBehandlingId());
-        return EndringsdatoBerørtUtleder.harEndretStrukturEllerRedusertAntallStønadsdager(utløsendeUttak.orElse(null), berørtUttak.orElse(null));
+        return UtregnetStønadskontoTjeneste.harEndretStrukturEllerRedusertAntallStønadsdager(
+            berørtUttak.map(ForeldrepengerUttak::getStønadskontoBeregning).orElse(Map.of()), utløsendeUttak.map(ForeldrepengerUttak::getStønadskontoBeregning).orElse(Map.of()));
     }
 
     private static Long annenpartsBehandling(ForeldrepengerGrunnlag fpGrunnlag) {

--- a/domenetjenester/vedtak/src/main/java/no/nav/foreldrepenger/domene/vedtak/intern/AvsluttBehandling.java
+++ b/domenetjenester/vedtak/src/main/java/no/nav/foreldrepenger/domene/vedtak/intern/AvsluttBehandling.java
@@ -27,6 +27,7 @@ public class AvsluttBehandling {
     private BehandlingVedtakRepository behandlingVedtakRepository;
     private BehandlingProsesseringTjeneste behandlingProsesseringTjeneste;
     private VurderBehandlingerUnderIverksettelse vurderBehandlingerUnderIverksettelse;
+    private OppdatereFagsakRelasjonVedVedtak oppdatereFagsakRelasjonVedVedtak;
 
     public AvsluttBehandling() {
         // CDI
@@ -37,19 +38,23 @@ public class AvsluttBehandling {
                              BehandlingskontrollTjeneste behandlingskontrollTjeneste,
                              BehandlingVedtakEventPubliserer behandlingVedtakEventPubliserer,
                              VurderBehandlingerUnderIverksettelse vurderBehandlingerUnderIverksettelse,
-                             BehandlingProsesseringTjeneste behandlingProsesseringTjeneste) {
+                             BehandlingProsesseringTjeneste behandlingProsesseringTjeneste,
+                             OppdatereFagsakRelasjonVedVedtak oppdatereFagsakRelasjonVedVedtak) {
         this.behandlingRepository = repositoryProvider.getBehandlingRepository();
         this.behandlingskontrollTjeneste = behandlingskontrollTjeneste;
         this.behandlingVedtakRepository = repositoryProvider.getBehandlingVedtakRepository();
         this.behandlingVedtakEventPubliserer = behandlingVedtakEventPubliserer;
         this.vurderBehandlingerUnderIverksettelse = vurderBehandlingerUnderIverksettelse;
         this.behandlingProsesseringTjeneste = behandlingProsesseringTjeneste;
+        this.oppdatereFagsakRelasjonVedVedtak = oppdatereFagsakRelasjonVedVedtak;
     }
 
     void avsluttBehandling(Long behandlingId) {
         LOG.info("Avslutter behandling inngang {}", behandlingId);
         var kontekst = behandlingskontrollTjeneste.initBehandlingskontroll(behandlingId);
         var behandling = behandlingRepository.hentBehandling(behandlingId);
+
+        oppdatereFagsakRelasjonVedVedtak.oppdaterRelasjonVedVedtattBehandling(behandling);
 
         var vedtak = behandlingVedtakRepository.hentForBehandling(behandling.getId());
         vedtak.setIverksettingStatus(IverksettingStatus.IVERKSATT);

--- a/domenetjenester/vedtak/src/main/java/no/nav/foreldrepenger/domene/vedtak/intern/OppdatereFagsakRelasjonVedVedtak.java
+++ b/domenetjenester/vedtak/src/main/java/no/nav/foreldrepenger/domene/vedtak/intern/OppdatereFagsakRelasjonVedVedtak.java
@@ -1,0 +1,52 @@
+package no.nav.foreldrepenger.domene.vedtak.intern;
+
+import java.util.Map;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import no.nav.foreldrepenger.behandling.FagsakRelasjonTjeneste;
+import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
+import no.nav.foreldrepenger.behandlingslager.uttak.fp.FpUttakRepository;
+import no.nav.foreldrepenger.behandlingslager.uttak.fp.Stønadskontoberegning;
+import no.nav.foreldrepenger.domene.uttak.beregnkontoer.UtregnetStønadskontoTjeneste;
+
+@ApplicationScoped
+public class OppdatereFagsakRelasjonVedVedtak {
+
+    private FagsakRelasjonTjeneste fagsakRelasjonTjeneste;
+    private FpUttakRepository uttakRepository;
+
+
+    OppdatereFagsakRelasjonVedVedtak() {
+        // CDI
+    }
+
+    @Inject
+    public OppdatereFagsakRelasjonVedVedtak(FpUttakRepository uttakRepository,
+                                            FagsakRelasjonTjeneste fagsakRelasjonTjeneste) {
+        this.fagsakRelasjonTjeneste = fagsakRelasjonTjeneste;
+        this.uttakRepository = uttakRepository;
+    }
+
+
+
+    public void oppdaterRelasjonVedVedtattBehandling(Behandling behandling) {
+        var uttak = uttakRepository.hentUttakResultatHvisEksisterer(behandling.getId()).orElse(null);
+        if (uttak == null || uttak.getStønadskontoberegning().getStønadskontoutregning().isEmpty()) {
+            // Ikke Foreldrepenger eller avslag inngangsvilkår
+            return;
+        }
+        var fagsakrelasjon = fagsakRelasjonTjeneste.finnRelasjonFor(behandling.getFagsak());
+        var gjeldendeKontoutregning = fagsakrelasjon.getGjeldendeStønadskontoberegning()
+            .map(Stønadskontoberegning::getStønadskontoutregning)
+            .orElseGet(Map::of);
+        if (!UtregnetStønadskontoTjeneste.harSammeAntallStønadsdager(gjeldendeKontoutregning, uttak.getStønadskontoberegning().getStønadskontoutregning())) {
+            if (fagsakrelasjon.getOverstyrtStønadskontoberegning().isPresent()) {
+                fagsakRelasjonTjeneste.nullstillOverstyrtStønadskontoberegning(behandling.getFagsak());
+                fagsakrelasjon = fagsakRelasjonTjeneste.finnRelasjonFor(behandling.getFagsak());
+            }
+            fagsakRelasjonTjeneste.lagre(behandling.getFagsakId(), fagsakrelasjon, behandling.getId(), uttak.getStønadskontoberegning());
+        }
+    }
+}

--- a/domenetjenester/vedtak/src/test/java/no/nav/foreldrepenger/domene/vedtak/intern/AvsluttBehandlingTest.java
+++ b/domenetjenester/vedtak/src/test/java/no/nav/foreldrepenger/domene/vedtak/intern/AvsluttBehandlingTest.java
@@ -54,6 +54,9 @@ class AvsluttBehandlingTest {
     @Mock
     private BehandlingProsesseringTjeneste behandlingProsesseringTjeneste;
 
+    @Mock
+    private OppdatereFagsakRelasjonVedVedtak oppdatereFagsakRelasjonVedVedtak;
+
     private AvsluttBehandling avsluttBehandling;
     private Behandling behandling;
 
@@ -70,8 +73,8 @@ class AvsluttBehandlingTest {
         var vurderBehandlingerUnderIverksettelse = new VurderBehandlingerUnderIverksettelse(
                 repositoryProvider);
 
-        avsluttBehandling = new AvsluttBehandling(repositoryProvider, behandlingskontrollTjeneste,
-                behandlingVedtakEventPubliserer, vurderBehandlingerUnderIverksettelse, behandlingProsesseringTjeneste);
+        avsluttBehandling = new AvsluttBehandling(repositoryProvider, behandlingskontrollTjeneste, behandlingVedtakEventPubliserer,
+            vurderBehandlingerUnderIverksettelse, behandlingProsesseringTjeneste, oppdatereFagsakRelasjonVedVedtak);
 
         when(behandlingskontrollTjeneste.initBehandlingskontroll(Mockito.anyLong())).thenAnswer(invocation -> {
             Long behId = invocation.getArgument(0);

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/forvaltning/ForvaltningSøknadRestTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/forvaltning/ForvaltningSøknadRestTjeneste.java
@@ -184,4 +184,21 @@ public class ForvaltningSøknadRestTjeneste {
         return Response.ok(antall).build();
     }
 
+    @POST
+    @Path("/sanerOverstyrtKonto")
+    @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+    @Operation(description = "Saner overstyrt stønadskonto", tags = "FORVALTNING-søknad")
+    @BeskyttetRessurs(actionType = ActionType.CREATE, resourceType = ResourceType.DRIFT, sporingslogg = false)
+    public Response settNorskIdentAnnenpart() {
+        var antall = entityManager.createNativeQuery(
+                "UPDATE FAGSAK_RELASJON SET KONTO_BEREGNING_ID = OVERSTYRT_KONTO_BEREGNING_ID WHERE OVERSTYRT_KONTO_BEREGNING_ID is not null")
+            .executeUpdate();
+        entityManager.createNativeQuery(
+                "UPDATE FAGSAK_RELASJON SET OVERSTYRT_KONTO_BEREGNING_ID = null WHERE OVERSTYRT_KONTO_BEREGNING_ID is not null")
+            .executeUpdate();
+        entityManager.flush();
+
+        return Response.ok(antall).build();
+    }
+
 }


### PR DESCRIPTION
Forenkler uttaksteget slik at det beregner konto ut fra fagsakrelasjon dersom finnes (og det ikke er endret DG fra 80 til 100).
Konto på UR sammenlignes med evt eksisterende konto på FR og dersom endring av stønadsdager-kontoene så oppdater FR.

Semantikk endres til at FR/konto settes av første vedtatte behandling (nå settes den av første gjennom uttak - uansett beh.res)