### PR TITLE
    TFP-5383 muliggjør lagring av aktivitetskrav ved registerinnhenting

### DIFF
--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/aktivitetskrav/AktivitetskravArbeidRepository.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/aktivitetskrav/AktivitetskravArbeidRepository.java
@@ -22,15 +22,18 @@ public class AktivitetskravArbeidRepository {
         this.entityManager = entityManager;
     }
 
+    protected AktivitetskravArbeidRepository() {
+    }
+
     public void lagreAktivitetskravArbeidPerioder(Long behandlingId,
-                                                  AktivitetskravArbeidPerioderEntitet.Builder builder,
+                                                  AktivitetskravArbeidPerioderEntitet perioderEntitet,
                                                   LocalDate fraDato,
                                                   LocalDate tilDato) {
 
         var aktivtGrunnlag = hentGrunnlag(behandlingId);
         var nyttGrunnlag = AktivitetskravGrunnlagEntitet.Builder.oppdatere(aktivtGrunnlag)
             .medBehandlingId(behandlingId)
-            .medPerioderMedAktivitetskravArbeid(builder)
+            .medPerioderMedAktivitetskravArbeid(perioderEntitet)
             .medPeriode(fraDato, tilDato);
 
         lagreGrunnlag(aktivtGrunnlag, nyttGrunnlag.build());
@@ -52,6 +55,11 @@ public class AktivitetskravArbeidRepository {
             entityManager.persist(nyttGrunnlag);
             entityManager.flush();
         }
+    }
+
+    public void  fjernGrunnlag(AktivitetskravGrunnlagEntitet aktivitetskravGrunnlagEntitet) {
+        aktivitetskravGrunnlagEntitet.deaktiver();
+        entityManager.persist(aktivitetskravGrunnlagEntitet);
     }
 
     public Optional<AktivitetskravGrunnlagEntitet> hentGrunnlag(Long behandlingId) {

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/aktivitetskrav/AktivitetskravGrunnlagEntitet.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/aktivitetskrav/AktivitetskravGrunnlagEntitet.java
@@ -95,7 +95,7 @@ public class AktivitetskravGrunnlagEntitet extends BaseEntitet {
             this.kladd = kladd;
         }
 
-        private static AktivitetskravGrunnlagEntitet.Builder nytt() {
+        public static Builder nytt() {
             return new Builder(new AktivitetskravGrunnlagEntitet());
         }
 
@@ -104,15 +104,15 @@ public class AktivitetskravGrunnlagEntitet extends BaseEntitet {
         }
 
         public static AktivitetskravGrunnlagEntitet.Builder oppdatere(Optional<AktivitetskravGrunnlagEntitet> kladd) {
-            return kladd.map(AktivitetskravGrunnlagEntitet.Builder::oppdatere).orElseGet(AktivitetskravGrunnlagEntitet.Builder::nytt);
+            return kladd.map(AktivitetskravGrunnlagEntitet.Builder::oppdatere).orElseGet(Builder::nytt);
         }
 
         public Builder medBehandlingId(Long behandlingId) {
             this.kladd.behandlingId = behandlingId;
             return this;
         }
-        public Builder medPerioderMedAktivitetskravArbeid(AktivitetskravArbeidPerioderEntitet.Builder builder) {
-            this.kladd.perioderMedAktivitetskravArbeid = builder.build();
+        public Builder medPerioderMedAktivitetskravArbeid(AktivitetskravArbeidPerioderEntitet perioderEntitet) {
+            this.kladd.perioderMedAktivitetskravArbeid = perioderEntitet;
             return this;
         }
         public Builder medPeriode(LocalDate fom, LocalDate tom) {

--- a/behandlingslager/domene/src/test/java/no/nav/foreldrepenger/behandlingslager/behandling/aktivitetskrav/AktivitetskravArbeidRepositoryTest.java
+++ b/behandlingslager/domene/src/test/java/no/nav/foreldrepenger/behandlingslager/behandling/aktivitetskrav/AktivitetskravArbeidRepositoryTest.java
@@ -191,10 +191,10 @@ class AktivitetskravArbeidRepositoryTest extends EntityManagerAwareTest {
             .getVerdi()).isEqualTo(BigDecimal.ZERO);
     }
 
-    private AktivitetskravArbeidPerioderEntitet.Builder lagPerioderBUilder(List<AktivitetskravArbeidPeriodeEntitet.Builder> perioder) {
+    private AktivitetskravArbeidPerioderEntitet lagPerioderBUilder(List<AktivitetskravArbeidPeriodeEntitet.Builder> perioder) {
         var builder = new AktivitetskravArbeidPerioderEntitet.Builder();
         perioder.forEach(builder::leggTil);
-        return builder;
+        return builder.build();
     }
 
     private AktivitetskravArbeidPeriodeEntitet.Builder lagAktvitetskravArbeidPeriode(LocalDate fra, LocalDate til, BigDecimal stillingsprosent) {

--- a/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/iay/modell/kodeverk/PermisjonsbeskrivelseType.java
+++ b/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/iay/modell/kodeverk/PermisjonsbeskrivelseType.java
@@ -18,7 +18,8 @@ public enum PermisjonsbeskrivelseType implements Kodeverdi {
     UTDANNINGSPERMISJON_LOVFESTET("UTDANNINGSPERMISJON_LOVFESTET", "Utdanningspermisjon (Lovfestet)"),
     VELFERDSPERMISJON("VELFERDSPERMISJON", "Velferdspermisjon"), // Utgår 31/12-2022
     ANNEN_PERMISJON_IKKE_LOVFESTET("ANNEN_PERMISJON_IKKE_LOVFESTET", "Andre ikke-lovfestede permisjoner"),
-    ANNEN_PERMISJON_LOVFESTET("ANNEN_PERMISJON_LOVFESTET", "Andre lovfestede permisjoner"),PERMISJON_MED_FORELDREPENGER("PERMISJON_MED_FORELDREPENGER", "Permisjon med foreldrepenger"),
+    ANNEN_PERMISJON_LOVFESTET("ANNEN_PERMISJON_LOVFESTET", "Andre lovfestede permisjoner"),
+    PERMISJON_MED_FORELDREPENGER("PERMISJON_MED_FORELDREPENGER", "Permisjon med foreldrepenger"),
     PERMITTERING("PERMITTERING", "Permittering"),
     PERMISJON_VED_MILITÆRTJENESTE("PERMISJON_VED_MILITÆRTJENESTE", "Permisjon ved militærtjeneste"),
     ;

--- a/domenetjenester/dokumentbestiller/src/main/java/no/nav/foreldrepenger/dokumentbestiller/DokumentBehandlingTjeneste.java
+++ b/domenetjenester/dokumentbestiller/src/main/java/no/nav/foreldrepenger/dokumentbestiller/DokumentBehandlingTjeneste.java
@@ -77,8 +77,7 @@ public class DokumentBehandlingTjeneste {
             .map(BehandlingDokumentEntitet::getBestilteDokumenter)
             .orElse(List.of())
             .stream()
-            .anyMatch(dok -> dok.getDokumentMalType().equals(dokumentMalTypeKode.getKode()) || dokumentMalTypeKode.getKode()
-                .equals(dok.getOpprineligDokumentMal()));
+            .anyMatch(dok -> dok.getDokumentMalType().equals(dokumentMalTypeKode.getKode()) || dokumentMalTypeKode.getKode().equals(dok.getOpprineligDokumentMal()));
     }
 
     public boolean erDokumentBestiltForFagsak(Long fagsakId, DokumentMalType dokumentMalTypeKode) {

--- a/domenetjenester/registerinnhenting/src/main/java/no/nav/foreldrepenger/domene/registerinnhenting/MorsAktivitetInnhenter.java
+++ b/domenetjenester/registerinnhenting/src/main/java/no/nav/foreldrepenger/domene/registerinnhenting/MorsAktivitetInnhenter.java
@@ -1,0 +1,226 @@
+package no.nav.foreldrepenger.domene.registerinnhenting;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import no.nav.foreldrepenger.behandling.BehandlingReferanse;
+import no.nav.foreldrepenger.behandling.RelatertBehandlingTjeneste;
+import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
+import no.nav.foreldrepenger.behandlingslager.behandling.aktivitetskrav.AktivitetskravArbeidPeriodeEntitet;
+import no.nav.foreldrepenger.behandlingslager.behandling.aktivitetskrav.AktivitetskravArbeidPerioderEntitet;
+import no.nav.foreldrepenger.behandlingslager.behandling.aktivitetskrav.AktivitetskravArbeidRepository;
+import no.nav.foreldrepenger.behandlingslager.behandling.aktivitetskrav.AktivitetskravGrunnlagEntitet;
+import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.MorsAktivitet;
+import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.YtelseFordelingAggregat;
+import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.YtelsesFordelingRepository;
+import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.periode.OppgittPeriodeEntitet;
+import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.periode.UttakPeriodeType;
+import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakYtelseType;
+import no.nav.foreldrepenger.domene.abakus.ArbeidsforholdTjeneste;
+import no.nav.foreldrepenger.domene.iay.modell.ArbeidsforholdMedPermisjon;
+import no.nav.foreldrepenger.domene.personopplysning.PersonopplysningTjeneste;
+import no.nav.foreldrepenger.domene.typer.AktørId;
+import no.nav.fpsak.tidsserie.LocalDateSegment;
+import no.nav.fpsak.tidsserie.LocalDateSegmentCombinator;
+import no.nav.fpsak.tidsserie.LocalDateTimeline;
+import no.nav.fpsak.tidsserie.StandardCombinators;
+import no.nav.vedtak.konfig.Tid;
+
+@ApplicationScoped
+public class MorsAktivitetInnhenter {
+    private static final Logger LOG = LoggerFactory.getLogger(MorsAktivitetInnhenter.class);
+    private YtelsesFordelingRepository ytelseFordelingTjeneste;
+    private RelatertBehandlingTjeneste relatertBehandlingTjeneste;
+    private PersonopplysningTjeneste personopplysningTjeneste;
+    private ArbeidsforholdTjeneste abakusArbeidsforholdTjeneste;
+    private AktivitetskravArbeidRepository aktivitetskravArbeidRepository;
+
+    public MorsAktivitetInnhenter() {
+        //CDI
+    }
+
+    @Inject
+    public MorsAktivitetInnhenter(YtelsesFordelingRepository ytelseFordelingTjeneste,
+                                  RelatertBehandlingTjeneste relatertBehandlingTjeneste,
+                                  PersonopplysningTjeneste personopplysningTjeneste,
+                                  ArbeidsforholdTjeneste abakusArbeidsforholdTjeneste,
+                                  AktivitetskravArbeidRepository aktivitetskravArbeidRepository) {
+        this.ytelseFordelingTjeneste = ytelseFordelingTjeneste;
+        this.relatertBehandlingTjeneste = relatertBehandlingTjeneste;
+        this.personopplysningTjeneste = personopplysningTjeneste;
+        this.abakusArbeidsforholdTjeneste = abakusArbeidsforholdTjeneste;
+        this.aktivitetskravArbeidRepository = aktivitetskravArbeidRepository;
+    }
+
+    public void innhentMorsAktivitet(Behandling behandling) {
+        var behandlingId = behandling.getId();
+        var ytelseaggregat = ytelseFordelingTjeneste.hentAggregat(behandlingId);
+        var perioderAktivitetskravArbeid = hentPerioderMedAktivitetskrav(ytelseaggregat, behandling.getFagsakYtelseType());
+        var morsAktivitetsGrunnlag = aktivitetskravArbeidRepository.hentGrunnlag(behandlingId);
+
+        if (perioderAktivitetskravArbeid.isEmpty() && morsAktivitetsGrunnlag.isEmpty()) {
+            return;
+        }
+
+        var annenPartAktørId = hentAnnenPartAktørId(BehandlingReferanse.fra(behandling));
+        if (annenPartAktørId == null) {
+            LOG.info("MorsAktivitetInnhenter: Finner ingen annen part for behandling med aktivitetskrav arbeid for behandlingId: {}", behandlingId);
+            return;
+        }
+        var morAktvitet = finnMorsAktivitet(behandling, perioderAktivitetskravArbeid, annenPartAktørId, morsAktivitetsGrunnlag);
+        if (morAktvitet == null) {
+            LOG.info("MorsAktivitetInnhenter: Finner ingen aktivitet på mor for behandlingId: {}", behandlingId);
+            return;
+        }
+        aktivitetskravArbeidRepository.lagreAktivitetskravArbeidPerioder(behandlingId, morAktvitet.perioderEntitet(), morAktvitet.fraDato(), morAktvitet.tilDato());
+    }
+
+    public MorAktivitet finnMorsAktivitet(Behandling behandling,
+                                          List<OppgittPeriodeEntitet> perioderAktivitetskravArbeid,
+                                          AktørId annenPartAktørId,
+                                          Optional<AktivitetskravGrunnlagEntitet> gjeldendeAktivitetsgrunnlag) {
+
+        var nyMinsteAktvitetskravDato = minsteFraDatoMinusIntervall(perioderAktivitetskravArbeid).orElse(Tid.TIDENES_ENDE);
+        var nyHøyesteAktivitetskravDato = hentHøyesteFraDatoPlusIntervall(perioderAktivitetskravArbeid).orElse(null);
+
+        if (nyHøyesteAktivitetskravDato == null && gjeldendeAktivitetsgrunnlag.isEmpty()) {
+            return null;
+        }
+
+        var nyGrunnlagFraDato = utledNyGrunnlagFraDato(nyMinsteAktvitetskravDato, gjeldendeAktivitetsgrunnlag.orElse(null));
+        var nyGrunnlagTilDato = nyHøyesteAktivitetskravDato != null ? nyHøyesteAktivitetskravDato : gjeldendeAktivitetsgrunnlag.get().getPeriode().getFomDato();
+
+        LOG.info("MorsAktivitetInnhenter: Henter mors aktivitet for behandlingId: {} for periode:{} - {}", behandling.getId(), nyGrunnlagFraDato, nyHøyesteAktivitetskravDato);
+        var arbeidsforholdInfo = abakusArbeidsforholdTjeneste.hentArbeidsforholdInfoForEnPeriode(annenPartAktørId, nyGrunnlagFraDato, nyGrunnlagTilDato,
+            behandling.getFagsakYtelseType());
+
+        if (arbeidsforholdInfo.isEmpty()) {
+            return null;
+        }
+
+        var mapAvOrgnrOgAvtaler = arbeidsforholdInfo.stream().collect(Collectors.groupingBy(this::aktivitetskravNøkkel));
+        var perioderBuilder = lagAktivitetskravPerioderBuilder(mapAvOrgnrOgAvtaler, nyGrunnlagFraDato, nyHøyesteAktivitetskravDato);
+
+        return new MorAktivitet(nyGrunnlagFraDato, nyHøyesteAktivitetskravDato, perioderBuilder);
+    }
+
+    private LocalDate utledNyGrunnlagFraDato(LocalDate nyMinsteAktvitetskravDato, AktivitetskravGrunnlagEntitet gjeldendeAktivitetsgrunnlag) {
+        var fraDatoGjeldendeGrunnlag = gjeldendeAktivitetsgrunnlag != null ? gjeldendeAktivitetsgrunnlag.getPeriode().getFomDato() : Tid.TIDENES_ENDE;
+
+        if (nyMinsteAktvitetskravDato.isBefore(fraDatoGjeldendeGrunnlag)) {
+            return nyMinsteAktvitetskravDato;
+        } else if (fraDatoGjeldendeGrunnlag.isBefore(nyMinsteAktvitetskravDato)) {
+            return fraDatoGjeldendeGrunnlag;
+        } else {
+            return fraDatoGjeldendeGrunnlag;
+        }
+    }
+
+    public record MorAktivitet(LocalDate fraDato, LocalDate tilDato, AktivitetskravArbeidPerioderEntitet perioderEntitet) {
+    }
+
+    private static LocalDateTimeline<BigDecimal> permisjonTidslinje(List<ArbeidsforholdMedPermisjon> arbeidsforholdInfo) {
+        //sørger for at hull blir 0% og at de permisjonene som overlapper  per arbeidsforhold summeres
+        return new LocalDateTimeline<>(arbeidsforholdInfo.stream()
+            .flatMap(a -> a.permisjoner().stream())
+            .map(permisjon -> new LocalDateSegment<>(permisjon.periode().getFomDato(), permisjon.periode().getTomDato(), permisjon.prosent()))
+            .toList(), bigDesimalSum());
+    }
+
+    private static LocalDateTimeline<AktivitetskravPeriodeGrunnlag> lagTidslinjeMed0(LocalDate fraDato, LocalDate tilDato) {
+        return new LocalDateTimeline<>(fraDato, tilDato, new AktivitetskravPeriodeGrunnlag(BigDecimal.ZERO, BigDecimal.ZERO));
+    }
+
+    private static LocalDateSegmentCombinator<BigDecimal, BigDecimal, BigDecimal> bigDesimalSum() {
+        return StandardCombinators::sum;
+    }
+
+    private static LocalDateSegmentCombinator<BigDecimal, BigDecimal, AktivitetskravPeriodeGrunnlag> bigDecimalTilAktivitetskravVurderingGrunnlagCombinator() {
+        return (localDateInterval, stillingsprosent, permisjonsprosent) -> new LocalDateSegment<>(localDateInterval,
+            new AktivitetskravPeriodeGrunnlag(stillingsprosent != null ? stillingsprosent.getValue() : BigDecimal.ZERO,
+                permisjonsprosent != null ? permisjonsprosent.getValue() : BigDecimal.ZERO));
+    }
+
+    private static Optional<LocalDate> hentHøyesteFraDatoPlusIntervall(List<OppgittPeriodeEntitet> aktuellePerioder) {
+        return aktuellePerioder.stream()
+            .map(OppgittPeriodeEntitet::getTom)
+            .max(LocalDate::compareTo)
+            .map(maxDato -> maxDato.plusWeeks(2));
+    }
+
+    private static Optional<LocalDate> minsteFraDatoMinusIntervall(List<OppgittPeriodeEntitet> aktuellePerioder) {
+        return aktuellePerioder.stream()
+            .map(OppgittPeriodeEntitet::getFom)
+            .min(LocalDate::compareTo)
+            .map(minDato -> minDato.minusWeeks(2));
+    }
+
+    private static List<OppgittPeriodeEntitet> hentPerioderMedAktivitetskrav(YtelseFordelingAggregat ytelseaggregat, FagsakYtelseType ytelseType) {
+        return ytelseaggregat.getGjeldendeFordeling()
+            .getPerioder()
+            .stream()
+            .filter(p -> FagsakYtelseType.FORELDREPENGER.equals(ytelseType) && UttakPeriodeType.FELLESPERIODE.equals(p.getPeriodeType()) && MorsAktivitet.ARBEID.equals(p.getMorsAktivitet()))
+            .toList();
+    }
+
+    private AktivitetskravArbeidPerioderEntitet lagAktivitetskravPerioderBuilder(Map<String, List<ArbeidsforholdMedPermisjon>> mapAvOrgnrOgAvtaler,
+                                                                                         LocalDate fraDato,
+                                                                                         LocalDate tilDato) {
+        List<AktivitetskravArbeidPeriodeEntitet.Builder> builderListe = new ArrayList<>();
+        mapAvOrgnrOgAvtaler.forEach((key, value) -> {
+            var stillingsprosentTidslinje = stillingsprosentTidslinje(value);
+            var permisjonProsentTidslinje = permisjonTidslinje(value);
+            var grunnlagTidslinje = stillingsprosentTidslinje.crossJoin(permisjonProsentTidslinje,
+                    bigDecimalTilAktivitetskravVurderingGrunnlagCombinator())
+                .crossJoin(lagTidslinjeMed0(fraDato, tilDato), StandardCombinators::coalesceLeftHandSide)
+                .compress();
+
+            builderListe.addAll(grunnlagTidslinje.stream().map(segment -> opprettBuilder(segment, key)).toList());
+        });
+
+        var perioderBuilder = new AktivitetskravArbeidPerioderEntitet.Builder();
+
+        builderListe.forEach(perioderBuilder::leggTil);
+
+        return perioderBuilder.build();
+    }
+
+    private AktivitetskravArbeidPeriodeEntitet.Builder opprettBuilder(LocalDateSegment<AktivitetskravPeriodeGrunnlag> segment, String orgNummer) {
+        return new AktivitetskravArbeidPeriodeEntitet.Builder().medOrgNummer(orgNummer)
+            .medPeriode(segment.getFom(), segment.getTom())
+            .medSumStillingsprosent(segment.getValue().sumStillingsprosent())
+            .medSumPermisjonsprosent(segment.getValue().SumPermisjonsprosent());
+    }
+
+    private String aktivitetskravNøkkel(ArbeidsforholdMedPermisjon arbeidsforholdInfo) {
+        return arbeidsforholdInfo.arbeidsgiver().getOrgnr();
+    }
+
+    private LocalDateTimeline<BigDecimal> stillingsprosentTidslinje(List<ArbeidsforholdMedPermisjon> arbeidsforholdInfo) {
+        return new LocalDateTimeline<>(arbeidsforholdInfo.stream()
+            .flatMap(a -> a.aktivitetsavtaler().stream())
+            .map(aktivitetAvtale -> new LocalDateSegment<>(aktivitetAvtale.periode().getFomDato(), aktivitetAvtale.periode().getTomDato(),
+                aktivitetAvtale.stillingsprosent()))
+            .toList(), bigDesimalSum());
+    }
+
+    private AktørId hentAnnenPartAktørId(BehandlingReferanse behandlingReferanse) {
+        return relatertBehandlingTjeneste.hentAnnenPartsGjeldendeVedtattBehandling(behandlingReferanse.saksnummer())
+            .map(Behandling::getAktørId)
+            .orElseGet(() -> personopplysningTjeneste.hentOppgittAnnenPartAktørId(behandlingReferanse.behandlingId()).orElse(null));
+    }
+
+    private record AktivitetskravPeriodeGrunnlag(BigDecimal sumStillingsprosent, BigDecimal SumPermisjonsprosent) {
+    }
+}

--- a/domenetjenester/registerinnhenting/src/main/java/no/nav/foreldrepenger/domene/registerinnhenting/task/InnhentMedlemskapOpplysningerTask.java
+++ b/domenetjenester/registerinnhenting/src/main/java/no/nav/foreldrepenger/domene/registerinnhenting/task/InnhentMedlemskapOpplysningerTask.java
@@ -11,7 +11,6 @@ import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRe
 import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakProsesstaskRekkefølge;
 import no.nav.foreldrepenger.behandlingslager.task.BehandlingProsessTask;
 import no.nav.foreldrepenger.domene.registerinnhenting.RegisterdataInnhenter;
-import no.nav.foreldrepenger.domene.registerinnhenting.StønadsperioderInnhenter;
 import no.nav.foreldrepenger.domene.registerinnhenting.ufo.UføreInnhenter;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTask;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTaskData;
@@ -33,8 +32,7 @@ public class InnhentMedlemskapOpplysningerTask extends BehandlingProsessTask {
     @Inject
     public InnhentMedlemskapOpplysningerTask(BehandlingRepositoryProvider behandlingRepositoryProvider,
                                              RegisterdataInnhenter registerdataInnhenter,
-                                             UføreInnhenter uføreInnhenter,
-                                             StønadsperioderInnhenter stønadsperioderInnhenter) {
+                                             UføreInnhenter uføreInnhenter) {
         super(behandlingRepositoryProvider.getBehandlingLåsRepository());
         this.behandlingRepository = behandlingRepositoryProvider.getBehandlingRepository();
         this.registerdataInnhenter = registerdataInnhenter;

--- a/domenetjenester/registerinnhenting/src/main/java/no/nav/foreldrepenger/domene/registerinnhenting/task/InnhentMorsAktivitetTask.java
+++ b/domenetjenester/registerinnhenting/src/main/java/no/nav/foreldrepenger/domene/registerinnhenting/task/InnhentMorsAktivitetTask.java
@@ -1,0 +1,40 @@
+package no.nav.foreldrepenger.domene.registerinnhenting.task;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepository;
+import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakProsesstaskRekkefølge;
+import no.nav.foreldrepenger.behandlingslager.task.BehandlingProsessTask;
+import no.nav.foreldrepenger.domene.registerinnhenting.MorsAktivitetInnhenter;
+import no.nav.vedtak.felles.prosesstask.api.ProsessTask;
+import no.nav.vedtak.felles.prosesstask.api.ProsessTaskData;
+
+@ApplicationScoped
+@ProsessTask("innhentsaksopplysninger.morsAktivitet")
+@FagsakProsesstaskRekkefølge(gruppeSekvens = true)
+public class InnhentMorsAktivitetTask extends BehandlingProsessTask {
+    private static final Logger LOG = LoggerFactory.getLogger(InnhentMorsAktivitetTask.class);
+    private BehandlingRepository behandlingRepository;
+    private MorsAktivitetInnhenter morsAktivitetInnhenter;
+
+    InnhentMorsAktivitetTask() {
+        //CDI
+    }
+
+    @Inject
+    public InnhentMorsAktivitetTask(BehandlingRepository behandlingRepository, MorsAktivitetInnhenter morsAktivitetInnhenter) {
+        this.behandlingRepository = behandlingRepository;
+        this.morsAktivitetInnhenter = morsAktivitetInnhenter;
+    }
+
+    @Override
+    protected void prosesser(ProsessTaskData prosessTaskData, Long behandlingId) {
+        var behandling = behandlingRepository.hentBehandling(behandlingId);
+        LOG.info("Innhenter mors aktivitet for behandling: {}", behandling.getId());
+        morsAktivitetInnhenter.innhentMorsAktivitet(behandling);
+    }
+}

--- a/domenetjenester/registerinnhenting/src/test/java/no/nav/foreldrepenger/domene/registerinnhenting/MorsAktivitetInnhenterTest.java
+++ b/domenetjenester/registerinnhenting/src/test/java/no/nav/foreldrepenger/domene/registerinnhenting/MorsAktivitetInnhenterTest.java
@@ -1,0 +1,282 @@
+package no.nav.foreldrepenger.domene.registerinnhenting;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import no.nav.foreldrepenger.behandling.RelatertBehandlingTjeneste;
+import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingType;
+import no.nav.foreldrepenger.behandlingslager.behandling.aktivitetskrav.AktivitetskravArbeidPeriodeEntitet;
+import no.nav.foreldrepenger.behandlingslager.behandling.aktivitetskrav.AktivitetskravArbeidPerioderEntitet;
+import no.nav.foreldrepenger.behandlingslager.behandling.aktivitetskrav.AktivitetskravArbeidRepository;
+import no.nav.foreldrepenger.behandlingslager.behandling.aktivitetskrav.AktivitetskravGrunnlagEntitet;
+import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.MorsAktivitet;
+import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.YtelsesFordelingRepository;
+import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.periode.OppgittPeriodeBuilder;
+import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.periode.OppgittPeriodeEntitet;
+import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.periode.UttakPeriodeType;
+import no.nav.foreldrepenger.behandlingslager.testutilities.behandling.ScenarioMorSøkerForeldrepenger;
+import no.nav.foreldrepenger.behandlingslager.virksomhet.ArbeidType;
+import no.nav.foreldrepenger.behandlingslager.virksomhet.Arbeidsgiver;
+import no.nav.foreldrepenger.domene.abakus.ArbeidsforholdTjeneste;
+import no.nav.foreldrepenger.domene.iay.modell.ArbeidsforholdMedPermisjon;
+import no.nav.foreldrepenger.domene.iay.modell.kodeverk.PermisjonsbeskrivelseType;
+import no.nav.foreldrepenger.domene.personopplysning.PersonopplysningTjeneste;
+import no.nav.foreldrepenger.domene.tid.DatoIntervallEntitet;
+import no.nav.foreldrepenger.domene.typer.AktørId;
+import no.nav.foreldrepenger.domene.typer.EksternArbeidsforholdRef;
+
+@ExtendWith(MockitoExtension.class)
+class MorsAktivitetInnhenterTest {
+
+    private MorsAktivitetInnhenter morsAktivitetInnhenter;
+
+    @Mock
+    private YtelsesFordelingRepository ytelseFordelingTjeneste;
+    @Mock
+    private RelatertBehandlingTjeneste relatertBehandlingTjeneste;
+    @Mock
+    private PersonopplysningTjeneste personopplysningTjeneste;
+    @Mock
+    private ArbeidsforholdTjeneste abakusArbeidsforholdTjeneste;
+    @Mock
+    private AktivitetskravArbeidRepository aktivitetskravArbeidRepository;
+
+
+    @BeforeEach
+    void setUp() {
+        morsAktivitetInnhenter = new MorsAktivitetInnhenter(ytelseFordelingTjeneste, relatertBehandlingTjeneste, personopplysningTjeneste,
+            abakusArbeidsforholdTjeneste, aktivitetskravArbeidRepository);
+    }
+@Test
+    void mor_har_aktivitetskrav() {
+        var annenPartAktørId = AktørId.dummy();
+        var fraDato = LocalDate.now().minusWeeks(1);
+        var tilDato = LocalDate.now().plusWeeks(4);
+        var periode = DatoIntervallEntitet.fraOgMedTilOgMed(fraDato, tilDato);
+        var førstegangScenario = ScenarioMorSøkerForeldrepenger.forFødsel().medBehandlingType(BehandlingType.FØRSTEGANGSSØKNAD);
+        var behandling = førstegangScenario.lagMocked();
+        var perioderMedAktivitetskrav = List.of(lagOppgittPeriode(LocalDate.now().minusWeeks(1), LocalDate.now()), lagOppgittPeriode(LocalDate.now().plusWeeks(2), LocalDate.now().plusWeeks(4)));
+        var aktivitetsavtaler = List.of(lagAktivitetsavtale(periode, BigDecimal.valueOf(100)));
+
+        var arbeidsforholdMedPermisjon = List.of(lagArbeidsforholdMedPermisjon(Arbeidsgiver.virksomhet("999999999"), EksternArbeidsforholdRef.ref("01"), aktivitetsavtaler, Collections.emptyList()));
+
+        when(abakusArbeidsforholdTjeneste.hentArbeidsforholdInfoForEnPeriode(any(), any(), any(), any())).thenReturn(arbeidsforholdMedPermisjon);
+
+        var morAktivitet = morsAktivitetInnhenter.finnMorsAktivitet(behandling, perioderMedAktivitetskrav, annenPartAktørId, Optional.empty());
+        var aktivitetPeriodeEntitetListe = morAktivitet.perioderEntitet().getAktivitetskravArbeidPeriodeListe();
+
+
+        assertThat(morAktivitet.fraDato()).isEqualTo(fraDato.minusWeeks(2));
+        assertThat(morAktivitet.tilDato()).isEqualTo(tilDato.plusWeeks(2));
+        assertThat(aktivitetPeriodeEntitetListe).hasSize(3);
+    }
+
+    @Test
+    void mor_ikke_har_aktivitetskrav() {
+        var annenPartAktørId = AktørId.dummy();
+        var førstegangScenario = ScenarioMorSøkerForeldrepenger.forFødsel().medBehandlingType(BehandlingType.FØRSTEGANGSSØKNAD);
+        var behandling = førstegangScenario.lagMocked();
+        var perioderMedAktivitetskrav = List.of(lagOppgittPeriode(LocalDate.now().minusWeeks(1), LocalDate.now()), lagOppgittPeriode(LocalDate.now().plusWeeks(2), LocalDate.now().plusWeeks(4)));
+
+        when(abakusArbeidsforholdTjeneste.hentArbeidsforholdInfoForEnPeriode(any(), any(), any(), any())).thenReturn(Collections.emptyList());
+
+        assertThat(morsAktivitetInnhenter.finnMorsAktivitet(behandling, perioderMedAktivitetskrav, annenPartAktørId, Optional.empty())).isNull();
+    }
+
+    @Test
+    void mor_har_aktivitetskrav_i_hele_perioden() {
+        var annenPartAktørId = AktørId.dummy();
+        var fraDato = LocalDate.now().minusWeeks(1);
+        var tilDato = LocalDate.now().plusWeeks(4);
+        var periode = DatoIntervallEntitet.fraOgMedTilOgMed(fraDato.minusWeeks(2), tilDato.plusWeeks(2));
+        var førstegangScenario = ScenarioMorSøkerForeldrepenger.forFødsel().medBehandlingType(BehandlingType.FØRSTEGANGSSØKNAD);
+        var behandling = førstegangScenario.lagMocked();
+        var perioderMedAktivitetskrav = List.of(lagOppgittPeriode(LocalDate.now().minusWeeks(1), LocalDate.now()), lagOppgittPeriode(LocalDate.now().plusWeeks(2), LocalDate.now().plusWeeks(4)));
+        var aktivitetsavtaler = List.of(lagAktivitetsavtale(periode, BigDecimal.valueOf(100)));
+
+        var arbeidsforholdMedPermisjon = List.of(lagArbeidsforholdMedPermisjon(Arbeidsgiver.virksomhet("999999999"), EksternArbeidsforholdRef.ref("01"), aktivitetsavtaler, Collections.emptyList()));
+
+        when(abakusArbeidsforholdTjeneste.hentArbeidsforholdInfoForEnPeriode(any(), any(), any(), any())).thenReturn(arbeidsforholdMedPermisjon);
+
+        var morAktivitet = morsAktivitetInnhenter.finnMorsAktivitet(behandling, perioderMedAktivitetskrav, annenPartAktørId, Optional.empty());
+        var aktivitetPeriodeEntitetListe = morAktivitet.perioderEntitet().getAktivitetskravArbeidPeriodeListe();
+
+
+        assertThat(morAktivitet.fraDato()).isEqualTo(fraDato.minusWeeks(2));
+        assertThat(morAktivitet.tilDato()).isEqualTo(tilDato.plusWeeks(2));
+        assertThat(aktivitetPeriodeEntitetListe).hasSize(1);
+    }
+
+    @Test
+    void mor_har_aktvitetsgrunnlag_med_tidligere_fra_dato(){
+        var annenPartAktørId = AktørId.dummy();
+        var virksomhet = Arbeidsgiver.virksomhet("999999999");
+
+        //førstegangsbehandling
+        var nyfraDato = LocalDate.now();
+        var nytilDato = LocalDate.now().plusWeeks(4);
+        var periode = DatoIntervallEntitet.fraOgMedTilOgMed(nyfraDato, nytilDato);
+        var førstegangScenario = ScenarioMorSøkerForeldrepenger.forFødsel().medBehandlingType(BehandlingType.FØRSTEGANGSSØKNAD);
+        var behandling = førstegangScenario.lagMocked();
+        var perioderMedAktivitetskrav = List.of(lagOppgittPeriode(nyfraDato, nytilDato));
+        var aktivitetsavtaler = List.of(lagAktivitetsavtale(periode, BigDecimal.valueOf(100)));
+
+        //forrige aktivitetsgrunnlag
+        var grunnlagsFraDato = LocalDate.now().minusWeeks(4);
+        var grunnlagsTilDato = LocalDate.now();
+        var perioder = List.of(lagAktvitetskravArbeidPeriode(grunnlagsFraDato, grunnlagsTilDato, BigDecimal.valueOf(100),  virksomhet.getOrgnr()));
+        var aktvitetskravPerioder = lagPerioderBUilder(perioder);
+        var gjeldendeAktivitetsgrunnlag = lagAktivitetsgrunnlag(behandling.getId(), grunnlagsFraDato, grunnlagsTilDato, aktvitetskravPerioder);
+
+        var arbeidsforholdMedPermisjon = List.of(lagArbeidsforholdMedPermisjon(virksomhet, EksternArbeidsforholdRef.ref("01"), aktivitetsavtaler, Collections.emptyList()));
+
+        when(abakusArbeidsforholdTjeneste.hentArbeidsforholdInfoForEnPeriode(any(), any(), any(), any())).thenReturn(arbeidsforholdMedPermisjon);
+
+
+        var morAktivitet = morsAktivitetInnhenter.finnMorsAktivitet(behandling, perioderMedAktivitetskrav, annenPartAktørId, Optional.of(gjeldendeAktivitetsgrunnlag));
+        var aktivitetPeriodeEntitetListe = morAktivitet.perioderEntitet().getAktivitetskravArbeidPeriodeListe();
+
+
+        assertThat(morAktivitet.fraDato()).isEqualTo(grunnlagsFraDato);
+        assertThat(morAktivitet.tilDato()).isEqualTo(nytilDato.plusWeeks(2));
+        assertThat(aktivitetPeriodeEntitetListe).hasSize(3);
+    }
+
+    @Test
+    void mor_har_aktvitetsgrunnlag_med_senere_fra_dato(){
+        var annenPartAktørId = AktørId.dummy();
+        var virksomhet = Arbeidsgiver.virksomhet("999999999");
+
+        //førstegangsbehandling
+        var nyfraDato = LocalDate.now().minusWeeks(1);
+        var nytilDato = LocalDate.now().plusWeeks(2);
+        var periode = DatoIntervallEntitet.fraOgMedTilOgMed(nyfraDato, nytilDato);
+        var førstegangScenario = ScenarioMorSøkerForeldrepenger.forFødsel().medBehandlingType(BehandlingType.FØRSTEGANGSSØKNAD);
+        var behandling = førstegangScenario.lagMocked();
+        var perioderMedAktivitetskrav = List.of(lagOppgittPeriode(nyfraDato, nytilDato));
+        var aktivitetsavtaler = List.of(lagAktivitetsavtale(periode, BigDecimal.valueOf(100)));
+
+        //forrige aktivitetsgrunnlag
+        var grunnlagsFraDato = LocalDate.now().plusWeeks(1);
+        var grunnlagsTilDato = LocalDate.now().plusWeeks(3);
+        var perioder = List.of(lagAktvitetskravArbeidPeriode(grunnlagsFraDato, grunnlagsTilDato, BigDecimal.valueOf(100),  virksomhet.getOrgnr()));
+        var aktvitetskravPerioder = lagPerioderBUilder(perioder);
+        var gjeldendeAktivitetsgrunnlag = lagAktivitetsgrunnlag(behandling.getId(), grunnlagsFraDato, grunnlagsTilDato, aktvitetskravPerioder);
+
+        var arbeidsforholdMedPermisjon = List.of(lagArbeidsforholdMedPermisjon(virksomhet, EksternArbeidsforholdRef.ref("01"), aktivitetsavtaler, Collections.emptyList()));
+
+        when(abakusArbeidsforholdTjeneste.hentArbeidsforholdInfoForEnPeriode(any(), any(), any(), any())).thenReturn(arbeidsforholdMedPermisjon);
+
+
+        var morAktivitet = morsAktivitetInnhenter.finnMorsAktivitet(behandling, perioderMedAktivitetskrav, annenPartAktørId, Optional.of(gjeldendeAktivitetsgrunnlag));
+        var aktivitetPeriodeEntitetListe = morAktivitet.perioderEntitet().getAktivitetskravArbeidPeriodeListe();
+
+
+        assertThat(morAktivitet.fraDato()).isEqualTo(nyfraDato.minusWeeks(2));
+        assertThat(morAktivitet.tilDato()).isEqualTo(nytilDato.plusWeeks(2));
+        assertThat(aktivitetPeriodeEntitetListe).hasSize(3);
+    }
+
+    @Test
+    void mor_har_aktivitetskrav_i_flere_arbeidsforhold_med_ulik_stillingsprosent_i_perioden_og_permisjon_i_ett() {
+        var annenPartAktørId = AktørId.dummy();
+        var orgnr1 = Arbeidsgiver.virksomhet("999999999");
+        var orgnr2 = Arbeidsgiver.virksomhet("888888888");
+        var innhentingsperiodeFraDato = LocalDate.now().minusWeeks(1);
+        var innhentingsperiodeTilDato = LocalDate.now().plusWeeks(4);
+        var aktivitetsavtalePeriode = DatoIntervallEntitet.fraOgMedTilOgMed(innhentingsperiodeFraDato.minusWeeks(1), innhentingsperiodeTilDato.minusWeeks(2));
+        var aktivitetsavtalePeriode2 = DatoIntervallEntitet.fraOgMedTilOgMed(innhentingsperiodeTilDato.minusWeeks(2).plusDays(1), innhentingsperiodeTilDato);
+        var førstegangScenario = ScenarioMorSøkerForeldrepenger.forFødsel().medBehandlingType(BehandlingType.FØRSTEGANGSSØKNAD);
+        var behandling = førstegangScenario.lagMocked();
+        var perioderMedAktivitetskrav = List.of(lagOppgittPeriode(LocalDate.now().minusWeeks(1), LocalDate.now()), lagOppgittPeriode(LocalDate.now().plusWeeks(2), LocalDate.now().plusWeeks(4)));
+        var aktivitetsavtaler1 = List.of(lagAktivitetsavtale(aktivitetsavtalePeriode, BigDecimal.valueOf(55)));
+        var aktivitetsavtaler2 = List.of(lagAktivitetsavtale(aktivitetsavtalePeriode2, BigDecimal.valueOf(25)));
+        var permisjoner = List.of(lagPermisjon(aktivitetsavtalePeriode2, BigDecimal.valueOf(20)));
+
+        var arbeidsforholdMedPermisjon = List.of(lagArbeidsforholdMedPermisjon(orgnr1, EksternArbeidsforholdRef.ref("01"), aktivitetsavtaler1, permisjoner),
+            lagArbeidsforholdMedPermisjon(orgnr2, EksternArbeidsforholdRef.nullRef(), aktivitetsavtaler2, Collections.emptyList() ));
+
+        when(abakusArbeidsforholdTjeneste.hentArbeidsforholdInfoForEnPeriode(any(), any(), any(), any())).thenReturn(arbeidsforholdMedPermisjon);
+
+        var morAktivitet = morsAktivitetInnhenter.finnMorsAktivitet(behandling, perioderMedAktivitetskrav, annenPartAktørId, Optional.empty());
+        var aktivitetPeriodeEntitetListe = morAktivitet.perioderEntitet().getAktivitetskravArbeidPeriodeListe();
+
+
+        assertThat(morAktivitet.fraDato()).isEqualTo(innhentingsperiodeFraDato.minusWeeks(2));
+        assertThat(morAktivitet.tilDato()).isEqualTo(innhentingsperiodeTilDato.plusWeeks(2));
+        assertThat(aktivitetPeriodeEntitetListe).hasSize(7);
+
+        assertThat(aktivitetPeriodeEntitetListe.stream()
+            .filter(aktPeriode -> aktPeriode.getOrgNummer().getId().equals(orgnr1.getOrgnr())).toList()).hasSize(4);
+        assertThat(aktivitetPeriodeEntitetListe.stream()
+            .filter(aktPeriode -> aktPeriode.getOrgNummer().getId().equals(orgnr1.getOrgnr())))
+            .anyMatch(periode -> periode.getSumStillingsprosent().getVerdi().equals(BigDecimal.valueOf(55)));
+        assertThat(aktivitetPeriodeEntitetListe.stream()
+            .filter(aktPeriode -> aktPeriode.getOrgNummer().getId().equals(orgnr1.getOrgnr())))
+            .anyMatch(periode -> periode.getSumPermisjonsprosent().getVerdi().equals(BigDecimal.valueOf(20)));
+        assertThat(aktivitetPeriodeEntitetListe.stream()
+            .filter(aktPeriode -> aktPeriode.getOrgNummer().getId().equals(orgnr2.getOrgnr())))
+            .anyMatch(periode -> periode.getSumStillingsprosent().getVerdi().equals(BigDecimal.valueOf(25)));
+        assertThat(aktivitetPeriodeEntitetListe.stream()
+            .filter(aktPeriode -> aktPeriode.getOrgNummer().getId().equals(orgnr2.getOrgnr()))
+            .map(periode -> periode.getSumPermisjonsprosent().getVerdi())
+            .reduce(BigDecimal::add).orElse(BigDecimal.ZERO)).isEqualTo(BigDecimal.ZERO);
+        assertThat(aktivitetPeriodeEntitetListe.stream()
+            .filter(aktPeriode -> aktPeriode.getOrgNummer().getId().equals(orgnr2.getOrgnr())).toList()).hasSize(3);
+    }
+
+    private ArbeidsforholdTjeneste.Permisjon lagPermisjon(DatoIntervallEntitet periode, BigDecimal permisjonsprosent) {
+        return new ArbeidsforholdTjeneste.Permisjon(periode, PermisjonsbeskrivelseType.ANNEN_PERMISJON_LOVFESTET, permisjonsprosent);
+    }
+
+    private ArbeidsforholdMedPermisjon lagArbeidsforholdMedPermisjon(Arbeidsgiver arbeidsgiver, EksternArbeidsforholdRef ref, List<ArbeidsforholdTjeneste.AktivitetAvtale> aktivitetsavtaler, List<ArbeidsforholdTjeneste.Permisjon> permisjoner) {
+        return new ArbeidsforholdMedPermisjon(arbeidsgiver, ArbeidType.ORDINÆRT_ARBEIDSFORHOLD, ref, aktivitetsavtaler, permisjoner );
+    }
+
+    private ArbeidsforholdTjeneste.AktivitetAvtale lagAktivitetsavtale(DatoIntervallEntitet periode, BigDecimal stillingsprosent) {
+        return new ArbeidsforholdTjeneste.AktivitetAvtale(periode, stillingsprosent);
+    }
+
+    private OppgittPeriodeEntitet lagOppgittPeriode(LocalDate fraDato, LocalDate tildato) {
+        return OppgittPeriodeBuilder.ny()
+            .medPeriode(fraDato, tildato)
+            .medPeriodeType(UttakPeriodeType.FELLESPERIODE)
+            .medMorsAktivitet(MorsAktivitet.ARBEID)
+            .build();
+    }
+
+    private AktivitetskravGrunnlagEntitet lagAktivitetsgrunnlag(Long behandlingId, LocalDate fra, LocalDate til, AktivitetskravArbeidPerioderEntitet perioderEntitet) {
+        return AktivitetskravGrunnlagEntitet.Builder.nytt()
+            .medBehandlingId(behandlingId)
+            .medPeriode(fra, til)
+            .medPerioderMedAktivitetskravArbeid(perioderEntitet)
+            .build();
+    }
+
+    private AktivitetskravArbeidPerioderEntitet lagPerioderBUilder(List<AktivitetskravArbeidPeriodeEntitet.Builder> perioder) {
+        var builder = new AktivitetskravArbeidPerioderEntitet.Builder();
+        perioder.forEach(builder::leggTil);
+        return builder.build();
+    }
+
+    private AktivitetskravArbeidPeriodeEntitet.Builder lagAktvitetskravArbeidPeriode(LocalDate fra, LocalDate til, BigDecimal stillingsprosent, String orgnr) {
+        return new AktivitetskravArbeidPeriodeEntitet.Builder().medPeriode(fra, til)
+            .medOrgNummer(orgnr)
+            .medSumPermisjonsprosent(BigDecimal.ZERO)
+            .medSumStillingsprosent(stillingsprosent);
+    }
+
+}


### PR DESCRIPTION
TFP-5383 muliggjør lagring av aktivitetskrav ved registerinnhenting

Legger opp til ny innhentingsperiode velger den laveste datoen på henholdsvis nye aktivitetskravperioder og tidligere grunnlag