### PR TITLE
Endrer mapping papirsøknad til selvbetjening-standard

### DIFF
--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/søknad/OppgittTilknytningDto.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/søknad/OppgittTilknytningDto.java
@@ -45,17 +45,19 @@ public class OppgittTilknytningDto {
     }
 
     private static List<UtlandsoppholdDto> mapFør(Set<MedlemskapOppgittLandOppholdEntitet> opphold) {
-        return UtlandsoppholdDto.mapFra(opphold.stream()
+        return opphold.stream()
             .filter(MedlemskapOppgittLandOppholdEntitet::isTidligereOpphold)
             .filter(o -> !o.getLand().equals(Landkoder.NOR))
-            .toList());
+            .map(UtlandsoppholdDto::mapFra)
+            .toList();
     }
 
     private static List<UtlandsoppholdDto> mapEtter(Set<MedlemskapOppgittLandOppholdEntitet> utlandsopphold) {
-        return UtlandsoppholdDto.mapFra(utlandsopphold.stream()
+        return utlandsopphold.stream()
             .filter(o -> !o.isTidligereOpphold())
             .filter(o -> !o.getLand().equals(Landkoder.NOR))
-            .toList());
+            .map(UtlandsoppholdDto::mapFra)
+            .toList();
     }
 
     public boolean isOppholdNorgeNa() {

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/søknad/UtlandsoppholdDto.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/søknad/UtlandsoppholdDto.java
@@ -1,43 +1,11 @@
 package no.nav.foreldrepenger.web.app.tjenester.behandling.søknad;
 
 import java.time.LocalDate;
-import java.util.List;
 
 import no.nav.foreldrepenger.behandlingslager.behandling.medlemskap.MedlemskapOppgittLandOppholdEntitet;
 
-public class UtlandsoppholdDto {
-    private String landNavn;
-    private LocalDate fom;
-    private LocalDate tom;
-
-    public UtlandsoppholdDto() {
-        // trengs for deserialisering av JSON
-    }
-
-    private UtlandsoppholdDto(String landNavn, LocalDate fom, LocalDate tom) {
-        this.landNavn = landNavn;
-        this.fom = fom;
-        this.tom = tom;
-    }
-
-    public static List<UtlandsoppholdDto> mapFra(List<MedlemskapOppgittLandOppholdEntitet> utlandsoppholdList) {
-        return utlandsoppholdList.stream()
-                .map(utlandsopphold -> new UtlandsoppholdDto(
-                        utlandsopphold.getLand().getNavn(),
-                        utlandsopphold.getPeriodeFom(),
-                        utlandsopphold.getPeriodeTom())
-                ).toList();
-    }
-
-    public String getLandNavn() {
-        return landNavn;
-    }
-
-    public LocalDate getFom() {
-        return fom;
-    }
-
-    public LocalDate getTom() {
-        return tom;
+public record UtlandsoppholdDto(String landNavn, LocalDate fom, LocalDate tom) {
+    public static UtlandsoppholdDto mapFra(MedlemskapOppgittLandOppholdEntitet utlandsopphold) {
+        return new UtlandsoppholdDto(utlandsopphold.getLand().getNavn(), utlandsopphold.getPeriodeFom(), utlandsopphold.getPeriodeTom());
     }
 }

--- a/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/registrering/SøknadMapperFellesTest.java
+++ b/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/registrering/SøknadMapperFellesTest.java
@@ -204,7 +204,11 @@ class SøknadMapperFellesTest {
         registreringForeldrepengerDto.setOppholdINorge(true);
 
         var medlemskap = SøknadMapperFelles.mapMedlemskap(registreringForeldrepengerDto);
-        assertThat(medlemskap.getOppholdNorge()).as("Forventer at vi skal ha opphold norge når vi ikke har utenlandsopphold.").hasSize(2);
+
+        assertThat(medlemskap.isINorgeVedFoedselstidspunkt()).isTrue();
+        assertThat(medlemskap.isBoddINorgeSiste12Mnd()).isTrue();
+        assertThat(medlemskap.isBorINorgeNeste12Mnd()).isTrue();
+        assertThat(medlemskap.getOppholdNorge()).as("Forventer at vi ikke skal ha opphold norge når vi ikke har utenlandsopphold.").isEmpty();
     }
 
     @Test
@@ -216,6 +220,10 @@ class SøknadMapperFellesTest {
         registreringForeldrepengerDto.setOppholdINorge(true);
 
         var medlemskap = SøknadMapperFelles.mapMedlemskap(registreringForeldrepengerDto);
+
+        assertThat(medlemskap.isINorgeVedFoedselstidspunkt()).isTrue();
+        assertThat(medlemskap.isBoddINorgeSiste12Mnd()).isFalse();
+        assertThat(medlemskap.isBorINorgeNeste12Mnd()).isFalse();
         assertThat(medlemskap.getOppholdNorge()).as("Forventer at vi ikke har opphold norge når vi har utenlandsopphold.").isEmpty();
     }
 
@@ -240,9 +248,13 @@ class SøknadMapperFellesTest {
 
         // Assert tidligere opphold i norge(siden vi ikke har tidligere
         // utenlandsopphold.)
+        assertThat(medlemskap.isINorgeVedFoedselstidspunkt()).isTrue();
+        assertThat(medlemskap.isBoddINorgeSiste12Mnd()).isTrue();
+        assertThat(medlemskap.isBorINorgeNeste12Mnd()).isFalse();
+
         var oppholdNorgeListe = medlemskap.getOppholdNorge();
         assertThat(oppholdNorgeListe).isNotNull();
-        assertThat(oppholdNorgeListe).hasSize(1);
+        assertThat(oppholdNorgeListe).isEmpty();
 
         var alleOppholdUtlandet = medlemskap.getOppholdUtlandet();
         assertThat(alleOppholdUtlandet).isNotNull();
@@ -277,9 +289,13 @@ class SøknadMapperFellesTest {
         var medlemskap = SøknadMapperFelles.mapMedlemskap(registreringEngangsstonadDto);
 
         // Assert fremtidg opphold i norge(siden vi ikke har fremtidig utenlandsopphold.
+        assertThat(medlemskap.isINorgeVedFoedselstidspunkt()).isTrue();
+        assertThat(medlemskap.isBoddINorgeSiste12Mnd()).isFalse();
+        assertThat(medlemskap.isBorINorgeNeste12Mnd()).isTrue();
+
         var oppholdNorgeListe = medlemskap.getOppholdNorge();
         assertThat(oppholdNorgeListe).isNotNull();
-        assertThat(oppholdNorgeListe).hasSize(1);
+        assertThat(oppholdNorgeListe).isEmpty();
 
         var oppholdUtenlandsListe = medlemskap.getOppholdUtlandet();
         assertThat(oppholdUtenlandsListe).isNotNull();

--- a/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/registrering/es/SøknadMapperTest.java
+++ b/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/registrering/es/SøknadMapperTest.java
@@ -51,9 +51,13 @@ class SøknadMapperTest {
         registreringEngangsstonadDto.setOppholdINorge(true);
 
         var medlemskap = SøknadMapperFelles.mapMedlemskap(registreringEngangsstonadDto);
+
         assertThat(medlemskap.isINorgeVedFoedselstidspunkt()).isTrue();
+        assertThat(medlemskap.isBoddINorgeSiste12Mnd()).isTrue();
+        assertThat(medlemskap.isBorINorgeNeste12Mnd()).isTrue();
+
         assertThat(medlemskap.getOppholdUtlandet()).isEmpty();
-        assertThat(medlemskap.getOppholdNorge()).as("Forventer at vi skal ha opphold norge når vi ikke har utenlandsopphold.").hasSize(2);
+        assertThat(medlemskap.getOppholdNorge()).as("Forventer at vi skal ha opphold norge når vi ikke har utenlandsopphold.").isEmpty();
     }
 
     @Test
@@ -75,11 +79,13 @@ class SøknadMapperTest {
 
         var medlemskap = SøknadMapperFelles.mapMedlemskap(registreringEngangsstonadDto);
         assertThat(medlemskap.isINorgeVedFoedselstidspunkt()).isTrue();
+        assertThat(medlemskap.isBoddINorgeSiste12Mnd()).isTrue();
+        assertThat(medlemskap.isBorINorgeNeste12Mnd()).isFalse();
 
         // Assert tidligere opphold i norge(siden vi ikke har tidligere
         // utenlandsopphold.)
         var oppholdNorgeListe = medlemskap.getOppholdNorge();
-        assertThat(oppholdNorgeListe).isNotNull().hasSize(1);
+        assertThat(oppholdNorgeListe).isNotNull().isEmpty();
 
         var alleOppholdUtlandet = medlemskap.getOppholdUtlandet();
         assertThat(alleOppholdUtlandet).isNotNull().hasSize(1);
@@ -112,10 +118,12 @@ class SøknadMapperTest {
 
         var medlemskap = SøknadMapperFelles.mapMedlemskap(registreringEngangsstonadDto);
         assertThat(medlemskap.isINorgeVedFoedselstidspunkt()).isTrue();
+        assertThat(medlemskap.isBoddINorgeSiste12Mnd()).isFalse();
+        assertThat(medlemskap.isBorINorgeNeste12Mnd()).isTrue();
 
         // Assert fremtidg opphold i norge(siden vi ikke har fremtidig utenlandsopphold.
         var oppholdNorgeListe = medlemskap.getOppholdNorge();
-        assertThat(oppholdNorgeListe).isNotNull().hasSize(1);
+        assertThat(oppholdNorgeListe).isNotNull().isEmpty();
 
         var oppholdUtenlandsListe = medlemskap.getOppholdUtlandet();
         assertThat(oppholdUtenlandsListe).isNotNull().hasSize(1);


### PR DESCRIPTION
Papirsøknad (https://navikt.github.io/fp-frontend/@navikt/fp-papirsoknad) har til nå hatt som konvensjon å lage en XML med annen standard enn det som kommer fra selvbetjening.

Selvbetjening: Dersom opphold i Norge siste og/eller neste 12 mnd - sett boolsk (iNorge...) = true, ellers false og perioder med opphold utland.

Papirsøknad slik det var: Dersom man svarte Ja på i Norge siste og/eller neste 12 mnd - iNorge... ble false og det ble lager perioder med opphold i Norge.

Begge deler (oppholdNorge, oppholdUtland) ble lagret som en entitet med periode og landkode.