### PR TITLE
Samme anke kan sendes til TR flere ganger

### DIFF
--- a/domenetjenester/behandling-klage/src/main/java/no/nav/foreldrepenger/behandling/kabal/MottaFraKabalTask.java
+++ b/domenetjenester/behandling-klage/src/main/java/no/nav/foreldrepenger/behandling/kabal/MottaFraKabalTask.java
@@ -166,9 +166,6 @@ public class MottaFraKabalTask extends BehandlingProsessTask {
             .orElseThrow(() -> new IllegalStateException("Utviklerfeil: Kabal-anke avsluttet men mangler utfall"));
         var ankeBehandling = kabalTjeneste.finnAnkeBehandling(behandlingId, ref)
             .orElseThrow(() -> new IllegalStateException("Mangler ankebehandling for behandling " + behandlingId));
-        var ankeBehandlingSteg = Optional.ofNullable(ankeBehandling.getAktivtBehandlingSteg())
-            .filter(bst -> Set.of(BehandlingStegType.ANKE, BehandlingStegType.ANKE_MERKNADER).contains(bst))
-            .orElseThrow(() -> new IllegalStateException("Ankebehandling mangler aktiv tilstand " + behandlingId));
         var kontekst = behandlingskontrollTjeneste.initBehandlingskontroll(ankeBehandling.getId());
         kabalTjeneste.settKabalReferanse(ankeBehandling, ref);
         if (KabalUtfall.TRUKKET.equals(utfall) || KabalUtfall.HEVET.equals(utfall)) {


### PR DESCRIPTION
Fikser selve forholdet: TR sender i retur og Kabal sender en andre sendt-til-tr mens vis står i AnkeMerknaderSteg
Legger også inn feil dersom det finnes åpen anke på samme klage (kan fortsatt komme anker på klager som ikke er i Kabal).
Kommer mer forvaltning for å rydde behandlinger nå får svar fra Kabal på problemsaker