### PR TITLE
TFP-5821 botidskrav ikrafttredelse og overgang

### DIFF
--- a/domenetjenester/skjaeringstidspunkt/src/main/java/no/nav/foreldrepenger/skjæringstidspunkt/es/BotidCore2024.java
+++ b/domenetjenester/skjaeringstidspunkt/src/main/java/no/nav/foreldrepenger/skjæringstidspunkt/es/BotidCore2024.java
@@ -1,0 +1,97 @@
+package no.nav.foreldrepenger.skjæringstidspunkt.es;
+
+import java.time.LocalDate;
+import java.time.Month;
+import java.time.Period;
+import java.util.Optional;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import no.nav.foreldrepenger.behandlingslager.behandling.familiehendelse.AdopsjonEntitet;
+import no.nav.foreldrepenger.behandlingslager.behandling.familiehendelse.FamilieHendelseEntitet;
+import no.nav.foreldrepenger.behandlingslager.behandling.familiehendelse.FamilieHendelseGrunnlagEntitet;
+import no.nav.foreldrepenger.konfig.Environment;
+import no.nav.foreldrepenger.konfig.KonfigVerdi;
+
+/*
+ * OBSOBSOBS: Ikrafttredelsesdato og overgangsgangsordning er vedtatt i Stortinget og sanksjonert i Statsråd
+ * Klasse for styring av ikrafttredelese nytt regelverk for krav om 12 måneder forutgående medlemskap for engangsstønad
+ * Metode for å gi ikrafttredelsesdato avhengig av miljø
+ * Metode for å vurdere om en Familiehendelse skal vurderes etter nye eller gamle regler. Vil bli oppdatert
+ * Støtter ikke ikrafttredelse senere enn loven tilsier
+ * TODO: Slett denne etter at siste dato er passert
+ */
+@ApplicationScoped
+public class BotidCore2024 {
+
+
+    private static final Logger LOG = LoggerFactory.getLogger(BotidCore2024.class);
+    private static final Environment ENV = Environment.current();
+
+    private static final String PROP_NAME_DATO = "dato.for.botid";
+    private static final LocalDate DATO_FOR_PROD = LocalDate.of(2024, Month.OCTOBER,1); // LA STÅ
+
+    private LocalDate ikrafttredelseDato = DATO_FOR_PROD;
+
+    private LocalDate ikrafttredelseDatoMedOvergangsordning;
+
+    BotidCore2024() {
+        // CDI
+    }
+
+    @Inject
+    public BotidCore2024(@KonfigVerdi(value = PROP_NAME_DATO, required = false) LocalDate ikrafttredelse,
+                         @KonfigVerdi(value = "terminbekreftelse.tidligst.utstedelse.før.termin", defaultVerdi = "P18W3D") Period tidligsteUtstedelseAvTerminBekreftelse) {
+        this.ikrafttredelseDato = bestemDato(ikrafttredelse);
+        this.ikrafttredelseDatoMedOvergangsordning = ikrafttredelseDato.plus(tidligsteUtstedelseAvTerminBekreftelse);
+    }
+
+    public boolean ikkeBotidskrav(FamilieHendelseGrunnlagEntitet familieHendelseGrunnlag) {
+        if (familieHendelseGrunnlag == null || familieHendelseGrunnlag.getGjeldendeVersjon() == null) {
+            return LocalDate.now().isBefore(ikrafttredelseDato);
+        }
+        var bekreftetFamilieHendelse = familieHendelseGrunnlag.getGjeldendeBekreftetVersjon();
+        var datoFraBekreftetFamilieHendelse = bekreftetFamilieHendelse.flatMap(this::getTerminEllerFamiliehendelsedato);
+        if (bekreftetFamilieHendelse.isPresent() && datoFraBekreftetFamilieHendelse.isPresent()) {
+            return skalIkkeKreveBotid(bekreftetFamilieHendelse.get(), datoFraBekreftetFamilieHendelse.get());
+        }
+        var gjeldendeFamilieHendelse = familieHendelseGrunnlag.getGjeldendeVersjon();
+        var datoFraFamilieHendelse = getTerminEllerFamiliehendelsedato(gjeldendeFamilieHendelse);
+        return datoFraFamilieHendelse.map(date -> skalIkkeKreveBotid(gjeldendeFamilieHendelse, date))
+            .orElseGet(() -> LocalDate.now().isBefore(ikrafttredelseDato));
+    }
+
+    private boolean skalIkkeKreveBotid(FamilieHendelseEntitet familieHendelse, LocalDate familieHendelseDato) {
+        if (familieHendelse.getGjelderFødsel() && familieHendelse.getTermindato().isPresent()) {
+            return familieHendelse.getTermindato().get().isBefore(ikrafttredelseDatoMedOvergangsordning);
+        } else {
+            return familieHendelseDato.isBefore(ikrafttredelseDato);
+        }
+    }
+
+    private Optional<LocalDate> getTerminEllerFamiliehendelsedato(FamilieHendelseEntitet familieHendelse) {
+        if (familieHendelse.getGjelderFødsel()) {
+            return familieHendelse.getTermindato().or(familieHendelse::getFødselsdato);
+        } else {
+            return familieHendelse.getAdopsjon().map(AdopsjonEntitet::getOmsorgsovertakelseDato);
+        }
+    }
+
+    private static LocalDate bestemDato(LocalDate ikrafttredelseFraKonfig) {
+        if (ENV.isProd()) {
+            return BotidCore2024.DATO_FOR_PROD;
+        } else if (ikrafttredelseFraKonfig != null && ikrafttredelseFraKonfig.isAfter(BotidCore2024.DATO_FOR_PROD)) {
+            throw new IllegalArgumentException("Støtter ikke forsinket iverksettelse i test");
+        } else {
+            LOG.info("BOTID CORE 2024 ikrafttredelse {}", ikrafttredelseFraKonfig);
+            return ikrafttredelseFraKonfig == null ? BotidCore2024.DATO_FOR_PROD : ikrafttredelseFraKonfig;
+
+        }
+    }
+
+
+}

--- a/domenetjenester/skjaeringstidspunkt/src/test/java/no/nav/foreldrepenger/skjæringstidspunkt/es/BotidCore2024Test.java
+++ b/domenetjenester/skjaeringstidspunkt/src/test/java/no/nav/foreldrepenger/skjæringstidspunkt/es/BotidCore2024Test.java
@@ -1,0 +1,371 @@
+package no.nav.foreldrepenger.skjæringstidspunkt.es;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDate;
+import java.time.Month;
+import java.time.Period;
+
+import org.junit.jupiter.api.Test;
+
+import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingType;
+import no.nav.foreldrepenger.behandlingslager.testutilities.behandling.ScenarioMorSøkerForeldrepenger;
+
+class BotidCore2024Test {
+
+    private static final LocalDate IKRAFT = LocalDate.of(2024, Month.AUGUST, 1);
+    private static final Period OVERGANG = Period.parse("P18W3D");
+
+    @Test
+    void skal_returnere_uten_botidskrav_hvis_bekreftet_termin_før_ikrafttredelsedato() {
+        // Arrange
+        var bekreftettermindato = IKRAFT.plusWeeks(10);
+
+        var førstegangScenario = ScenarioMorSøkerForeldrepenger.forFødsel()
+            .medBehandlingType(BehandlingType.FØRSTEGANGSSØKNAD);
+        var terminbekreftelse = førstegangScenario.medBekreftetHendelse().getTerminbekreftelseBuilder()
+            .medTermindato(bekreftettermindato)
+            .medNavnPå("LEGEN LEGESEN")
+            .medUtstedtDato(bekreftettermindato.minusMonths(2));
+        førstegangScenario.medBekreftetHendelse().medTerminbekreftelse(terminbekreftelse);
+        var mockprovider = førstegangScenario.mockBehandlingRepositoryProvider();
+        var behandling = førstegangScenario.lagMocked();
+
+        // Act/Assert
+        var fhg = mockprovider.getFamilieHendelseRepository().hentAggregat(behandling.getId());
+        assertThat(new BotidCore2024(IKRAFT, OVERGANG).ikkeBotidskrav(fhg)).isTrue();
+    }
+
+    @Test
+    void skal_returnere_uten_botidskrav_hvis_bekreftet_termin_og_fødsel_før_ikrafttredelsedato() {
+        // Arrange
+        var bekreftettermindato = IKRAFT.plusWeeks(10);
+        var fødselsdato = IKRAFT.minusWeeks(1);
+
+        var førstegangScenario = ScenarioMorSøkerForeldrepenger.forFødsel()
+            .medBehandlingType(BehandlingType.FØRSTEGANGSSØKNAD);
+        var terminbekreftelse = førstegangScenario.medBekreftetHendelse().getTerminbekreftelseBuilder()
+            .medTermindato(bekreftettermindato)
+            .medNavnPå("LEGEN LEGESEN")
+            .medUtstedtDato(bekreftettermindato.minusMonths(2));
+        førstegangScenario.medBekreftetHendelse().medFødselsDato(fødselsdato, 1).medTerminbekreftelse(terminbekreftelse);
+        var mockprovider = førstegangScenario.mockBehandlingRepositoryProvider();
+        var behandling = førstegangScenario.lagMocked();
+
+        // Act/Assert
+        var fhg = mockprovider.getFamilieHendelseRepository().hentAggregat(behandling.getId());
+        assertThat(new BotidCore2024(IKRAFT, OVERGANG).ikkeBotidskrav(fhg)).isTrue();
+    }
+
+    @Test
+    void skal_returnere_uten_botidskrav_hvis_bekreftet_fødsel_før_ikrafttredelsedato_uten_termin() {
+        // Arrange
+        var fødselsdato = IKRAFT.minusWeeks(1);
+
+        var førstegangScenario = ScenarioMorSøkerForeldrepenger.forFødsel()
+            .medBehandlingType(BehandlingType.FØRSTEGANGSSØKNAD);
+        førstegangScenario.medBekreftetHendelse().medFødselsDato(fødselsdato, 1);
+        var mockprovider = førstegangScenario.mockBehandlingRepositoryProvider();
+        var behandling = førstegangScenario.lagMocked();
+
+        // Act/Assert
+        var fhg = mockprovider.getFamilieHendelseRepository().hentAggregat(behandling.getId());
+        assertThat(new BotidCore2024(IKRAFT, OVERGANG).ikkeBotidskrav(fhg)).isTrue();
+    }
+
+    @Test
+    void skal_returnere_uten_botidskrav_hvis_bekreftet_adopsjon_før_ikrafttredelsedato() {
+        // Arrange
+        var omsorgsdato = IKRAFT.minusWeeks(1);
+
+        var førstegangScenario = ScenarioMorSøkerForeldrepenger.forFødsel()
+            .medBehandlingType(BehandlingType.FØRSTEGANGSSØKNAD);
+        var adopsjon = førstegangScenario.medBekreftetHendelse().getAdopsjonBuilder()
+            .medOmsorgsovertakelseDato(omsorgsdato)
+            .medAdoptererAlene(false).medErEktefellesBarn(false);
+        førstegangScenario.medBekreftetHendelse().medFødselsDato(IKRAFT.minusYears(2), 1)
+            .medAdopsjon(adopsjon);
+        var mockprovider = førstegangScenario.mockBehandlingRepositoryProvider();
+        var behandling = førstegangScenario.lagMocked();
+
+        // Act/Assert
+        var fhg = mockprovider.getFamilieHendelseRepository().hentAggregat(behandling.getId());
+        assertThat(new BotidCore2024(IKRAFT, OVERGANG).ikkeBotidskrav(fhg)).isTrue();
+    }
+
+    @Test
+    void skal_returnere_botidskrav_hvis_bekreftet_termin_etter_ikrafttredelsedato() {
+        // Arrange
+        var bekreftettermindato = IKRAFT.plus(OVERGANG).plusWeeks(1);
+
+        var førstegangScenario = ScenarioMorSøkerForeldrepenger.forFødsel()
+            .medBehandlingType(BehandlingType.FØRSTEGANGSSØKNAD);
+        var terminbekreftelse = førstegangScenario.medBekreftetHendelse().getTerminbekreftelseBuilder()
+            .medTermindato(bekreftettermindato)
+            .medNavnPå("LEGEN LEGESEN")
+            .medUtstedtDato(bekreftettermindato.minusMonths(2));
+        førstegangScenario.medBekreftetHendelse().medTerminbekreftelse(terminbekreftelse);
+        var mockprovider = førstegangScenario.mockBehandlingRepositoryProvider();
+        var behandling = førstegangScenario.lagMocked();
+
+        // Act/Assert
+        var fhg = mockprovider.getFamilieHendelseRepository().hentAggregat(behandling.getId());
+        assertThat(new BotidCore2024(IKRAFT, OVERGANG).ikkeBotidskrav(fhg)).isFalse();
+    }
+
+    @Test
+    void skal_returnere_botidskrav_hvis_bekreftet_termin_og_fødsel_etter_ikrafttredelsedato() {
+        // Arrange
+        var bekreftettermindato = IKRAFT.plus(OVERGANG).plusWeeks(1);
+        var fødselsdato = IKRAFT.plus(OVERGANG);
+
+        var førstegangScenario = ScenarioMorSøkerForeldrepenger.forFødsel()
+            .medBehandlingType(BehandlingType.FØRSTEGANGSSØKNAD);
+        var terminbekreftelse = førstegangScenario.medBekreftetHendelse().getTerminbekreftelseBuilder()
+            .medTermindato(bekreftettermindato)
+            .medNavnPå("LEGEN LEGESEN")
+            .medUtstedtDato(bekreftettermindato.minusMonths(2));
+        førstegangScenario.medBekreftetHendelse().medFødselsDato(fødselsdato, 1).medTerminbekreftelse(terminbekreftelse);
+        var mockprovider = førstegangScenario.mockBehandlingRepositoryProvider();
+        var behandling = førstegangScenario.lagMocked();
+
+        // Act/Assert
+        var fhg = mockprovider.getFamilieHendelseRepository().hentAggregat(behandling.getId());
+        assertThat(new BotidCore2024(IKRAFT, OVERGANG).ikkeBotidskrav(fhg)).isFalse();
+    }
+
+    @Test
+    void skal_returnere_botidskrav_hvis_bekreftet_termin_etter_ikrafttredelsedato_fødsel_før() {
+        // Arrange
+        var bekreftettermindato = IKRAFT.plus(OVERGANG).plusWeeks(1);
+        var fødselsdato = IKRAFT.minusDays(2);
+
+        var førstegangScenario = ScenarioMorSøkerForeldrepenger.forFødsel()
+            .medBehandlingType(BehandlingType.FØRSTEGANGSSØKNAD);
+        var terminbekreftelse = førstegangScenario.medBekreftetHendelse().getTerminbekreftelseBuilder()
+            .medTermindato(bekreftettermindato)
+            .medNavnPå("LEGEN LEGESEN")
+            .medUtstedtDato(bekreftettermindato.minusMonths(2));
+        førstegangScenario.medBekreftetHendelse().medFødselsDato(fødselsdato, 1).medTerminbekreftelse(terminbekreftelse);
+        var mockprovider = førstegangScenario.mockBehandlingRepositoryProvider();
+        var behandling = førstegangScenario.lagMocked();
+
+        // Act/Assert
+        var fhg = mockprovider.getFamilieHendelseRepository().hentAggregat(behandling.getId());
+        assertThat(new BotidCore2024(IKRAFT, OVERGANG).ikkeBotidskrav(fhg)).isFalse();
+    }
+
+    @Test
+    void skal_returnere_botidskrav_hvis_bekreftet_fødsel_etter_ikrafttredelsedato_uten_termin() {
+        // Arrange
+        var fødselsdato = IKRAFT.plusWeeks(2);
+
+        var førstegangScenario = ScenarioMorSøkerForeldrepenger.forFødsel()
+            .medBehandlingType(BehandlingType.FØRSTEGANGSSØKNAD);
+        førstegangScenario.medBekreftetHendelse().medFødselsDato(fødselsdato, 1);
+        var mockprovider = førstegangScenario.mockBehandlingRepositoryProvider();
+        var behandling = førstegangScenario.lagMocked();
+
+        // Act/Assert
+        var fhg = mockprovider.getFamilieHendelseRepository().hentAggregat(behandling.getId());
+        assertThat(new BotidCore2024(IKRAFT, OVERGANG).ikkeBotidskrav(fhg)).isFalse();
+    }
+
+    @Test
+    void skal_returnere_botidskrav_hvis_bekreftet_adopsjon_etter_ikrafttredelsedato() {
+        // Arrange
+        var omsorgsdato = IKRAFT.plus(OVERGANG).plusWeeks(1);
+
+        var førstegangScenario = ScenarioMorSøkerForeldrepenger.forFødsel()
+            .medBehandlingType(BehandlingType.FØRSTEGANGSSØKNAD);
+        var adopsjon = førstegangScenario.medBekreftetHendelse().getAdopsjonBuilder()
+            .medOmsorgsovertakelseDato(omsorgsdato)
+            .medAdoptererAlene(false).medErEktefellesBarn(false);
+        førstegangScenario.medBekreftetHendelse().medFødselsDato(IKRAFT.minusYears(2), 1)
+            .medAdopsjon(adopsjon);
+        var mockprovider = førstegangScenario.mockBehandlingRepositoryProvider();
+        var behandling = førstegangScenario.lagMocked();
+
+        // Act/Assert
+        var fhg = mockprovider.getFamilieHendelseRepository().hentAggregat(behandling.getId());
+        assertThat(new BotidCore2024(IKRAFT, OVERGANG).ikkeBotidskrav(fhg)).isFalse();
+    }
+
+    // Søknadshendelse
+    @Test
+    void skal_returnere_uten_botidskrav_hvis_gjeldende_termin_før_ikrafttredelsedato() {
+        // Arrange
+        var bekreftettermindato = IKRAFT.plusWeeks(10);
+
+        var førstegangScenario = ScenarioMorSøkerForeldrepenger.forFødsel()
+            .medBehandlingType(BehandlingType.FØRSTEGANGSSØKNAD);
+        var terminbekreftelse = førstegangScenario.medSøknadHendelse().getTerminbekreftelseBuilder()
+            .medTermindato(bekreftettermindato)
+            .medNavnPå("LEGEN LEGESEN")
+            .medUtstedtDato(bekreftettermindato.minusMonths(2));
+        førstegangScenario.medSøknadHendelse().medTerminbekreftelse(terminbekreftelse);
+        var mockprovider = førstegangScenario.mockBehandlingRepositoryProvider();
+        var behandling = førstegangScenario.lagMocked();
+
+        // Act/Assert
+        var fhg = mockprovider.getFamilieHendelseRepository().hentAggregat(behandling.getId());
+        assertThat(new BotidCore2024(IKRAFT, OVERGANG).ikkeBotidskrav(fhg)).isTrue();
+    }
+
+    @Test
+    void skal_returnere_uten_botidskrav_hvis_gjeldende_termin_og_fødsel_før_ikrafttredelsedato() {
+        // Arrange
+        var bekreftettermindato = IKRAFT.plusWeeks(10);
+        var fødselsdato = IKRAFT.minusWeeks(1);
+
+        var førstegangScenario = ScenarioMorSøkerForeldrepenger.forFødsel()
+            .medBehandlingType(BehandlingType.FØRSTEGANGSSØKNAD);
+        var terminbekreftelse = førstegangScenario.medSøknadHendelse().getTerminbekreftelseBuilder()
+            .medTermindato(bekreftettermindato)
+            .medNavnPå("LEGEN LEGESEN")
+            .medUtstedtDato(bekreftettermindato.minusMonths(2));
+        førstegangScenario.medSøknadHendelse().medFødselsDato(fødselsdato, 1).medTerminbekreftelse(terminbekreftelse);
+        var mockprovider = førstegangScenario.mockBehandlingRepositoryProvider();
+        var behandling = førstegangScenario.lagMocked();
+
+        // Act/Assert
+        var fhg = mockprovider.getFamilieHendelseRepository().hentAggregat(behandling.getId());
+        assertThat(new BotidCore2024(IKRAFT, OVERGANG).ikkeBotidskrav(fhg)).isTrue();
+    }
+
+    @Test
+    void skal_returnere_uten_botidskrav_hvis_gjeldende_fødsel_før_ikrafttredelsedato_uten_termin() {
+        // Arrange
+        var fødselsdato = IKRAFT.minusWeeks(1);
+
+        var førstegangScenario = ScenarioMorSøkerForeldrepenger.forFødsel()
+            .medBehandlingType(BehandlingType.FØRSTEGANGSSØKNAD);
+        førstegangScenario.medSøknadHendelse().medFødselsDato(fødselsdato, 1);
+        var mockprovider = førstegangScenario.mockBehandlingRepositoryProvider();
+        var behandling = førstegangScenario.lagMocked();
+
+        // Act/Assert
+        var fhg = mockprovider.getFamilieHendelseRepository().hentAggregat(behandling.getId());
+        assertThat(new BotidCore2024(IKRAFT, OVERGANG).ikkeBotidskrav(fhg)).isTrue();
+    }
+
+    @Test
+    void skal_returnere_uten_botidskrav_hvis_gjeldende_adopsjon_før_ikrafttredelsedato() {
+        // Arrange
+        var omsorgsdato = IKRAFT.minusWeeks(1);
+
+        var førstegangScenario = ScenarioMorSøkerForeldrepenger.forFødsel()
+            .medBehandlingType(BehandlingType.FØRSTEGANGSSØKNAD);
+        var adopsjon = førstegangScenario.medSøknadHendelse().getAdopsjonBuilder()
+            .medOmsorgsovertakelseDato(omsorgsdato)
+            .medAdoptererAlene(false).medErEktefellesBarn(false);
+        førstegangScenario.medSøknadHendelse().medFødselsDato(IKRAFT.minusYears(2), 1)
+            .medAdopsjon(adopsjon);
+        var mockprovider = førstegangScenario.mockBehandlingRepositoryProvider();
+        var behandling = førstegangScenario.lagMocked();
+
+        // Act/Assert
+        var fhg = mockprovider.getFamilieHendelseRepository().hentAggregat(behandling.getId());
+        assertThat(new BotidCore2024(IKRAFT, OVERGANG).ikkeBotidskrav(fhg)).isTrue();
+    }
+
+    @Test
+    void skal_returnere_botidskrav_hvis_gjeldende_termin_etter_ikrafttredelsedato() {
+        // Arrange
+        var bekreftettermindato = IKRAFT.plus(OVERGANG).plusWeeks(1);
+
+        var førstegangScenario = ScenarioMorSøkerForeldrepenger.forFødsel()
+            .medBehandlingType(BehandlingType.FØRSTEGANGSSØKNAD);
+        var terminbekreftelse = førstegangScenario.medSøknadHendelse().getTerminbekreftelseBuilder()
+            .medTermindato(bekreftettermindato)
+            .medNavnPå("LEGEN LEGESEN")
+            .medUtstedtDato(bekreftettermindato.minusMonths(2));
+        førstegangScenario.medSøknadHendelse().medTerminbekreftelse(terminbekreftelse);
+        var mockprovider = førstegangScenario.mockBehandlingRepositoryProvider();
+        var behandling = førstegangScenario.lagMocked();
+
+        // Act/Assert
+        var fhg = mockprovider.getFamilieHendelseRepository().hentAggregat(behandling.getId());
+        assertThat(new BotidCore2024(IKRAFT, OVERGANG).ikkeBotidskrav(fhg)).isFalse();
+    }
+
+    @Test
+    void skal_returnere_botidskrav_hvis_gjeldende_termin_og_fødsel_etter_ikrafttredelsedato() {
+        // Arrange
+        var bekreftettermindato = IKRAFT.plus(OVERGANG).plusWeeks(1);
+        var fødselsdato = IKRAFT.plus(OVERGANG);
+
+        var førstegangScenario = ScenarioMorSøkerForeldrepenger.forFødsel()
+            .medBehandlingType(BehandlingType.FØRSTEGANGSSØKNAD);
+        var terminbekreftelse = førstegangScenario.medSøknadHendelse().getTerminbekreftelseBuilder()
+            .medTermindato(bekreftettermindato)
+            .medNavnPå("LEGEN LEGESEN")
+            .medUtstedtDato(bekreftettermindato.minusMonths(2));
+        førstegangScenario.medSøknadHendelse().medFødselsDato(fødselsdato, 1).medTerminbekreftelse(terminbekreftelse);
+        var mockprovider = førstegangScenario.mockBehandlingRepositoryProvider();
+        var behandling = førstegangScenario.lagMocked();
+
+        // Act/Assert
+        var fhg = mockprovider.getFamilieHendelseRepository().hentAggregat(behandling.getId());
+        assertThat(new BotidCore2024(IKRAFT, OVERGANG).ikkeBotidskrav(fhg)).isFalse();
+    }
+
+    @Test
+    void skal_returnere_botidskrav_hvis_gjeldende_termin_etter_ikrafttredelsedato_fødsel_før() {
+        // Arrange
+        var bekreftettermindato = IKRAFT.plus(OVERGANG).plusWeeks(1);
+        var fødselsdato = IKRAFT.minusDays(2);
+
+        var førstegangScenario = ScenarioMorSøkerForeldrepenger.forFødsel()
+            .medBehandlingType(BehandlingType.FØRSTEGANGSSØKNAD);
+        var terminbekreftelse = førstegangScenario.medSøknadHendelse().getTerminbekreftelseBuilder()
+            .medTermindato(bekreftettermindato)
+            .medNavnPå("LEGEN LEGESEN")
+            .medUtstedtDato(bekreftettermindato.minusMonths(2));
+        førstegangScenario.medSøknadHendelse().medFødselsDato(fødselsdato, 1).medTerminbekreftelse(terminbekreftelse);
+        var mockprovider = førstegangScenario.mockBehandlingRepositoryProvider();
+        var behandling = førstegangScenario.lagMocked();
+
+        // Act/Assert
+        var fhg = mockprovider.getFamilieHendelseRepository().hentAggregat(behandling.getId());
+        assertThat(new BotidCore2024(IKRAFT, OVERGANG).ikkeBotidskrav(fhg)).isFalse();
+    }
+
+    @Test
+    void skal_returnere_botidskrav_hvis_gjeldende_fødsel_etter_ikrafttredelsedato_uten_termin() {
+        // Arrange
+        var fødselsdato = IKRAFT.plusWeeks(2);
+
+        var førstegangScenario = ScenarioMorSøkerForeldrepenger.forFødsel()
+            .medBehandlingType(BehandlingType.FØRSTEGANGSSØKNAD);
+        førstegangScenario.medSøknadHendelse().medFødselsDato(fødselsdato, 1);
+        var mockprovider = førstegangScenario.mockBehandlingRepositoryProvider();
+        var behandling = førstegangScenario.lagMocked();
+
+        // Act/Assert
+        var fhg = mockprovider.getFamilieHendelseRepository().hentAggregat(behandling.getId());
+        assertThat(new BotidCore2024(IKRAFT, OVERGANG).ikkeBotidskrav(fhg)).isFalse();
+    }
+
+    @Test
+    void skal_returnere_botidskrav_hvis_gjeldende_adopsjon_etter_ikrafttredelsedato() {
+        // Arrange
+        var omsorgsdato = IKRAFT.plus(OVERGANG).plusWeeks(1);
+
+        var førstegangScenario = ScenarioMorSøkerForeldrepenger.forFødsel()
+            .medBehandlingType(BehandlingType.FØRSTEGANGSSØKNAD);
+        var adopsjon = førstegangScenario.medSøknadHendelse().getAdopsjonBuilder()
+            .medOmsorgsovertakelseDato(omsorgsdato)
+            .medAdoptererAlene(false).medErEktefellesBarn(false);
+        førstegangScenario.medSøknadHendelse().medFødselsDato(IKRAFT.minusYears(2), 1)
+            .medAdopsjon(adopsjon);
+        var mockprovider = førstegangScenario.mockBehandlingRepositoryProvider();
+        var behandling = førstegangScenario.lagMocked();
+
+        // Act/Assert
+        var fhg = mockprovider.getFamilieHendelseRepository().hentAggregat(behandling.getId());
+        assertThat(new BotidCore2024(IKRAFT, OVERGANG).ikkeBotidskrav(fhg)).isFalse();
+    }
+
+
+}


### PR DESCRIPTION
Ikrafttredelse 1/10 (eller som angitt med konfigverdi i DEV og autotest og enhetstest)
Overgangsordning for de som er i uke 22 eller senere - bruker samme logikk som terminutstedelse i uke 22 - dvs botidskrav trer i kraft etter 1/10 + 18u + 3d, dvs fom 8/2-25. 
Bare tilfelle der vi har termindato kan vurderes for overgangsordning. Dersom vi mangler termindato gjelder 1/10.