### PR TITLE
TFP-5381 tjeneste for å utlede medlemskapsvurderingsperioder

### DIFF
--- a/.oracle/docker-compose.yml
+++ b/.oracle/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.7'
 services:
   oracle:
-    image: gvenzl/oracle-free:23.5-slim-faststart
+    image: gvenzl/oracle-free:23-slim-faststart
     environment:
       - ORACLE_RANDOM_PASSWORD=true
     shm_size: 4gb

--- a/behandlingsprosess/src/main/java/no/nav/foreldrepenger/behandling/steg/kompletthet/fp/VurderKompletthetStegImpl.java
+++ b/behandlingsprosess/src/main/java/no/nav/foreldrepenger/behandling/steg/kompletthet/fp/VurderKompletthetStegImpl.java
@@ -10,6 +10,7 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 
 import no.nav.foreldrepenger.behandling.BehandlingReferanse;
+import no.nav.foreldrepenger.behandling.FamilieHendelseDato;
 import no.nav.foreldrepenger.behandling.Skjæringstidspunkt;
 import no.nav.foreldrepenger.behandling.steg.kompletthet.VurderKompletthetSteg;
 import no.nav.foreldrepenger.behandling.steg.kompletthet.VurderKompletthetStegFelles;
@@ -91,7 +92,7 @@ public class VurderKompletthetStegImpl implements VurderKompletthetSteg {
         if (RelasjonsRolleType.erMor(behandling.getRelasjonsRolleType())) {
             return false;
         }
-        var søknadFHDato = stp.getFamiliehendelsedato();
+        var søknadFHDato = stp.getFamilieHendelseDato().map(FamilieHendelseDato::familieHendelseDato).orElse(null);
         var farRundtFødselTom = TidsperiodeFarRundtFødsel.intervallFarRundtFødsel(false, true, søknadFHDato, søknadFHDato)
             .map(LocalDateInterval::getTomDato).orElse(søknadFHDato);
         var farØnskerJustert = ytelsesFordelingRepository.hentAggregatHvisEksisterer(behandling.getId())

--- a/domenetjenester/behandling/src/main/java/no/nav/foreldrepenger/behandling/BehandlingReferanse.java
+++ b/domenetjenester/behandling/src/main/java/no/nav/foreldrepenger/behandling/BehandlingReferanse.java
@@ -97,9 +97,15 @@ public record BehandlingReferanse(Saksnummer saksnummer,
         return skjæringstidspunkt.getSkjæringstidspunktHvisUtledet();
     }
 
+    public Optional<LocalDateInterval> getUttaksintervall() {
+        sjekkSkjæringstidspunkt();
+        return skjæringstidspunkt.getUttaksintervall();
+    }
+
+
     public LocalDateInterval getUtledetMedlemsintervall() {
         sjekkSkjæringstidspunkt();
-        return skjæringstidspunkt.getUtledetMedlemsintervall();
+        return skjæringstidspunkt.getUttaksintervall().orElse(null);
     }
 
     public Skjæringstidspunkt getSkjæringstidspunkt() {

--- a/domenetjenester/behandling/src/main/java/no/nav/foreldrepenger/behandling/FamilieHendelseDato.java
+++ b/domenetjenester/behandling/src/main/java/no/nav/foreldrepenger/behandling/FamilieHendelseDato.java
@@ -1,0 +1,31 @@
+package no.nav.foreldrepenger.behandling;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+public record FamilieHendelseDato(LocalDate termindato, LocalDate fødselsdato, LocalDate omsorgsovertakelse) {
+
+    public static FamilieHendelseDato forFødsel(LocalDate termindato, LocalDate fødselsdato) {
+        return new FamilieHendelseDato(termindato, fødselsdato, null);
+    }
+
+    public static FamilieHendelseDato forAdopsjonOmsorg(LocalDate omsorgsovertakelse) {
+        return new FamilieHendelseDato(null, null, omsorgsovertakelse);
+    }
+
+    public LocalDate familieHendelseDato() {
+        return Optional.ofNullable(omsorgsovertakelse)
+            .or(() -> Optional.ofNullable(fødselsdato))
+            .or(() -> Optional.ofNullable(termindato))
+            .orElse(null);
+    }
+
+    public boolean gjelderFødsel() {
+        return omsorgsovertakelse == null;
+    }
+
+    public boolean gjelderAdopsjonOmsorg() {
+        return omsorgsovertakelse != null;
+    }
+
+}

--- a/domenetjenester/behandling/src/main/java/no/nav/foreldrepenger/behandling/Skjæringstidspunkt.java
+++ b/domenetjenester/behandling/src/main/java/no/nav/foreldrepenger/behandling/Skjæringstidspunkt.java
@@ -16,10 +16,8 @@ public class Skjæringstidspunkt {
     private LocalDate førsteUttaksdato;
     private LocalDate førsteUttaksdatoGrunnbeløp;
     private LocalDate førsteUttaksdatoSøknad;
-    private LocalDateInterval utledetMedlemsintervall;
-    private boolean gjelderFødsel = true;
-    private LocalDate familiehendelsedato;
-    private LocalDate bekreftetFamiliehendelsedato;
+    private LocalDateInterval uttaksintervall;
+    private FamilieHendelseDato familieHendelseDato;
     private boolean kreverSammenhengendeUttak;
     private boolean utenMinsterett;
     private boolean uttakSkalJusteresTilFødselsdato;
@@ -35,21 +33,15 @@ public class Skjæringstidspunkt {
         this.førsteUttaksdato = other.førsteUttaksdato;
         this.førsteUttaksdatoGrunnbeløp = other.førsteUttaksdatoGrunnbeløp;
         this.førsteUttaksdatoSøknad = other.førsteUttaksdatoSøknad;
-        this.utledetMedlemsintervall = other.utledetMedlemsintervall;
-        this.gjelderFødsel = other.gjelderFødsel;
-        this.familiehendelsedato = other.familiehendelsedato;
+        this.uttaksintervall = other.uttaksintervall;
+        this.familieHendelseDato = other.familieHendelseDato;
         this.kreverSammenhengendeUttak = other.kreverSammenhengendeUttak;
-        this.bekreftetFamiliehendelsedato = other.bekreftetFamiliehendelsedato;
         this.utenMinsterett = other.utenMinsterett;
         this.uttakSkalJusteresTilFødselsdato = other.uttakSkalJusteresTilFødselsdato;
     }
 
     public Optional<LocalDate> getSkjæringstidspunktHvisUtledet() {
         return Optional.ofNullable(utledetSkjæringstidspunkt);
-    }
-
-    public LocalDateInterval getUtledetMedlemsintervall() {
-        return utledetMedlemsintervall;
     }
 
     public LocalDate getUtledetSkjæringstidspunkt() {
@@ -93,19 +85,19 @@ public class Skjæringstidspunkt {
         return Optional.ofNullable(førsteUttaksdatoSøknad);
     }
 
+    /** Periode fra skjæringstidspunkt til siste uttaksdag, inntil 3 år for foreldrepenger. Skal normalt være satt */
+    public Optional<LocalDateInterval> getUttaksintervall() {
+        return Optional.ofNullable(uttaksintervall);
+    }
+
     /** Sak relatert til termin/fødsel - alternativet er adopsjon/omsorgsovertagelse */
     public boolean gjelderFødsel() {
-        return this.gjelderFødsel;
+        return familieHendelseDato == null || !familieHendelseDato.gjelderAdopsjonOmsorg();
     }
 
-    /** Gjeldende dato for fødsel, termin, eller omsorgsovertagelse. Kan være null dersom behandling før søknad */
-    public LocalDate getFamiliehendelsedato() {
-        return familiehendelsedato;
-    }
-
-    /** Bekreftet dato for fødsel, termin, eller omsorgsovertagelse. */
-    public Optional<LocalDate> getBekreftetFamiliehendelsedato() {
-        return Optional.ofNullable(bekreftetFamiliehendelsedato);
+    /** Gjeldende dato for fødsel, termin, eller omsorgsovertagelse. Kan være empty dersom behandling før søknad */
+    public Optional<FamilieHendelseDato> getFamilieHendelseDato() {
+        return Optional.ofNullable(familieHendelseDato);
     }
 
     /** Skal behandles etter nytt regelverk for uttak anno 2021. True = gamle regler */
@@ -172,11 +164,6 @@ public class Skjæringstidspunkt {
             return this;
         }
 
-        public Builder medUtledetMedlemsintervall(LocalDateInterval datointervall) {
-            kladd.utledetMedlemsintervall = datointervall;
-            return this;
-        }
-
         public Builder medSkjæringstidspunktOpptjening(LocalDate dato) {
             kladd.skjæringstidspunktOpptjening = dato;
             return this;
@@ -202,18 +189,13 @@ public class Skjæringstidspunkt {
             return this;
         }
 
-        public Builder medGjelderFødsel(boolean gjelderFødsel) {
-            kladd.gjelderFødsel = gjelderFødsel;
+        public Builder medUttaksintervall(LocalDateInterval uttaksperiode) {
+            kladd.uttaksintervall = uttaksperiode;
             return this;
         }
 
-        public Builder medFamiliehendelsedato(LocalDate dato) {
-            kladd.familiehendelsedato = dato;
-            return this;
-        }
-
-        public Builder medBekreftetFamiliehendelsedato(LocalDate dato) {
-            kladd.bekreftetFamiliehendelsedato = dato;
+        public Builder medFamilieHendelseDato(FamilieHendelseDato familieHendelseDato) {
+            kladd.familieHendelseDato = familieHendelseDato;
             return this;
         }
 

--- a/domenetjenester/datavarehus/src/main/java/no/nav/foreldrepenger/datavarehus/v2/StønadsstatistikkTjeneste.java
+++ b/domenetjenester/datavarehus/src/main/java/no/nav/foreldrepenger/datavarehus/v2/StønadsstatistikkTjeneste.java
@@ -34,6 +34,7 @@ import jakarta.inject.Inject;
 
 import no.nav.foreldrepenger.behandling.BehandlingReferanse;
 import no.nav.foreldrepenger.behandling.FagsakRelasjonTjeneste;
+import no.nav.foreldrepenger.behandling.FamilieHendelseDato;
 import no.nav.foreldrepenger.behandling.Skjæringstidspunkt;
 import no.nav.foreldrepenger.behandling.revurdering.ytelse.UttakInputTjeneste;
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
@@ -406,13 +407,9 @@ public class StønadsstatistikkTjeneste {
         if (stp.utenMinsterett()) {
             return stp.kreverSammenhengendeUttak() ? LovVersjon.FORELDREPENGER_2019_01_01 : LovVersjon.FORELDREPENGER_FRI_2021_10_01;
         }
-        var familieHendelseDato = stp.getFamiliehendelsedato();
-        if (LocalDate.now().isBefore(FORELDREPENGER_UTJEVNE80_2024_07_01.getDatoFom())) {
+        var familieHendelseDato = stp.getFamilieHendelseDato().map(FamilieHendelseDato::familieHendelseDato).orElse(null);
+        if (familieHendelseDato != null && familieHendelseDato.isBefore(FORELDREPENGER_UTJEVNE80_2024_07_01.getDatoFom())) {
             return FORELDREPENGER_MINSTERETT_2022_08_02;
-        } else if (familieHendelseDato != null && familieHendelseDato.isBefore(FORELDREPENGER_UTJEVNE80_2024_07_01.getDatoFom())) {
-            return FORELDREPENGER_MINSTERETT_2022_08_02;
-        } if (LocalDate.now().isBefore(FORELDREPENGER_MINSTERETT_2024_08_02.getDatoFom())) {
-            return FORELDREPENGER_UTJEVNE80_2024_07_01;
         } else if (familieHendelseDato != null && familieHendelseDato.isBefore(FORELDREPENGER_MINSTERETT_2024_08_02.getDatoFom())) {
             return FORELDREPENGER_UTJEVNE80_2024_07_01;
         } else {

--- a/domenetjenester/medlem/src/main/java/no/nav/foreldrepenger/domene/medlem/MedlemskapVurderingPeriodeTjeneste.java
+++ b/domenetjenester/medlem/src/main/java/no/nav/foreldrepenger/domene/medlem/MedlemskapVurderingPeriodeTjeneste.java
@@ -1,0 +1,96 @@
+package no.nav.foreldrepenger.domene.medlem;
+
+import java.time.LocalDate;
+import java.time.Period;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import no.nav.foreldrepenger.behandling.BehandlingReferanse;
+import no.nav.foreldrepenger.behandling.FamilieHendelseDato;
+import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakYtelseType;
+import no.nav.foreldrepenger.skjæringstidspunkt.es.BotidCore2024;
+import no.nav.fpsak.tidsserie.LocalDateInterval;
+
+@ApplicationScoped
+public class MedlemskapVurderingPeriodeTjeneste {
+
+    private static final Period BOSATT_TILBAKE_TID = Period.ofMonths(12);
+    private static final Period MEDLEMSKAP_ES = Period.ofMonths(12);
+
+    private BotidCore2024 botidCore2024;
+    MedlemskapVurderingPeriodeTjeneste() {
+        // CDI
+    }
+
+    @Inject
+    public MedlemskapVurderingPeriodeTjeneste(BotidCore2024 botidCore2024) {
+        this.botidCore2024 = botidCore2024;
+    }
+
+
+    public LocalDateInterval bosattVurderingsintervall(BehandlingReferanse ref) {
+        var referansedato = getReferansedato(ref);
+        var maxdato = switch (ref.fagsakYtelseType()) {
+            case ENGANGSTØNAD -> referansedato;
+            case FORELDREPENGER, SVANGERSKAPSPENGER -> ref.getUttaksintervall().map(LocalDateInterval::getTomDato).orElse(referansedato);
+            case null, default -> throw new IllegalArgumentException("Mangler ytelse");
+        };
+        var startdato = minDato(referansedato, LocalDate.now());
+        return new LocalDateInterval(startdato.minus(BOSATT_TILBAKE_TID), maxdato);
+    }
+
+    public LocalDateInterval fortsattBosattVurderingsintervall(BehandlingReferanse ref) {
+        var referansedato = getReferansedato(ref);
+        var maxdato = switch (ref.fagsakYtelseType()) {
+            case FORELDREPENGER, SVANGERSKAPSPENGER -> ref.getUttaksintervall().map(LocalDateInterval::getTomDato).orElse(referansedato);
+            case null, default -> throw new IllegalArgumentException("Mangler ytelse");
+        };
+        return new LocalDateInterval(referansedato, maxdato);
+    }
+
+    public LocalDateInterval lovligOppholdVurderingsintervall(BehandlingReferanse ref) {
+        var referansedato = getReferansedato(ref);
+        var maxdato = switch (ref.fagsakYtelseType()) {
+            case ENGANGSTØNAD -> referansedato;
+            case FORELDREPENGER, SVANGERSKAPSPENGER -> ref.getUttaksintervall().map(LocalDateInterval::getTomDato).orElse(referansedato);
+            case null, default -> throw new IllegalArgumentException("Mangler ytelse");
+        };
+        var startdato = FagsakYtelseType.ENGANGSTØNAD.equals(ref.fagsakYtelseType()) ? startLovligOppholdES(ref, referansedato) : referansedato;
+        return new LocalDateInterval(startdato, maxdato);
+    }
+
+    private LocalDate getReferansedato(BehandlingReferanse ref) {
+        return switch (ref.fagsakYtelseType()) {
+            case ENGANGSTØNAD -> referansedatoES(ref);
+            case FORELDREPENGER, SVANGERSKAPSPENGER -> ref.getUtledetSkjæringstidspunkt();
+            case null, default -> throw new IllegalArgumentException("Mangler ytelse");
+        };
+    }
+
+    private LocalDate referansedatoES(BehandlingReferanse ref) {
+        if (botidCore2024.ikkeBotidskrav(ref.skjæringstidspunkt().getFamilieHendelseDato().orElse(null))) {
+            return ref.getUtledetSkjæringstidspunkt();
+        } else { // Default etter overgansperiode (8/2-25)
+            return ref.skjæringstidspunkt().getFamilieHendelseDato().map(FamilieHendelseDato::termindato)
+                .orElseGet(ref::getUtledetSkjæringstidspunkt);
+        }
+    }
+
+    private LocalDate startLovligOppholdES(BehandlingReferanse ref, LocalDate referansedato) {
+        if (botidCore2024.ikkeBotidskrav(ref.skjæringstidspunkt().getFamilieHendelseDato().orElse(null))) {
+            return referansedato;
+        } else { // Default etter overgansperiode (8/2-25)
+            return minDato(referansedato, LocalDate.now()).minus(MEDLEMSKAP_ES);
+        }
+    }
+
+    private LocalDate minDato(LocalDate dato1, LocalDate dato2) {
+        if (dato1 != null && dato2 != null) {
+            return dato1.isBefore(dato2) ? dato1 : dato2;
+        } else {
+            return dato1 != null ? dato1 : dato2;
+        }
+    }
+
+}

--- a/domenetjenester/medlem/src/test/java/no/nav/foreldrepenger/domene/medlem/MedlemskapVurderingPeriodeTjenesteTest.java
+++ b/domenetjenester/medlem/src/test/java/no/nav/foreldrepenger/domene/medlem/MedlemskapVurderingPeriodeTjenesteTest.java
@@ -1,0 +1,314 @@
+package no.nav.foreldrepenger.domene.medlem;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDate;
+import java.time.Period;
+
+import org.junit.jupiter.api.Test;
+
+import no.nav.foreldrepenger.behandling.BehandlingReferanse;
+import no.nav.foreldrepenger.behandling.FamilieHendelseDato;
+import no.nav.foreldrepenger.behandling.Skjæringstidspunkt;
+import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingType;
+import no.nav.foreldrepenger.behandlingslager.testutilities.behandling.ScenarioMorSøkerEngangsstønad;
+import no.nav.foreldrepenger.behandlingslager.testutilities.behandling.ScenarioMorSøkerForeldrepenger;
+import no.nav.foreldrepenger.behandlingslager.testutilities.behandling.ScenarioMorSøkerSvangerskapspenger;
+import no.nav.foreldrepenger.skjæringstidspunkt.es.BotidCore2024;
+import no.nav.fpsak.tidsserie.LocalDateInterval;
+
+class MedlemskapVurderingPeriodeTjenesteTest {
+
+    private static final LocalDate IKRAFT = LocalDate.now().minusWeeks(2);
+    private static final Period OVERGANG = Period.parse("P18W3D");
+    private static final Period BOSATT_TILBAKE = Period.ofMonths(12);
+
+    private static final Period ES_MEDLEMSKAP = Period.ofMonths(12);
+    private static final BotidCore2024 BOTID_CORE = new BotidCore2024(IKRAFT, OVERGANG);
+
+    @Test
+    void engangsstønad_termin_uten_botid() {
+        // Arrange
+        var termindato = IKRAFT.plus(OVERGANG).minusDays(1); // Dagen før ny ordning
+
+        var behandling = ScenarioMorSøkerEngangsstønad.forFødsel()
+            .medBehandlingType(BehandlingType.FØRSTEGANGSSØKNAD).lagMocked();
+
+        var ref = BehandlingReferanse.fra(behandling, Skjæringstidspunkt.builder()
+            .medUtledetSkjæringstidspunkt(termindato)
+            .medUttaksintervall(new LocalDateInterval(termindato, termindato))
+            .medFamilieHendelseDato(FamilieHendelseDato.forFødsel(termindato, null))
+            .build());
+
+        // Act/Assert
+        assertThat(new MedlemskapVurderingPeriodeTjeneste(BOTID_CORE).bosattVurderingsintervall(ref))
+            .isEqualTo(new LocalDateInterval(LocalDate.now().minus(BOSATT_TILBAKE), termindato));
+        assertThat(new MedlemskapVurderingPeriodeTjeneste(BOTID_CORE).lovligOppholdVurderingsintervall(ref))
+            .isEqualTo(new LocalDateInterval(termindato, termindato));
+    }
+
+    @Test
+    void engangsstønad_termin_fødsel_uten_botid() {
+        // Arrange
+        var termindato = IKRAFT.minusWeeks(1);
+        var fødselsdato = IKRAFT.minusWeeks(1).minusDays(2);
+
+        var behandling = ScenarioMorSøkerEngangsstønad.forFødsel()
+            .medBehandlingType(BehandlingType.FØRSTEGANGSSØKNAD).lagMocked();
+
+        var ref = BehandlingReferanse.fra(behandling, Skjæringstidspunkt.builder()
+            .medUtledetSkjæringstidspunkt(fødselsdato)
+            .medUttaksintervall(new LocalDateInterval(fødselsdato, fødselsdato))
+            .medFamilieHendelseDato(FamilieHendelseDato.forFødsel(termindato, fødselsdato))
+            .build());
+
+        // Act/Assert
+        assertThat(new MedlemskapVurderingPeriodeTjeneste(BOTID_CORE).bosattVurderingsintervall(ref))
+            .isEqualTo(new LocalDateInterval(fødselsdato.minus(BOSATT_TILBAKE), fødselsdato));
+        assertThat(new MedlemskapVurderingPeriodeTjeneste(BOTID_CORE).lovligOppholdVurderingsintervall(ref))
+            .isEqualTo(new LocalDateInterval(fødselsdato, fødselsdato));
+    }
+
+    @Test
+    void engangsstønad_fødsel_uten_botid() {
+        // Arrange
+        var fødselsdato = IKRAFT.minusDays(2);
+
+        var behandling = ScenarioMorSøkerEngangsstønad.forFødsel()
+            .medBehandlingType(BehandlingType.FØRSTEGANGSSØKNAD).lagMocked();
+
+        var ref = BehandlingReferanse.fra(behandling, Skjæringstidspunkt.builder()
+            .medUtledetSkjæringstidspunkt(fødselsdato)
+            .medUttaksintervall(new LocalDateInterval(fødselsdato, fødselsdato))
+            .medFamilieHendelseDato(FamilieHendelseDato.forFødsel(null, fødselsdato))
+            .build());
+
+        // Act/Assert
+        assertThat(new MedlemskapVurderingPeriodeTjeneste(BOTID_CORE).bosattVurderingsintervall(ref))
+            .isEqualTo(new LocalDateInterval(fødselsdato.minus(BOSATT_TILBAKE), fødselsdato));
+        assertThat(new MedlemskapVurderingPeriodeTjeneste(BOTID_CORE).lovligOppholdVurderingsintervall(ref))
+            .isEqualTo(new LocalDateInterval(fødselsdato, fødselsdato));
+    }
+
+    @Test
+    void engangsstønad_adopsjon_uten_botid() {
+        // Arrange
+        var omsorgsdato = IKRAFT.minusWeeks(2);
+
+        var behandling = ScenarioMorSøkerEngangsstønad.forAdopsjon()
+            .medBehandlingType(BehandlingType.FØRSTEGANGSSØKNAD).lagMocked();
+
+        var ref = BehandlingReferanse.fra(behandling, Skjæringstidspunkt.builder()
+            .medUtledetSkjæringstidspunkt(omsorgsdato)
+            .medUttaksintervall(new LocalDateInterval(omsorgsdato, omsorgsdato))
+            .medFamilieHendelseDato(FamilieHendelseDato.forAdopsjonOmsorg(omsorgsdato))
+            .build());
+
+        // Act/Assert
+        assertThat(new MedlemskapVurderingPeriodeTjeneste(BOTID_CORE).bosattVurderingsintervall(ref))
+            .isEqualTo(new LocalDateInterval(omsorgsdato.minus(BOSATT_TILBAKE), omsorgsdato));
+        assertThat(new MedlemskapVurderingPeriodeTjeneste(BOTID_CORE).lovligOppholdVurderingsintervall(ref))
+            .isEqualTo(new LocalDateInterval(omsorgsdato, omsorgsdato));
+    }
+
+
+    @Test
+    void engangsstønad_termin_med_botid() {
+        // Arrange
+        var termindato = IKRAFT.plus(OVERGANG).plusWeeks(1);
+
+        var behandling = ScenarioMorSøkerEngangsstønad.forFødsel()
+            .medBehandlingType(BehandlingType.FØRSTEGANGSSØKNAD).lagMocked();
+
+        var ref = BehandlingReferanse.fra(behandling, Skjæringstidspunkt.builder()
+            .medUtledetSkjæringstidspunkt(termindato)
+            .medUttaksintervall(new LocalDateInterval(termindato, termindato))
+            .medFamilieHendelseDato(FamilieHendelseDato.forFødsel(termindato, null))
+            .build());
+
+        // Act/Assert
+        assertThat(new MedlemskapVurderingPeriodeTjeneste(BOTID_CORE).bosattVurderingsintervall(ref))
+            .isEqualTo(new LocalDateInterval(LocalDate.now().minus(ES_MEDLEMSKAP), termindato));
+        assertThat(new MedlemskapVurderingPeriodeTjeneste(BOTID_CORE).lovligOppholdVurderingsintervall(ref))
+            .isEqualTo(new LocalDateInterval(LocalDate.now().minus(ES_MEDLEMSKAP), termindato));
+    }
+
+    @Test
+    void engangsstønad_termin_fødsel_med_botid() {
+        // Arrange
+        var termindato = IKRAFT.plus(OVERGANG).plusWeeks(1);
+        var fødselsdato = IKRAFT.plus(OVERGANG);
+
+        var behandling = ScenarioMorSøkerEngangsstønad.forFødsel()
+            .medBehandlingType(BehandlingType.FØRSTEGANGSSØKNAD).lagMocked();
+
+        var ref = BehandlingReferanse.fra(behandling, Skjæringstidspunkt.builder()
+            .medUtledetSkjæringstidspunkt(fødselsdato)
+            .medUttaksintervall(new LocalDateInterval(fødselsdato, fødselsdato))
+            .medFamilieHendelseDato(FamilieHendelseDato.forFødsel(termindato, fødselsdato))
+            .build());
+
+        // Act/Assert
+        assertThat(new MedlemskapVurderingPeriodeTjeneste(BOTID_CORE).bosattVurderingsintervall(ref))
+            .isEqualTo(new LocalDateInterval(LocalDate.now().minus(ES_MEDLEMSKAP), termindato));
+        assertThat(new MedlemskapVurderingPeriodeTjeneste(BOTID_CORE).lovligOppholdVurderingsintervall(ref))
+            .isEqualTo(new LocalDateInterval(LocalDate.now().minus(ES_MEDLEMSKAP), termindato));
+    }
+
+    @Test
+    void engangsstønad_fødsel_med_botid() {
+        // Arrange
+        var fødselsdato = IKRAFT.plusWeeks(1);
+
+        var behandling = ScenarioMorSøkerEngangsstønad.forFødsel()
+            .medBehandlingType(BehandlingType.FØRSTEGANGSSØKNAD).lagMocked();
+
+        var ref = BehandlingReferanse.fra(behandling, Skjæringstidspunkt.builder()
+            .medUtledetSkjæringstidspunkt(fødselsdato)
+            .medUttaksintervall(new LocalDateInterval(fødselsdato, fødselsdato))
+            .medFamilieHendelseDato(FamilieHendelseDato.forFødsel(null, fødselsdato))
+            .build());
+
+        // Act/Assert
+        assertThat(new MedlemskapVurderingPeriodeTjeneste(BOTID_CORE).bosattVurderingsintervall(ref))
+            .isEqualTo(new LocalDateInterval(fødselsdato.minus(ES_MEDLEMSKAP), fødselsdato));
+        assertThat(new MedlemskapVurderingPeriodeTjeneste(BOTID_CORE).lovligOppholdVurderingsintervall(ref))
+            .isEqualTo(new LocalDateInterval(fødselsdato.minus(ES_MEDLEMSKAP), fødselsdato));
+    }
+
+    @Test
+    void engangsstønad_adopsjon_med_botid() {
+        // Arrange
+        var omsorgsdato = IKRAFT.plusWeeks(3);
+
+        var behandling = ScenarioMorSøkerEngangsstønad.forAdopsjon()
+            .medBehandlingType(BehandlingType.FØRSTEGANGSSØKNAD).lagMocked();
+
+        var ref = BehandlingReferanse.fra(behandling, Skjæringstidspunkt.builder()
+            .medUtledetSkjæringstidspunkt(omsorgsdato)
+            .medUttaksintervall(new LocalDateInterval(omsorgsdato, omsorgsdato))
+            .medFamilieHendelseDato(FamilieHendelseDato.forAdopsjonOmsorg(omsorgsdato))
+            .build());
+
+        // Act/Assert
+        assertThat(new MedlemskapVurderingPeriodeTjeneste(BOTID_CORE).bosattVurderingsintervall(ref))
+            .isEqualTo(new LocalDateInterval(LocalDate.now().minus(ES_MEDLEMSKAP), omsorgsdato));
+        assertThat(new MedlemskapVurderingPeriodeTjeneste(BOTID_CORE).lovligOppholdVurderingsintervall(ref))
+            .isEqualTo(new LocalDateInterval(LocalDate.now().minus(ES_MEDLEMSKAP), omsorgsdato));
+    }
+
+    @Test
+    void foreldrepenger_termin() {
+        // Arrange
+        var termindato = LocalDate.now().plusWeeks(4);
+        var skjæringstidspunkt = termindato.minusWeeks(3);
+        var maxdato = termindato.plusWeeks(15);
+
+        var behandling = ScenarioMorSøkerForeldrepenger.forFødsel()
+            .medBehandlingType(BehandlingType.FØRSTEGANGSSØKNAD).lagMocked();
+
+        var ref = BehandlingReferanse.fra(behandling, Skjæringstidspunkt.builder()
+            .medUtledetSkjæringstidspunkt(skjæringstidspunkt)
+            .medUttaksintervall(new LocalDateInterval(skjæringstidspunkt, maxdato))
+            .medFamilieHendelseDato(FamilieHendelseDato.forFødsel(termindato, null))
+            .build());
+
+        // Act/Assert
+        assertThat(new MedlemskapVurderingPeriodeTjeneste(BOTID_CORE).bosattVurderingsintervall(ref))
+            .isEqualTo(new LocalDateInterval(LocalDate.now().minus(BOSATT_TILBAKE), maxdato));
+        assertThat(new MedlemskapVurderingPeriodeTjeneste(BOTID_CORE).lovligOppholdVurderingsintervall(ref))
+            .isEqualTo(new LocalDateInterval(skjæringstidspunkt, maxdato));
+    }
+
+    @Test
+    void foreldrepenger_adopsjon() {
+        // Arrange
+        var omsorgsdato = LocalDate.now().minusDays(3);
+        var maxdato = omsorgsdato.plusWeeks(15);
+
+        var behandling = ScenarioMorSøkerForeldrepenger.forAdopsjon()
+            .medBehandlingType(BehandlingType.FØRSTEGANGSSØKNAD).lagMocked();
+
+        var ref = BehandlingReferanse.fra(behandling, Skjæringstidspunkt.builder()
+            .medUtledetSkjæringstidspunkt(omsorgsdato)
+            .medUttaksintervall(new LocalDateInterval(omsorgsdato, maxdato))
+            .medFamilieHendelseDato(FamilieHendelseDato.forAdopsjonOmsorg(omsorgsdato))
+            .build());
+
+        // Act/Assert
+        assertThat(new MedlemskapVurderingPeriodeTjeneste(BOTID_CORE).bosattVurderingsintervall(ref))
+            .isEqualTo(new LocalDateInterval(omsorgsdato.minus(BOSATT_TILBAKE), maxdato));
+        assertThat(new MedlemskapVurderingPeriodeTjeneste(BOTID_CORE).lovligOppholdVurderingsintervall(ref))
+            .isEqualTo(new LocalDateInterval(omsorgsdato, maxdato));
+    }
+
+    @Test
+    void svangerskapspenger_termin() {
+        // Arrange
+        var termindato = LocalDate.now().plusWeeks(12);
+        var skjæringstidspunkt = LocalDate.now().minusWeeks(1);
+        var maxdato = termindato.minusWeeks(3);
+
+        var behandling = ScenarioMorSøkerSvangerskapspenger.forSvangerskapspenger()
+            .medBehandlingType(BehandlingType.FØRSTEGANGSSØKNAD).lagMocked();
+
+        var ref = BehandlingReferanse.fra(behandling, Skjæringstidspunkt.builder()
+            .medUtledetSkjæringstidspunkt(skjæringstidspunkt)
+            .medUttaksintervall(new LocalDateInterval(skjæringstidspunkt, maxdato))
+            .medFamilieHendelseDato(FamilieHendelseDato.forFødsel(termindato, null))
+            .build());
+
+        // Act/Assert
+        assertThat(new MedlemskapVurderingPeriodeTjeneste(BOTID_CORE).bosattVurderingsintervall(ref))
+            .isEqualTo(new LocalDateInterval(skjæringstidspunkt.minus(BOSATT_TILBAKE), maxdato));
+        assertThat(new MedlemskapVurderingPeriodeTjeneste(BOTID_CORE).lovligOppholdVurderingsintervall(ref))
+            .isEqualTo(new LocalDateInterval(skjæringstidspunkt, maxdato));
+    }
+
+    @Test
+    void fortsatt_foreldrepenger_adopsjon() {
+        // Arrange
+        var omsorgsdato = LocalDate.now().minusDays(3);
+        var maxdato = omsorgsdato.plusWeeks(15);
+
+        var behandling = ScenarioMorSøkerForeldrepenger.forAdopsjon()
+            .medBehandlingType(BehandlingType.FØRSTEGANGSSØKNAD).lagMocked();
+
+        var ref = BehandlingReferanse.fra(behandling, Skjæringstidspunkt.builder()
+            .medUtledetSkjæringstidspunkt(omsorgsdato)
+            .medUttaksintervall(new LocalDateInterval(omsorgsdato, maxdato))
+            .medFamilieHendelseDato(FamilieHendelseDato.forAdopsjonOmsorg(omsorgsdato))
+            .build());
+
+        // Act/Assert
+        assertThat(new MedlemskapVurderingPeriodeTjeneste(BOTID_CORE).fortsattBosattVurderingsintervall(ref))
+            .isEqualTo(new LocalDateInterval(omsorgsdato, maxdato));
+        assertThat(new MedlemskapVurderingPeriodeTjeneste(BOTID_CORE).lovligOppholdVurderingsintervall(ref))
+            .isEqualTo(new LocalDateInterval(omsorgsdato, maxdato));
+    }
+
+    @Test
+    void fortsatt_svangerskapspenger_termin() {
+        // Arrange
+        var termindato = LocalDate.now().plusWeeks(12);
+        var skjæringstidspunkt = LocalDate.now().minusWeeks(1);
+        var maxdato = termindato.minusWeeks(3);
+
+        var behandling = ScenarioMorSøkerSvangerskapspenger.forSvangerskapspenger()
+            .medBehandlingType(BehandlingType.REVURDERING).lagMocked();
+
+        var ref = BehandlingReferanse.fra(behandling, Skjæringstidspunkt.builder()
+            .medUtledetSkjæringstidspunkt(skjæringstidspunkt)
+            .medUttaksintervall(new LocalDateInterval(skjæringstidspunkt, maxdato))
+            .medFamilieHendelseDato(FamilieHendelseDato.forFødsel(termindato, null))
+            .build());
+
+        // Act/Assert
+        assertThat(new MedlemskapVurderingPeriodeTjeneste(BOTID_CORE).fortsattBosattVurderingsintervall(ref))
+            .isEqualTo(new LocalDateInterval(skjæringstidspunkt, maxdato));
+        assertThat(new MedlemskapVurderingPeriodeTjeneste(BOTID_CORE).lovligOppholdVurderingsintervall(ref))
+            .isEqualTo(new LocalDateInterval(skjæringstidspunkt, maxdato));
+    }
+
+
+}

--- a/domenetjenester/medlem/src/test/java/no/nav/foreldrepenger/domene/medlem/impl/AvklarOmErBosattTest.java
+++ b/domenetjenester/medlem/src/test/java/no/nav/foreldrepenger/domene/medlem/impl/AvklarOmErBosattTest.java
@@ -389,7 +389,7 @@ class AvklarOmErBosattTest {
     private BehandlingReferanse lagRef(Behandling behandling) {
         return BehandlingReferanse.fra(behandling, Skjæringstidspunkt.builder()
             .medUtledetSkjæringstidspunkt(SKJÆRINGSDATO)
-            .medUtledetMedlemsintervall(new LocalDateInterval(SKJÆRINGSDATO.minusWeeks(4), SKJÆRINGSDATO.plusWeeks(4)))
+            .medUttaksintervall(new LocalDateInterval(SKJÆRINGSDATO.minusWeeks(4), SKJÆRINGSDATO.plusWeeks(4)))
             .medFørsteUttaksdato(SKJÆRINGSDATO).build());
     }
 }

--- a/domenetjenester/medlem/src/test/java/no/nav/foreldrepenger/domene/medlem/impl/AvklarOmSøkerOppholderSegINorgeTest.java
+++ b/domenetjenester/medlem/src/test/java/no/nav/foreldrepenger/domene/medlem/impl/AvklarOmSøkerOppholderSegINorgeTest.java
@@ -164,7 +164,7 @@ class AvklarOmSøkerOppholderSegINorgeTest {
 
     private Optional<MedlemResultat> kallTjeneste(Behandling behandling, LocalDate dato) {
         var ref = BehandlingReferanse.fra(behandling, Skjæringstidspunkt.builder().medUtledetSkjæringstidspunkt(dato)
-            .medUtledetMedlemsintervall(new LocalDateInterval(dato.minusWeeks(4), dato.plusWeeks(4)))
+            .medUttaksintervall(new LocalDateInterval(dato.minusWeeks(4), dato.plusWeeks(4)))
             .build());
         return tjeneste.utledVedSTP(ref);
     }

--- a/domenetjenester/medlem/src/test/java/no/nav/foreldrepenger/domene/medlem/impl/AvklaringFaktaMedlemskapTest.java
+++ b/domenetjenester/medlem/src/test/java/no/nav/foreldrepenger/domene/medlem/impl/AvklaringFaktaMedlemskapTest.java
@@ -87,7 +87,7 @@ class AvklaringFaktaMedlemskapTest extends EntityManagerAwareTest {
     private BehandlingReferanse lagRef(Behandling behandling) {
         return BehandlingReferanse.fra(behandling, Skjæringstidspunkt.builder()
             .medUtledetSkjæringstidspunkt(SKJÆRINGSDATO_FØDSEL)
-            .medUtledetMedlemsintervall(new LocalDateInterval(SKJÆRINGSDATO_FØDSEL.minusWeeks(4), SKJÆRINGSDATO_FØDSEL.plusWeeks(4)))
+            .medUttaksintervall(new LocalDateInterval(SKJÆRINGSDATO_FØDSEL.minusWeeks(4), SKJÆRINGSDATO_FØDSEL.plusWeeks(4)))
             .medFørsteUttaksdato(SKJÆRINGSDATO_FØDSEL).build());
     }
 

--- a/domenetjenester/medlem/src/test/java/no/nav/foreldrepenger/domene/medlem/impl/UtledVurderingsdatoerForMedlemskapTjenesteTest.java
+++ b/domenetjenester/medlem/src/test/java/no/nav/foreldrepenger/domene/medlem/impl/UtledVurderingsdatoerForMedlemskapTjenesteTest.java
@@ -367,7 +367,7 @@ class UtledVurderingsdatoerForMedlemskapTjenesteTest {
     private BehandlingReferanse lagRef(Behandling behandling, LocalDate fom, LocalDate tom) {
         return BehandlingReferanse.fra(behandling, Skjæringstidspunkt.builder()
             .medUtledetSkjæringstidspunkt(fom)
-            .medUtledetMedlemsintervall(new LocalDateInterval(fom, tom))
+            .medUttaksintervall(new LocalDateInterval(fom, tom))
             .medFørsteUttaksdato(fom)
             .medSkjæringstidspunktOpptjening(fom)
             .build());

--- a/domenetjenester/person/src/test/java/no/nav/foreldrepenger/domene/personopplysning/PersonopplysningTjenesteTest.java
+++ b/domenetjenester/person/src/test/java/no/nav/foreldrepenger/domene/personopplysning/PersonopplysningTjenesteTest.java
@@ -39,7 +39,7 @@ class PersonopplysningTjenesteTest {
 
         var ref = BehandlingReferanse.fra(behandling, Skjæringstidspunkt.builder()
                 .medUtledetSkjæringstidspunkt(tidspunkt)
-                .medUtledetMedlemsintervall(new LocalDateInterval(tidspunkt, tidspunkt.plusWeeks(31)))
+                .medUttaksintervall(new LocalDateInterval(tidspunkt, tidspunkt.plusWeeks(31)))
                 .medFørsteUttaksdato(tidspunkt).build());
 
         // Act

--- a/domenetjenester/registerinnhenting/src/main/java/no/nav/foreldrepenger/domene/registerinnhenting/impl/startpunkt/StartpunktUtlederFamilieHendelse.java
+++ b/domenetjenester/registerinnhenting/src/main/java/no/nav/foreldrepenger/domene/registerinnhenting/impl/startpunkt/StartpunktUtlederFamilieHendelse.java
@@ -5,6 +5,7 @@ import jakarta.inject.Inject;
 
 import no.nav.foreldrepenger.behandling.BehandlingReferanse;
 import no.nav.foreldrepenger.behandling.DekningsgradTjeneste;
+import no.nav.foreldrepenger.behandling.FamilieHendelseDato;
 import no.nav.foreldrepenger.behandlingslager.behandling.GrunnlagRef;
 import no.nav.foreldrepenger.behandlingslager.behandling.familiehendelse.FamilieHendelseEntitet;
 import no.nav.foreldrepenger.behandlingslager.behandling.familiehendelse.FamilieHendelseGrunnlagEntitet;
@@ -69,7 +70,8 @@ class StartpunktUtlederFamilieHendelse implements StartpunktUtleder {
         var origSkjæringstidspunkt = ref.getOriginalBehandlingId()
             .map(origId -> skjæringstidspunktTjeneste.getSkjæringstidspunkter(origId).getUtledetSkjæringstidspunkt());
 
-        var nyBekreftetFødselsdato = ref.getSkjæringstidspunkt().getBekreftetFamiliehendelsedato().orElse(null);
+        var nyBekreftetFødselsdato = ref.getSkjæringstidspunkt().getFamilieHendelseDato()
+            .map(FamilieHendelseDato::familieHendelseDato).orElse(null);
         var origBekreftetFødselsdato = ref.getOriginalBehandlingId()
             .flatMap(origId -> familieHendelseTjeneste.hentAggregat(origId).getGjeldendeBekreftetVersjon())
             .flatMap(FamilieHendelseEntitet::getFødselsdato).orElse(null);

--- a/domenetjenester/registerinnhenting/src/test/java/no/nav/foreldrepenger/domene/registerinnhenting/impl/startpunkt/StartpunktUtlederFamilieHendelseTest.java
+++ b/domenetjenester/registerinnhenting/src/test/java/no/nav/foreldrepenger/domene/registerinnhenting/impl/startpunkt/StartpunktUtlederFamilieHendelseTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.Test;
 
 import no.nav.foreldrepenger.behandling.BehandlingReferanse;
 import no.nav.foreldrepenger.behandling.DekningsgradTjeneste;
+import no.nav.foreldrepenger.behandling.FamilieHendelseDato;
 import no.nav.foreldrepenger.behandling.Skjæringstidspunkt;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingType;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingÅrsakType;
@@ -39,7 +40,7 @@ class StartpunktUtlederFamilieHendelseTest {
 
         var skjæringstidspunktTjeneste = mock(SkjæringstidspunktTjeneste.class);
         var skjæringstidspunkt = Skjæringstidspunkt.builder()
-            .medBekreftetFamiliehendelsedato(nyBekreftetfødselsdato)
+            .medFamilieHendelseDato(FamilieHendelseDato.forFødsel(null, nyBekreftetfødselsdato))
             .medUtledetSkjæringstidspunkt(origSkjæringsdato)
             .build();
         when(skjæringstidspunktTjeneste.getSkjæringstidspunkter(originalBehandling.getId())).thenReturn(skjæringstidspunkt);
@@ -71,7 +72,7 @@ class StartpunktUtlederFamilieHendelseTest {
 
         var skjæringstidspunktTjeneste = mock(SkjæringstidspunktTjeneste.class);
         var skjæringstidspunkt = Skjæringstidspunkt.builder()
-            .medBekreftetFamiliehendelsedato(nyBekreftetfødselsdato)
+            .medFamilieHendelseDato(FamilieHendelseDato.forFødsel(null, nyBekreftetfødselsdato))
             .medUtledetSkjæringstidspunkt(origSkjæringsdato).build();
         when(skjæringstidspunktTjeneste.getSkjæringstidspunkter(originalBehandling.getId())).thenReturn(skjæringstidspunkt);
 
@@ -102,7 +103,7 @@ class StartpunktUtlederFamilieHendelseTest {
 
         var skjæringstidspunktTjeneste = mock(SkjæringstidspunktTjeneste.class);
         var skjæringstidspunkt = Skjæringstidspunkt.builder()
-            .medBekreftetFamiliehendelsedato(skjæringsdato)
+            .medFamilieHendelseDato(FamilieHendelseDato.forFødsel(fødselsdato, fødselsdato))
             .medUtledetSkjæringstidspunkt(skjæringsdato).build();
         when(skjæringstidspunktTjeneste.getSkjæringstidspunkter(originalBehandling.getId())).thenReturn(skjæringstidspunkt);
 
@@ -140,7 +141,7 @@ class StartpunktUtlederFamilieHendelseTest {
 
         var skjæringstidspunktTjeneste = mock(SkjæringstidspunktTjeneste.class);
         var skjæringstidspunkt = Skjæringstidspunkt.builder()
-            .medBekreftetFamiliehendelsedato(fødselsdato)
+            .medFamilieHendelseDato(FamilieHendelseDato.forFødsel(null, fødselsdato))
             .medUtledetSkjæringstidspunkt(skjæringsdato).build();
         when(skjæringstidspunktTjeneste.getSkjæringstidspunkter(originalBehandling.getId())).thenReturn(skjæringstidspunkt);
 
@@ -181,7 +182,9 @@ class StartpunktUtlederFamilieHendelseTest {
         var originalBehandling = førstegangScenario.lagre(repositoryProvider);
 
         var skjæringstidspunktTjeneste = mock(SkjæringstidspunktTjeneste.class);
-        var skjæringstidspunkt = Skjæringstidspunkt.builder().medBekreftetFamiliehendelsedato(fødselsdato).medUtledetSkjæringstidspunkt(skjæringsdato).build();
+        var skjæringstidspunkt = Skjæringstidspunkt.builder()
+            .medFamilieHendelseDato(FamilieHendelseDato.forFødsel(null, fødselsdato))
+            .medUtledetSkjæringstidspunkt(skjæringsdato).build();
         when(skjæringstidspunktTjeneste.getSkjæringstidspunkter(originalBehandling.getId())).thenReturn(skjæringstidspunkt);
 
         var revurderingScenario = ScenarioMorSøkerForeldrepenger.forFødsel()
@@ -229,7 +232,8 @@ class StartpunktUtlederFamilieHendelseTest {
         revurderingScenario.medOriginalBehandling(originalBehandling, BehandlingÅrsakType.RE_MANGLER_FØDSEL);
         var revurdering = revurderingScenario.lagre(repositoryProvider);
         var nySkjæringstidspunkt = Skjæringstidspunkt.builder()
-            .medBekreftetFamiliehendelsedato(nySkjæringsdato).medUtledetSkjæringstidspunkt(nySkjæringsdato).build();
+            .medFamilieHendelseDato(FamilieHendelseDato.forFødsel(null, nySkjæringsdato))
+            .medUtledetSkjæringstidspunkt(nySkjæringsdato).build();
         when(skjæringstidspunktTjeneste.getSkjæringstidspunkter(revurdering.getId())).thenReturn(nySkjæringstidspunkt);
 
         // Act/Assert
@@ -262,7 +266,7 @@ class StartpunktUtlederFamilieHendelseTest {
         var nySkjæringstidspunkt = Skjæringstidspunkt.builder()
             .medUtledetSkjæringstidspunkt(nySkjæringsdato)
             .medUttakSkalJusteresTilFødselsdato(true)
-            .medBekreftetFamiliehendelsedato(nySkjæringsdato)
+            .medFamilieHendelseDato(FamilieHendelseDato.forFødsel(null, nySkjæringsdato))
             .build();
         when(skjæringstidspunktTjeneste.getSkjæringstidspunkter(revurdering.getId())).thenReturn(nySkjæringstidspunkt);
 

--- a/domenetjenester/skjaeringstidspunkt/src/main/java/no/nav/foreldrepenger/skjæringstidspunkt/FamilieHendelseMapper.java
+++ b/domenetjenester/skjaeringstidspunkt/src/main/java/no/nav/foreldrepenger/skjæringstidspunkt/FamilieHendelseMapper.java
@@ -1,0 +1,19 @@
+package no.nav.foreldrepenger.skjæringstidspunkt;
+
+import no.nav.foreldrepenger.behandling.FamilieHendelseDato;
+import no.nav.foreldrepenger.behandlingslager.behandling.familiehendelse.FamilieHendelseEntitet;
+
+public class FamilieHendelseMapper {
+
+    private FamilieHendelseMapper() {
+    }
+
+    public static FamilieHendelseDato mapTilFamilieHendelseDato(FamilieHendelseEntitet familieHendelse) {
+        if (familieHendelse.getGjelderFødsel()) {
+            return new FamilieHendelseDato(familieHendelse.getTermindato().orElse(null), familieHendelse.getFødselsdato().orElse(null), null);
+        } else {
+            return new FamilieHendelseDato(null, null, familieHendelse.getSkjæringstidspunkt());
+        }
+    }
+
+}

--- a/domenetjenester/skjaeringstidspunkt/src/main/java/no/nav/foreldrepenger/skjæringstidspunkt/es/BotidCore2024.java
+++ b/domenetjenester/skjaeringstidspunkt/src/main/java/no/nav/foreldrepenger/skjæringstidspunkt/es/BotidCore2024.java
@@ -11,6 +11,7 @@ import jakarta.inject.Inject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import no.nav.foreldrepenger.behandling.FamilieHendelseDato;
 import no.nav.foreldrepenger.behandlingslager.behandling.familiehendelse.AdopsjonEntitet;
 import no.nav.foreldrepenger.behandlingslager.behandling.familiehendelse.FamilieHendelseEntitet;
 import no.nav.foreldrepenger.behandlingslager.behandling.familiehendelse.FamilieHendelseGrunnlagEntitet;
@@ -78,6 +79,17 @@ public class BotidCore2024 {
             return familieHendelse.getTermindato().or(familieHendelse::getFødselsdato);
         } else {
             return familieHendelse.getAdopsjon().map(AdopsjonEntitet::getOmsorgsovertakelseDato);
+        }
+    }
+
+    public boolean ikkeBotidskrav(FamilieHendelseDato familieHendelseDato) {
+        if (familieHendelseDato == null || familieHendelseDato.familieHendelseDato() == null) {
+            return LocalDate.now().isBefore(ikrafttredelseDato);
+        }
+        if (familieHendelseDato.gjelderFødsel() && familieHendelseDato.termindato() != null) {
+            return familieHendelseDato.termindato().isBefore(ikrafttredelseDatoMedOvergangsordning);
+        } else {
+            return familieHendelseDato.familieHendelseDato().isBefore(ikrafttredelseDato);
         }
     }
 

--- a/domenetjenester/skjaeringstidspunkt/src/test/java/no/nav/foreldrepenger/skjæringstidspunkt/StønadsperiodeTjenesteTest.java
+++ b/domenetjenester/skjaeringstidspunkt/src/test/java/no/nav/foreldrepenger/skjæringstidspunkt/StønadsperiodeTjenesteTest.java
@@ -16,6 +16,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import no.nav.foreldrepenger.behandling.FagsakRelasjonTjeneste;
+import no.nav.foreldrepenger.behandling.FamilieHendelseDato;
 import no.nav.foreldrepenger.behandling.Skjæringstidspunkt;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingResultatType;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingType;
@@ -199,7 +200,8 @@ class StønadsperiodeTjenesteTest {
             );
         when(fpUttakRepository.hentUttakResultatHvisEksisterer(behandling.getId())).thenReturn(Optional.of(ur.build()));
         when(skjæringstidspunktTjeneste.getSkjæringstidspunkter(behandling.getId()))
-            .thenReturn(Skjæringstidspunkt.builder().medUtledetSkjæringstidspunkt(skjæringsdato).medGjelderFødsel(false).build());
+            .thenReturn(Skjæringstidspunkt.builder().medUtledetSkjæringstidspunkt(skjæringsdato)
+                .medFamilieHendelseDato(FamilieHendelseDato.forAdopsjonOmsorg(skjæringsdato)).build());
 
         // Act/Assert
         var periode = stønadsperiodeTjeneste.stønadsperiode(behandling);

--- a/domenetjenester/skjaeringstidspunkt/src/test/java/no/nav/foreldrepenger/skjæringstidspunkt/es/BotidCore2024FamilieHendelseDatoTest.java
+++ b/domenetjenester/skjaeringstidspunkt/src/test/java/no/nav/foreldrepenger/skjæringstidspunkt/es/BotidCore2024FamilieHendelseDatoTest.java
@@ -1,0 +1,86 @@
+package no.nav.foreldrepenger.skjæringstidspunkt.es;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDate;
+import java.time.Month;
+import java.time.Period;
+
+import org.junit.jupiter.api.Test;
+
+import no.nav.foreldrepenger.behandling.FamilieHendelseDato;
+
+class BotidCore2024FamilieHendelseDatoTest {
+
+    private static final LocalDate IKRAFT = LocalDate.of(2024, Month.AUGUST, 1);
+    private static final Period OVERGANG = Period.parse("P18W3D");
+
+    @Test
+    void skal_returnere_uten_botidskrav_hvis_gjeldende_termin_før_ikrafttredelsedato() {
+        var bekreftettermindato = IKRAFT.plusWeeks(10);
+        var fhd = FamilieHendelseDato.forFødsel(bekreftettermindato, null);
+        assertThat(new BotidCore2024(IKRAFT, OVERGANG).ikkeBotidskrav(fhd)).isTrue();
+    }
+
+    @Test
+    void skal_returnere_uten_botidskrav_hvis_gjeldende_termin_og_fødsel_før_ikrafttredelsedato() {
+        var bekreftettermindato = IKRAFT.plusWeeks(10);
+        var fødselsdato = IKRAFT.minusWeeks(1);
+        var fhd = FamilieHendelseDato.forFødsel(bekreftettermindato, fødselsdato);
+        assertThat(new BotidCore2024(IKRAFT, OVERGANG).ikkeBotidskrav(fhd)).isTrue();
+    }
+
+    @Test
+    void skal_returnere_uten_botidskrav_hvis_gjeldende_fødsel_før_ikrafttredelsedato_uten_termin() {
+        // Arrange
+        var fødselsdato = IKRAFT.minusWeeks(1);
+        var fhd = FamilieHendelseDato.forFødsel(null, fødselsdato);
+        assertThat(new BotidCore2024(IKRAFT, OVERGANG).ikkeBotidskrav(fhd)).isTrue();
+    }
+
+    @Test
+    void skal_returnere_uten_botidskrav_hvis_gjeldende_adopsjon_før_ikrafttredelsedato() {
+        var omsorgsdato = IKRAFT.minusWeeks(1);
+        var fhd = FamilieHendelseDato.forAdopsjonOmsorg(omsorgsdato);
+        assertThat(new BotidCore2024(IKRAFT, OVERGANG).ikkeBotidskrav(fhd)).isTrue();
+    }
+
+    @Test
+    void skal_returnere_botidskrav_hvis_gjeldende_termin_etter_ikrafttredelsedato() {
+        var bekreftettermindato = IKRAFT.plus(OVERGANG).plusWeeks(1);
+        var fhd = FamilieHendelseDato.forFødsel(bekreftettermindato, null);
+        assertThat(new BotidCore2024(IKRAFT, OVERGANG).ikkeBotidskrav(fhd)).isFalse();
+    }
+
+    @Test
+    void skal_returnere_botidskrav_hvis_gjeldende_termin_og_fødsel_etter_ikrafttredelsedato() {
+        var bekreftettermindato = IKRAFT.plus(OVERGANG).plusWeeks(1);
+        var fødselsdato = IKRAFT.plus(OVERGANG);
+        var fhd = FamilieHendelseDato.forFødsel(bekreftettermindato, fødselsdato);
+        assertThat(new BotidCore2024(IKRAFT, OVERGANG).ikkeBotidskrav(fhd)).isFalse();
+    }
+
+    @Test
+    void skal_returnere_botidskrav_hvis_gjeldende_termin_etter_ikrafttredelsedato_fødsel_før() {
+        var bekreftettermindato = IKRAFT.plus(OVERGANG).plusWeeks(1);
+        var fødselsdato = IKRAFT.minusDays(2);
+        var fhd = FamilieHendelseDato.forFødsel(bekreftettermindato, fødselsdato);
+        assertThat(new BotidCore2024(IKRAFT, OVERGANG).ikkeBotidskrav(fhd)).isFalse();
+    }
+
+    @Test
+    void skal_returnere_botidskrav_hvis_gjeldende_fødsel_etter_ikrafttredelsedato_uten_termin() {
+        var fødselsdato = IKRAFT.plusWeeks(2);
+        var fhd = FamilieHendelseDato.forFødsel(null, fødselsdato);
+        assertThat(new BotidCore2024(IKRAFT, OVERGANG).ikkeBotidskrav(fhd)).isFalse();
+    }
+
+    @Test
+    void skal_returnere_botidskrav_hvis_gjeldende_adopsjon_etter_ikrafttredelsedato() {
+        var omsorgsdato = IKRAFT.plusWeeks(1);
+        var fhd = FamilieHendelseDato.forAdopsjonOmsorg(omsorgsdato);
+        assertThat(new BotidCore2024(IKRAFT, OVERGANG).ikkeBotidskrav(fhd)).isFalse();
+    }
+
+
+}

--- a/domenetjenester/skjaeringstidspunkt/src/test/java/no/nav/foreldrepenger/skjæringstidspunkt/es/BotidCore2024Test.java
+++ b/domenetjenester/skjaeringstidspunkt/src/test/java/no/nav/foreldrepenger/skjæringstidspunkt/es/BotidCore2024Test.java
@@ -350,7 +350,7 @@ class BotidCore2024Test {
     @Test
     void skal_returnere_botidskrav_hvis_gjeldende_adopsjon_etter_ikrafttredelsedato() {
         // Arrange
-        var omsorgsdato = IKRAFT.plus(OVERGANG).plusWeeks(1);
+        var omsorgsdato = IKRAFT.plusWeeks(1);
 
         var førstegangScenario = ScenarioMorSøkerForeldrepenger.forFødsel()
             .medBehandlingType(BehandlingType.FØRSTEGANGSSØKNAD);

--- a/domenetjenester/skjaeringstidspunkt/src/test/java/no/nav/foreldrepenger/skjæringstidspunkt/fp/SkjæringstidspunktTjenesteImplTest.java
+++ b/domenetjenester/skjaeringstidspunkt/src/test/java/no/nav/foreldrepenger/skjæringstidspunkt/fp/SkjæringstidspunktTjenesteImplTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import no.nav.foreldrepenger.behandling.FagsakRelasjonTjeneste;
+import no.nav.foreldrepenger.behandling.FamilieHendelseDato;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingType;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingÅrsakType;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepositoryProvider;
@@ -85,8 +86,7 @@ class SkjæringstidspunktTjenesteImplTest extends EntityManagerAwareTest {
         assertThat(stp.getFørsteUttaksdato()).isEqualTo(skjæringstidspunkt);
         assertThat(stp.getFørsteUttaksdatoGrunnbeløp()).isEqualTo(VirkedagUtil.fomVirkedag(skjæringstidspunkt));
         assertThat(stp.getUtledetSkjæringstidspunkt()).isEqualTo(skjæringstidspunkt);
-        assertThat(stp.getFamiliehendelsedato()).isEqualTo(skjæringstidspunkt.plusWeeks(3));
-        assertThat(stp.getBekreftetFamiliehendelsedato()).hasValueSatisfying(d -> assertThat(d).isEqualTo(skjæringstidspunkt.plusWeeks(3)));
+        assertThat(stp.getFamilieHendelseDato().map(FamilieHendelseDato::familieHendelseDato).orElse(null)).isEqualTo(skjæringstidspunkt.plusWeeks(3));
     }
 
     @Test
@@ -223,7 +223,7 @@ class SkjæringstidspunktTjenesteImplTest extends EntityManagerAwareTest {
         assertThat(stp.getFørsteUttaksdato()).isEqualTo(skjæringstidspunkt.minusWeeks(1));
         assertThat(stp.getFørsteUttaksdatoGrunnbeløp()).isEqualTo(VirkedagUtil.fomVirkedag(skjæringstidspunkt.minusWeeks(1)));
         assertThat(stp.getUtledetSkjæringstidspunkt()).isEqualTo(skjæringstidspunkt.minusWeeks(1));
-        assertThat(stp.getFamiliehendelsedato()).isEqualTo(skjæringstidspunkt);
+        assertThat(stp.getFamilieHendelseDato().map(FamilieHendelseDato::familieHendelseDato).orElse(null)).isEqualTo(skjæringstidspunkt);
         assertThat(stp.uttakSkalJusteresTilFødselsdato()).isFalse();
     }
 
@@ -246,7 +246,7 @@ class SkjæringstidspunktTjenesteImplTest extends EntityManagerAwareTest {
         assertThat(stp.getFørsteUttaksdato()).isEqualTo(forventetStp);
         assertThat(stp.getFørsteUttaksdatoGrunnbeløp()).isEqualTo(forventetStp);
         assertThat(stp.getUtledetSkjæringstidspunkt()).isEqualTo(forventetStp);
-        assertThat(stp.getFamiliehendelsedato()).isEqualTo(termindato.plusDays(1));
+        assertThat(stp.getFamilieHendelseDato().map(FamilieHendelseDato::familieHendelseDato).orElse(null)).isEqualTo(termindato.plusDays(1));
         assertThat(stp.uttakSkalJusteresTilFødselsdato()).isTrue();
     }
 

--- a/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/PersonopplysningerForUttakImpl.java
+++ b/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/PersonopplysningerForUttakImpl.java
@@ -8,6 +8,7 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 
 import no.nav.foreldrepenger.behandling.BehandlingReferanse;
+import no.nav.foreldrepenger.behandling.Skjæringstidspunkt;
 import no.nav.foreldrepenger.behandlingslager.behandling.personopplysning.OppgittAnnenPartEntitet;
 import no.nav.foreldrepenger.behandlingslager.behandling.personopplysning.PersonAdresseEntitet;
 import no.nav.foreldrepenger.behandlingslager.behandling.personopplysning.PersonRelasjonEntitet;
@@ -52,7 +53,8 @@ public class PersonopplysningerForUttakImpl implements PersonopplysningerForUtta
 
     @Override
     public boolean ektefelleHarSammeBosted(BehandlingReferanse ref) {
-        var personopplysningerAggregat = Optional.ofNullable(ref.getSkjæringstidspunkt().getUtledetMedlemsintervall())
+        var personopplysningerAggregat = Optional.ofNullable(ref.getSkjæringstidspunkt())
+            .flatMap(Skjæringstidspunkt::getUttaksintervall)
             .map(intervall -> DatoIntervallEntitet.fraOgMedTilOgMed(intervall.getFomDato(), intervall.getTomDato()))
             .flatMap(intervall -> personopplysningTjeneste.hentGjeldendePersoninformasjonForPeriodeHvisEksisterer(ref, intervall))
             .orElseGet(() -> personopplysningTjeneste.hentPersonopplysninger(ref));
@@ -63,7 +65,8 @@ public class PersonopplysningerForUttakImpl implements PersonopplysningerForUtta
 
     @Override
     public boolean annenpartHarSammeBosted(BehandlingReferanse ref) {
-        var personopplysningerAggregat = Optional.ofNullable(ref.getSkjæringstidspunkt().getUtledetMedlemsintervall())
+        var personopplysningerAggregat = Optional.ofNullable(ref.getSkjæringstidspunkt())
+            .flatMap(Skjæringstidspunkt::getUttaksintervall)
             .map(intervall -> DatoIntervallEntitet.fraOgMedTilOgMed(intervall.getFomDato(), intervall.getTomDato()))
             .flatMap(intervall -> personopplysningTjeneste.hentGjeldendePersoninformasjonForPeriodeHvisEksisterer(ref, intervall))
             .orElseGet(() -> personopplysningTjeneste.hentPersonopplysninger(ref));
@@ -75,7 +78,8 @@ public class PersonopplysningerForUttakImpl implements PersonopplysningerForUtta
 
     @Override
     public boolean barnHarSammeBosted(BehandlingReferanse ref) {
-        var personopplysningerAggregat = Optional.ofNullable(ref.getSkjæringstidspunkt().getUtledetMedlemsintervall())
+        var personopplysningerAggregat = Optional.ofNullable(ref.getSkjæringstidspunkt())
+            .flatMap(Skjæringstidspunkt::getUttaksintervall)
             .map(intervall -> DatoIntervallEntitet.fraOgMedTilOgMed(intervall.getFomDato(), intervall.getTomDato()))
             .flatMap(intervall -> personopplysningTjeneste.hentGjeldendePersoninformasjonForPeriodeHvisEksisterer(ref, intervall))
             .orElseGet(() -> personopplysningTjeneste.hentPersonopplysninger(ref));

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
         <svp-uttak.version>2.4.4</svp-uttak.version>
         <fp-ytelse-beregn.version>1.0.4</fp-ytelse-beregn.version>
 
-        <felles.version>7.2.1</felles.version>
+        <felles.version>7.2.6</felles.version>
         <prosesstask.version>5.0.15</prosesstask.version>
 
         <fp-kontrakter.version>9.1.19</fp-kontrakter.version>


### PR DESCRIPTION
Ny tjeneste MedlemskapVurderingPeriodeTjeneste med test. 
Ryddet noe i Skjæringstidspunkt-klassen.
Forenklet utgave av botid-kjerne.
TODO: Nøye gjennomgang av tabellen for perioder med produktleder/fag.