### PR TITLE
TFP-5606 Foreslå vedtak manuelt for tilfelle aksjonspunkt, avslag, opphør/inngang

### DIFF
--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/søknad/aksjonspunkt/BekreftSøkersOpplysningspliktManuellOppdaterer.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/søknad/aksjonspunkt/BekreftSøkersOpplysningspliktManuellOppdaterer.java
@@ -68,7 +68,6 @@ public class BekreftSøkersOpplysningspliktManuellOppdaterer implements Aksjonsp
                 .medFremoverHopp(FellesTransisjoner.FREMHOPP_VED_AVSLAG_VILKÅR)
                 .leggTilManueltAvslåttVilkår(VilkårType.SØKERSOPPLYSNINGSPLIKT, Avslagsårsak.MANGLENDE_DOKUMENTASJON)
                 .medVilkårResultatType(VilkårResultatType.AVSLÅTT)
-                .medEkstraAksjonspunktResultat(AksjonspunktDefinisjon.VEDTAK_UTEN_TOTRINNSKONTROLL, AksjonspunktStatus.OPPRETTET)
                 .build();
         }
     }

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/vilkår/aksjonspunkt/SøkersOpplysningspliktOverstyringshåndterer.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/vilkår/aksjonspunkt/SøkersOpplysningspliktOverstyringshåndterer.java
@@ -62,7 +62,7 @@ public class SøkersOpplysningspliktOverstyringshåndterer extends AbstractOvers
                 .ifPresent(ap -> builder.medEkstraAksjonspunktResultat(ap.getAksjonspunktDefinisjon(), AksjonspunktStatus.AVBRUTT));
             return builder.build();
         }
-        builder.medFremoverHopp(FellesTransisjoner.FREMHOPP_VED_AVSLAG_VILKÅR).medEkstraAksjonspunktResultat(AksjonspunktDefinisjon.VEDTAK_UTEN_TOTRINNSKONTROLL, AksjonspunktStatus.OPPRETTET);
+        builder.medFremoverHopp(FellesTransisjoner.FREMHOPP_VED_AVSLAG_VILKÅR);
         return builder.build();
     }
 

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/forvaltning/ForvaltningUttrekkRestTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/forvaltning/ForvaltningUttrekkRestTjeneste.java
@@ -174,6 +174,18 @@ public class ForvaltningUttrekkRestTjeneste {
 
     }
 
+    @POST
+    @Path("/samleEntrinnsVedtak")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    @Operation(description = "Starter ny revurdering (berørt)", tags = "FORVALTNING-uttrekk")
+    @BeskyttetRessurs(actionType = ActionType.CREATE, resourceType = ResourceType.DRIFT)
+    public Response samleEntrinnsVedtak() {
+        var oppdatert = entityManager.createNativeQuery(" update aksjonspunkt set aksjonspunkt_def = '5028' where aksjonspunkt_def = '5018'")
+            .executeUpdate();
+        return Response.ok(oppdatert).build();
+    }
+
     @GET
     @Path("/listFagsakUtenBehandling")
     @Produces(MediaType.APPLICATION_JSON)

--- a/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/vilkår/aksjonspunkt/SøkersopplysningspliktOverstyringhåndtererTest.java
+++ b/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/vilkår/aksjonspunkt/SøkersopplysningspliktOverstyringhåndtererTest.java
@@ -64,7 +64,7 @@ class SøkersopplysningspliktOverstyringhåndtererTest {
                 .filter(ap -> ap.getAksjonspunktDefinisjon().equals(AksjonspunktDefinisjon.SØKERS_OPPLYSNINGSPLIKT_OVST)))
                         .anySatisfy(ap -> assertThat(ap.getStatus()).isEqualTo(AksjonspunktStatus.UTFØRT));
 
-        assertThat(aksjonspunktSet).hasSize(3);
+        assertThat(aksjonspunktSet).hasSize(2);
     }
 
 }

--- a/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/vilkår/aksjonspunkt/SøkersopplysningspliktOverstyringhåndtererTest.java
+++ b/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/vilkår/aksjonspunkt/SøkersopplysningspliktOverstyringhåndtererTest.java
@@ -64,10 +64,6 @@ class SøkersopplysningspliktOverstyringhåndtererTest {
                 .filter(ap -> ap.getAksjonspunktDefinisjon().equals(AksjonspunktDefinisjon.SØKERS_OPPLYSNINGSPLIKT_OVST)))
                         .anySatisfy(ap -> assertThat(ap.getStatus()).isEqualTo(AksjonspunktStatus.UTFØRT));
 
-        assertThat(aksjonspunktSet.stream()
-                .filter(ap -> ap.getAksjonspunktDefinisjon().equals(AksjonspunktDefinisjon.VEDTAK_UTEN_TOTRINNSKONTROLL)))
-                        .anySatisfy(ap -> assertThat(ap.getStatus()).isEqualTo(AksjonspunktStatus.OPPRETTET));
-
         assertThat(aksjonspunktSet).hasSize(3);
     }
 


### PR DESCRIPTION
Fjerner arven fra Engangsstønad-tiden: Foreslå vedtak manuelt (1trinn) dersom ikke totrinn og
* Aksjonspunkt er løst av saksbehandler
* Avslag
* Opphør der inngangsvilkår ikke er oppfylt - øvrige opphørstilfelle går automatisk (typisk ny ytelse pga fødsel)
* Diverse - manuell revurdering, dødstilfelle, HR-saken

Samler to aksjonspunkt til ett: 5018 / VEDTAK_UTEN_TOTRINNSKONTROLL konverteres til 5028 / FORESLÅ_VEDTAK_MANUELT
@palfi Dermed blir 5018 ledig til medlemsvilkårsformål 