### PR TITLE
TFP-5185 Endring på uttaksresultatperioder til front end og fpformidling

### DIFF
--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/uttak/dto/UttakResultatPeriodeDto.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/uttak/dto/UttakResultatPeriodeDto.java
@@ -35,6 +35,7 @@ public class UttakResultatPeriodeDto {
     private OppholdÅrsak oppholdÅrsak;
     private LocalDate mottattDato;
     private LocalDate tidligstMottattDato; // brukes bare i formidling, ikke i front end
+    private boolean erUtbetalingRedusertTilMorsStillingsprosent; // brukes bare i formidling, ikke i front end
 
     private UttakResultatPeriodeDto() {
 
@@ -127,6 +128,10 @@ public class UttakResultatPeriodeDto {
         return tidligstMottattDato;
     }
 
+    public boolean erUtbetalingRedusertTilMorsStillingsprosent() {
+        return erUtbetalingRedusertTilMorsStillingsprosent;
+    }
+
     public static class Builder {
 
         private final UttakResultatPeriodeDto kladd = new UttakResultatPeriodeDto();
@@ -201,8 +206,14 @@ public class UttakResultatPeriodeDto {
             kladd.mottattDato = mottattDato;
             return this;
         }
+
         public Builder medTidligstMottattDato(LocalDate tidligstMottattDato) {
             kladd.tidligstMottattDato = tidligstMottattDato;
+            return this;
+        }
+
+        public Builder medErUtbetalingRedusertTilMorsStillingsprosent(boolean erUtbetalingRedusertTilMorsStillingsprosent) {
+            kladd.erUtbetalingRedusertTilMorsStillingsprosent = erUtbetalingRedusertTilMorsStillingsprosent;
             return this;
         }
 

--- a/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/uttak/app/UttakPerioderDtoTjenesteTest.java
+++ b/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/uttak/app/UttakPerioderDtoTjenesteTest.java
@@ -315,6 +315,7 @@ class UttakPerioderDtoTjenesteTest extends EntityManagerAwareTest {
 
         var periodeAktivitet = new UttakResultatPeriodeAktivitetEntitet.Builder(periode, uttakAktivitet)
             .medArbeidsprosent(BigDecimal.ZERO)
+            .medUtbetalingsgrad(new Utbetalingsgrad(BigDecimal.valueOf(100)))
             .build();
 
         periode.leggTilAktivitet(periodeAktivitet);
@@ -485,7 +486,6 @@ class UttakPerioderDtoTjenesteTest extends EntityManagerAwareTest {
     }
     @Test
     void skal_sette_erUtbetalingRedusertTilMorsStillingsprosent_til_false_utbetalingen_ikke_er_redusert_med_mors_stillingsprosent() {
-
         var perioder = new UttakResultatPerioderEntitet();
         var periodeType = UttakPeriodeType.FORELDREPENGER;
         var mottattDato = LocalDate.now();
@@ -498,7 +498,7 @@ class UttakPerioderDtoTjenesteTest extends EntityManagerAwareTest {
         var periodeSøknad = new UttakResultatPeriodeSøknadEntitet.Builder()
             .medUttakPeriodeType(periodeType)
             .medMorsAktivitet(MorsAktivitet.ARBEID)
-            .medDokumentasjonVurdering(new DokumentasjonVurdering(DokumentasjonVurdering.Type.MORS_AKTIVITET_GODKJENT, new MorsStillingsprosent(BigDecimal.valueOf(75))))
+            .medDokumentasjonVurdering(new DokumentasjonVurdering(DokumentasjonVurdering.Type.MORS_AKTIVITET_GODKJENT))
             .medMottattDato(mottattDato)
             .build();
         var periode = periodeBuilder(LocalDate.now(), LocalDate.now().plusWeeks(2))
@@ -511,7 +511,7 @@ class UttakPerioderDtoTjenesteTest extends EntityManagerAwareTest {
             .medTrekkonto(UttakPeriodeType.FORELDREPENGER)
             .medErSøktGradering(false)
             .medArbeidsprosent(BigDecimal.ZERO)
-            .medUtbetalingsgrad(new Utbetalingsgrad(100))
+            .medUtbetalingsgrad(new Utbetalingsgrad(75))
             .build();
         periode.leggTilAktivitet(periodeAktivitet);
         perioder.leggTilPeriode(periode);

--- a/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/uttak/app/UttakPerioderDtoTjenesteTest.java
+++ b/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/uttak/app/UttakPerioderDtoTjenesteTest.java
@@ -485,7 +485,7 @@ class UttakPerioderDtoTjenesteTest extends EntityManagerAwareTest {
         assertThat(result.perioderSøker().stream().anyMatch(UttakResultatPeriodeDto::erUtbetalingRedusertTilMorsStillingsprosent)).isTrue();
     }
     @Test
-    void skal_sette_erUtbetalingRedusertTilMorsStillingsprosent_til_false_utbetalingen_ikke_er_redusert_med_mors_stillingsprosent() {
+    void skal_sette_erUtbetalingRedusertTilMorsStillingsprosent_til_false_når_utbetalingen_erRedusert_men_innvilget_gradering() {
         var perioder = new UttakResultatPerioderEntitet();
         var periodeType = UttakPeriodeType.FORELDREPENGER;
         var mottattDato = LocalDate.now();
@@ -498,11 +498,11 @@ class UttakPerioderDtoTjenesteTest extends EntityManagerAwareTest {
         var periodeSøknad = new UttakResultatPeriodeSøknadEntitet.Builder()
             .medUttakPeriodeType(periodeType)
             .medMorsAktivitet(MorsAktivitet.ARBEID)
-            .medDokumentasjonVurdering(new DokumentasjonVurdering(DokumentasjonVurdering.Type.MORS_AKTIVITET_GODKJENT))
+            .medDokumentasjonVurdering(new DokumentasjonVurdering(DokumentasjonVurdering.Type.MORS_AKTIVITET_GODKJENT, new MorsStillingsprosent(BigDecimal.valueOf(40))))
             .medMottattDato(mottattDato)
             .build();
         var periode = periodeBuilder(LocalDate.now(), LocalDate.now().plusWeeks(2))
-            .medGraderingInnvilget(false)
+            .medGraderingInnvilget(true)
             .medSamtidigUttak(false)
             .medResultatType(PeriodeResultatType.INNVILGET, PeriodeResultatÅrsak.UKJENT)
             .medPeriodeSoknad(periodeSøknad)
@@ -510,12 +510,11 @@ class UttakPerioderDtoTjenesteTest extends EntityManagerAwareTest {
         var periodeAktivitet = new UttakResultatPeriodeAktivitetEntitet.Builder(periode, uttakAktivitet)
             .medTrekkonto(UttakPeriodeType.FORELDREPENGER)
             .medErSøktGradering(false)
-            .medArbeidsprosent(BigDecimal.ZERO)
-            .medUtbetalingsgrad(new Utbetalingsgrad(75))
+            .medArbeidsprosent(BigDecimal.valueOf(60))
+            .medUtbetalingsgrad(new Utbetalingsgrad(40))
             .build();
         periode.leggTilAktivitet(periodeAktivitet);
         perioder.leggTilPeriode(periode);
-
 
         var behandling = morBehandlingMedUttak(perioder);
 


### PR DESCRIPTION
Endringen gjelder kun formidling. Legger ved om uttaksperioden har redusert utbetalingen når det er aktivitetskrav arbeid, og mor jobber under 75%