### PR TITLE
TFP-5822 første steg i rydding av innhentingsperiodelogikk

### DIFF
--- a/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/avklarfakta/es/KontrollerFaktaStegImplTest.java
+++ b/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/avklarfakta/es/KontrollerFaktaStegImplTest.java
@@ -5,7 +5,6 @@ import static org.mockito.Mockito.mock;
 
 import java.time.LocalDate;
 import java.time.Month;
-import java.time.Period;
 
 import jakarta.inject.Inject;
 
@@ -30,7 +29,6 @@ import no.nav.foreldrepenger.behandlingslager.testutilities.behandling.ScenarioF
 import no.nav.foreldrepenger.dbstoette.CdiDbAwareTest;
 import no.nav.foreldrepenger.domene.typer.AktørId;
 import no.nav.foreldrepenger.skjæringstidspunkt.SkjæringstidspunktTjeneste;
-import no.nav.foreldrepenger.skjæringstidspunkt.es.RegisterInnhentingIntervall;
 import no.nav.foreldrepenger.skjæringstidspunkt.es.SkjæringstidspunktTjenesteImpl;
 
 @CdiDbAwareTest
@@ -68,8 +66,7 @@ class KontrollerFaktaStegImplTest {
 
     @BeforeEach
     public void oppsett() {
-        SkjæringstidspunktTjeneste skjæringstidspunktTjeneste = new SkjæringstidspunktTjenesteImpl(repositoryProvider,
-                new RegisterInnhentingIntervall(Period.of(1, 0, 0), Period.of(0, 6, 0)));
+        SkjæringstidspunktTjeneste skjæringstidspunktTjeneste = new SkjæringstidspunktTjenesteImpl(repositoryProvider);
         var scenario = byggBehandlingMedFarSøkerType(FarSøkerType.ADOPTERER_ALENE);
         scenario.medBruker(AktørId.dummy(), NavBrukerKjønn.MANN);
         behandling = scenario.lagre(repositoryProvider);

--- a/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/beregnytelse/es/BeregneYtelseStegImplTest.java
+++ b/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/beregnytelse/es/BeregneYtelseStegImplTest.java
@@ -4,13 +4,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.Period;
 import java.util.stream.IntStream;
 
 import jakarta.inject.Inject;
 import jakarta.persistence.EntityManager;
-
-import no.nav.foreldrepenger.behandlingslager.behandling.beregning.SatsRepository;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -27,6 +24,7 @@ import no.nav.foreldrepenger.behandlingslager.behandling.beregning.Beregningsres
 import no.nav.foreldrepenger.behandlingslager.behandling.beregning.LegacyESBeregning;
 import no.nav.foreldrepenger.behandlingslager.behandling.beregning.LegacyESBeregningRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.beregning.LegacyESBeregningsresultat;
+import no.nav.foreldrepenger.behandlingslager.behandling.beregning.SatsRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepositoryProvider;
 import no.nav.foreldrepenger.behandlingslager.behandling.søknad.SøknadEntitet;
@@ -35,7 +33,6 @@ import no.nav.foreldrepenger.behandlingslager.testutilities.fagsak.FagsakBuilder
 import no.nav.foreldrepenger.dbstoette.CdiDbAwareTest;
 import no.nav.foreldrepenger.konfig.KonfigVerdi;
 import no.nav.foreldrepenger.skjæringstidspunkt.SkjæringstidspunktTjeneste;
-import no.nav.foreldrepenger.skjæringstidspunkt.es.RegisterInnhentingIntervall;
 import no.nav.foreldrepenger.skjæringstidspunkt.es.SkjæringstidspunktTjenesteImpl;
 
 @CdiDbAwareTest
@@ -70,8 +67,7 @@ class BeregneYtelseStegImplTest {
         behandlingRepository = repositoryProvider.getBehandlingRepository();
         behandlingsresultatRepository = repositoryProvider.getBehandlingsresultatRepository();
         beregningsresultatRepository = repositoryProvider.getBeregningsresultatRepository();
-        skjæringstidspunktTjeneste = new SkjæringstidspunktTjenesteImpl(repositoryProvider,
-                new RegisterInnhentingIntervall(Period.of(0, 1, 0), Period.of(0, 6, 0)));
+        skjæringstidspunktTjeneste = new SkjæringstidspunktTjenesteImpl(repositoryProvider);
         entityManager.persist(fagsak.getNavBruker());
         entityManager.persist(fagsak);
         entityManager.flush();

--- a/domenetjenester/behandling/src/main/java/no/nav/foreldrepenger/behandling/FamilieHendelseDato.java
+++ b/domenetjenester/behandling/src/main/java/no/nav/foreldrepenger/behandling/FamilieHendelseDato.java
@@ -20,6 +20,13 @@ public record FamilieHendelseDato(LocalDate termindato, LocalDate fødselsdato, 
             .orElse(null);
     }
 
+    public LocalDate forventetFamilieHendelseDato() {
+        return Optional.ofNullable(omsorgsovertakelse)
+            .or(() -> Optional.ofNullable(termindato))
+            .or(() -> Optional.ofNullable(fødselsdato))
+            .orElse(null);
+    }
+
     public boolean gjelderFødsel() {
         return omsorgsovertakelse == null;
     }

--- a/domenetjenester/datavarehus/src/test/java/no/nav/foreldrepenger/datavarehus/tjeneste/DatavarehusTjenesteImplTest.java
+++ b/domenetjenester/datavarehus/src/test/java/no/nav/foreldrepenger/datavarehus/tjeneste/DatavarehusTjenesteImplTest.java
@@ -21,7 +21,6 @@ import static org.mockito.Mockito.when;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.Period;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -70,7 +69,6 @@ import no.nav.foreldrepenger.datavarehus.xml.DvhVedtakXmlTjeneste;
 import no.nav.foreldrepenger.dbstoette.JpaExtension;
 import no.nav.foreldrepenger.domene.typer.JournalpostId;
 import no.nav.foreldrepenger.skjæringstidspunkt.SkjæringstidspunktTjeneste;
-import no.nav.foreldrepenger.skjæringstidspunkt.es.RegisterInnhentingIntervall;
 import no.nav.foreldrepenger.skjæringstidspunkt.es.SkjæringstidspunktTjenesteImpl;
 
 @ExtendWith(MockitoExtension.class)
@@ -98,8 +96,7 @@ class DatavarehusTjenesteImplTest {
     public void setUp(EntityManager entityManager) {
         repositoryProvider = new BehandlingRepositoryProvider(entityManager);
         behandlingRepository = new BehandlingRepository(entityManager);
-        skjæringstidspunktTjeneste = new SkjæringstidspunktTjenesteImpl(repositoryProvider,
-            new RegisterInnhentingIntervall(Period.of(1, 0, 0), Period.of(0, 6, 0)));
+        skjæringstidspunktTjeneste = new SkjæringstidspunktTjenesteImpl(repositoryProvider);
     }
 
     private DatavarehusTjenesteImpl nyDatavarehusTjeneste(BehandlingRepositoryProvider repositoryProvider) {

--- a/domenetjenester/familie-hendelse/src/test/java/no/nav/foreldrepenger/familiehendelse/aksjonspunkt/BekreftDokumentasjonOppdatererTest.java
+++ b/domenetjenester/familie-hendelse/src/test/java/no/nav/foreldrepenger/familiehendelse/aksjonspunkt/BekreftDokumentasjonOppdatererTest.java
@@ -5,7 +5,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.time.LocalDate;
-import java.time.Period;
 import java.time.format.DateTimeFormatter;
 import java.util.HashMap;
 import java.util.Map;
@@ -31,7 +30,6 @@ import no.nav.foreldrepenger.familiehendelse.aksjonspunkt.dto.BekreftDokumentert
 import no.nav.foreldrepenger.historikk.HistorikkInnslagTekstBuilder;
 import no.nav.foreldrepenger.historikk.HistorikkTjenesteAdapter;
 import no.nav.foreldrepenger.skjæringstidspunkt.SkjæringstidspunktRegisterinnhentingTjeneste;
-import no.nav.foreldrepenger.skjæringstidspunkt.es.RegisterInnhentingIntervall;
 import no.nav.foreldrepenger.skjæringstidspunkt.es.SkjæringstidspunktTjenesteImpl;
 
 class BekreftDokumentasjonOppdatererTest extends EntityManagerAwareTest {
@@ -47,8 +45,8 @@ class BekreftDokumentasjonOppdatererTest extends EntityManagerAwareTest {
         repositoryProvider = new BehandlingRepositoryProvider(getEntityManager());
         familieHendelseTjeneste = new FamilieHendelseTjeneste(null,
             repositoryProvider.getFamilieHendelseRepository());
-        skjæringstidspunktTjeneste = new SkjæringstidspunktTjenesteImpl(repositoryProvider,
-            new RegisterInnhentingIntervall(Period.of(1, 0, 0), Period.of(0, 6, 0)));
+        skjæringstidspunktTjeneste = new SkjæringstidspunktTjenesteImpl(repositoryProvider
+        );
     }
 
     @Test

--- a/domenetjenester/familie-hendelse/src/test/java/no/nav/foreldrepenger/familiehendelse/aksjonspunkt/BekreftTerminbekreftelseOppdatererTest.java
+++ b/domenetjenester/familie-hendelse/src/test/java/no/nav/foreldrepenger/familiehendelse/aksjonspunkt/BekreftTerminbekreftelseOppdatererTest.java
@@ -28,7 +28,6 @@ import no.nav.foreldrepenger.familiehendelse.aksjonspunkt.dto.BekreftTerminbekre
 import no.nav.foreldrepenger.historikk.HistorikkInnslagTekstBuilder;
 import no.nav.foreldrepenger.historikk.HistorikkTjenesteAdapter;
 import no.nav.foreldrepenger.skjæringstidspunkt.SkjæringstidspunktRegisterinnhentingTjeneste;
-import no.nav.foreldrepenger.skjæringstidspunkt.es.RegisterInnhentingIntervall;
 import no.nav.foreldrepenger.skjæringstidspunkt.es.SkjæringstidspunktTjenesteImpl;
 
 class BekreftTerminbekreftelseOppdatererTest extends EntityManagerAwareTest {
@@ -46,8 +45,8 @@ class BekreftTerminbekreftelseOppdatererTest extends EntityManagerAwareTest {
     @BeforeEach
     void setUp() {
         repositoryProvider = new BehandlingRepositoryProvider(getEntityManager());
-        skjæringstidspunktTjeneste = new SkjæringstidspunktTjenesteImpl(repositoryProvider,
-            new RegisterInnhentingIntervall(Period.of(1, 0, 0), Period.of(0, 6, 0)));
+        skjæringstidspunktTjeneste = new SkjæringstidspunktTjenesteImpl(repositoryProvider
+        );
         familieHendelseTjeneste = new FamilieHendelseTjeneste(null,
             repositoryProvider.getFamilieHendelseRepository());
     }

--- a/domenetjenester/familie-hendelse/src/test/java/no/nav/foreldrepenger/familiehendelse/aksjonspunkt/SjekkManglendeFødselOppdatererTest.java
+++ b/domenetjenester/familie-hendelse/src/test/java/no/nav/foreldrepenger/familiehendelse/aksjonspunkt/SjekkManglendeFødselOppdatererTest.java
@@ -5,7 +5,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.lenient;
 
 import java.time.LocalDate;
-import java.time.Period;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
@@ -43,7 +42,6 @@ import no.nav.foreldrepenger.familiehendelse.event.FamiliehendelseEventPublisere
 import no.nav.foreldrepenger.historikk.HistorikkInnslagTekstBuilder;
 import no.nav.foreldrepenger.historikk.HistorikkTjenesteAdapter;
 import no.nav.foreldrepenger.skjæringstidspunkt.SkjæringstidspunktRegisterinnhentingTjeneste;
-import no.nav.foreldrepenger.skjæringstidspunkt.es.RegisterInnhentingIntervall;
 import no.nav.foreldrepenger.skjæringstidspunkt.es.SkjæringstidspunktTjenesteImpl;
 import no.nav.vedtak.exception.FunksjonellException;
 
@@ -66,8 +64,7 @@ class SjekkManglendeFødselOppdatererTest extends EntityManagerAwareTest {
     @BeforeEach
     public void setUp() {
         repositoryProvider = new BehandlingRepositoryProvider(getEntityManager());
-        skjæringstidspunktTjeneste = new SkjæringstidspunktTjenesteImpl(repositoryProvider,
-            new RegisterInnhentingIntervall(Period.of(1, 0, 0), Period.of(0, 6, 0)));
+        skjæringstidspunktTjeneste = new SkjæringstidspunktTjenesteImpl(repositoryProvider);
         tekstBuilder =  new HistorikkInnslagTekstBuilder();
         familieHendelseTjeneste = new FamilieHendelseTjeneste(familiehendelseEventPubliserer, repositoryProvider.getFamilieHendelseRepository());
 

--- a/domenetjenester/familie-hendelse/src/test/java/no/nav/foreldrepenger/familiehendelse/omsorg/AvklarOmsorgOgForeldreansvarOppdatererTest.java
+++ b/domenetjenester/familie-hendelse/src/test/java/no/nav/foreldrepenger/familiehendelse/omsorg/AvklarOmsorgOgForeldreansvarOppdatererTest.java
@@ -4,7 +4,6 @@ import static no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.Aks
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.LocalDate;
-import java.time.Period;
 import java.util.Objects;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -36,7 +35,6 @@ import no.nav.foreldrepenger.familiehendelse.aksjonspunkt.dto.AvklarFaktaForOmso
 import no.nav.foreldrepenger.historikk.HistorikkInnslagTekstBuilder;
 import no.nav.foreldrepenger.historikk.HistorikkTjenesteAdapter;
 import no.nav.foreldrepenger.skjæringstidspunkt.SkjæringstidspunktRegisterinnhentingTjeneste;
-import no.nav.foreldrepenger.skjæringstidspunkt.es.RegisterInnhentingIntervall;
 import no.nav.foreldrepenger.skjæringstidspunkt.es.SkjæringstidspunktTjenesteImpl;
 
 class AvklarOmsorgOgForeldreansvarOppdatererTest extends EntityManagerAwareTest {
@@ -52,8 +50,7 @@ class AvklarOmsorgOgForeldreansvarOppdatererTest extends EntityManagerAwareTest 
     @BeforeEach
     void setUp() {
         repositoryProvider = new BehandlingRepositoryProvider(getEntityManager());
-        skjæringstidspunktTjeneste = new SkjæringstidspunktTjenesteImpl(repositoryProvider,
-            new RegisterInnhentingIntervall(Period.of(1, 0, 0), Period.of(0, 6, 0)));
+        skjæringstidspunktTjeneste = new SkjæringstidspunktTjenesteImpl(repositoryProvider);
         familieHendelseTjeneste = new FamilieHendelseTjeneste(null, repositoryProvider.getFamilieHendelseRepository());
     }
 

--- a/domenetjenester/inngangsvilkar/src/test/java/no/nav/foreldrepenger/inngangsvilkaar/adopsjon/AdopsjonsvilkårEngangsstønadTest.java
+++ b/domenetjenester/inngangsvilkar/src/test/java/no/nav/foreldrepenger/inngangsvilkaar/adopsjon/AdopsjonsvilkårEngangsstønadTest.java
@@ -3,7 +3,6 @@ package no.nav.foreldrepenger.inngangsvilkaar.adopsjon;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.LocalDate;
-import java.time.Period;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -23,7 +22,6 @@ import no.nav.foreldrepenger.dbstoette.EntityManagerAwareTest;
 import no.nav.foreldrepenger.domene.json.StandardJsonConfig;
 import no.nav.foreldrepenger.domene.personopplysning.PersonopplysningTjeneste;
 import no.nav.foreldrepenger.skjæringstidspunkt.SkjæringstidspunktTjeneste;
-import no.nav.foreldrepenger.skjæringstidspunkt.es.RegisterInnhentingIntervall;
 import no.nav.foreldrepenger.skjæringstidspunkt.es.SkjæringstidspunktTjenesteImpl;
 
 class AdopsjonsvilkårEngangsstønadTest extends EntityManagerAwareTest {
@@ -36,8 +34,8 @@ class AdopsjonsvilkårEngangsstønadTest extends EntityManagerAwareTest {
     @BeforeEach
     void setUp() {
         repositoryProvider = new BehandlingRepositoryProvider(getEntityManager());
-        skjæringstidspunktTjeneste = new SkjæringstidspunktTjenesteImpl(repositoryProvider,
-            new RegisterInnhentingIntervall(Period.of(1, 0, 0), Period.of(0, 6, 0)));
+        skjæringstidspunktTjeneste = new SkjæringstidspunktTjenesteImpl(repositoryProvider
+        );
         var personopplysningTjeneste = new PersonopplysningTjeneste(repositoryProvider.getPersonopplysningRepository());
         oversetter = new AdopsjonsvilkårOversetter(repositoryProvider, personopplysningTjeneste);
     }

--- a/domenetjenester/inngangsvilkar/src/test/java/no/nav/foreldrepenger/inngangsvilkaar/adopsjon/AdopsjonsvilkårForeldrepengerTest.java
+++ b/domenetjenester/inngangsvilkar/src/test/java/no/nav/foreldrepenger/inngangsvilkaar/adopsjon/AdopsjonsvilkårForeldrepengerTest.java
@@ -3,7 +3,6 @@ package no.nav.foreldrepenger.inngangsvilkaar.adopsjon;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.LocalDate;
-import java.time.Period;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -23,7 +22,6 @@ import no.nav.foreldrepenger.dbstoette.EntityManagerAwareTest;
 import no.nav.foreldrepenger.domene.json.StandardJsonConfig;
 import no.nav.foreldrepenger.domene.personopplysning.PersonopplysningTjeneste;
 import no.nav.foreldrepenger.skjæringstidspunkt.SkjæringstidspunktTjeneste;
-import no.nav.foreldrepenger.skjæringstidspunkt.es.RegisterInnhentingIntervall;
 import no.nav.foreldrepenger.skjæringstidspunkt.es.SkjæringstidspunktTjenesteImpl;
 
 class AdopsjonsvilkårForeldrepengerTest extends EntityManagerAwareTest {
@@ -37,8 +35,8 @@ class AdopsjonsvilkårForeldrepengerTest extends EntityManagerAwareTest {
     @BeforeEach
     void setUp() {
         repositoryProvider = new BehandlingRepositoryProvider(getEntityManager());
-        skjæringstidspunktTjeneste = new SkjæringstidspunktTjenesteImpl(repositoryProvider,
-            new RegisterInnhentingIntervall(Period.of(1, 0, 0), Period.of(0, 6, 0)));
+        skjæringstidspunktTjeneste = new SkjæringstidspunktTjenesteImpl(repositoryProvider
+        );
         personopplysningTjeneste = new PersonopplysningTjeneste(repositoryProvider.getPersonopplysningRepository());
         oversetter = new AdopsjonsvilkårOversetter(repositoryProvider, personopplysningTjeneste);
     }

--- a/domenetjenester/inngangsvilkar/src/test/java/no/nav/foreldrepenger/inngangsvilkaar/adopsjon/AdopsjonsvilkårOversetterTest.java
+++ b/domenetjenester/inngangsvilkar/src/test/java/no/nav/foreldrepenger/inngangsvilkaar/adopsjon/AdopsjonsvilkårOversetterTest.java
@@ -3,7 +3,6 @@ package no.nav.foreldrepenger.inngangsvilkaar.adopsjon;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.LocalDate;
-import java.time.Period;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -23,7 +22,6 @@ import no.nav.foreldrepenger.dbstoette.CdiDbAwareTest;
 import no.nav.foreldrepenger.domene.personopplysning.PersonopplysningTjeneste;
 import no.nav.foreldrepenger.inngangsvilkaar.regelmodell.RegelKjønn;
 import no.nav.foreldrepenger.skjæringstidspunkt.SkjæringstidspunktTjeneste;
-import no.nav.foreldrepenger.skjæringstidspunkt.es.RegisterInnhentingIntervall;
 import no.nav.foreldrepenger.skjæringstidspunkt.es.SkjæringstidspunktTjenesteImpl;
 
 @CdiDbAwareTest
@@ -41,8 +39,8 @@ class AdopsjonsvilkårOversetterTest {
 
     @BeforeEach
     public void oppsett() {
-        skjæringstidspunktTjeneste = new SkjæringstidspunktTjenesteImpl(repositoryProvider,
-                new RegisterInnhentingIntervall(Period.of(1, 0, 0), Period.of(0, 6, 0)));
+        skjæringstidspunktTjeneste = new SkjæringstidspunktTjenesteImpl(repositoryProvider
+        );
         adopsjonsoversetter = new AdopsjonsvilkårOversetter(repositoryProvider, personopplysningTjeneste);
     }
 

--- a/domenetjenester/inngangsvilkar/src/test/java/no/nav/foreldrepenger/inngangsvilkaar/fødsel/FødselsvilkårFarTest.java
+++ b/domenetjenester/inngangsvilkar/src/test/java/no/nav/foreldrepenger/inngangsvilkaar/fødsel/FødselsvilkårFarTest.java
@@ -32,15 +32,12 @@ import no.nav.foreldrepenger.domene.personopplysning.PersonopplysningTjeneste;
 import no.nav.foreldrepenger.domene.typer.AktørId;
 import no.nav.foreldrepenger.skjæringstidspunkt.SkjæringstidspunktTjeneste;
 import no.nav.foreldrepenger.skjæringstidspunkt.fp.SkjæringstidspunktTjenesteImpl;
-import no.nav.foreldrepenger.skjæringstidspunkt.fp.SkjæringstidspunktUtils;
 import no.nav.foreldrepenger.skjæringstidspunkt.overganger.MinsterettBehandling2022;
 import no.nav.foreldrepenger.skjæringstidspunkt.overganger.UtsettelseBehandling2021;
 
 class FødselsvilkårFarTest extends EntityManagerAwareTest {
 
     private BehandlingRepositoryProvider repositoryProvider;
-    private final SkjæringstidspunktUtils stputil = new SkjæringstidspunktUtils(
-        Period.parse("P1Y"), Period.parse("P6M"));
     private SkjæringstidspunktTjeneste skjæringstidspunktTjeneste;
     private MinsterettBehandling2022 mockMinsterett;
 
@@ -56,8 +53,7 @@ class FødselsvilkårFarTest extends EntityManagerAwareTest {
             fagsakRelasjonTjeneste);
         mockMinsterett = mock(MinsterettBehandling2022.class);
         when(mockMinsterett.utenMinsterett(any())).thenReturn(false);
-        skjæringstidspunktTjeneste = new SkjæringstidspunktTjenesteImpl(repositoryProvider, ytelseMaksdatoTjeneste, stputil,
-            mock(UtsettelseBehandling2021.class), mockMinsterett);
+        skjæringstidspunktTjeneste = new SkjæringstidspunktTjenesteImpl(repositoryProvider, ytelseMaksdatoTjeneste, mock(UtsettelseBehandling2021.class), mockMinsterett);
     }
 
     @Test // FP_VK 11.2 Vilkårsutfall oppfylt

--- a/domenetjenester/inngangsvilkar/src/test/java/no/nav/foreldrepenger/inngangsvilkaar/fødsel/FødselsvilkårMorTest.java
+++ b/domenetjenester/inngangsvilkar/src/test/java/no/nav/foreldrepenger/inngangsvilkaar/fødsel/FødselsvilkårMorTest.java
@@ -28,7 +28,6 @@ import no.nav.foreldrepenger.domene.json.StandardJsonConfig;
 import no.nav.foreldrepenger.domene.personopplysning.PersonopplysningTjeneste;
 import no.nav.foreldrepenger.domene.typer.AktørId;
 import no.nav.foreldrepenger.skjæringstidspunkt.SkjæringstidspunktTjeneste;
-import no.nav.foreldrepenger.skjæringstidspunkt.es.RegisterInnhentingIntervall;
 import no.nav.foreldrepenger.skjæringstidspunkt.es.SkjæringstidspunktTjenesteImpl;
 
 class FødselsvilkårMorTest extends EntityManagerAwareTest {
@@ -42,8 +41,7 @@ class FødselsvilkårMorTest extends EntityManagerAwareTest {
     void setUp() {
         repositoryProvider = new BehandlingRepositoryProvider(getEntityManager());
         InntektArbeidYtelseTjeneste iayTjeneste = new AbakusInMemoryInntektArbeidYtelseTjeneste();
-        skjæringstidspunktTjeneste = new SkjæringstidspunktTjenesteImpl(repositoryProvider,
-            new RegisterInnhentingIntervall(Period.of(1, 0, 0), Period.of(0, 6, 0)));
+        skjæringstidspunktTjeneste = new SkjæringstidspunktTjenesteImpl(repositoryProvider);
         var personopplysningTjeneste = new PersonopplysningTjeneste(
             repositoryProvider.getPersonopplysningRepository());
         oversetter = new FødselsvilkårOversetter(repositoryProvider, personopplysningTjeneste, Period.parse("P18W3D"));

--- a/domenetjenester/inngangsvilkar/src/test/java/no/nav/foreldrepenger/inngangsvilkaar/fødsel/FødselsvilkårOversetterTest.java
+++ b/domenetjenester/inngangsvilkar/src/test/java/no/nav/foreldrepenger/inngangsvilkaar/fødsel/FødselsvilkårOversetterTest.java
@@ -3,7 +3,6 @@ package no.nav.foreldrepenger.inngangsvilkaar.fødsel;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.LocalDate;
-import java.time.Period;
 
 import jakarta.inject.Inject;
 
@@ -24,7 +23,6 @@ import no.nav.foreldrepenger.domene.typer.AktørId;
 import no.nav.foreldrepenger.inngangsvilkaar.regelmodell.RegelKjønn;
 import no.nav.foreldrepenger.inngangsvilkaar.regelmodell.RegelSøkerRolle;
 import no.nav.foreldrepenger.skjæringstidspunkt.SkjæringstidspunktTjeneste;
-import no.nav.foreldrepenger.skjæringstidspunkt.es.RegisterInnhentingIntervall;
 import no.nav.foreldrepenger.skjæringstidspunkt.es.SkjæringstidspunktTjenesteImpl;
 
 @CdiDbAwareTest
@@ -42,8 +40,7 @@ class FødselsvilkårOversetterTest {
 
     @BeforeEach
     public void oppsett() {
-        skjæringstidspunktTjeneste = new SkjæringstidspunktTjenesteImpl(repositoryProvider,
-                new RegisterInnhentingIntervall(Period.of(1, 0, 0), Period.of(0, 6, 0)));
+        skjæringstidspunktTjeneste = new SkjæringstidspunktTjenesteImpl(repositoryProvider);
         fødselsoversetter = new FødselsvilkårOversetter(repositoryProvider, personopplysningTjeneste, null);
     }
 

--- a/domenetjenester/inngangsvilkar/src/test/java/no/nav/foreldrepenger/inngangsvilkaar/medlemskap/MedlemskapsvilkårTest.java
+++ b/domenetjenester/inngangsvilkar/src/test/java/no/nav/foreldrepenger/inngangsvilkaar/medlemskap/MedlemskapsvilkårTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
-import java.time.Period;
 import java.util.Optional;
 import java.util.stream.Stream;
 
@@ -50,7 +49,6 @@ import no.nav.foreldrepenger.domene.typer.AktørId;
 import no.nav.foreldrepenger.domene.typer.InternArbeidsforholdRef;
 import no.nav.foreldrepenger.inngangsvilkaar.medlemskap.v2.AvklarMedlemskapUtleder;
 import no.nav.foreldrepenger.skjæringstidspunkt.SkjæringstidspunktTjeneste;
-import no.nav.foreldrepenger.skjæringstidspunkt.es.RegisterInnhentingIntervall;
 import no.nav.foreldrepenger.skjæringstidspunkt.es.SkjæringstidspunktTjenesteImpl;
 
 @CdiDbAwareTest
@@ -81,8 +79,7 @@ class MedlemskapsvilkårTest {
 
     @BeforeEach
     public void before() {
-        skjæringstidspunktTjeneste = new SkjæringstidspunktTjenesteImpl(repositoryProvider,
-                new RegisterInnhentingIntervall(Period.of(1, 0, 0), Period.of(0, 6, 0)));
+        skjæringstidspunktTjeneste = new SkjæringstidspunktTjenesteImpl(repositoryProvider);
         this.oversetter = new MedlemsvilkårOversetter(repositoryProvider, personopplysningTjeneste, iayTjeneste);
         this.vurderMedlemskapsvilkarEngangsstonad = new InngangsvilkårMedlemskap(oversetter, repositoryProvider.getBehandlingRepository(),
             avklarMedlemskapUtleder);

--- a/domenetjenester/inngangsvilkar/src/test/java/no/nav/foreldrepenger/inngangsvilkaar/medlemskap/MedlemsvilkårOversetterTest.java
+++ b/domenetjenester/inngangsvilkar/src/test/java/no/nav/foreldrepenger/inngangsvilkaar/medlemskap/MedlemsvilkårOversetterTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
-import java.time.Period;
 import java.util.Optional;
 import java.util.stream.Stream;
 
@@ -41,7 +40,6 @@ import no.nav.foreldrepenger.domene.tid.DatoIntervallEntitet;
 import no.nav.foreldrepenger.domene.typer.AktørId;
 import no.nav.foreldrepenger.domene.typer.InternArbeidsforholdRef;
 import no.nav.foreldrepenger.skjæringstidspunkt.SkjæringstidspunktTjeneste;
-import no.nav.foreldrepenger.skjæringstidspunkt.es.RegisterInnhentingIntervall;
 import no.nav.foreldrepenger.skjæringstidspunkt.es.SkjæringstidspunktTjenesteImpl;
 
 @CdiDbAwareTest
@@ -62,8 +60,7 @@ class MedlemsvilkårOversetterTest {
 
     @BeforeEach
     public void oppsett() {
-        skjæringstidspunktTjeneste = new SkjæringstidspunktTjenesteImpl(repositoryProvider,
-                new RegisterInnhentingIntervall(Period.of(1, 0, 0), Period.of(0, 6, 0)));
+        skjæringstidspunktTjeneste = new SkjæringstidspunktTjenesteImpl(repositoryProvider);
         medlemsoversetter = new MedlemsvilkårOversetter(repositoryProvider, personopplysningTjeneste, iayTjeneste);
     }
 

--- a/domenetjenester/inngangsvilkar/src/test/java/no/nav/foreldrepenger/inngangsvilkaar/opptjening/OpptjeningsperiodeVilkårTest.java
+++ b/domenetjenester/inngangsvilkar/src/test/java/no/nav/foreldrepenger/inngangsvilkaar/opptjening/OpptjeningsperiodeVilkårTest.java
@@ -3,7 +3,6 @@ package no.nav.foreldrepenger.inngangsvilkaar.opptjening;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.LocalDate;
-import java.time.Period;
 import java.util.List;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -31,7 +30,6 @@ import no.nav.foreldrepenger.inngangsvilkaar.opptjening.fp.OpptjeningsperiodeVil
 import no.nav.foreldrepenger.inngangsvilkaar.regelmodell.opptjeningsperiode.OpptjeningsPeriode;
 import no.nav.foreldrepenger.skjæringstidspunkt.SkjæringstidspunktTjeneste;
 import no.nav.foreldrepenger.skjæringstidspunkt.fp.SkjæringstidspunktTjenesteImpl;
-import no.nav.foreldrepenger.skjæringstidspunkt.fp.SkjæringstidspunktUtils;
 import no.nav.foreldrepenger.skjæringstidspunkt.overganger.MinsterettBehandling2022;
 import no.nav.foreldrepenger.skjæringstidspunkt.overganger.UtsettelseBehandling2021;
 
@@ -44,15 +42,12 @@ class OpptjeningsperiodeVilkårTest extends EntityManagerAwareTest {
     @BeforeEach
     void setUp() {
         repositoryProvider = new BehandlingRepositoryProvider(getEntityManager());
-        var stputil = new SkjæringstidspunktUtils(
-            Period.parse("P1Y"), Period.parse("P6M"));
         var fagsakRelasjonTjeneste = new FagsakRelasjonTjeneste(repositoryProvider);
         var ytelseMaksdatoTjeneste = new YtelseMaksdatoTjeneste(new RelatertBehandlingTjeneste(repositoryProvider, fagsakRelasjonTjeneste), repositoryProvider.getFpUttakRepository(),
             fagsakRelasjonTjeneste);
         var utsettelse2021 = new UtsettelseBehandling2021(repositoryProvider, fagsakRelasjonTjeneste);
         var minsterett2022 = new MinsterettBehandling2022(repositoryProvider, fagsakRelasjonTjeneste);
-        skjæringstidspunktTjeneste = new SkjæringstidspunktTjenesteImpl(repositoryProvider, ytelseMaksdatoTjeneste,
-            stputil, utsettelse2021, minsterett2022);
+        skjæringstidspunktTjeneste = new SkjæringstidspunktTjenesteImpl(repositoryProvider, ytelseMaksdatoTjeneste, utsettelse2021, minsterett2022);
         opptjeningsperiodeVilkårTjeneste = new OpptjeningsperiodeVilkårTjenesteImpl(
             repositoryProvider.getFamilieHendelseRepository(), ytelseMaksdatoTjeneste);
     }

--- a/domenetjenester/inngangsvilkar/src/test/java/no/nav/foreldrepenger/inngangsvilkaar/opptjening/fp/OpptjeningsperiodeVilkårUttakVarianterTest.java
+++ b/domenetjenester/inngangsvilkar/src/test/java/no/nav/foreldrepenger/inngangsvilkaar/opptjening/fp/OpptjeningsperiodeVilkårUttakVarianterTest.java
@@ -7,7 +7,6 @@ import static org.mockito.Mockito.when;
 
 import java.time.LocalDate;
 import java.time.Month;
-import java.time.Period;
 import java.util.List;
 import java.util.Optional;
 
@@ -35,7 +34,6 @@ import no.nav.foreldrepenger.inngangsvilkaar.opptjening.OpptjeningsperiodeVilkå
 import no.nav.foreldrepenger.inngangsvilkaar.regelmodell.opptjeningsperiode.OpptjeningsPeriode;
 import no.nav.foreldrepenger.skjæringstidspunkt.SkjæringstidspunktTjeneste;
 import no.nav.foreldrepenger.skjæringstidspunkt.fp.SkjæringstidspunktTjenesteImpl;
-import no.nav.foreldrepenger.skjæringstidspunkt.fp.SkjæringstidspunktUtils;
 import no.nav.foreldrepenger.skjæringstidspunkt.overganger.MinsterettBehandling2022;
 import no.nav.foreldrepenger.skjæringstidspunkt.overganger.UtsettelseBehandling2021;
 import no.nav.foreldrepenger.skjæringstidspunkt.overganger.UtsettelseCore2021;
@@ -51,8 +49,6 @@ class OpptjeningsperiodeVilkårUttakVarianterTest extends EntityManagerAwareTest
     private MinsterettBehandling2022 minsterett2022;
     @Mock
     private YtelseMaksdatoTjeneste ytelseMaksdatoTjeneste;
-    private SkjæringstidspunktUtils stputil = new SkjæringstidspunktUtils(
-        Period.parse("P1Y"), Period.parse("P6M"));
 
     @BeforeEach
     void setUp() {
@@ -67,8 +63,7 @@ class OpptjeningsperiodeVilkårUttakVarianterTest extends EntityManagerAwareTest
         var førsteUttaksdato = morsmaksdato.plusWeeks(4);
         utsettelse2021 = new UtsettelseBehandling2021(repositoryProvider, fagsakRelasjonTjeneste);
         minsterett2022 = new MinsterettBehandling2022(repositoryProvider, fagsakRelasjonTjeneste);
-        skjæringstidspunktTjeneste = new SkjæringstidspunktTjenesteImpl(repositoryProvider, ytelseMaksdatoTjeneste,
-            stputil, utsettelse2021, minsterett2022);
+        skjæringstidspunktTjeneste = new SkjæringstidspunktTjenesteImpl(repositoryProvider, ytelseMaksdatoTjeneste, utsettelse2021, minsterett2022);
         opptjeningsperiodeVilkårTjeneste = new OpptjeningsperiodeVilkårTjenesteImpl(
             repositoryProvider.getFamilieHendelseRepository(), ytelseMaksdatoTjeneste);
 
@@ -114,8 +109,7 @@ class OpptjeningsperiodeVilkårUttakVarianterTest extends EntityManagerAwareTest
         var førsteUttaksdato = morsmaksdato.minusWeeks(4);
         utsettelse2021 = new UtsettelseBehandling2021(repositoryProvider, fagsakRelasjonTjeneste);
         minsterett2022 = new MinsterettBehandling2022(repositoryProvider, fagsakRelasjonTjeneste);
-        skjæringstidspunktTjeneste = new SkjæringstidspunktTjenesteImpl(repositoryProvider, ytelseMaksdatoTjeneste,
-            stputil, utsettelse2021, minsterett2022);
+        skjæringstidspunktTjeneste = new SkjæringstidspunktTjenesteImpl(repositoryProvider, ytelseMaksdatoTjeneste, utsettelse2021, minsterett2022);
         opptjeningsperiodeVilkårTjeneste = new OpptjeningsperiodeVilkårTjenesteImpl(
             repositoryProvider.getFamilieHendelseRepository(), ytelseMaksdatoTjeneste);
 
@@ -161,8 +155,7 @@ class OpptjeningsperiodeVilkårUttakVarianterTest extends EntityManagerAwareTest
         var førsteUttaksdato = morsmaksdato.plusWeeks(4);
         utsettelse2021 = new UtsettelseBehandling2021(repositoryProvider, fagsakRelasjonTjeneste);
         minsterett2022 = new MinsterettBehandling2022(repositoryProvider, fagsakRelasjonTjeneste);
-        skjæringstidspunktTjeneste = new SkjæringstidspunktTjenesteImpl(repositoryProvider, ytelseMaksdatoTjeneste,
-            stputil, utsettelse2021, minsterett2022);
+        skjæringstidspunktTjeneste = new SkjæringstidspunktTjenesteImpl(repositoryProvider, ytelseMaksdatoTjeneste, utsettelse2021, minsterett2022);
         opptjeningsperiodeVilkårTjeneste = new OpptjeningsperiodeVilkårTjenesteImpl(
             repositoryProvider.getFamilieHendelseRepository(), ytelseMaksdatoTjeneste);
 
@@ -208,8 +201,7 @@ class OpptjeningsperiodeVilkårUttakVarianterTest extends EntityManagerAwareTest
         var førsteUttaksdato = termindato.minusDays(3);
         utsettelse2021 = new UtsettelseBehandling2021(repositoryProvider, fagsakRelasjonTjeneste);
         minsterett2022 = new MinsterettBehandling2022(repositoryProvider, fagsakRelasjonTjeneste);
-        skjæringstidspunktTjeneste = new SkjæringstidspunktTjenesteImpl(repositoryProvider, ytelseMaksdatoTjeneste,
-            stputil, utsettelse2021, minsterett2022);
+        skjæringstidspunktTjeneste = new SkjæringstidspunktTjenesteImpl(repositoryProvider, ytelseMaksdatoTjeneste, utsettelse2021, minsterett2022);
         opptjeningsperiodeVilkårTjeneste = new OpptjeningsperiodeVilkårTjenesteImpl(
             repositoryProvider.getFamilieHendelseRepository(), ytelseMaksdatoTjeneste);
 

--- a/domenetjenester/inngangsvilkar/src/test/java/no/nav/foreldrepenger/inngangsvilkaar/søknad/SøknadsfristvilkårTest.java
+++ b/domenetjenester/inngangsvilkar/src/test/java/no/nav/foreldrepenger/inngangsvilkaar/søknad/SøknadsfristvilkårTest.java
@@ -3,7 +3,6 @@ package no.nav.foreldrepenger.inngangsvilkaar.søknad;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.LocalDate;
-import java.time.Period;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -17,7 +16,6 @@ import no.nav.foreldrepenger.behandlingslager.behandling.vilkår.VilkårUtfallTy
 import no.nav.foreldrepenger.behandlingslager.testutilities.behandling.ScenarioMorSøkerEngangsstønad;
 import no.nav.foreldrepenger.dbstoette.EntityManagerAwareTest;
 import no.nav.foreldrepenger.skjæringstidspunkt.SkjæringstidspunktTjeneste;
-import no.nav.foreldrepenger.skjæringstidspunkt.es.RegisterInnhentingIntervall;
 import no.nav.foreldrepenger.skjæringstidspunkt.es.SkjæringstidspunktTjenesteImpl;
 import no.nav.foreldrepenger.skjæringstidspunkt.es.SøknadsperiodeFristTjenesteImpl;
 
@@ -29,7 +27,7 @@ class SøknadsfristvilkårTest extends EntityManagerAwareTest {
     @BeforeEach
     void setUp() {
         repositoryProvider = new BehandlingRepositoryProvider(getEntityManager());
-        skjæringstidspunktTjeneste = new SkjæringstidspunktTjenesteImpl(repositoryProvider, new RegisterInnhentingIntervall(Period.of(1, 0, 0), Period.of(0, 6, 0)));
+        skjæringstidspunktTjeneste = new SkjæringstidspunktTjenesteImpl(repositoryProvider);
     }
 
     @Test

--- a/domenetjenester/skjaeringstidspunkt/src/main/java/no/nav/foreldrepenger/skjæringstidspunkt/es/RegisterInnhentingIntervall.java
+++ b/domenetjenester/skjaeringstidspunkt/src/main/java/no/nav/foreldrepenger/skjæringstidspunkt/es/RegisterInnhentingIntervall.java
@@ -3,48 +3,33 @@ package no.nav.foreldrepenger.skjæringstidspunkt.es;
 import java.time.LocalDate;
 import java.time.Period;
 
-import jakarta.enterprise.context.ApplicationScoped;
-import jakarta.inject.Inject;
-
-import no.nav.foreldrepenger.konfig.KonfigVerdi;
-
-@ApplicationScoped
 public class RegisterInnhentingIntervall {
 
-    private Period grenseverdiFør;
-    private Period grenseverdiEtter;
-
-    RegisterInnhentingIntervall() {
-        // CDI
-    }
-
     /**
-     * @param grenseverdiFørES- Maks avvik før STP for registerinnhenting før justering av perioden (Engangsstønad)
-     * @param grenseverdiPeriodeEtter Maks avvik etter STP for registerinnhenting før justering av perioden (Engangsstønad)
+     * Maks avvik før/etter STP for registerinnhenting før justering av perioden
      */
-    @Inject
-    public RegisterInnhentingIntervall(@KonfigVerdi(value="es.registerinnhenting.avvik.periode.før", defaultVerdi = "P9M") Period grenseverdiPeriodeFør,
-                                       @KonfigVerdi(value="es.registerinnhenting.avvik.periode.etter", defaultVerdi = "P6M") Period grenseverdiPeriodeEtter) {
-        this.grenseverdiFør = grenseverdiPeriodeFør;
-        this.grenseverdiEtter = grenseverdiPeriodeEtter;
+    private static final Period GRENSEVERDI_FØR = Period.ofMonths(9);
+    private static final Period GRENSEVERDI_ETTER = Period.ofMonths(6);
+
+    private RegisterInnhentingIntervall() {
     }
 
-    boolean erEndringIPerioden(LocalDate oppgittSkjæringstidspunkt, LocalDate bekreftetSkjæringstidspunkt) {
+    static boolean erEndringIPerioden(LocalDate oppgittSkjæringstidspunkt, LocalDate bekreftetSkjæringstidspunkt) {
         if (bekreftetSkjæringstidspunkt == null) {
             return false;
         }
-        return vurderEndringFør(oppgittSkjæringstidspunkt, bekreftetSkjæringstidspunkt, grenseverdiFør)
-            || vurderEndringEtter(oppgittSkjæringstidspunkt, bekreftetSkjæringstidspunkt, grenseverdiEtter);
+        return vurderEndringFør(oppgittSkjæringstidspunkt, bekreftetSkjæringstidspunkt)
+            || vurderEndringEtter(oppgittSkjæringstidspunkt, bekreftetSkjæringstidspunkt);
     }
 
-    private boolean vurderEndringEtter(LocalDate oppgittSkjæringstidspunkt, LocalDate bekreftetSkjæringstidspunkt, Period grenseverdiEtter) {
+    private static boolean vurderEndringEtter(LocalDate oppgittSkjæringstidspunkt, LocalDate bekreftetSkjæringstidspunkt) {
         var avstand = Period.between(oppgittSkjæringstidspunkt, bekreftetSkjæringstidspunkt);
-        return !avstand.isNegative() && størreEnn(avstand, grenseverdiEtter);
+        return !avstand.isNegative() && størreEnn(avstand, RegisterInnhentingIntervall.GRENSEVERDI_ETTER);
     }
 
-    private boolean vurderEndringFør(LocalDate oppgittSkjæringstidspunkt, LocalDate bekreftetSkjæringstidspunkt, Period grenseverdiFør) {
+    private static boolean vurderEndringFør(LocalDate oppgittSkjæringstidspunkt, LocalDate bekreftetSkjæringstidspunkt) {
         var avstand = Period.between(bekreftetSkjæringstidspunkt, oppgittSkjæringstidspunkt);
-        return !avstand.isNegative() && størreEnn(avstand, grenseverdiFør);
+        return !avstand.isNegative() && størreEnn(avstand, RegisterInnhentingIntervall.GRENSEVERDI_FØR);
     }
 
     private static boolean størreEnn(Period period, Period sammenligning) {

--- a/domenetjenester/skjaeringstidspunkt/src/main/java/no/nav/foreldrepenger/skjæringstidspunkt/es/SkjæringstidspunktTjenesteImpl.java
+++ b/domenetjenester/skjaeringstidspunkt/src/main/java/no/nav/foreldrepenger/skjæringstidspunkt/es/SkjæringstidspunktTjenesteImpl.java
@@ -23,17 +23,14 @@ import no.nav.fpsak.tidsserie.LocalDateInterval;
 public class SkjæringstidspunktTjenesteImpl implements SkjæringstidspunktTjeneste, SkjæringstidspunktRegisterinnhentingTjeneste {
 
     private FamilieHendelseRepository familieGrunnlagRepository;
-    private RegisterInnhentingIntervall endringTjeneste;
 
     SkjæringstidspunktTjenesteImpl() {
         // CDI
     }
 
     @Inject
-    public SkjæringstidspunktTjenesteImpl(BehandlingRepositoryProvider repositoryProvider,
-                                          RegisterInnhentingIntervall endringTjeneste) {
+    public SkjæringstidspunktTjenesteImpl(BehandlingRepositoryProvider repositoryProvider) {
         this.familieGrunnlagRepository = repositoryProvider.getFamilieHendelseRepository();
-        this.endringTjeneste = endringTjeneste;
     }
 
     /**
@@ -59,7 +56,7 @@ public class SkjæringstidspunktTjenesteImpl implements SkjæringstidspunktTjene
         var oppgittSkjæringstidspunkt = utledSkjæringstidspunktFraOppgitteData(familieHendelseAggregat);
         var bekreftetSkjæringstidspunkt = utledSkjæringstidspunktFraBekreftedeData(familieHendelseAggregat);
 
-        if (endringTjeneste.erEndringIPerioden(oppgittSkjæringstidspunkt, bekreftetSkjæringstidspunkt.orElse(null))) {
+        if (RegisterInnhentingIntervall.erEndringIPerioden(oppgittSkjæringstidspunkt, bekreftetSkjæringstidspunkt.orElse(null))) {
             return bekreftetSkjæringstidspunkt.orElseThrow(IllegalStateException::new);
         }
         return oppgittSkjæringstidspunkt;

--- a/domenetjenester/skjaeringstidspunkt/src/main/java/no/nav/foreldrepenger/skjæringstidspunkt/fp/SkjæringstidspunktTjenesteImpl.java
+++ b/domenetjenester/skjaeringstidspunkt/src/main/java/no/nav/foreldrepenger/skjæringstidspunkt/fp/SkjæringstidspunktTjenesteImpl.java
@@ -55,7 +55,6 @@ public class SkjæringstidspunktTjenesteImpl implements SkjæringstidspunktTjene
     private static final Period MAX_STØNADSPERIODE = Period.ofYears(3);
 
     private FamilieHendelseRepository familieGrunnlagRepository;
-    private SkjæringstidspunktUtils utlederUtils;
     private YtelsesFordelingRepository ytelsesFordelingRepository;
     private FpUttakRepository fpUttakRepository;
     private OpptjeningRepository opptjeningRepository;
@@ -72,7 +71,6 @@ public class SkjæringstidspunktTjenesteImpl implements SkjæringstidspunktTjene
     @Inject
     public SkjæringstidspunktTjenesteImpl(BehandlingRepositoryProvider repositoryProvider,
                                           YtelseMaksdatoTjeneste ytelseMaksdatoTjeneste,
-                                          SkjæringstidspunktUtils utlederUtils,
                                           UtsettelseBehandling2021 utsettelse2021,
                                           MinsterettBehandling2022 minsterett2022) {
         this.behandlingRepository = repositoryProvider.getBehandlingRepository();
@@ -81,7 +79,6 @@ public class SkjæringstidspunktTjenesteImpl implements SkjæringstidspunktTjene
         this.opptjeningRepository = repositoryProvider.getOpptjeningRepository();
         this.søknadRepository = repositoryProvider.getSøknadRepository();
         this.familieGrunnlagRepository = repositoryProvider.getFamilieHendelseRepository();
-        this.utlederUtils = utlederUtils;
         this.ytelseMaksdatoTjeneste = ytelseMaksdatoTjeneste;
         this.utsettelse2021 = utsettelse2021;
         this.minsterett2022 = minsterett2022;
@@ -91,7 +88,7 @@ public class SkjæringstidspunktTjenesteImpl implements SkjæringstidspunktTjene
     public LocalDate utledSkjæringstidspunktForRegisterInnhenting(Long behandlingId) {
         var familieHendelseAggregat = familieGrunnlagRepository.hentAggregatHvisEksisterer(behandlingId);
 
-        return familieHendelseAggregat.map(utlederUtils::utledSkjæringstidspunktRegisterinnhenting).orElse(LocalDate.now());
+        return familieHendelseAggregat.map(SkjæringstidspunktUtils::utledSkjæringstidspunktRegisterinnhenting).orElse(LocalDate.now());
     }
 
     @Override
@@ -142,7 +139,7 @@ public class SkjæringstidspunktTjenesteImpl implements SkjæringstidspunktTjene
 
         Optional<LocalDate> morsMaksDato = !sammenhengendeUttak ? Optional.empty() :
             ytelseMaksdatoTjeneste.beregnMorsMaksdato(behandling.getFagsak().getSaksnummer(), behandling.getFagsak().getRelasjonsRolleType());
-        var utledetSkjæringstidspunkt = utlederUtils.utledSkjæringstidspunktFraBehandling(behandling, førsteUttaksdato,
+        var utledetSkjæringstidspunkt = SkjæringstidspunktUtils.utledSkjæringstidspunktFraBehandling(behandling, førsteUttaksdato,
             familieHendelseGrunnlag, morsMaksDato, utenMinsterett);
 
         return builder.medUtledetSkjæringstidspunkt(utledetSkjæringstidspunkt)
@@ -182,7 +179,7 @@ public class SkjæringstidspunktTjenesteImpl implements SkjæringstidspunktTjene
 
         Optional<LocalDate> morsMaksDato = !sammenhengendeUttak ? Optional.empty() :
             ytelseMaksdatoTjeneste.beregnMorsMaksdato(behandling.getFagsak().getSaksnummer(), behandling.getFagsak().getRelasjonsRolleType());
-        var utledetSkjæringstidspunkt = utlederUtils.utledSkjæringstidspunktFraBehandling(behandling, førsteUttaksdato,
+        var utledetSkjæringstidspunkt = SkjæringstidspunktUtils.utledSkjæringstidspunktFraBehandling(behandling, førsteUttaksdato,
             familieHendelseGrunnlag, morsMaksDato, utenMinsterett);
 
         return builder.medUtledetSkjæringstidspunkt(utledetSkjæringstidspunkt)

--- a/domenetjenester/skjaeringstidspunkt/src/test/java/no/nav/foreldrepenger/skjæringstidspunkt/es/RegisterinnhentingElastisiTest.java
+++ b/domenetjenester/skjaeringstidspunkt/src/test/java/no/nav/foreldrepenger/skjæringstidspunkt/es/RegisterinnhentingElastisiTest.java
@@ -3,20 +3,17 @@ package no.nav.foreldrepenger.skjæringstidspunkt.es;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.LocalDate;
-import java.time.Period;
 
 import org.junit.jupiter.api.Test;
 
 class RegisterinnhentingElastisiTest {
-
-    private RegisterInnhentingIntervall innhentingIntervall = new RegisterInnhentingIntervall(Period.parse("P9M"), Period.parse("P6M"));
 
     @Test
     void skal_gi_false_hvis_like() {
         var oppgitt = LocalDate.now();
         var bekreftet = LocalDate.now();
 
-        var resultat = innhentingIntervall.erEndringIPerioden(oppgitt, bekreftet);
+        var resultat = RegisterInnhentingIntervall.erEndringIPerioden(oppgitt, bekreftet);
         assertThat(resultat).isFalse();
     }
 
@@ -25,7 +22,7 @@ class RegisterinnhentingElastisiTest {
         var oppgitt = LocalDate.now();
         var bekreftet = LocalDate.now().plusMonths(1);
 
-        var resultat = innhentingIntervall.erEndringIPerioden(oppgitt, bekreftet);
+        var resultat = RegisterInnhentingIntervall.erEndringIPerioden(oppgitt, bekreftet);
         assertThat(resultat).isFalse();
     }
 
@@ -34,7 +31,7 @@ class RegisterinnhentingElastisiTest {
         var oppgitt = LocalDate.now();
         var bekreftet = LocalDate.now().minusYears(1);
 
-        var resultat = innhentingIntervall.erEndringIPerioden(oppgitt, bekreftet);
+        var resultat = RegisterInnhentingIntervall.erEndringIPerioden(oppgitt, bekreftet);
         assertThat(resultat).isTrue();
     }
 
@@ -43,7 +40,7 @@ class RegisterinnhentingElastisiTest {
         var oppgitt = LocalDate.now();
         var bekreftet = LocalDate.now().plusYears(1);
 
-        var resultat = innhentingIntervall.erEndringIPerioden(oppgitt, bekreftet);
+        var resultat = RegisterInnhentingIntervall.erEndringIPerioden(oppgitt, bekreftet);
         assertThat(resultat).isTrue();
     }
 }

--- a/domenetjenester/skjaeringstidspunkt/src/test/java/no/nav/foreldrepenger/skjæringstidspunkt/fp/SkjæringstidspunktTjenesteImplTest.java
+++ b/domenetjenester/skjaeringstidspunkt/src/test/java/no/nav/foreldrepenger/skjæringstidspunkt/fp/SkjæringstidspunktTjenesteImplTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
-import java.time.Period;
 import java.time.YearMonth;
 import java.util.List;
 
@@ -45,7 +44,6 @@ class SkjæringstidspunktTjenesteImplTest extends EntityManagerAwareTest {
 
     private BehandlingRepositoryProvider repositoryProvider;
     private SkjæringstidspunktTjeneste skjæringstidspunktTjeneste;
-    private final SkjæringstidspunktUtils stputil = new SkjæringstidspunktUtils(Period.parse("P4M"), Period.parse("P1Y"));
     private UtsettelseBehandling2021 utsettelse2021;
     private MinsterettBehandling2022 minsterett2022;
 
@@ -57,7 +55,7 @@ class SkjæringstidspunktTjenesteImplTest extends EntityManagerAwareTest {
         utsettelse2021 = new UtsettelseBehandling2021(repositoryProvider,
             fagsakRelasjonTjeneste);
         minsterett2022 = new MinsterettBehandling2022(repositoryProvider, fagsakRelasjonTjeneste);
-        skjæringstidspunktTjeneste = new SkjæringstidspunktTjenesteImpl(repositoryProvider, null, stputil, utsettelse2021, minsterett2022);
+        skjæringstidspunktTjeneste = new SkjæringstidspunktTjenesteImpl(repositoryProvider, null, utsettelse2021, minsterett2022);
     }
 
     @Test
@@ -274,7 +272,7 @@ class SkjæringstidspunktTjenesteImplTest extends EntityManagerAwareTest {
     void skal_finne_fud_søkt_utsettelse_fra_start() {
         // Sikre fritt uttak
         utsettelse2021 = new UtsettelseBehandling2021(repositoryProvider, new FagsakRelasjonTjeneste(repositoryProvider));
-        skjæringstidspunktTjeneste = new SkjæringstidspunktTjenesteImpl(repositoryProvider, null, stputil, utsettelse2021, minsterett2022);
+        skjæringstidspunktTjeneste = new SkjæringstidspunktTjenesteImpl(repositoryProvider, null, utsettelse2021, minsterett2022);
 
 
         var skjæringstidspunktOriginal = VirkedagUtil.fomVirkedag(YearMonth.from(LocalDate.now()).atEndOfMonth().plusDays(1));

--- a/domenetjenester/skjaeringstidspunkt/src/test/java/no/nav/foreldrepenger/skjæringstidspunkt/fp/SkjæringstidspunktUtilsTest.java
+++ b/domenetjenester/skjaeringstidspunkt/src/test/java/no/nav/foreldrepenger/skjæringstidspunkt/fp/SkjæringstidspunktUtilsTest.java
@@ -13,8 +13,6 @@ import no.nav.foreldrepenger.behandlingslager.behandling.familiehendelse.Hendels
 
 class SkjæringstidspunktUtilsTest {
 
-    private final SkjæringstidspunktUtils innhentingIntervall = new SkjæringstidspunktUtils();
-
     @Test
     void skal_gi_false_hvis_like() {
         var oppgitt = LocalDate.now();
@@ -23,7 +21,7 @@ class SkjæringstidspunktUtilsTest {
             .medSøknadVersjon(FamilieHendelseBuilder.oppdatere(Optional.empty(),HendelseVersjonType.SØKNAD).medFødselsDato(oppgitt))
             .medBekreftetVersjon(FamilieHendelseBuilder.oppdatere(Optional.empty(),HendelseVersjonType.BEKREFTET).medFødselsDato(bekreftet));
 
-        var resultat = innhentingIntervall.utledSkjæringstidspunktRegisterinnhenting(builder.build());
+        var resultat = SkjæringstidspunktUtils.utledSkjæringstidspunktRegisterinnhenting(builder.build());
         assertThat(resultat).isEqualTo(oppgitt);
     }
 
@@ -39,7 +37,7 @@ class SkjæringstidspunktUtilsTest {
             .medSøknadVersjon(fhOppgitt)
             .medOverstyrtVersjon(fhBekreftet);
 
-        var resultat = innhentingIntervall.utledSkjæringstidspunktRegisterinnhenting(builder.build());
+        var resultat = SkjæringstidspunktUtils.utledSkjæringstidspunktRegisterinnhenting(builder.build());
         assertThat(resultat).isEqualTo(oppgitt);
     }
 
@@ -56,7 +54,7 @@ class SkjæringstidspunktUtilsTest {
             .medSøknadVersjon(fhOppgitt)
             .medBekreftetVersjon(fhBekreftet);
 
-        var resultat = innhentingIntervall.utledSkjæringstidspunktRegisterinnhenting(builder.build());
+        var resultat = SkjæringstidspunktUtils.utledSkjæringstidspunktRegisterinnhenting(builder.build());
         assertThat(resultat).isEqualTo(bekreftet);
     }
 
@@ -73,7 +71,7 @@ class SkjæringstidspunktUtilsTest {
             .medSøknadVersjon(fhOppgitt)
             .medOverstyrtVersjon(fhBekreftet);
 
-        var resultat = innhentingIntervall.utledSkjæringstidspunktRegisterinnhenting(builder.build());
+        var resultat = SkjæringstidspunktUtils.utledSkjæringstidspunktRegisterinnhenting(builder.build());
         assertThat(resultat).isEqualTo(bekreftet);
     }
 }

--- a/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/BehandlingRestTjenesteESTest.java
+++ b/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/BehandlingRestTjenesteESTest.java
@@ -6,7 +6,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.time.LocalDate;
-import java.time.Period;
 
 import jakarta.persistence.EntityManager;
 
@@ -34,7 +33,6 @@ import no.nav.foreldrepenger.domene.typer.AktørId;
 import no.nav.foreldrepenger.domene.uttak.ForeldrepengerUttakTjeneste;
 import no.nav.foreldrepenger.domene.uttak.beregnkontoer.UtregnetStønadskontoTjeneste;
 import no.nav.foreldrepenger.domene.vedtak.TotrinnTjeneste;
-import no.nav.foreldrepenger.skjæringstidspunkt.es.RegisterInnhentingIntervall;
 import no.nav.foreldrepenger.skjæringstidspunkt.es.SkjæringstidspunktTjenesteImpl;
 import no.nav.foreldrepenger.web.app.tjenester.behandling.aksjonspunkt.BehandlingsoppretterTjeneste;
 import no.nav.foreldrepenger.web.app.tjenester.behandling.aksjonspunkt.BehandlingsprosessTjeneste;
@@ -72,8 +70,7 @@ class BehandlingRestTjenesteESTest {
         repositoryProvider = new BehandlingRepositoryProvider(entityManager);
         var fagsakTjeneste = new FagsakTjeneste(repositoryProvider.getFagsakRepository(),
             repositoryProvider.getSøknadRepository());
-        var skjæringstidspunktTjeneste = new SkjæringstidspunktTjenesteImpl(repositoryProvider,
-            new RegisterInnhentingIntervall(Period.of(1, 0, 0), Period.of(0, 6, 0)));
+        var skjæringstidspunktTjeneste = new SkjæringstidspunktTjenesteImpl(repositoryProvider);
         var fagsakRelasjonTjeneste = new FagsakRelasjonTjeneste(repositoryProvider);
         var behandlingDtoTjeneste = new BehandlingDtoTjeneste(repositoryProvider, beregningTjeneste,
             tilbakekrevingRepository, skjæringstidspunktTjeneste, behandlingDokumentRepository,

--- a/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/medlem/MedlemDtoTjenesteTest.java
+++ b/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/medlem/MedlemDtoTjenesteTest.java
@@ -6,7 +6,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.time.LocalDate;
-import java.time.Period;
 import java.util.List;
 
 import jakarta.inject.Inject;
@@ -37,7 +36,6 @@ import no.nav.foreldrepenger.domene.personopplysning.PersonopplysningTjeneste;
 import no.nav.foreldrepenger.domene.tid.DatoIntervallEntitet;
 import no.nav.foreldrepenger.domene.typer.AktørId;
 import no.nav.foreldrepenger.skjæringstidspunkt.SkjæringstidspunktTjeneste;
-import no.nav.foreldrepenger.skjæringstidspunkt.es.RegisterInnhentingIntervall;
 import no.nav.foreldrepenger.skjæringstidspunkt.es.SkjæringstidspunktTjenesteImpl;
 import no.nav.foreldrepenger.web.app.tjenester.behandling.personopplysning.PersonopplysningDtoTjeneste;
 import no.nav.vedtak.konfig.Tid;
@@ -79,8 +77,8 @@ class MedlemDtoTjenesteTest {
         var behandling = scenario.lagMocked();
         var repositoryProvider = scenario.mockBehandlingRepositoryProvider();
 
-        SkjæringstidspunktTjeneste skjæringstidspunktTjeneste = new SkjæringstidspunktTjenesteImpl(repositoryProvider,
-                new RegisterInnhentingIntervall(Period.of(1, 0, 0), Period.of(0, 6, 0)));
+        SkjæringstidspunktTjeneste skjæringstidspunktTjeneste = new SkjæringstidspunktTjenesteImpl(repositoryProvider
+        );
 
         var personopplysningTjenesteMock = new PersonopplysningTjeneste(repositoryProvider.getPersonopplysningRepository());
         var medlemTjenesteMock = mock(MedlemTjeneste.class);
@@ -127,8 +125,8 @@ class MedlemDtoTjenesteTest {
         var behandling = scenario.lagMocked();
         var repositoryProvider = scenario.mockBehandlingRepositoryProvider();
 
-        SkjæringstidspunktTjeneste skjæringstidspunktTjeneste = new SkjæringstidspunktTjenesteImpl(repositoryProvider,
-                new RegisterInnhentingIntervall(Period.of(1, 0, 0), Period.of(0, 6, 0)));
+        SkjæringstidspunktTjeneste skjæringstidspunktTjeneste = new SkjæringstidspunktTjenesteImpl(repositoryProvider
+        );
 
         var personopplysningTjenesteMock = new PersonopplysningTjeneste(repositoryProvider.getPersonopplysningRepository());
         var medlemTjenesteMock = mock(MedlemTjeneste.class);
@@ -181,8 +179,8 @@ class MedlemDtoTjenesteTest {
         var behandling = scenario.lagMocked();
         var repositoryProvider = scenario.mockBehandlingRepositoryProvider();
 
-        SkjæringstidspunktTjeneste skjæringstidspunktTjeneste = new SkjæringstidspunktTjenesteImpl(repositoryProvider,
-                new RegisterInnhentingIntervall(Period.of(1, 0, 0), Period.of(0, 6, 0)));
+        SkjæringstidspunktTjeneste skjæringstidspunktTjeneste = new SkjæringstidspunktTjenesteImpl(repositoryProvider
+        );
 
         var personopplysningTjenesteMock = new PersonopplysningTjeneste(repositoryProvider.getPersonopplysningRepository());
 
@@ -210,8 +208,8 @@ class MedlemDtoTjenesteTest {
         var behandling = scenario.lagMocked();
         var repositoryProvider = scenario.mockBehandlingRepositoryProvider();
 
-        SkjæringstidspunktTjeneste skjæringstidspunktTjeneste = new SkjæringstidspunktTjenesteImpl(repositoryProvider,
-            new RegisterInnhentingIntervall(Period.of(1, 0, 0), Period.of(0, 6, 0)));
+        SkjæringstidspunktTjeneste skjæringstidspunktTjeneste = new SkjæringstidspunktTjenesteImpl(repositoryProvider
+        );
 
         var personopplysningTjenesteMock = new PersonopplysningTjeneste(repositoryProvider.getPersonopplysningRepository());
 

--- a/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/medlem/aksjonspunkt/BekreftBosattVurderingOppdatererTest.java
+++ b/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/medlem/aksjonspunkt/BekreftBosattVurderingOppdatererTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
 import java.time.LocalDate;
-import java.time.Period;
 import java.util.List;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -23,7 +22,6 @@ import no.nav.foreldrepenger.domene.medlem.MedlemskapAksjonspunktTjeneste;
 import no.nav.foreldrepenger.historikk.HistorikkInnslagTekstBuilder;
 import no.nav.foreldrepenger.historikk.HistorikkTjenesteAdapter;
 import no.nav.foreldrepenger.skjæringstidspunkt.SkjæringstidspunktTjeneste;
-import no.nav.foreldrepenger.skjæringstidspunkt.es.RegisterInnhentingIntervall;
 import no.nav.foreldrepenger.skjæringstidspunkt.es.SkjæringstidspunktTjenesteImpl;
 
 class BekreftBosattVurderingOppdatererTest extends EntityManagerAwareTest {
@@ -37,8 +35,8 @@ class BekreftBosattVurderingOppdatererTest extends EntityManagerAwareTest {
     @BeforeEach
     public void beforeEach() {
         repositoryProvider = new BehandlingRepositoryProvider(getEntityManager());
-        skjæringstidspunktTjeneste = new SkjæringstidspunktTjenesteImpl(repositoryProvider,
-                new RegisterInnhentingIntervall(Period.of(1, 0, 0), Period.of(0, 6, 0)));
+        skjæringstidspunktTjeneste = new SkjæringstidspunktTjenesteImpl(repositoryProvider
+        );
     }
 
     @Test

--- a/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/medlem/aksjonspunkt/BekreftErMedlemOppdatererTest.java
+++ b/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/medlem/aksjonspunkt/BekreftErMedlemOppdatererTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
 import java.time.LocalDate;
-import java.time.Period;
 import java.util.List;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -24,7 +23,6 @@ import no.nav.foreldrepenger.domene.medlem.MedlemskapAksjonspunktTjeneste;
 import no.nav.foreldrepenger.historikk.HistorikkInnslagTekstBuilder;
 import no.nav.foreldrepenger.historikk.HistorikkTjenesteAdapter;
 import no.nav.foreldrepenger.skjæringstidspunkt.SkjæringstidspunktTjeneste;
-import no.nav.foreldrepenger.skjæringstidspunkt.es.RegisterInnhentingIntervall;
 import no.nav.foreldrepenger.skjæringstidspunkt.es.SkjæringstidspunktTjenesteImpl;
 
 class BekreftErMedlemOppdatererTest extends EntityManagerAwareTest {
@@ -37,8 +35,8 @@ class BekreftErMedlemOppdatererTest extends EntityManagerAwareTest {
     @BeforeEach
     public void beforeEach() {
         repositoryProvider = new BehandlingRepositoryProvider(getEntityManager());
-        skjæringstidspunktTjeneste = new SkjæringstidspunktTjenesteImpl(repositoryProvider,
-                new RegisterInnhentingIntervall(Period.of(1, 0, 0), Period.of(0, 6, 0)));
+        skjæringstidspunktTjeneste = new SkjæringstidspunktTjenesteImpl(repositoryProvider
+        );
     }
 
     @Test

--- a/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/medlem/aksjonspunkt/BekreftOppholdVurderingTest.java
+++ b/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/medlem/aksjonspunkt/BekreftOppholdVurderingTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
 import java.time.LocalDate;
-import java.time.Period;
 import java.util.List;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -31,7 +30,6 @@ import no.nav.foreldrepenger.domene.personopplysning.PersonopplysningTjeneste;
 import no.nav.foreldrepenger.historikk.HistorikkInnslagTekstBuilder;
 import no.nav.foreldrepenger.historikk.HistorikkTjenesteAdapter;
 import no.nav.foreldrepenger.skjæringstidspunkt.SkjæringstidspunktTjeneste;
-import no.nav.foreldrepenger.skjæringstidspunkt.es.RegisterInnhentingIntervall;
 import no.nav.foreldrepenger.skjæringstidspunkt.es.SkjæringstidspunktTjenesteImpl;
 
 @ExtendWith(MockitoExtension.class)
@@ -48,8 +46,8 @@ class BekreftOppholdVurderingTest extends EntityManagerAwareTest {
     @BeforeEach
     public void beforeEach() {
         repositoryProvider = new BehandlingRepositoryProvider(getEntityManager());
-        skjæringstidspunktTjeneste = new SkjæringstidspunktTjenesteImpl(repositoryProvider,
-                new RegisterInnhentingIntervall(Period.of(1, 0, 0), Period.of(0, 6, 0)));
+        skjæringstidspunktTjeneste = new SkjæringstidspunktTjenesteImpl(repositoryProvider
+        );
     }
 
     @Test


### PR DESCRIPTION
Målbilde-elementer (dette er bare starten)
* Sanere ubrukt konfigurasjon - flytt inn i kode.
* Bygge mer utilities for FamilieHendelseDato
* Basere på søkt/forventet (termin/adopsjon) - justere intervall i nekelte tilfelle 
* Justering: Dersom bekreftetFraAP eller fødsel er mer enn et intervall utenfor eksisterende - se FamilieHendelseTjeneste
* Dagens logikk - ta utgangspunkt i forventet familiehendelsedato fra søknad - dersom bekreftet er langt unna, så brukes den - ellers prøver man beholder opprinnelig opplysningsperiode