### PR TITLE
Fikser feil utledning av oppholdsrett for tredjeland

### DIFF
--- a/domenetjenester/inngangsvilkar/src/main/java/no/nav/foreldrepenger/inngangsvilkaar/medlemskap/v2/MedlemFellesRegler.java
+++ b/domenetjenester/inngangsvilkar/src/main/java/no/nav/foreldrepenger/inngangsvilkaar/medlemskap/v2/MedlemFellesRegler.java
@@ -73,6 +73,10 @@ final class MedlemFellesRegler {
         return regionTimeline.disjoint(ansettelseTimeline).isEmpty();
     }
 
+    static boolean harRegionIPeriode(Personopplysninger personopplysninger, Personopplysninger.Region region, LocalDateInterval vurderingsperiode) {
+        return !regionTimelineIVurderingsperiode(personopplysninger.regioner(), region, vurderingsperiode).isEmpty();
+    }
+
     private static LocalDateTimeline<Personopplysninger.Region> regionTimelineIVurderingsperiode(Set<Personopplysninger.RegionPeriode> regioner,
                                                                                                  Personopplysninger.Region region,
                                                                                                  LocalDateInterval vurderingsperiode) {

--- a/domenetjenester/inngangsvilkar/src/main/java/no/nav/foreldrepenger/inngangsvilkaar/medlemskap/v2/MedlemFortsattRegel.java
+++ b/domenetjenester/inngangsvilkar/src/main/java/no/nav/foreldrepenger/inngangsvilkaar/medlemskap/v2/MedlemFortsattRegel.java
@@ -1,5 +1,6 @@
 package no.nav.foreldrepenger.inngangsvilkaar.medlemskap.v2;
 
+import static no.nav.foreldrepenger.inngangsvilkaar.medlemskap.v2.MedlemFellesRegler.harRegionIPeriode;
 import static no.nav.foreldrepenger.inngangsvilkaar.medlemskap.v2.MedlemFellesRegler.sjekkOmAnsettelseIHelePeriodenMedEøsRegion;
 import static no.nav.foreldrepenger.inngangsvilkaar.medlemskap.v2.MedlemFellesRegler.sjekkOmOppholdstillatelserIHelePeriodenMedTredjelandsRegion;
 import static no.nav.foreldrepenger.inngangsvilkaar.medlemskap.v2.MedlemFellesRegler.sjekkOmBosattPersonstatus;
@@ -29,12 +30,15 @@ final class MedlemFortsattRegel {
         utledBosattÅrsak(grunnlag).ifPresent(resultat::add);
 
         // LOVLIG OPPHOLD
-        utledOppholdÅrsak(grunnlag).ifPresent(resultat::add);
+        utledLovligOppholdÅrsak(grunnlag).ifPresent(resultat::add);
         utledOppholdsrettÅrsak(grunnlag).ifPresent(resultat::add);
         return resultat;
     }
 
     private static Optional<MedlemskapAksjonspunktÅrsak> utledOppholdsrettÅrsak(MedlemFortsattRegelGrunnlag grunnlag) {
+        if (!harRegionIPeriode(grunnlag.personopplysninger(), Personopplysninger.Region.EØS, grunnlag.vurderingsperiode())) {
+            return Optional.empty();
+        }
         if (sjekkOmAnsettelseIHelePeriodenMedEøsRegion(grunnlag.arbeid().ansettelsePerioder(), grunnlag.personopplysninger(),
             grunnlag.vurderingsperiode())) {
             return Optional.empty();
@@ -42,7 +46,10 @@ final class MedlemFortsattRegel {
         return Optional.of(OPPHOLDSRETT);
     }
 
-    private static Optional<MedlemskapAksjonspunktÅrsak> utledOppholdÅrsak(MedlemFortsattRegelGrunnlag grunnlag) {
+    private static Optional<MedlemskapAksjonspunktÅrsak> utledLovligOppholdÅrsak(MedlemFortsattRegelGrunnlag grunnlag) {
+        if (!harRegionIPeriode(grunnlag.personopplysninger(), Personopplysninger.Region.TREDJELAND, grunnlag.vurderingsperiode())) {
+            return Optional.empty();
+        }
         if (sjekkOmOppholdstillatelserIHelePeriodenMedTredjelandsRegion(grunnlag.vurderingsperiode(), grunnlag.personopplysninger())) {
             return Optional.empty();
         }

--- a/domenetjenester/inngangsvilkar/src/main/java/no/nav/foreldrepenger/inngangsvilkaar/medlemskap/v2/MedlemInngangsvilkårRegel.java
+++ b/domenetjenester/inngangsvilkar/src/main/java/no/nav/foreldrepenger/inngangsvilkaar/medlemskap/v2/MedlemInngangsvilkårRegel.java
@@ -1,5 +1,6 @@
 package no.nav.foreldrepenger.inngangsvilkaar.medlemskap.v2;
 
+import static no.nav.foreldrepenger.inngangsvilkaar.medlemskap.v2.MedlemFellesRegler.harRegionIPeriode;
 import static no.nav.foreldrepenger.inngangsvilkaar.medlemskap.v2.MedlemFellesRegler.sjekkOmAnsettelseIHelePeriodenMedEøsRegion;
 import static no.nav.foreldrepenger.inngangsvilkaar.medlemskap.v2.MedlemFellesRegler.sjekkOmBosattPersonstatus;
 import static no.nav.foreldrepenger.inngangsvilkaar.medlemskap.v2.MedlemFellesRegler.sjekkOmManglendeBosted;
@@ -37,12 +38,15 @@ final class MedlemInngangsvilkårRegel {
         utledBosattÅrsak(grunnlag).ifPresent(resultat::add);
 
         // LOVLIG OPPHOLD
-        utledOppholdÅrsak(grunnlag).ifPresent(resultat::add);
+        utledLovligOppholdÅrsak(grunnlag).ifPresent(resultat::add);
         utledOppholdsrettÅrsak(grunnlag).ifPresent(resultat::add);
         return resultat;
     }
 
     private static Optional<MedlemskapAksjonspunktÅrsak> utledOppholdsrettÅrsak(MedlemInngangsvilkårRegelGrunnlag grunnlag) {
+        if (!harRegionIPeriode(grunnlag.personopplysninger(), Personopplysninger.Region.EØS, grunnlag.vurderingsperiodeLovligOpphold())) {
+            return Optional.empty();
+        }
         if (sjekkOmAnsettelseIHelePeriodenMedEøsRegion(grunnlag.arbeid().ansettelsePerioder(), grunnlag.personopplysninger(),
             grunnlag.vurderingsperiodeLovligOpphold())) {
             if (sjekkOmInntektSiste3mndFørStp(grunnlag)) {
@@ -65,7 +69,10 @@ final class MedlemInngangsvilkårRegel {
         return inntektTimeline.stream().map(LocalDateSegment::getValue).reduce(Beløp.ZERO, Beløp::add).erMerEnn(godkjentSamletInntekt);
     }
 
-    private static Optional<MedlemskapAksjonspunktÅrsak> utledOppholdÅrsak(MedlemInngangsvilkårRegelGrunnlag grunnlag) {
+    private static Optional<MedlemskapAksjonspunktÅrsak> utledLovligOppholdÅrsak(MedlemInngangsvilkårRegelGrunnlag grunnlag) {
+        if (!harRegionIPeriode(grunnlag.personopplysninger(), Personopplysninger.Region.TREDJELAND, grunnlag.vurderingsperiodeLovligOpphold())) {
+            return Optional.empty();
+        }
         if (sjekkOmOppholdstillatelserIHelePeriodenMedTredjelandsRegion(grunnlag.vurderingsperiodeLovligOpphold(), grunnlag.personopplysninger())) {
             return Optional.empty();
         }

--- a/domenetjenester/inngangsvilkar/src/main/java/no/nav/foreldrepenger/inngangsvilkaar/medlemskap/v2/MedlemRegelGrunnlagBygger.java
+++ b/domenetjenester/inngangsvilkar/src/main/java/no/nav/foreldrepenger/inngangsvilkaar/medlemskap/v2/MedlemRegelGrunnlagBygger.java
@@ -14,6 +14,7 @@ import jakarta.inject.Inject;
 
 import no.nav.foreldrepenger.behandling.BehandlingReferanse;
 import no.nav.foreldrepenger.behandlingslager.aktør.AdresseType;
+import no.nav.foreldrepenger.behandlingslager.aktør.OppholdstillatelseType;
 import no.nav.foreldrepenger.behandlingslager.behandling.beregning.BeregningSatsType;
 import no.nav.foreldrepenger.behandlingslager.behandling.beregning.SatsRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.medlemskap.MedlemskapOppgittTilknytningEntitet;
@@ -140,6 +141,7 @@ class MedlemRegelGrunnlagBygger {
             .collect(Collectors.toSet());
         var oppholdstillatelser = personopplysningerAggregat.getOppholdstillatelseFor(aktørId)
             .stream()
+            .filter(o -> !OppholdstillatelseType.UDEFINERT.equals(o.getTillatelse()))
             .map(o -> map(o.getPeriode()))
             .collect(Collectors.toSet());
         var personstatus = personopplysningerAggregat.getPersonstatuserFor(aktørId).stream().map(this::map).collect(Collectors.toSet());
@@ -161,10 +163,10 @@ class MedlemRegelGrunnlagBygger {
     private static Personopplysninger.Adresse.Type map(AdresseType adresseType) {
         return switch (adresseType) {
             case BOSTEDSADRESSE -> Personopplysninger.Adresse.Type.BOSTEDSADRESSE;
-            case POSTADRESSE -> Personopplysninger.Adresse.Type.POSTADRESSE;
-            case POSTADRESSE_UTLAND -> Personopplysninger.Adresse.Type.POSTADRESSE_UTLAND;
-            case MIDLERTIDIG_POSTADRESSE_NORGE -> Personopplysninger.Adresse.Type.MIDLERTIDIG_POSTADRESSE_NORGE;
-            case MIDLERTIDIG_POSTADRESSE_UTLAND -> Personopplysninger.Adresse.Type.MIDLERTIDIG_POSTADRESSE_UTLAND;
+            case POSTADRESSE -> Personopplysninger.Adresse.Type.KONTAKTADRESSE;
+            case POSTADRESSE_UTLAND -> Personopplysninger.Adresse.Type.KONTAKTADRESSE_UTLAND;
+            case MIDLERTIDIG_POSTADRESSE_NORGE -> Personopplysninger.Adresse.Type.OPPHOLDSADRESSE_NORGE;
+            case MIDLERTIDIG_POSTADRESSE_UTLAND -> Personopplysninger.Adresse.Type.OPPHOLDSADRESSE_UTLAND;
             case UKJENT_ADRESSE -> Personopplysninger.Adresse.Type.UKJENT_ADRESSE;
         };
     }

--- a/domenetjenester/inngangsvilkar/src/main/java/no/nav/foreldrepenger/inngangsvilkaar/medlemskap/v2/Personopplysninger.java
+++ b/domenetjenester/inngangsvilkar/src/main/java/no/nav/foreldrepenger/inngangsvilkaar/medlemskap/v2/Personopplysninger.java
@@ -33,10 +33,10 @@ record Personopplysninger(Set<RegionPeriode> regioner,
 
         enum Type {
             BOSTEDSADRESSE,
-            POSTADRESSE,
-            POSTADRESSE_UTLAND,
-            MIDLERTIDIG_POSTADRESSE_NORGE,
-            MIDLERTIDIG_POSTADRESSE_UTLAND,
+            KONTAKTADRESSE,
+            KONTAKTADRESSE_UTLAND,
+            OPPHOLDSADRESSE_NORGE,
+            OPPHOLDSADRESSE_UTLAND,
             UKJENT_ADRESSE,
         }
     }

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
         <svp-uttak.version>2.4.4</svp-uttak.version>
         <fp-ytelse-beregn.version>1.0.4</fp-ytelse-beregn.version>
 
-        <felles.version>7.2.7</felles.version>
+        <felles.version>7.2.9</felles.version>
         <prosesstask.version>5.0.15</prosesstask.version>
 
         <fp-kontrakter.version>9.1.19</fp-kontrakter.version>


### PR DESCRIPTION
Nå fikk tredjelandsborgere oppholdsrett for ES - hele den tomme EØS-perioden "dekt av arbeid", men ikke inntekt.
Endrer adressetyper til å bli likt FREG/PDL