### PR TITLE
Startpunktutledning for endringer som skal innom medlemskap

### DIFF
--- a/domenetjenester/medlem/src/main/java/no/nav/foreldrepenger/domene/medlem/identifiserer/MedlemEndringIdentifiserer.java
+++ b/domenetjenester/medlem/src/main/java/no/nav/foreldrepenger/domene/medlem/identifiserer/MedlemEndringIdentifiserer.java
@@ -21,4 +21,15 @@ public class MedlemEndringIdentifiserer {
             .collect(Collectors.toSet());
         return differ.erForskjellPå(medlemPerioder1, medlemPerioder2);
     }
+
+    public static boolean harBeslutningsdatoInnenforPeriode(MedlemskapAggregat grunnlag1, MedlemskapAggregat grunnlag2, DatoIntervallEntitet periode) {
+        var differ = new RegisterdataDiffsjekker(true);
+        var medlemPerioder1 = grunnlag1.getRegistrertMedlemskapPerioder().stream()
+            .filter(p -> p.getBeslutningsdato() == null || periode.inkluderer(p.getBeslutningsdato()))
+            .collect(Collectors.toSet());
+        var medlemPerioder2 = grunnlag2.getRegistrertMedlemskapPerioder().stream()
+            .filter(p -> p.getBeslutningsdato() == null || periode.inkluderer(p.getBeslutningsdato()))
+            .collect(Collectors.toSet());
+        return differ.erForskjellPå(medlemPerioder1, medlemPerioder2);
+    }
 }

--- a/domenetjenester/registerinnhenting/src/main/java/no/nav/foreldrepenger/domene/registerinnhenting/impl/startpunkt/StartpunktUtlederMedlemskap.java
+++ b/domenetjenester/registerinnhenting/src/main/java/no/nav/foreldrepenger/domene/registerinnhenting/impl/startpunkt/StartpunktUtlederMedlemskap.java
@@ -43,7 +43,7 @@ class StartpunktUtlederMedlemskap implements StartpunktUtleder {
                 "medlemskap uttak", grunnlagId1, grunnlagId2);
             return StartpunktType.UTTAKSVILKÅR;
         } else if (!ENV.isProd() && MedlemEndringIdentifiserer.harBeslutningsdatoInnenforPeriode(grunnlag1, grunnlag2, periode)) {
-            FellesStartpunktUtlederLogger.loggEndringSomFørteTilStartpunkt(this.getClass().getSimpleName(), StartpunktType.UTTAKSVILKÅR,
+            FellesStartpunktUtlederLogger.loggEndringSomFørteTilStartpunkt(this.getClass().getSimpleName(), StartpunktType.INNGANGSVILKÅR_MEDLEMSKAP,
                 "medlemskap medlemsvikår (ny)", grunnlagId1, grunnlagId2);
             return StartpunktType.INNGANGSVILKÅR_MEDLEMSKAP;
         }

--- a/domenetjenester/registerinnhenting/src/test/java/no/nav/foreldrepenger/domene/registerinnhenting/impl/startpunkt/StartpunktUtlederPersonopplysningTest.java
+++ b/domenetjenester/registerinnhenting/src/test/java/no/nav/foreldrepenger/domene/registerinnhenting/impl/startpunkt/StartpunktUtlederPersonopplysningTest.java
@@ -104,8 +104,8 @@ class StartpunktUtlederPersonopplysningTest extends EntityManagerAwareTest {
         var revurderingId = revurdering.getId();
 
         // Act/Assert
-        var utleder = new StartpunktUtlederPersonopplysning(repositoryProvider.getPersonopplysningRepository(), barnBorteEndringIdentifiserer,
-            dekningsgradTjeneste);
+        var utleder = new StartpunktUtlederPersonopplysning(repositoryProvider.getPersonopplysningRepository(),
+            repositoryProvider.getBehandlingRepository(), barnBorteEndringIdentifiserer, dekningsgradTjeneste);
         assertThat(utleder.utledStartpunkt(BehandlingReferanse.fra(revurdering), skjæringstidspunkt,
             repositoryProvider.getPersonopplysningRepository().hentPersonopplysninger(behandlingId).getId(),
             repositoryProvider.getPersonopplysningRepository().hentPersonopplysninger(revurderingId).getId())).isEqualTo(UDEFINERT);
@@ -190,8 +190,8 @@ class StartpunktUtlederPersonopplysningTest extends EntityManagerAwareTest {
         var revurderingId = revurdering.getId();
 
         // Act/Assert
-        var utleder = new StartpunktUtlederPersonopplysning(repositoryProvider.getPersonopplysningRepository(), barnBorteEndringIdentifiserer,
-            dekningsgradTjeneste);
+        var utleder = new StartpunktUtlederPersonopplysning(repositoryProvider.getPersonopplysningRepository(),
+            repositoryProvider.getBehandlingRepository(), barnBorteEndringIdentifiserer, dekningsgradTjeneste);
 
         // Arrange
         var revurdering2Scenario = ScenarioMorSøkerForeldrepenger.forFødsel().medBehandlingType(BehandlingType.REVURDERING);
@@ -267,8 +267,8 @@ class StartpunktUtlederPersonopplysningTest extends EntityManagerAwareTest {
         var revurderingId = revurdering.getId();
 
         // Act/Assert
-        var utleder = new StartpunktUtlederPersonopplysning(repositoryProvider.getPersonopplysningRepository(), barnBorteEndringIdentifiserer,
-            dekningsgradTjeneste);
+        var utleder = new StartpunktUtlederPersonopplysning(repositoryProvider.getPersonopplysningRepository(),
+            repositoryProvider.getBehandlingRepository(), barnBorteEndringIdentifiserer, dekningsgradTjeneste);
         assertThat(utleder.utledStartpunkt(BehandlingReferanse.fra(revurdering), skjæringstidspunkt,
             repositoryProvider.getPersonopplysningRepository().hentPersonopplysninger(behandlingId).getId(),
             repositoryProvider.getPersonopplysningRepository().hentPersonopplysninger(revurderingId).getId())).isEqualTo(SØKERS_RELASJON_TIL_BARNET);
@@ -342,8 +342,8 @@ class StartpunktUtlederPersonopplysningTest extends EntityManagerAwareTest {
         var revurderingId = revurdering.getId();
 
         // Act/Assert
-        var utleder = new StartpunktUtlederPersonopplysning(repositoryProvider.getPersonopplysningRepository(), barnBorteEndringIdentifiserer,
-            dekningsgradTjeneste);
+        var utleder = new StartpunktUtlederPersonopplysning(repositoryProvider.getPersonopplysningRepository(),
+            repositoryProvider.getBehandlingRepository(), barnBorteEndringIdentifiserer, dekningsgradTjeneste);
         assertThat(utleder.utledStartpunkt(BehandlingReferanse.fra(revurdering), skjæringstidspunkt,
             repositoryProvider.getPersonopplysningRepository().hentPersonopplysninger(behandlingId).getId(),
             repositoryProvider.getPersonopplysningRepository().hentPersonopplysninger(revurderingId).getId())).isEqualTo(UTTAKSVILKÅR);


### PR DESCRIPTION
Startpunktutledere vil gi startpunkt medlemskap dersom endringer i personopplysninger eller medlemskap tilsier det.
Dette vil erstatte behovet for egne "fortsatt medlem"-regler ettersom disse tilfellene går innom medlemskap