### PR TITLE
Avbryt medlemsaksjonspunkt + fortsett eller tilbakehopp

### DIFF
--- a/domenetjenester/medlem/src/main/java/no/nav/foreldrepenger/domene/medlem/kontrollerfakta/AksjonspunktutlederForMedlemskapSkjæringstidspunkt.java
+++ b/domenetjenester/medlem/src/main/java/no/nav/foreldrepenger/domene/medlem/kontrollerfakta/AksjonspunktutlederForMedlemskapSkjæringstidspunkt.java
@@ -14,7 +14,7 @@ import no.nav.foreldrepenger.konfig.Environment;
 @ApplicationScoped
 public class AksjonspunktutlederForMedlemskapSkjæringstidspunkt implements AksjonspunktUtleder {
 
-    private static final Environment ENV = Environment.current();
+    private static final Environment ENV = Environment.current(); // TODO medlemskap2 standardisere etter omlegging
     private VurderMedlemskapTjeneste tjeneste;
 
     AksjonspunktutlederForMedlemskapSkjæringstidspunkt() {

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/forvaltning/ForvaltningStegRestTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/forvaltning/ForvaltningStegRestTjeneste.java
@@ -135,7 +135,7 @@ public class ForvaltningStegRestTjeneste {
     @BeskyttetRessurs(actionType = ActionType.READ, resourceType = ResourceType.DRIFT, sporingslogg = false)
     public Response avbrytMedlemsAksjonspunkt() {
         var medlemsaksjonspunkt = List.of(AksjonspunktDefinisjon.AVKLAR_LOVLIG_OPPHOLD, AksjonspunktDefinisjon.AVKLAR_OM_ER_BOSATT,
-            AksjonspunktDefinisjon.AVKLAR_GYLDIG_MEDLEMSKAPSPERIODE, AksjonspunktDefinisjon.AVKLAR_OPPHOLDSRETT);
+            AksjonspunktDefinisjon.AVKLAR_GYLDIG_MEDLEMSKAPSPERIODE, AksjonspunktDefinisjon.AVKLAR_OPPHOLDSRETT, AksjonspunktDefinisjon.OVERSTYRING_AV_MEDLEMSKAPSVILKÅRET);
         entityManager.createQuery("select behandling from Aksjonspunkt ap where ap.aksjonspunktDefinisjon in (:apdef) and ap.status = :opprettet", Behandling.class)
             .setParameter("apdef",medlemsaksjonspunkt)
             .setParameter("opprettet", AksjonspunktStatus.OPPRETTET)


### PR DESCRIPTION
De 4 vanlige aksjonspunktene blir avbrutt og prosessen tatt videre (til vurdering av vilkår og evt nytt AP)
Fortsatt medlemskap hopper tilbake til Kontroller Fakta og finner nytt startpunkt (medlemskap eller uttak)