### PR TITLE
TFP-5732 lagring og bruk av opphørsdato i nytt medlemskap

### DIFF
--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/medlemskap/MedlemskapVilkårPeriodeRepository.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/medlemskap/MedlemskapVilkårPeriodeRepository.java
@@ -93,7 +93,6 @@ public class MedlemskapVilkårPeriodeRepository {
         var periodeEntitet = hentAktivtGrunnlag(behandling)
                 .map(MedlemskapVilkårPeriodeGrunnlagEntitet::getMedlemskapsvilkårPeriode);
 
-        // tar hensyn til overstrying av vilkåret
         if (periodeEntitet.isPresent()) {
             var entitet = periodeEntitet.get();
             var overstyringOpt = entitet.getOverstyring();

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/medlemskap/MedlemskapsvilkårPeriodeEntitet.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/medlemskap/MedlemskapsvilkårPeriodeEntitet.java
@@ -136,13 +136,18 @@ public class MedlemskapsvilkårPeriodeEntitet extends BaseEntitet {
             return this;
         }
 
-        public MedlemskapsvilkårPeriodeEntitet.Builder opprettOverstryingAvslag(LocalDate overstryingsdato, Avslagsårsak avslagsårsak) {
-            kladd.opprettOverstyringFor(overstryingsdato, VilkårUtfallType.IKKE_OPPFYLT, avslagsårsak);
+        public MedlemskapsvilkårPeriodeEntitet.Builder opprettOverstyringAvslag(LocalDate overstyringsdato, Avslagsårsak avslagsårsak) {
+            kladd.opprettOverstyringFor(overstyringsdato, VilkårUtfallType.IKKE_OPPFYLT, avslagsårsak);
             return this;
         }
 
-        public MedlemskapsvilkårPeriodeEntitet.Builder opprettOverstryingOppfylt(LocalDate overstryingsdato) {
-            kladd.opprettOverstyringFor(overstryingsdato, VilkårUtfallType.OPPFYLT, Avslagsårsak.UDEFINERT);
+        public MedlemskapsvilkårPeriodeEntitet.Builder opprettOverstyringOppfylt(LocalDate overstyringsdato) {
+            kladd.opprettOverstyringFor(overstyringsdato, VilkårUtfallType.OPPFYLT, Avslagsårsak.UDEFINERT);
+            return this;
+        }
+
+        public MedlemskapsvilkårPeriodeEntitet.Builder opprettOverstyring(LocalDate overstyringsdato, Avslagsårsak avslagsårsak, VilkårUtfallType utfallType) {
+            kladd.opprettOverstyringFor(overstyringsdato, utfallType, avslagsårsak);
             return this;
         }
 

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/medlemskap/OverstyrtLøpendeMedlemskap.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/medlemskap/OverstyrtLøpendeMedlemskap.java
@@ -34,7 +34,7 @@ public class OverstyrtLøpendeMedlemskap {
     public OverstyrtLøpendeMedlemskap(LocalDate overstyringsdato, VilkårUtfallType vilkårUtfall, Avslagsårsak avslagsårsak) {
         this.overstyringsdato = overstyringsdato;
         this.vilkårUtfall = vilkårUtfall;
-        this.avslagsårsak = avslagsårsak;
+        this.avslagsårsak = avslagsårsak == null ? Avslagsårsak.UDEFINERT : avslagsårsak;
     }
 
     public Optional<LocalDate> getOverstyringsdato() {

--- a/behandlingslager/domene/src/test/java/no/nav/foreldrepenger/behandlingslager/behandling/medlemskap/MedlemskapVilkårPeriodeRepositoryTest.java
+++ b/behandlingslager/domene/src/test/java/no/nav/foreldrepenger/behandlingslager/behandling/medlemskap/MedlemskapVilkårPeriodeRepositoryTest.java
@@ -39,7 +39,7 @@ class MedlemskapVilkårPeriodeRepositoryTest extends EntityManagerAwareTest {
         var behandling = lagBehandling();
         var builderIkkeOppfylt = medlemskapVilkårPeriodeRepository.hentBuilderFor(behandling);
         var periodeBuilderIkkeOppylt = builderIkkeOppfylt.getPeriodeBuilder();
-        periodeBuilderIkkeOppylt.opprettOverstryingAvslag(LocalDate.now(), Avslagsårsak.SØKER_ER_IKKE_MEDLEM);
+        periodeBuilderIkkeOppylt.opprettOverstyringAvslag(LocalDate.now(), Avslagsårsak.SØKER_ER_IKKE_MEDLEM);
         builderIkkeOppfylt.medMedlemskapsvilkårPeriode(periodeBuilderIkkeOppylt);
         medlemskapVilkårPeriodeRepository.lagreMedlemskapsvilkår(behandling, builderIkkeOppfylt);
 
@@ -52,7 +52,7 @@ class MedlemskapVilkårPeriodeRepositoryTest extends EntityManagerAwareTest {
         var builderOppfylt = medlemskapVilkårPeriodeRepository.hentBuilderFor(behandling);
 
         var periodeBuilderOppfylt = builderOppfylt.getPeriodeBuilder();
-        periodeBuilderOppfylt.opprettOverstryingOppfylt(LocalDate.now());
+        periodeBuilderOppfylt.opprettOverstyringOppfylt(LocalDate.now());
         builderOppfylt.medMedlemskapsvilkårPeriode(periodeBuilderOppfylt);
 
         medlemskapVilkårPeriodeRepository.lagreMedlemskapsvilkår(behandling, builderOppfylt);

--- a/domenetjenester/medlem/src/test/java/no/nav/foreldrepenger/domene/medlem/impl/MedlemTjenesteTest.java
+++ b/domenetjenester/medlem/src/test/java/no/nav/foreldrepenger/domene/medlem/impl/MedlemTjenesteTest.java
@@ -73,6 +73,14 @@ class MedlemTjenesteTest {
         grBuilder.medMedlemskapsvilkårPeriode(mbuilder);
         medlemskapVilkårPeriodeRepository.lagreMedlemskapsvilkår(behandling, grBuilder);
 
+        var grBuilder2 = medlemskapVilkårPeriodeRepository.hentBuilderFor(behandling);
+        var mbuilder2 = grBuilder2.getPeriodeBuilder();
+        var periode2 = mbuilder2.getBuilderForVurderingsdato(now);
+        periode2.medVilkårUtfall(VilkårUtfallType.OPPFYLT);
+        mbuilder2.leggTil(periode2);
+        grBuilder2.medMedlemskapsvilkårPeriode(mbuilder2);
+        medlemskapVilkårPeriodeRepository.lagreMedlemskapsvilkår(behandling, grBuilder2);
+
         // Act
         var localDate = tjeneste.hentOpphørsdatoHvisEksisterer(behandling.getId());
 

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/medlem/MedlemDtoTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/medlem/MedlemDtoTjeneste.java
@@ -37,7 +37,7 @@ import no.nav.foreldrepenger.behandlingslager.behandling.personopplysning.Person
 import no.nav.foreldrepenger.behandlingslager.behandling.personopplysning.PersonopplysningerAggregat;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepositoryProvider;
-import no.nav.foreldrepenger.behandlingslager.behandling.vilkår.Vilkår;
+import no.nav.foreldrepenger.behandlingslager.behandling.vilkår.Avslagsårsak;
 import no.nav.foreldrepenger.behandlingslager.behandling.vilkår.VilkårResultatRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.vilkår.VilkårType;
 import no.nav.foreldrepenger.behandlingslager.behandling.vilkår.VilkårUtfallType;
@@ -204,9 +204,9 @@ public class MedlemDtoTjeneste {
             .filter(v -> v.getVilkårType().equals(VilkårType.MEDLEMSKAPSVILKÅRET)) //TODO forutgående
             .findFirst();
         var opphørsdato = medlemTjeneste.hentOpphørsdatoHvisEksisterer(behandling.getId());
-        var avslagskode = medlemskapsvilkår.map(Vilkår::getAvslagsårsak).orElse(null);
-        var resultat = medlemskapsvilkår.filter(m -> VilkårUtfallType.erFastsatt(m.getVilkårUtfallManuelt())).isPresent() ? new MedlemskapV3Dto.ManuellBehandling.Resultat(avslagskode,
-            null, opphørsdato.orElse(null)) : null;
+        var avslagskode = medlemTjeneste.hentAvslagsårsak(behandling.getId()).filter(å -> !å.equals(Avslagsårsak.UDEFINERT));
+        var resultat = medlemskapsvilkår.filter(m -> VilkårUtfallType.erFastsatt(m.getVilkårUtfallManuelt())).isPresent() ?
+            new MedlemskapV3Dto.ManuellBehandling.Resultat(avslagskode.orElse(null), null, opphørsdato.orElse(null)) : null;
         return Optional.of(new MedlemskapV3Dto.ManuellBehandling(avvik, resultat));
     }
 

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/medlem/aksjonspunkt/MedlemskapsvilkåretLøpendeOverstyringshåndterer.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/medlem/aksjonspunkt/MedlemskapsvilkåretLøpendeOverstyringshåndterer.java
@@ -66,12 +66,12 @@ public class MedlemskapsvilkåretLøpendeOverstyringshåndterer extends Abstract
 
         var vilkårResultatBuilder = VilkårResultat.builderFraEksisterende(behandlingsresultatRepository.hent(behandling.getId()).getVilkårResultat());
         if (dto.getErVilkarOk()) {
-            periodeBuilder.opprettOverstryingOppfylt(dto.getOverstryingsdato());
+            periodeBuilder.opprettOverstyringOppfylt(dto.getOverstryingsdato());
             vilkårResultatBuilder.overstyrVilkår(VilkårType.MEDLEMSKAPSVILKÅRET_LØPENDE, VilkårUtfallType.OPPFYLT, Avslagsårsak.UDEFINERT);
         } else {
             var avslagsårsak = Avslagsårsak.fraDefinertKode(dto.getAvslagskode())
                 .orElseThrow(() -> new FunksjonellException("FP-MANGLER-ÅRSAK", "Ugyldig avslagsårsak", "Velg gyldig avslagsårsak"));
-            periodeBuilder.opprettOverstryingAvslag(dto.getOverstryingsdato(), avslagsårsak);
+            periodeBuilder.opprettOverstyringAvslag(dto.getOverstryingsdato(), avslagsårsak);
             vilkårResultatBuilder.overstyrVilkår(VilkårType.MEDLEMSKAPSVILKÅRET_LØPENDE, VilkårUtfallType.IKKE_OPPFYLT, avslagsårsak);
         }
         var lås = kontekst.getSkriveLås();


### PR DESCRIPTION
Input?

Lagrer i overstyringens vurderingsdato. Ser dette feltet aldri har vært i bruk i prod db, så det er kanskje bedre å lage et nytt felt med "opphørFom"?