### PR TITLE
Ny kabal-hendelse for hjemsending fra Trygderett

### DIFF
--- a/domenetjenester/behandling-klage/src/main/java/no/nav/foreldrepenger/behandling/kabal/KabalHendelse.java
+++ b/domenetjenester/behandling-klage/src/main/java/no/nav/foreldrepenger/behandling/kabal/KabalHendelse.java
@@ -13,13 +13,15 @@ public record KabalHendelse(UUID eventId,
 
     public enum BehandlingEventType {
         BEHANDLING_FEILREGISTRERT, KLAGEBEHANDLING_AVSLUTTET,
-        ANKEBEHANDLING_OPPRETTET, ANKE_I_TRYGDERETTENBEHANDLING_OPPRETTET, ANKEBEHANDLING_AVSLUTTET
+        ANKEBEHANDLING_OPPRETTET, ANKE_I_TRYGDERETTENBEHANDLING_OPPRETTET, ANKEBEHANDLING_AVSLUTTET,
+        BEHANDLING_ETTER_TRYGDERETTEN_OPPHEVET_AVSLUTTET
     }
 
     public record BehandlingDetaljer(KlagebehandlingAvsluttetDetaljer klagebehandlingAvsluttet,
                                      AnkebehandlingOpprettetDetaljer ankebehandlingOpprettet,
                                      AnkeITrygderettenbehandlingOpprettetDetaljer ankeITrygderettenbehandlingOpprettet,
                                      AnkebehandlingAvsluttetDetaljer ankebehandlingAvsluttet,
+                                     BehandlingEtterTrygderettenOpphevetAvsluttet behandlingEtterTrygderettenOpphevetAvsluttet,
                                      BehandlingFeilregistrertDetaljer behandlingFeilregistrert) {}
 
     public record KlagebehandlingAvsluttetDetaljer(LocalDateTime avsluttet, KabalUtfall utfall, List<String> journalpostReferanser) {}
@@ -29,6 +31,8 @@ public record KabalHendelse(UUID eventId,
     public record AnkeITrygderettenbehandlingOpprettetDetaljer(LocalDateTime sendtTilTrygderetten, KabalUtfall utfall) {}
 
     public record AnkebehandlingAvsluttetDetaljer(LocalDateTime avsluttet, KabalUtfall utfall, List<String> journalpostReferanser) {}
+
+    public record BehandlingEtterTrygderettenOpphevetAvsluttet(LocalDateTime avsluttet, KabalUtfall utfall, List<String> journalpostReferanser) {}
 
     public record BehandlingFeilregistrertDetaljer(LocalDateTime feilregistrert, BehandlingType type, String navIdent, String reason) {}
 

--- a/domenetjenester/behandling-klage/src/main/java/no/nav/foreldrepenger/behandling/kabal/MottaFraKabalTask.java
+++ b/domenetjenester/behandling-klage/src/main/java/no/nav/foreldrepenger/behandling/kabal/MottaFraKabalTask.java
@@ -84,7 +84,7 @@ public class MottaFraKabalTask extends BehandlingProsessTask {
             case KLAGEBEHANDLING_AVSLUTTET -> klageAvsluttet(prosessTaskData, behandlingId, ref);
             case ANKEBEHANDLING_OPPRETTET -> ankeOpprettet(behandlingId, ref);
             case ANKE_I_TRYGDERETTENBEHANDLING_OPPRETTET -> ankeTrygdrett(prosessTaskData, behandlingId, ref);
-            case ANKEBEHANDLING_AVSLUTTET -> ankeAvsluttet(prosessTaskData, behandlingId, ref);
+            case ANKEBEHANDLING_AVSLUTTET, BEHANDLING_ETTER_TRYGDERETTEN_OPPHEVET_AVSLUTTET -> ankeAvsluttet(prosessTaskData, behandlingId, ref);
             case BEHANDLING_FEILREGISTRERT -> henleggFeilopprettet(prosessTaskData, behandlingId, ref);
         }
     }

--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/kabal/KabalHendelseHåndterer.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/kabal/KabalHendelseHåndterer.java
@@ -122,6 +122,10 @@ public class KabalHendelseHåndterer implements KafkaMessageHandler.KafkaStringM
             task.setProperty(MottaFraKabalTask.UTFALL_KEY, mottattHendelse.detaljer().ankebehandlingAvsluttet().utfall().name());
             mottattHendelse.detaljer().ankebehandlingAvsluttet().journalpostReferanser().stream()
                 .findFirst().ifPresent(journalpost -> task.setProperty(MottaFraKabalTask.JOURNALPOST_KEY, journalpost));
+        } else if (KabalHendelse.BehandlingEventType.BEHANDLING_ETTER_TRYGDERETTEN_OPPHEVET_AVSLUTTET.equals(mottattHendelse.type())) {
+            task.setProperty(MottaFraKabalTask.UTFALL_KEY, mottattHendelse.detaljer().behandlingEtterTrygderettenOpphevetAvsluttet().utfall().name());
+            mottattHendelse.detaljer().behandlingEtterTrygderettenOpphevetAvsluttet().journalpostReferanser().stream()
+                .findFirst().ifPresent(journalpost -> task.setProperty(MottaFraKabalTask.JOURNALPOST_KEY, journalpost));
         } else if (KabalHendelse.BehandlingEventType.BEHANDLING_FEILREGISTRERT.equals(mottattHendelse.type())) {
             task.setProperty(MottaFraKabalTask.FEILOPPRETTET_TYPE_KEY, mottattHendelse.detaljer().behandlingFeilregistrert().type().name());
         }


### PR DESCRIPTION
Ny hendelse for tilfeller der Trygderetten opphever vedtak og hjemsender anke. 
Vedtak fattes av KA og må etter behov effektueres av førsteinstans.
Vedtak i slike tilfelle kan ikke påklages, men de kan påankes.