### PR TITLE
Hindre reåpning av utgåtte medlemsaksjonspunkt

### DIFF
--- a/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/vedtak/FatteVedtakStegTest.java
+++ b/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/vedtak/FatteVedtakStegTest.java
@@ -29,6 +29,7 @@ import no.nav.foreldrepenger.behandling.BehandlingEventPubliserer;
 import no.nav.foreldrepenger.behandling.FagsakRelasjonTjeneste;
 import no.nav.foreldrepenger.behandling.Skjæringstidspunkt;
 import no.nav.foreldrepenger.behandlingskontroll.BehandlingskontrollKontekst;
+import no.nav.foreldrepenger.behandlingskontroll.BehandlingskontrollTjeneste;
 import no.nav.foreldrepenger.behandlingskontroll.transisjoner.FellesTransisjoner;
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingResultatType;
@@ -107,6 +108,8 @@ class FatteVedtakStegTest {
     private LagretVedtakRepository lagretVedtakRepository;
     @Inject
     private VilkårResultatRepository vilkårResultatRepository;
+    @Inject
+    private BehandlingskontrollTjeneste behandlingskontrollTjeneste;
 
     private FatteVedtakSteg fatteVedtakSteg;
 
@@ -150,7 +153,7 @@ class FatteVedtakStegTest {
 
         behandlingVedtakTjeneste = new BehandlingVedtakTjeneste(behandlingVedtakEventPubliserer, repositoryProvider);
         var klageanke = new KlageAnkeVedtakTjeneste(klageRepository, mock(AnkeRepository.class));
-        var fatteVedtakTjeneste = new FatteVedtakTjeneste(lagretVedtakRepository, klageanke, fpSakVedtakXmlTjeneste, vedtakTjeneste, totrinnTjeneste, behandlingVedtakTjeneste);
+        var fatteVedtakTjeneste = new FatteVedtakTjeneste(lagretVedtakRepository, klageanke, fpSakVedtakXmlTjeneste, vedtakTjeneste, totrinnTjeneste, behandlingVedtakTjeneste, behandlingskontrollTjeneste);
         var simuler = new SimulerInntrekkSjekkeTjeneste(null, null, null, null);
         fatteVedtakSteg = new FatteVedtakSteg(repositoryProvider, fatteVedtakTjeneste, simuler);
     }
@@ -375,7 +378,7 @@ class FatteVedtakStegTest {
         totrinnsvurderings.add(ttvurdering);
         when(totrinnTjeneste.hentTotrinnaksjonspunktvurderinger(behandling.getId())).thenReturn(totrinnsvurderings);
         var klageanke = new KlageAnkeVedtakTjeneste(klageRepository, mock(AnkeRepository.class));
-        var fvtei = new FatteVedtakTjeneste(lagretVedtakRepository, klageanke, fpSakVedtakXmlTjeneste, vedtakTjeneste, totrinnTjeneste, behandlingVedtakTjeneste);
+        var fvtei = new FatteVedtakTjeneste(lagretVedtakRepository, klageanke, fpSakVedtakXmlTjeneste, vedtakTjeneste, totrinnTjeneste, behandlingVedtakTjeneste, behandlingskontrollTjeneste);
 
         var simuler = new SimulerInntrekkSjekkeTjeneste(null, null, null, null);
         fatteVedtakSteg = new FatteVedtakSteg(repositoryProvider, fvtei, simuler);
@@ -443,7 +446,7 @@ class FatteVedtakStegTest {
         totrinnsvurderings.add(vurderesOk);
         when(totrinnTjeneste.hentTotrinnaksjonspunktvurderinger(behandling.getId())).thenReturn(totrinnsvurderings);
         var klageanke = new KlageAnkeVedtakTjeneste(klageRepository, mock(AnkeRepository.class));
-        var fvtei = new FatteVedtakTjeneste(lagretVedtakRepository, klageanke, fpSakVedtakXmlTjeneste, vedtakTjeneste, totrinnTjeneste, behandlingVedtakTjeneste);
+        var fvtei = new FatteVedtakTjeneste(lagretVedtakRepository, klageanke, fpSakVedtakXmlTjeneste, vedtakTjeneste, totrinnTjeneste, behandlingVedtakTjeneste, behandlingskontrollTjeneste);
 
         var simuler = new SimulerInntrekkSjekkeTjeneste(null, null, null, null);
         fatteVedtakSteg = new FatteVedtakSteg(repositoryProvider, fvtei, simuler);

--- a/domenetjenester/behandlingskontroll/src/main/java/no/nav/foreldrepenger/behandlingskontroll/BehandleStegResultat.java
+++ b/domenetjenester/behandlingskontroll/src/main/java/no/nav/foreldrepenger/behandlingskontroll/BehandleStegResultat.java
@@ -70,8 +70,8 @@ public class BehandleStegResultat {
         return new BehandleStegResultat(FellesTransisjoner.TILBAKEFØRT_TIL_AKSJONSPUNKT, aksjonspunktResultater);
     }
 
-    public static BehandleStegResultat tilbakeførtForeslåVedtak() {
-        return new BehandleStegResultat(FellesTransisjoner.TILBAKEFØRT_TIL_FORESLÅ_VEDTAK, Collections.emptyList());
+    public static BehandleStegResultat tilbakeførtMedlemskap() { // TODO medlemskap - fjern når alle behandlinger med gamle medl-ap er avsluttet
+        return new BehandleStegResultat(FellesTransisjoner.TILBAKEFØRT_TIL_MEDLEMSKAP, Collections.emptyList());
     }
 
     public static BehandleStegResultat fremoverførtMedAksjonspunkter(TransisjonIdentifikator transisjon,

--- a/domenetjenester/behandlingskontroll/src/main/java/no/nav/foreldrepenger/behandlingskontroll/impl/transisjoner/Transisjoner.java
+++ b/domenetjenester/behandlingskontroll/src/main/java/no/nav/foreldrepenger/behandlingskontroll/impl/transisjoner/Transisjoner.java
@@ -16,7 +16,7 @@ public class Transisjoner {
             new HenleggelseTransisjon(),
             new SettPåVent(),
             new TilbakeføringTransisjon(FellesTransisjoner.TILBAKEFØRT_TIL_AKSJONSPUNKT.getId()),
-            new TilbakeføringTransisjon(FellesTransisjoner.TILBAKEFØRT_TIL_FORESLÅ_VEDTAK.getId(), BehandlingStegType.FORESLÅ_VEDTAK),
+            new TilbakeføringTransisjon(FellesTransisjoner.TILBAKEFØRT_TIL_MEDLEMSKAP.getId(), BehandlingStegType.VURDER_MEDLEMSKAPVILKÅR),
             new FremoverhoppTransisjon(FellesTransisjoner.FREMHOPP_TIL_FATTE_VEDTAK.getId(), BehandlingStegType.FATTE_VEDTAK),
             new FremoverhoppTransisjon(FellesTransisjoner.FREMHOPP_TIL_FORESLÅ_VEDTAK.getId(), BehandlingStegType.FORESLÅ_VEDTAK),
             new FremoverhoppTransisjon(FellesTransisjoner.FREMHOPP_TIL_FORESLÅ_BEHANDLINGSRESULTAT.getId(),

--- a/domenetjenester/behandlingskontroll/src/main/java/no/nav/foreldrepenger/behandlingskontroll/transisjoner/FellesTransisjoner.java
+++ b/domenetjenester/behandlingskontroll/src/main/java/no/nav/foreldrepenger/behandlingskontroll/transisjoner/FellesTransisjoner.java
@@ -11,7 +11,7 @@ public class FellesTransisjoner {
     public static final TransisjonIdentifikator HENLAGT = TransisjonIdentifikator.forId("henlagt");
     public static final TransisjonIdentifikator SETT_PÅ_VENT = TransisjonIdentifikator.forId("sett-på-vent");
     public static final TransisjonIdentifikator TILBAKEFØRT_TIL_AKSJONSPUNKT = TransisjonIdentifikator.forId(TILBAKEFØR_PREFIX + "aksjonspunkt");
-    public static final TransisjonIdentifikator TILBAKEFØRT_TIL_FORESLÅ_VEDTAK = TransisjonIdentifikator.forId(TILBAKEFØR_PREFIX + "foreslå-vedtak");
+    public static final TransisjonIdentifikator TILBAKEFØRT_TIL_MEDLEMSKAP = TransisjonIdentifikator.forId(TILBAKEFØR_PREFIX + "medlemskap");
     public static final TransisjonIdentifikator FREMHOPP_TIL_FATTE_VEDTAK = TransisjonIdentifikator.forId(FREMHOPP_PREFIX + "fatte-vedtak");
     public static final TransisjonIdentifikator FREMHOPP_TIL_FORESLÅ_VEDTAK = TransisjonIdentifikator.forId(FREMHOPP_PREFIX + "foreslå-vedtak");
     public static final TransisjonIdentifikator FREMHOPP_TIL_FORESLÅ_BEHANDLINGSRESULTAT = TransisjonIdentifikator

--- a/domenetjenester/vedtak/src/main/java/no/nav/foreldrepenger/domene/vedtak/impl/FatterVedtakAksjonspunkt.java
+++ b/domenetjenester/vedtak/src/main/java/no/nav/foreldrepenger/domene/vedtak/impl/FatterVedtakAksjonspunkt.java
@@ -3,6 +3,7 @@ package no.nav.foreldrepenger.domene.vedtak.impl;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import jakarta.enterprise.context.ApplicationScoped;
@@ -19,10 +20,17 @@ import no.nav.foreldrepenger.domene.arbeidsforhold.InntektArbeidYtelseTjeneste;
 import no.nav.foreldrepenger.domene.vedtak.TotrinnTjeneste;
 import no.nav.foreldrepenger.domene.vedtak.VedtakAksjonspunktData;
 import no.nav.foreldrepenger.domene.vedtak.VedtakTjeneste;
+import no.nav.foreldrepenger.konfig.Environment;
 import no.nav.vedtak.sikkerhet.kontekst.KontekstHolder;
 
 @ApplicationScoped
 public class FatterVedtakAksjonspunkt {
+
+    private static final Environment ENV = Environment.current(); // TODO medlemskap2 standardisere etter omlegging
+
+    private static final Set<AksjonspunktDefinisjon> LEGACY_MEDLEM = Set.of(AksjonspunktDefinisjon.AVKLAR_LOVLIG_OPPHOLD,
+        AksjonspunktDefinisjon.AVKLAR_OM_ER_BOSATT, AksjonspunktDefinisjon.AVKLAR_GYLDIG_MEDLEMSKAPSPERIODE, AksjonspunktDefinisjon.AVKLAR_OPPHOLDSRETT,
+        AksjonspunktDefinisjon.AVKLAR_FORTSATT_MEDLEMSKAP);
 
     private VedtakTjeneste vedtakTjeneste;
     private TotrinnTjeneste totrinnTjeneste;
@@ -59,7 +67,11 @@ public class FatterVedtakAksjonspunkt {
             var erTotrinnGodkjent = aks.isGodkjent();
             var aksjonspunkt = behandling.getAksjonspunktFor(aks.getAksjonspunktDefinisjon());
             if (!aks.isGodkjent()) {
-                skalReåpnes.add(aksjonspunkt);
+                if (ENV.isProd()) {
+                    skalReåpnes.add(aksjonspunkt);
+                } else if (!LEGACY_MEDLEM.contains(aks.getAksjonspunktDefinisjon())) {
+                    skalReåpnes.add(aksjonspunkt);
+                }
             }
 
             var koder = aks.getVurderÅrsakskoder();

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/forvaltning/ForvaltningStegRestTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/forvaltning/ForvaltningStegRestTjeneste.java
@@ -135,7 +135,7 @@ public class ForvaltningStegRestTjeneste {
     @BeskyttetRessurs(actionType = ActionType.READ, resourceType = ResourceType.DRIFT, sporingslogg = false)
     public Response avbrytMedlemsAksjonspunkt() {
         var medlemsaksjonspunkt = List.of(AksjonspunktDefinisjon.AVKLAR_LOVLIG_OPPHOLD, AksjonspunktDefinisjon.AVKLAR_OM_ER_BOSATT,
-            AksjonspunktDefinisjon.AVKLAR_GYLDIG_MEDLEMSKAPSPERIODE, AksjonspunktDefinisjon.AVKLAR_OPPHOLDSRETT, AksjonspunktDefinisjon.OVERSTYRING_AV_MEDLEMSKAPSVILKÅRET);
+            AksjonspunktDefinisjon.AVKLAR_GYLDIG_MEDLEMSKAPSPERIODE, AksjonspunktDefinisjon.AVKLAR_OPPHOLDSRETT);
         entityManager.createQuery("select behandling from Aksjonspunkt ap where ap.aksjonspunktDefinisjon in (:apdef) and ap.status = :opprettet", Behandling.class)
             .setParameter("apdef",medlemsaksjonspunkt)
             .setParameter("opprettet", AksjonspunktStatus.OPPRETTET)


### PR DESCRIPTION
Midlertidig kode så lenge det finnes åpne behandlinger med gamle medlemsaksjonspunkt.
Vil ikke reåpne gamle medlemsaksjonspunkt når beslutter lagrer. Påfølgende steg vil bruke vanlig tilbakeføring dersom noen er før medlemskap, ellers tvinges behandlingen tilbake til medlemskap.