### PR TITLE
Sikre aksjonspunkt medlemskap i revurdering

### DIFF
--- a/behandlingsprosess/src/main/java/no/nav/foreldrepenger/behandling/steg/inngangsvilkår/InngangsvilkårStegImpl.java
+++ b/behandlingsprosess/src/main/java/no/nav/foreldrepenger/behandling/steg/inngangsvilkår/InngangsvilkårStegImpl.java
@@ -6,7 +6,6 @@ import static no.nav.foreldrepenger.behandlingskontroll.transisjoner.FellesTrans
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
@@ -26,15 +25,12 @@ import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRe
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepositoryProvider;
 import no.nav.foreldrepenger.behandlingslager.behandling.vilkår.Vilkår;
 import no.nav.foreldrepenger.behandlingslager.behandling.vilkår.VilkårResultat;
-import no.nav.foreldrepenger.behandlingslager.behandling.vilkår.VilkårType;
 import no.nav.foreldrepenger.behandlingslager.behandling.vilkår.VilkårUtfallType;
 import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakYtelseType;
 import no.nav.foreldrepenger.inngangsvilkaar.RegelResultat;
-import no.nav.foreldrepenger.konfig.Environment;
 
 public abstract class InngangsvilkårStegImpl implements InngangsvilkårSteg {
 
-    private static final Set<VilkårType> ALLTID_MANUELL_NÅR_REGEL_IKKE_OPPFYLT = Environment.current().isProd() ? Set.of() : Set.of(VilkårType.MEDLEMSKAPSVILKÅRET);
     private BehandlingRepository behandlingRepository;
     private InngangsvilkårFellesTjeneste inngangsvilkårFellesTjeneste;
     private BehandlingRepositoryProvider repositoryProvider;

--- a/behandlingsprosess/src/main/java/no/nav/foreldrepenger/behandling/steg/inngangsvilkår/medlemskap/es/VurderMedlemskapvilkårStegImpl.java
+++ b/behandlingsprosess/src/main/java/no/nav/foreldrepenger/behandling/steg/inngangsvilkår/medlemskap/es/VurderMedlemskapvilkårStegImpl.java
@@ -41,6 +41,11 @@ public class VurderMedlemskapvilkårStegImpl extends InngangsvilkårStegImpl {
     }
 
     @Override
+    protected boolean manuellVurderingNårRegelVilkårIkkeOppfylt() {
+        return !ENV.isProd();
+    }
+
+    @Override
     protected BehandleStegResultat stegResultatVilkårIkkeOppfylt(RegelResultat regelResultat, Behandling behandling) {
         if (ENV.isProd()) {
             return super.stegResultatVilkårIkkeOppfylt(regelResultat, behandling);

--- a/behandlingsprosess/src/main/java/no/nav/foreldrepenger/behandling/steg/inngangsvilkår/medlemskap/fp/VurderMedlemskapvilkårStegImpl.java
+++ b/behandlingsprosess/src/main/java/no/nav/foreldrepenger/behandling/steg/inngangsvilkår/medlemskap/fp/VurderMedlemskapvilkårStegImpl.java
@@ -84,6 +84,11 @@ public class VurderMedlemskapvilkårStegImpl extends InngangsvilkårStegImpl {
     }
 
     @Override
+    protected boolean manuellVurderingNårRegelVilkårIkkeOppfylt() {
+        return !ENV.isProd();
+    }
+
+    @Override
     protected BehandleStegResultat stegResultatVilkårIkkeOppfylt(RegelResultat regelResultat, Behandling behandling) {
         if (ENV.isProd()) {
             return super.stegResultatVilkårIkkeOppfylt(regelResultat, behandling);

--- a/behandlingsprosess/src/main/java/no/nav/foreldrepenger/behandling/steg/inngangsvilkår/medlemskap/svp/VurderMedlemskapvilkårStegImpl.java
+++ b/behandlingsprosess/src/main/java/no/nav/foreldrepenger/behandling/steg/inngangsvilkår/medlemskap/svp/VurderMedlemskapvilkårStegImpl.java
@@ -84,6 +84,11 @@ public class VurderMedlemskapvilkårStegImpl extends InngangsvilkårStegImpl {
     }
 
     @Override
+    protected boolean manuellVurderingNårRegelVilkårIkkeOppfylt() {
+        return !ENV.isProd();
+    }
+
+    @Override
     protected BehandleStegResultat stegResultatVilkårIkkeOppfylt(RegelResultat regelResultat, Behandling behandling) {
         if (ENV.isProd()) {
             return super.stegResultatVilkårIkkeOppfylt(regelResultat, behandling);

--- a/domenetjenester/medlem/src/main/java/no/nav/foreldrepenger/domene/medlem/impl/MedlemEndringssjekker.java
+++ b/domenetjenester/medlem/src/main/java/no/nav/foreldrepenger/domene/medlem/impl/MedlemEndringssjekker.java
@@ -1,35 +1,17 @@
 package no.nav.foreldrepenger.domene.medlem.impl;
 
 import java.util.List;
-import java.util.Optional;
 
 import no.nav.foreldrepenger.behandlingslager.behandling.RegisterdataDiffsjekker;
-import no.nav.foreldrepenger.behandlingslager.behandling.medlemskap.MedlemskapAggregat;
 import no.nav.foreldrepenger.behandlingslager.behandling.medlemskap.MedlemskapPerioderEntitet;
 
 public abstract class MedlemEndringssjekker {
 
     abstract RegisterdataDiffsjekker opprettNyDiffer();
 
-    public boolean erEndret(Optional<MedlemskapAggregat> medlemskap, List<MedlemskapPerioderEntitet> list1, List<MedlemskapPerioderEntitet> list2) {
+    public boolean erEndret(List<MedlemskapPerioderEntitet> list1, List<MedlemskapPerioderEntitet> list2) {
         var differ = opprettNyDiffer();
-        return medlemskap.isEmpty() || differ.erForskjellPå(list1, list2);
-    }
-
-    public boolean erEndring(Optional<MedlemskapAggregat> nyttMedlemskap, Optional<MedlemskapAggregat> eksisterendeMedlemskap) {
-
-        if (eksisterendeMedlemskap.isEmpty() && nyttMedlemskap.isEmpty()) {
-            return false;
-        }
-        if (eksisterendeMedlemskap.isPresent() && nyttMedlemskap.isEmpty()) {
-            return true;
-        }
-        if (eksisterendeMedlemskap.isEmpty() && nyttMedlemskap.isPresent()) {  // NOSONAR - "redundant" her er false pos.
-            return true;
-        }
-
-        var differ = opprettNyDiffer();
-        return !differ.erForskjellPå(nyttMedlemskap.get().getRegistrertMedlemskapPerioderList(), eksisterendeMedlemskap.get().getRegistrertMedlemskapPerioderList());
+        return list1.size() != list2.size() || differ.erForskjellPå(list1, list2);
     }
 
     public boolean erEndring(MedlemskapPerioderEntitet perioder1, MedlemskapPerioderEntitet perioder2) {

--- a/domenetjenester/medlem/src/test/java/no/nav/foreldrepenger/domene/medlem/impl/MedlemEndringssjekkerEngangsstønadTest.java
+++ b/domenetjenester/medlem/src/test/java/no/nav/foreldrepenger/domene/medlem/impl/MedlemEndringssjekkerEngangsstønadTest.java
@@ -3,7 +3,6 @@ package no.nav.foreldrepenger.domene.medlem.impl;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
-import java.util.Optional;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -26,7 +25,7 @@ class MedlemEndringssjekkerEngangsstønadTest {
         var periode2 = new MedlemskapPerioderBuilder().medMedlId(2L).build();
 
         // Act
-        var endringsresultat = endringssjekker.erEndret(Optional.empty(), List.of(periode1), List.of(periode1, periode2));
+        var endringsresultat = endringssjekker.erEndret(List.of(periode1), List.of(periode1, periode2));
 
         // Assert
         assertThat(endringsresultat).isTrue();
@@ -39,7 +38,7 @@ class MedlemEndringssjekkerEngangsstønadTest {
         var periode2 = new MedlemskapPerioderBuilder().medMedlId(2L).build();
 
         // Act
-        var endringsresultat = endringssjekker.erEndret(Optional.empty(), List.of(periode1, periode2), List.of(periode1));
+        var endringsresultat = endringssjekker.erEndret(List.of(periode1, periode2), List.of(periode1));
 
         // Assert
         assertThat(endringsresultat).isTrue();
@@ -52,7 +51,7 @@ class MedlemEndringssjekkerEngangsstønadTest {
         var periode2 = new MedlemskapPerioderBuilder().medMedlId(1L).medErMedlem(false).build();
 
         // Act
-        var endringsresultat = endringssjekker.erEndret(Optional.empty(), List.of(periode1), List.of(periode2));
+        var endringsresultat = endringssjekker.erEndret(List.of(periode1), List.of(periode2));
 
         // Assert
         assertThat(endringsresultat).isTrue();


### PR DESCRIPTION
Denne sikrer ny vurdering av medlemsvilkåret når regelkjøring sier nei, også i tilfelle der det er manuelt satt til Oppfylt

Dersom det finnes overstyring så stopper man ikke (da slår skipSteget()) til.