### PR TITLE
POFIM-49 Lukke Inntektsmeldingsforespørsler for sak og orgnr

### DIFF
--- a/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/abakus/AbakusInMemoryInntektArbeidYtelseTjeneste.java
+++ b/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/abakus/AbakusInMemoryInntektArbeidYtelseTjeneste.java
@@ -247,10 +247,11 @@ public class AbakusInMemoryInntektArbeidYtelseTjeneste implements InntektArbeidY
     }
 
     @Override
-    public void lagreInntektsmeldinger(Saksnummer saksnummer, Long behandlingId, Collection<InntektsmeldingBuilder> builders) {
+    public List<Inntektsmelding> lagreInntektsmeldinger(Saksnummer saksnummer, Long behandlingId, Collection<InntektsmeldingBuilder> builders) {
         Objects.requireNonNull(builders, "builders");
         var builder = opprettGrunnlagBuilderFor(behandlingId);
         var inntektsmeldinger = builder.getInntektsmeldinger();
+        List<Inntektsmelding> lagretInntektsmeldinger = new ArrayList<>();
 
         for (var inntektsmeldingBuilder : builders) {
             var informasjon = builder.getInformasjon();
@@ -273,9 +274,11 @@ public class AbakusInMemoryInntektArbeidYtelseTjeneste implements InntektArbeidY
 
             builder.medInformasjon(informasjonBuilder.build());
             inntektsmeldinger.leggTil(inntektsmelding);
+            lagretInntektsmeldinger.add(inntektsmelding);
         }
         builder.setInntektsmeldinger(inntektsmeldinger);
         lagreOgFlush(behandlingId, builder.build());
+        return lagretInntektsmeldinger;
     }
 
     private static Optional<Arbeidsgiver> utledeArbeidsgiverSomMåTilbakestilles(Inntektsmelding inntektsmelding,

--- a/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/abakus/AbakusInntektArbeidYtelseTjeneste.java
+++ b/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/abakus/AbakusInntektArbeidYtelseTjeneste.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -13,11 +14,6 @@ import java.util.UUID;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Default;
 import jakarta.inject.Inject;
-
-import no.nav.foreldrepenger.behandlingslager.behandling.SpesialBehandling;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import no.nav.abakus.iaygrunnlag.AktørIdPersonident;
 import no.nav.abakus.iaygrunnlag.inntektsmelding.v1.InntektsmeldingerDto;
@@ -30,6 +26,7 @@ import no.nav.abakus.iaygrunnlag.request.OppgittOpptjeningMottattRequest;
 import no.nav.abakus.iaygrunnlag.v1.InntektArbeidYtelseGrunnlagDto;
 import no.nav.abakus.iaygrunnlag.v1.OverstyrtInntektArbeidYtelseDto;
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
+import no.nav.foreldrepenger.behandlingslager.behandling.SpesialBehandling;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepository;
 import no.nav.foreldrepenger.behandlingslager.fagsak.Fagsak;
 import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakRepository;
@@ -236,8 +233,8 @@ public class AbakusInntektArbeidYtelseTjeneste implements InntektArbeidYtelseTje
     }
 
     @Override
-    public void lagreInntektsmeldinger(Saksnummer saksnummer, Long behandlingId,
-            Collection<InntektsmeldingBuilder> inntektsmeldingBuilderCollection) {
+    public List<Inntektsmelding> lagreInntektsmeldinger(Saksnummer saksnummer, Long behandlingId,
+                                                        Collection<InntektsmeldingBuilder> inntektsmeldingBuilderCollection) {
         Objects.requireNonNull(inntektsmeldingBuilderCollection, "inntektsmeldingBuilderCollection");
         var behandling = behandlingRepository.hentBehandling(behandlingId);
         var inntektsmeldingerDto = new IAYTilDtoMapper(behandling.getAktørId(),
@@ -245,7 +242,7 @@ public class AbakusInntektArbeidYtelseTjeneste implements InntektArbeidYtelseTje
                 null, behandling.getUuid()).mapTilDto(inntektsmeldingBuilderCollection);
 
         if (inntektsmeldingerDto == null) {
-            return;
+            return Collections.emptyList();
         }
         var aktør = new AktørIdPersonident(behandling.getAktørId().getId());
         var inntektsmeldingerMottattRequest = new InntektsmeldingerMottattRequest(saksnummer.getVerdi(),
@@ -256,6 +253,8 @@ public class AbakusInntektArbeidYtelseTjeneste implements InntektArbeidYtelseTje
         } catch (IOException e) {
             throw feilVedKallTilAbakus("Lagre mottatte inntektsmeldinger i abakus: " + e.getMessage(), e);
         }
+        //Brukes ikke til noe
+        return Collections.emptyList();
     }
 
     @Override

--- a/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/arbeidsforhold/InntektArbeidYtelseTjeneste.java
+++ b/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/arbeidsforhold/InntektArbeidYtelseTjeneste.java
@@ -137,6 +137,7 @@ public interface InntektArbeidYtelseTjeneste {
      * @param saksnummer   - Saksnummer
      * @param behandlingId - Behandling Id
      * @param builders     - Collection med {@link InntektsmeldingBuilder}
+     * @return
      */
-    void lagreInntektsmeldinger(Saksnummer saksnummer, Long behandlingId, Collection<InntektsmeldingBuilder> builders);
+    List<Inntektsmelding> lagreInntektsmeldinger(Saksnummer saksnummer, Long behandlingId, Collection<InntektsmeldingBuilder> builders);
 }

--- a/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/fpinntektsmelding/LukkForespørselRequest.java
+++ b/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/fpinntektsmelding/LukkForespørselRequest.java
@@ -1,0 +1,8 @@
+package no.nav.foreldrepenger.domene.fpinntektsmelding;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+
+public record LukkForespørselRequest(@NotNull @Valid OpprettForespørselRequest.OrganisasjonsnummerDto orgnummer,
+                                     @NotNull @Valid OpprettForespørselRequest.SaksnummerDto saksnummer) {
+}

--- a/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/fpinntektsmelding/LukkForespørslerImTask.java
+++ b/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/fpinntektsmelding/LukkForespørslerImTask.java
@@ -1,0 +1,42 @@
+package no.nav.foreldrepenger.domene.fpinntektsmelding;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import no.nav.foreldrepenger.behandlingslager.task.GenerellProsessTask;
+import no.nav.vedtak.felles.prosesstask.api.ProsessTask;
+import no.nav.vedtak.felles.prosesstask.api.ProsessTaskData;
+
+@ApplicationScoped
+@ProsessTask(value = "fpinntektsmelding.lukkForesporsler")
+public class LukkForespørslerImTask extends GenerellProsessTask {
+    public static final String SAK_NUMMER = "saksnummer";
+    public static final String ORG_NUMMER = "organisasjonnummer";
+
+    private static final Logger LOG = LoggerFactory.getLogger(LukkForespørslerImTask.class);
+
+    private FpInntektsmeldingTjeneste fpInntektsmeldingTjeneste;
+
+    LukkForespørslerImTask() {
+        //CDI
+    }
+
+
+    @Inject
+    public LukkForespørslerImTask(FpInntektsmeldingTjeneste fpInntektsmeldingTjeneste) {
+        this.fpInntektsmeldingTjeneste = fpInntektsmeldingTjeneste;
+    }
+
+    @Override
+    protected void prosesser(ProsessTaskData prosessTaskData, Long fagsakId, Long behandlingId) {
+        var saksnummer = prosessTaskData.getPropertyValue(SAK_NUMMER);
+        var orgnummer = prosessTaskData.getPropertyValue(ORG_NUMMER);
+
+        LOG.info("Starter task for å lukke eventuelle forespørsler i fpinntektsmelding for saksnummer {} og orgnummer {}",  saksnummer, orgnummer);
+        fpInntektsmeldingTjeneste.lukkForespørsel(saksnummer, orgnummer);
+    }
+
+}

--- a/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/iay/modell/Inntektsmelding.java
+++ b/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/iay/modell/Inntektsmelding.java
@@ -19,6 +19,9 @@ import no.nav.foreldrepenger.domene.typer.JournalpostId;
 
 public class Inntektsmelding implements IndexKey {
 
+    public static final String NAV_NO = "NAV_NO";
+    private static final String OVERSTYRING_FPSAK = "OVERSTYRING_FPSAK";
+
     @ChangeTracked
     private List<Gradering> graderinger = new ArrayList<>();
 
@@ -326,6 +329,10 @@ public class Inntektsmelding implements IndexKey {
 
     void leggTil(Refusjon refusjon) {
         this.endringerRefusjon.add(refusjon);
+    }
+
+    public boolean kommerFraArbeidsgiverPortal() {
+        return NAV_NO.equals(this.kildesystem) || OVERSTYRING_FPSAK.equals(this.kildesystem);
     }
 
     @Override

--- a/domenetjenester/arbeidsforhold/src/test/java/no/nav/foreldrepenger/domene/arbeidsforhold/fp/InntektsmeldingTjenesteTest.java
+++ b/domenetjenester/arbeidsforhold/src/test/java/no/nav/foreldrepenger/domene/arbeidsforhold/fp/InntektsmeldingTjenesteTest.java
@@ -1,6 +1,7 @@
 package no.nav.foreldrepenger.domene.arbeidsforhold.fp;
 
 import static no.nav.foreldrepenger.behandlingslager.virksomhet.OrgNummer.KUNSTIG_ORG;
+import static no.nav.foreldrepenger.domene.iay.modell.Inntektsmelding.NAV_NO;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -48,6 +49,7 @@ import no.nav.foreldrepenger.domene.arbeidsforhold.InntektsmeldingTjeneste;
 import no.nav.foreldrepenger.domene.arbeidsforhold.impl.InntektsmeldingRegisterTjeneste;
 import no.nav.foreldrepenger.domene.arbeidsforhold.testutilities.behandling.IAYRepositoryProvider;
 import no.nav.foreldrepenger.domene.arbeidsgiver.VirksomhetTjeneste;
+import no.nav.foreldrepenger.domene.fpinntektsmelding.FpInntektsmeldingTjeneste;
 import no.nav.foreldrepenger.domene.iay.modell.InntektArbeidYtelseAggregatBuilder;
 import no.nav.foreldrepenger.domene.iay.modell.Inntektsmelding;
 import no.nav.foreldrepenger.domene.iay.modell.InntektsmeldingBuilder;
@@ -85,7 +87,7 @@ class InntektsmeldingTjenesteTest {
     private BehandlingRepository behandlingRepository;
     private FagsakRepository fagsakRepository;
     private final InntektArbeidYtelseTjeneste iayTjeneste = new AbakusInMemoryInntektArbeidYtelseTjeneste();
-    private final InntektsmeldingTjeneste inntektsmeldingTjeneste = new InntektsmeldingTjeneste(iayTjeneste);
+    private final InntektsmeldingTjeneste inntektsmeldingTjeneste = new InntektsmeldingTjeneste(iayTjeneste, new FpInntektsmeldingTjeneste());
     private InntektsmeldingRegisterTjeneste inntektsmeldingArkivTjeneste;
     private Arbeidsgiver arbeidsgiver;
     private Arbeidsgiver arbeidsgiver2;
@@ -277,10 +279,12 @@ class InntektsmeldingTjenesteTest {
             DatoIntervallEntitet.fraOgMedTilOgMed(ARBEIDSFORHOLD_FRA, ARBEIDSFORHOLD_TIL),
             ARBEIDSFORHOLD_ID, ArbeidType.ORDINÆRT_ARBEIDSFORHOLD, BigDecimal.TEN);
 
-        lagreInntektsmelding(skjæringstidspunktet.minusMonths(1).minusWeeks(5), behandling, ARBEIDSFORHOLD_ID, ARBEIDSFORHOLD_ID_EKSTERN, BigDecimal.TEN, arbeidsgiver, skjæringstidspunktet.minusMonths(1));
+        lagreInntektsmelding(skjæringstidspunktet.minusMonths(1).minusWeeks(5), behandling, ARBEIDSFORHOLD_ID, ARBEIDSFORHOLD_ID_EKSTERN, BigDecimal.TEN, arbeidsgiver, skjæringstidspunktet.minusMonths(1),
+            NAV_NO);
         assertThat(inntektsmeldingTjeneste.hentInntektsmeldinger(ref, skjæringstidspunktet)).isEmpty();
 
-        lagreInntektsmelding(skjæringstidspunktet.minusWeeks(3), behandling, ARBEIDSFORHOLD_ID, ARBEIDSFORHOLD_ID_EKSTERN, BigDecimal.TEN, arbeidsgiver, skjæringstidspunktet);
+        lagreInntektsmelding(skjæringstidspunktet.minusWeeks(3), behandling, ARBEIDSFORHOLD_ID, ARBEIDSFORHOLD_ID_EKSTERN, BigDecimal.TEN, arbeidsgiver, skjæringstidspunktet,
+            null);
 
         // Assert
         assertThat(inntektsmeldingTjeneste.hentInntektsmeldinger(ref, skjæringstidspunktet)).hasSize(1);
@@ -299,9 +303,11 @@ class InntektsmeldingTjenesteTest {
             DatoIntervallEntitet.fraOgMedTilOgMed(ARBEIDSFORHOLD_FRA, ARBEIDSFORHOLD_TIL),
             ARBEIDSFORHOLD_ID, ArbeidType.ORDINÆRT_ARBEIDSFORHOLD, BigDecimal.TEN);
 
-        lagreInntektsmelding(skjæringstidspunktet.minusMonths(2), behandling, ARBEIDSFORHOLD_ID, ARBEIDSFORHOLD_ID_EKSTERN, BigDecimal.TEN, arbeidsgiver2, skjæringstidspunktet.minusMonths(2));
+        lagreInntektsmelding(skjæringstidspunktet.minusMonths(2), behandling, ARBEIDSFORHOLD_ID, ARBEIDSFORHOLD_ID_EKSTERN, BigDecimal.TEN, arbeidsgiver2, skjæringstidspunktet.minusMonths(2),
+            NAV_NO);
         var skalAksepteres = YearMonth.from(skjæringstidspunktet.minusMonths(2)).atEndOfMonth().plusDays(1);
-        lagreInntektsmelding(skalAksepteres, behandling, ARBEIDSFORHOLD_ID, ARBEIDSFORHOLD_ID_EKSTERN, BigDecimal.TEN, arbeidsgiver, skjæringstidspunktet);
+        lagreInntektsmelding(skalAksepteres, behandling, ARBEIDSFORHOLD_ID, ARBEIDSFORHOLD_ID_EKSTERN, BigDecimal.TEN, arbeidsgiver, skjæringstidspunktet,
+            NAV_NO);
 
         // Assert
         assertThat(inntektsmeldingTjeneste.hentInntektsmeldinger(ref, skjæringstidspunktet)).hasSize(1);
@@ -321,24 +327,28 @@ class InntektsmeldingTjenesteTest {
 
     private void lagreInntektsmelding(LocalDate mottattDato, Behandling behandling, InternArbeidsforholdRef arbeidsforholdIdIntern,
                                       EksternArbeidsforholdRef arbeidsforholdId, BigDecimal beløp, Arbeidsgiver arbeidsgiver) {
-        lagreInntektsmelding(mottattDato, behandling, arbeidsforholdIdIntern, arbeidsforholdId, beløp, arbeidsgiver, I_DAG);
+        lagreInntektsmelding(mottattDato, behandling, arbeidsforholdIdIntern, arbeidsforholdId, beløp, arbeidsgiver, I_DAG, NAV_NO);
     }
 
     private void lagreInntektsmelding(LocalDate mottattDato, Behandling behandling, InternArbeidsforholdRef arbeidsforholdIdIntern,
-            EksternArbeidsforholdRef arbeidsforholdId, BigDecimal beløp, Arbeidsgiver arbeidsgiver, LocalDate startdato) {
+                                      EksternArbeidsforholdRef arbeidsforholdId, BigDecimal beløp, Arbeidsgiver arbeidsgiver, LocalDate startdato,
+                                      String kildeSystem) {
         var journalPostId = new JournalpostId(journalpostIdInc.getAndIncrement());
 
         var inntektsmelding = InntektsmeldingBuilder.builder()
-                .medStartDatoPermisjon(startdato)
-                .medArbeidsgiver(arbeidsgiver)
-                .medBeløp(beløp)
-                .medNærRelasjon(false)
-                .medArbeidsforholdId(arbeidsforholdId)
-                .medArbeidsforholdId(arbeidsforholdIdIntern)
-                .medInnsendingstidspunkt(LocalDateTime.of(mottattDato, LocalTime.MIN))
-                .medJournalpostId(journalPostId);
+            .medStartDatoPermisjon(startdato)
+            .medArbeidsgiver(arbeidsgiver)
+            .medBeløp(beløp)
+            .medNærRelasjon(false)
+            .medArbeidsforholdId(arbeidsforholdId)
+            .medArbeidsforholdId(arbeidsforholdIdIntern)
+            .medInnsendingstidspunkt(LocalDateTime.of(mottattDato, LocalTime.MIN))
+            .medJournalpostId(journalPostId);
+        if (kildeSystem != null) {
+            inntektsmelding.medKildesystem(kildeSystem);
+        }
 
-        inntektsmeldingTjeneste.lagreInntektsmelding(behandling.getFagsak().getSaksnummer(), behandling.getId(), inntektsmelding);
+        inntektsmeldingTjeneste.lagreInntektsmelding(inntektsmelding,behandling );
 
     }
 

--- a/domenetjenester/arbeidsforhold/src/test/java/no/nav/foreldrepenger/domene/arbeidsforhold/svp/InntektsmeldingTjenesteTest.java
+++ b/domenetjenester/arbeidsforhold/src/test/java/no/nav/foreldrepenger/domene/arbeidsforhold/svp/InntektsmeldingTjenesteTest.java
@@ -43,6 +43,7 @@ import no.nav.foreldrepenger.domene.arbeidsforhold.InntektArbeidYtelseTjeneste;
 import no.nav.foreldrepenger.domene.arbeidsforhold.InntektsmeldingTjeneste;
 import no.nav.foreldrepenger.domene.arbeidsforhold.impl.InntektsmeldingRegisterTjeneste;
 import no.nav.foreldrepenger.domene.arbeidsgiver.VirksomhetTjeneste;
+import no.nav.foreldrepenger.domene.fpinntektsmelding.FpInntektsmeldingTjeneste;
 import no.nav.foreldrepenger.domene.iay.modell.InntektArbeidYtelseAggregatBuilder;
 import no.nav.foreldrepenger.domene.iay.modell.InntektsmeldingBuilder;
 import no.nav.foreldrepenger.domene.iay.modell.OppgittAnnenAktivitet;
@@ -75,7 +76,7 @@ class InntektsmeldingTjenesteTest {
     private BehandlingRepository behandlingRepository;
     private FagsakRepository fagsakRepository;
     private final InntektArbeidYtelseTjeneste iayTjeneste = new AbakusInMemoryInntektArbeidYtelseTjeneste();
-    private final InntektsmeldingTjeneste inntektsmeldingTjeneste = new InntektsmeldingTjeneste(iayTjeneste);
+    private final InntektsmeldingTjeneste inntektsmeldingTjeneste = new InntektsmeldingTjeneste(iayTjeneste, new FpInntektsmeldingTjeneste());
 
     private Arbeidsgiver arbeidsgiver;
 
@@ -176,7 +177,7 @@ class InntektsmeldingTjenesteTest {
                 .medInnsendingstidspunkt(LocalDateTime.of(mottattDato, LocalTime.MIN))
                 .medJournalpostId(journalPostId);
 
-        inntektsmeldingTjeneste.lagreInntektsmelding(behandling.getFagsak().getSaksnummer(), behandling.getId(), inntektsmelding);
+        inntektsmeldingTjeneste.lagreInntektsmelding(inntektsmelding, behandling);
 
     }
 

--- a/domenetjenester/arbeidsforhold/src/test/java/no/nav/foreldrepenger/domene/fpinntektsmelding/FpInntektsmeldingTjenesteTest.java
+++ b/domenetjenester/arbeidsforhold/src/test/java/no/nav/foreldrepenger/domene/fpinntektsmelding/FpInntektsmeldingTjenesteTest.java
@@ -10,10 +10,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 
-import no.nav.foreldrepenger.behandlingslager.behandling.historikk.HistorikkRepository;
-
-import no.nav.foreldrepenger.domene.arbeidsgiver.ArbeidsgiverTjeneste;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -24,9 +20,11 @@ import no.nav.foreldrepenger.behandling.BehandlingReferanse;
 import no.nav.foreldrepenger.behandling.Skjæringstidspunkt;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingStatus;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingType;
+import no.nav.foreldrepenger.behandlingslager.behandling.historikk.HistorikkRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.personopplysning.RelasjonsRolleType;
 import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakYtelseType;
 import no.nav.foreldrepenger.behandlingslager.virksomhet.Arbeidsgiver;
+import no.nav.foreldrepenger.domene.arbeidsgiver.ArbeidsgiverTjeneste;
 import no.nav.foreldrepenger.domene.iay.modell.InntektsmeldingBuilder;
 import no.nav.foreldrepenger.domene.iay.modell.Refusjon;
 import no.nav.foreldrepenger.domene.typer.AktørId;
@@ -83,9 +81,5 @@ class FpInntektsmeldingTjenesteTest {
         var forventetRequest = new OverstyrInntektsmeldingRequest(new OverstyrInntektsmeldingRequest.AktørIdDto("9999999999999"), new OverstyrInntektsmeldingRequest.ArbeidsgiverDto("999999999"), stp, OverstyrInntektsmeldingRequest.YtelseType.FORELDREPENGER, BigDecimal.valueOf(5000), BigDecimal.valueOf(5000),
             foventedeRefusjonsendringer, Collections.emptyList(), "Truls Test");
         verify(klient, times(1)).overstyrInntektsmelding(forventetRequest);
-
-
-
     }
-
 }

--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/dokumentpersiterer/impl/inntektsmelding/v1/InntektsmeldingOversetter.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/dokumentpersiterer/impl/inntektsmelding/v1/InntektsmeldingOversetter.java
@@ -94,8 +94,7 @@ public class InntektsmeldingOversetter implements MottattDokumentOversetter<Innt
         mapUtsettelse(wrapper, builder);
         mapRefusjon(wrapper, builder);
 
-        inntektsmeldingTjeneste.lagreInntektsmelding(behandling.getFagsak().getSaksnummer(), behandling.getId(),
-            builder);
+        inntektsmeldingTjeneste.lagreInntektsmelding(builder, behandling);
     }
 
     private void mapArbeidsforholdOgBeløp(InntektsmeldingWrapper wrapper,

--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/dokumentpersiterer/impl/inntektsmelding/v2/InntektsmeldingOversetter.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/dokumentpersiterer/impl/inntektsmelding/v2/InntektsmeldingOversetter.java
@@ -101,8 +101,7 @@ public class InntektsmeldingOversetter implements MottattDokumentOversetter<Innt
         mapUtsettelse(wrapper, builder);
         mapRefusjon(wrapper, builder);
 
-        inntektsmeldingTjeneste.lagreInntektsmelding(behandling.getFagsak().getSaksnummer(), behandling.getId(),
-            builder);
+        inntektsmeldingTjeneste.lagreInntektsmelding(builder, behandling);
     }
 
     private void mapArbeidsforholdOgBeløp(InntektsmeldingWrapper wrapper,

--- a/domenetjenester/mottak/src/test/java/no/nav/foreldrepenger/mottak/dokumentmottak/impl/InntektsmeldingOversetterTest.java
+++ b/domenetjenester/mottak/src/test/java/no/nav/foreldrepenger/mottak/dokumentmottak/impl/InntektsmeldingOversetterTest.java
@@ -31,6 +31,7 @@ import no.nav.foreldrepenger.domene.abakus.AbakusInMemoryInntektArbeidYtelseTjen
 import no.nav.foreldrepenger.domene.arbeidsforhold.InntektArbeidYtelseTjeneste;
 import no.nav.foreldrepenger.domene.arbeidsforhold.InntektsmeldingTjeneste;
 import no.nav.foreldrepenger.domene.arbeidsgiver.VirksomhetTjeneste;
+import no.nav.foreldrepenger.domene.fpinntektsmelding.FpInntektsmeldingTjeneste;
 import no.nav.foreldrepenger.domene.iay.modell.Inntektsmelding;
 import no.nav.foreldrepenger.domene.iay.modell.InntektsmeldingAggregat;
 import no.nav.foreldrepenger.domene.iay.modell.NaturalYtelse;
@@ -58,7 +59,7 @@ class InntektsmeldingOversetterTest extends EntityManagerAwareTest {
             .medRegistrert(LocalDate.now().minusDays(1))
             .build()));
         iayTjeneste = new AbakusInMemoryInntektArbeidYtelseTjeneste();
-        var inntektsmeldingTjeneste = new InntektsmeldingTjeneste(iayTjeneste);
+        var inntektsmeldingTjeneste = new InntektsmeldingTjeneste(iayTjeneste, new FpInntektsmeldingTjeneste());
         oversetter = new InntektsmeldingOversetter(inntektsmeldingTjeneste, virksomhetTjeneste);
         repositoryProvider = new BehandlingRepositoryProvider(getEntityManager());
         mottatteDokumentRepository = new MottatteDokumentRepository(getEntityManager());

--- a/domenetjenester/mottak/src/test/java/no/nav/foreldrepenger/mottak/kompletthettjeneste/impl/fp/KompletthetsjekkerRevurderingImplTest.java
+++ b/domenetjenester/mottak/src/test/java/no/nav/foreldrepenger/mottak/kompletthettjeneste/impl/fp/KompletthetsjekkerRevurderingImplTest.java
@@ -42,6 +42,7 @@ class KompletthetsjekkerRevurderingImplTest extends EntityManagerAwareTest {
     private final KompletthetssjekkerSøknad kompletthetssjekkerSøknad = mock(KompletthetssjekkerSøknad.class);
 
     private KompletthetsjekkerRevurderingImpl kompletthetsjekkerRevurderingImpl;
+    private final FpInntektsmeldingTjeneste fpInntektsmeldingTjeneste = new FpInntektsmeldingTjeneste();
 
     @BeforeEach
     void setUp() {
@@ -50,10 +51,8 @@ class KompletthetsjekkerRevurderingImplTest extends EntityManagerAwareTest {
         testUtil = new KompletthetssjekkerTestUtil(repositoryProvider);
         var dokumentBestillerApplikasjonTjeneste = mock(DokumentBestillerTjeneste.class);
         var dokumentBehandlingTjeneste = mock(DokumentBehandlingTjeneste.class);
-        var fpInntektsmeldingTjeneste = mock(FpInntektsmeldingTjeneste.class);
-
         var kompletthetsjekkerFelles = new KompletthetsjekkerFelles(repositoryProvider, dokumentBestillerApplikasjonTjeneste,
-            dokumentBehandlingTjeneste, null, new InntektsmeldingTjeneste(new AbakusInMemoryInntektArbeidYtelseTjeneste()), fpInntektsmeldingTjeneste);
+            dokumentBehandlingTjeneste, null, new InntektsmeldingTjeneste(new AbakusInMemoryInntektArbeidYtelseTjeneste(), fpInntektsmeldingTjeneste), fpInntektsmeldingTjeneste);
         kompletthetsjekkerRevurderingImpl = new KompletthetsjekkerRevurderingImpl(
             kompletthetssjekkerSøknad, kompletthetsjekkerFelles,
             new SøknadRepository(entityManager, new BehandlingRepository(entityManager)),

--- a/domenetjenester/uttak/src/test/java/no/nav/foreldrepenger/domene/uttak/UttakRevurderingTestUtil.java
+++ b/domenetjenester/uttak/src/test/java/no/nav/foreldrepenger/domene/uttak/UttakRevurderingTestUtil.java
@@ -32,6 +32,7 @@ import no.nav.foreldrepenger.behandlingslager.virksomhet.Arbeidsgiver;
 import no.nav.foreldrepenger.behandlingslager.virksomhet.Virksomhet;
 import no.nav.foreldrepenger.domene.arbeidsforhold.InntektArbeidYtelseTjeneste;
 import no.nav.foreldrepenger.domene.arbeidsforhold.InntektsmeldingTjeneste;
+import no.nav.foreldrepenger.domene.fpinntektsmelding.FpInntektsmeldingTjeneste;
 import no.nav.foreldrepenger.domene.iay.modell.InntektsmeldingBuilder;
 import no.nav.foreldrepenger.domene.tid.VirkedagUtil;
 import no.nav.foreldrepenger.domene.typer.AktørId;
@@ -58,6 +59,7 @@ public class UttakRevurderingTestUtil {
                                     InntektArbeidYtelseTjeneste iayTjeneste) {
         this.repositoryProvider = repositoryProvider;
         this.iayTjeneste = iayTjeneste;
+
     }
 
     public Behandling opprettRevurdering(BehandlingÅrsakType behandlingÅrsakType) {
@@ -237,8 +239,7 @@ public class UttakRevurderingTestUtil {
             .medInnsendingstidspunkt(FØDSELSDATO.atStartOfDay())
             .medJournalpostId(journalpostId);
 
-        new InntektsmeldingTjeneste(iayTjeneste).lagreInntektsmelding(revurdering.getFagsak().getSaksnummer(),
-            revurdering.getId(), inntektsmeldingBuilder);
+        new InntektsmeldingTjeneste(iayTjeneste, new FpInntektsmeldingTjeneste() ).lagreInntektsmelding(inntektsmeldingBuilder, revurdering);
     }
 
     public Behandling byggFørstegangsbehandlingForRevurderingBerørtSak(AktørId aktørId,

--- a/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/fpoversikt/InntektsmeldingDtoTjenesteTest.java
+++ b/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/fpoversikt/InntektsmeldingDtoTjenesteTest.java
@@ -18,6 +18,7 @@ import no.nav.foreldrepenger.behandlingslager.virksomhet.Arbeidsgiver;
 import no.nav.foreldrepenger.dbstoette.JpaExtension;
 import no.nav.foreldrepenger.domene.abakus.AbakusInMemoryInntektArbeidYtelseTjeneste;
 import no.nav.foreldrepenger.domene.arbeidsforhold.InntektsmeldingTjeneste;
+import no.nav.foreldrepenger.domene.fpinntektsmelding.FpInntektsmeldingTjeneste;
 import no.nav.foreldrepenger.domene.iay.modell.InntektsmeldingBuilder;
 import no.nav.foreldrepenger.domene.typer.Beløp;
 import no.nav.foreldrepenger.domene.typer.JournalpostId;
@@ -29,7 +30,7 @@ class InntektsmeldingDtoTjenesteTest {
     void henter_im(EntityManager entityManager) {
         var iayTjeneste = new AbakusInMemoryInntektArbeidYtelseTjeneste();
         var repositoryProvider = new BehandlingRepositoryProvider(entityManager);
-        var tjeneste = new InntektsmeldingDtoTjeneste(new InntektsmeldingTjeneste(iayTjeneste), repositoryProvider.getMottatteDokumentRepository());
+        var tjeneste = new InntektsmeldingDtoTjeneste(new InntektsmeldingTjeneste(iayTjeneste, new FpInntektsmeldingTjeneste()), repositoryProvider.getMottatteDokumentRepository());
 
         var scenario = ScenarioMorSøkerForeldrepenger.forFødsel();
         var behandling = scenario.lagre(repositoryProvider);


### PR DESCRIPTION
Det er lagt inn kall til fpinntektsmelding for å lukke  eventuelle forespørsler for saken og gitt orgnummer når en inntektsmelding fra LPS eller Altinn lagres i abakus. Kallet skjer kun for virksomheter.