### PR TITLE
TFP-5869 opplysningsperiode for næring/PGI

### DIFF
--- a/domenetjenester/registerinnhenting/src/main/java/no/nav/foreldrepenger/domene/registerinnhenting/RegisterdataInnhenter.java
+++ b/domenetjenester/registerinnhenting/src/main/java/no/nav/foreldrepenger/domene/registerinnhenting/RegisterdataInnhenter.java
@@ -213,10 +213,6 @@ public class RegisterdataInnhenter {
     }
 
     private void doInnhentIAYIAbakus(Behandling behandling, BehandlingType behandlingType, FagsakYtelseType fagsakYtelseType) {
-        abakusTjeneste.innhentRegisterdata(lagInnhentIAYRequest(behandling, behandlingType, fagsakYtelseType));
-    }
-
-    private InnhentRegisterdataRequest lagInnhentIAYRequest(Behandling behandling, BehandlingType behandlingType, FagsakYtelseType fagsakYtelseType) {
         LOG.info("Trigger innhenting i abakus for behandling med id={} og uuid={}", behandling.getId(), behandling.getUuid());
         var behandlingUuid = behandling.getUuid();
         var saksnummer = behandling.getFagsak().getSaksnummer().getVerdi();
@@ -226,7 +222,13 @@ public class RegisterdataInnhenter {
         var aktør = new AktørIdPersonident(behandling.getAktørId().getId());
         var informasjonsElementer = utledBasertPå(behandlingType);
 
-        return new InnhentRegisterdataRequest(saksnummer, behandlingUuid, ytelseType, periode, aktør, informasjonsElementer);
+        var request = new InnhentRegisterdataRequest(saksnummer, behandlingUuid, ytelseType, periode, aktør, informasjonsElementer);
+
+        var næringsperiode = opplysningsPeriodeTjeneste.beregnForNæringPGI(behandling.getId(), fagsakYtelseType);
+        LOG.info("ABAKUS NÆRINGSPERIODE {} OPPLYSNINGSPERIODE {} behandling id={}", næringsperiode, opplysningsperiode, behandling.getId());
+        request.setOpplysningsperiodeSkattegrunnlag(new Periode(næringsperiode.getFomDato(), næringsperiode.getTomDato()));
+
+        abakusTjeneste.innhentRegisterdata(request);
     }
 
     private Set<RegisterdataType> utledBasertPå(BehandlingType behandlingType) {

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/abakus/IAYRegisterdataTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/abakus/IAYRegisterdataTjeneste.java
@@ -1,6 +1,5 @@
 package no.nav.foreldrepenger.web.app.tjenester.abakus;
 
-import java.util.Objects;
 import java.util.Properties;
 import java.util.UUID;
 
@@ -10,7 +9,6 @@ import jakarta.inject.Inject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import no.nav.foreldrepenger.domene.arbeidsforhold.InntektArbeidYtelseTjeneste;
 import no.nav.foreldrepenger.domene.arbeidsforhold.RegisterdataCallback;
 import no.nav.foreldrepenger.domene.registerinnhenting.task.InnhentIAYIAbakusTask;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTaskData;
@@ -26,7 +24,6 @@ public class IAYRegisterdataTjeneste {
 
     private static final Logger LOG = LoggerFactory.getLogger(IAYRegisterdataTjeneste.class);
 
-    private InntektArbeidYtelseTjeneste iayTjeneste;
     private ProsessTaskTjeneste taskTjeneste;
 
     public IAYRegisterdataTjeneste() {
@@ -37,8 +34,7 @@ public class IAYRegisterdataTjeneste {
      * Standard ctor som injectes av CDI.
      */
     @Inject
-    public IAYRegisterdataTjeneste(InntektArbeidYtelseTjeneste iayTjeneste, ProsessTaskTjeneste taskTjeneste) {
-        this.iayTjeneste = Objects.requireNonNull(iayTjeneste, "iayTjeneste");
+    public IAYRegisterdataTjeneste(ProsessTaskTjeneste taskTjeneste) {
         this.taskTjeneste = taskTjeneste;
     }
 
@@ -56,16 +52,6 @@ public class IAYRegisterdataTjeneste {
             LOG.info("Mottatt callback hvor ingen task venter på svar... {}", callback);
         }
         tasksSomVenterPåSvar.forEach(t -> mottaHendelse(t, callback.getOppdatertGrunnlagRef()));
-        /*
-        if (tasksSomVenterPåSvar.size() == 1) {
-            mottaHendelse(tasksSomVenterPåSvar.get(0), callback.getOppdatertGrunnlagRef());
-        } else if (tasksSomVenterPåSvar.isEmpty()) {
-            LOG.info("Mottatt callback hvor ingen task venter på svar... {}", callback);
-        } else {
-            LOG.info("Mottatt callback som svarer til flere tasks som venter. callback={}, tasks={}", callback, tasksSomVenterPåSvar);
-        }
-        */
-
     }
 
     private void mottaHendelse(ProsessTaskData task, UUID oppdatertGrunnlagRef) {


### PR DESCRIPTION
Det har fungert greit å ikke ta med næringsperiode, fram til et spesialtilfelle (STP i 2023, behandlingsdato okt24) som mangler 1 år
Bruker termin/fødsel/svp fra -4år til +3år (siden far kan begynne når som helst i en 3års periode - de fleste ila 1 år).
Innhenting er basert på informasjonselementer (næring kun i førstegang) + oppgitt næring, men setter alltid opplysningsperiodeSkattegrunnlag siden revurderinger kopierer med gamle data - slik at vi har sporing av aktuell periode.
 