### PR TITLE
TFP-5887 TFP-5890 opprett maskinelle oppgaver uten enhet. Delvis medhold anke

### DIFF
--- a/domenetjenester/behandling-revurdering/src/main/java/no/nav/foreldrepenger/behandling/revurdering/etterkontroll/tjeneste/EtterkontrollEventObserver.java
+++ b/domenetjenester/behandling-revurdering/src/main/java/no/nav/foreldrepenger/behandling/revurdering/etterkontroll/tjeneste/EtterkontrollEventObserver.java
@@ -112,8 +112,7 @@ public class EtterkontrollEventObserver {
         if (!Set.of(FagsakYtelseType.FORELDREPENGER, FagsakYtelseType.ENGANGSTØNAD).contains(behandling.getFagsak().getYtelseType())) {
             return Optional.empty();
         }
-        if (familieHendelseGrunnlag.getBekreftetVersjon().map(FamilieHendelseEntitet::getType).map(FamilieHendelseType.FØDSEL::equals)
-                .orElse(false)) {
+        if (familieHendelseGrunnlag.getGjeldendeBekreftetVersjon().map(FamilieHendelseEntitet::getType).filter(FamilieHendelseType.FØDSEL::equals).isPresent()) {
             return Optional.empty();
         }
         return Optional.of(familieHendelseGrunnlag.finnGjeldendeFødselsdato());

--- a/domenetjenester/behandling-revurdering/src/test/java/no/nav/foreldrepenger/behandling/revurdering/etterkontroll/es/AutomatiskEtterkontrollTaskTest.java
+++ b/domenetjenester/behandling-revurdering/src/test/java/no/nav/foreldrepenger/behandling/revurdering/etterkontroll/es/AutomatiskEtterkontrollTaskTest.java
@@ -12,8 +12,6 @@ import java.util.Collections;
 
 import jakarta.persistence.EntityManager;
 
-import no.nav.foreldrepenger.behandlingslager.behandling.beregning.SatsRepository;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -33,6 +31,7 @@ import no.nav.foreldrepenger.behandlingslager.behandling.beregning.BeregningSats
 import no.nav.foreldrepenger.behandlingslager.behandling.beregning.LegacyESBeregning;
 import no.nav.foreldrepenger.behandlingslager.behandling.beregning.LegacyESBeregningRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.beregning.LegacyESBeregningsresultat;
+import no.nav.foreldrepenger.behandlingslager.behandling.beregning.SatsRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.historikk.HistorikkRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepositoryProvider;
@@ -47,7 +46,6 @@ import no.nav.foreldrepenger.domene.typer.PersonIdent;
 import no.nav.foreldrepenger.familiehendelse.FamilieHendelseTjeneste;
 import no.nav.foreldrepenger.produksjonsstyring.behandlingenhet.BehandlendeEnhetTjeneste;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTaskData;
-import no.nav.vedtak.felles.prosesstask.api.ProsessTaskTjeneste;
 
 @ExtendWith(MockitoExtension.class)
 @ExtendWith(JpaExtension.class)
@@ -57,9 +55,6 @@ class AutomatiskEtterkontrollTaskTest {
     private PersoninfoAdapter personinfoAdapter;
 
     private BehandlingRepository behandlingRepository;
-
-    @Mock
-    private ProsessTaskTjeneste taskTjenesteMock;
 
     private AutomatiskEtterkontrollTask task;
     @Mock
@@ -90,8 +85,7 @@ class AutomatiskEtterkontrollTaskTest {
         etterkontrollRepository = new EtterkontrollRepository(entityManager);
         familieHendelseTjeneste = new FamilieHendelseTjeneste(null, repositoryProvider.getFamilieHendelseRepository());
         task = new AutomatiskEtterkontrollTask(repositoryProvider, etterkontrollRepository, historikkRepository,
-                familieHendelseTjeneste, personinfoAdapter,
-                taskTjenesteMock, behandlendeEnhetTjeneste);
+                familieHendelseTjeneste, personinfoAdapter, behandlendeEnhetTjeneste);
         lenient().when(behandlendeEnhetTjeneste.finnBehandlendeEnhetFor(any(Fagsak.class)))
                 .thenReturn(new OrganisasjonsEnhet("1234", "Testlokasjon"));
     }
@@ -137,7 +131,7 @@ class AutomatiskEtterkontrollTaskTest {
         Period.parse("P11W");
         task = new AutomatiskEtterkontrollTask(repositoryProvider, etterkontrollRepository, historikkRepository,
                 familieHendelseTjeneste, personinfoAdapter,
-                taskTjenesteMock, behandlendeEnhetTjeneste);
+                behandlendeEnhetTjeneste);
     }
 
     @Test

--- a/domenetjenester/behandling-revurdering/src/test/java/no/nav/foreldrepenger/behandling/revurdering/etterkontroll/fp/AutomatiskEtterkontrollTaskTest.java
+++ b/domenetjenester/behandling-revurdering/src/test/java/no/nav/foreldrepenger/behandling/revurdering/etterkontroll/fp/AutomatiskEtterkontrollTaskTest.java
@@ -65,7 +65,6 @@ import no.nav.foreldrepenger.produksjonsstyring.behandlingenhet.BehandlendeEnhet
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.TrekkdagerUtregningUtil;
 import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.grunnlag.Periode;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTaskData;
-import no.nav.vedtak.felles.prosesstask.api.ProsessTaskTjeneste;
 
 @ExtendWith(MockitoExtension.class)
 @ExtendWith(JpaExtension.class)
@@ -73,9 +72,6 @@ class AutomatiskEtterkontrollTaskTest {
 
     @Mock
     private PersoninfoAdapter personinfoAdapter;
-
-    @Mock
-    private ProsessTaskTjeneste taskTjenesteMock;
 
     private BehandlingRepositoryProvider repositoryProvider;
     private FagsakRelasjonTjeneste fagsakRelasjonTjeneste;
@@ -404,7 +400,7 @@ class AutomatiskEtterkontrollTaskTest {
 
     private void createTask() {
         task = new AutomatiskEtterkontrollTask(repositoryProvider, etterkontrollRepository, historikkRepository, familieHendelseTjeneste,
-            personinfoAdapter, taskTjenesteMock, behandlendeEnhetTjeneste);
+            personinfoAdapter, behandlendeEnhetTjeneste);
     }
 
     @Test

--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/vedtak/observer/MottaKlageAnkeVedtakTask.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/vedtak/observer/MottaKlageAnkeVedtakTask.java
@@ -97,13 +97,13 @@ public class MottaKlageAnkeVedtakTask extends GenerellProsessTask {
         }
     }
 
-    private void lagOpprettVurderKonsekvensTask(Behandling behandling, String beskrivelse) {
+    private void lagOpprettVurderKonsekvensTask(Behandling sisteYtelseBehandling, String beskrivelse) {
         var opprettOppgave = ProsessTaskData.forProsessTask(OpprettOppgaveVurderKonsekvensTask.class);
-        opprettOppgave.setProperty(OpprettOppgaveVurderKonsekvensTask.KEY_BEHANDLENDE_ENHET, behandling.getBehandlendeEnhet());
+        opprettOppgave.setProperty(OpprettOppgaveVurderKonsekvensTask.KEY_BEHANDLENDE_ENHET, sisteYtelseBehandling.getBehandlendeEnhet());
         opprettOppgave.setProperty(OpprettOppgaveVurderKonsekvensTask.KEY_BESKRIVELSE, beskrivelse);
         opprettOppgave.setProperty(OpprettOppgaveVurderKonsekvensTask.KEY_PRIORITET, OpprettOppgaveVurderKonsekvensTask.PRIORITET_HØY);
         opprettOppgave.setCallIdFraEksisterende();
-        opprettOppgave.setBehandling(behandling.getFagsakId(), behandling.getId(), behandling.getAktørId().getId());
+        opprettOppgave.setBehandling(sisteYtelseBehandling.getFagsakId(), sisteYtelseBehandling.getId(), sisteYtelseBehandling.getAktørId().getId());
         taskTjeneste.lagre(opprettOppgave);
     }
 

--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/vedtak/overlapp/OverlappOppgaveTjeneste.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/vedtak/overlapp/OverlappOppgaveTjeneste.java
@@ -71,7 +71,7 @@ public class OverlappOppgaveTjeneste {
         // Beskrivelse må tilpasses dersom / når det skal opprettes oppgaver ved overlapp mot Infotrygd
         var beskrivelse = String.format("Det er innvilget %s (%s%%) som overlapper med sykepenger i periode %s - %s i %s. Vurder konsekvens for ytelse.",
             foreldrepengerYtelse, maxUtbetalingsprosent, minFom, maxTom, system );
-        oppgaveTjeneste.opprettVurderKonsekvensHosSykepenger(behandling.getBehandlendeEnhet(), beskrivelse, behandling.getAktørId());
+        oppgaveTjeneste.opprettVurderKonsekvensHosSykepenger(beskrivelse, behandling.getAktørId());
 
     }
 
@@ -94,11 +94,11 @@ public class OverlappOppgaveTjeneste {
         if (Fagsystem.K9SAK.equals(gruppering.fagsystem())) {
             var beskrivelse = String.format("Det er innvilget %s (%s%%) som overlapper med %s sak %s i periode %s - %s i K9-sak. Vurder konsekvens for ytelse.",
                     foreldrepengerYtelse, maxUtbetalingsprosent, omsorgspengerYtelse, gruppering.saksnummer(), minFom, maxTom );
-            oppgaveTjeneste.opprettVurderKonsekvensHosPleiepenger(behandling.getBehandlendeEnhet(), beskrivelse, behandling.getAktørId());
+            oppgaveTjeneste.opprettVurderKonsekvensHosPleiepenger(beskrivelse, behandling.getAktørId());
         } else {
             var beskrivelse = String.format("Det er innvilget %s (%s%%) som overlapper med pleiepenger i periode %s - %s i Infotrygd. Vurder konsekvens for ytelse.",
                     foreldrepengerYtelse, maxUtbetalingsprosent, minFom, maxTom );
-            oppgaveTjeneste.opprettVurderKonsekvensHosPleiepenger(behandling.getBehandlendeEnhet(), beskrivelse, behandling.getAktørId());
+            oppgaveTjeneste.opprettVurderKonsekvensHosPleiepenger(beskrivelse, behandling.getAktørId());
         }
     }
 

--- a/domenetjenester/mottak/src/test/java/no/nav/foreldrepenger/mottak/vedtak/overlapp/LoggOverlappEksterneYtelserTjenesteTest.java
+++ b/domenetjenester/mottak/src/test/java/no/nav/foreldrepenger/mottak/vedtak/overlapp/LoggOverlappEksterneYtelserTjenesteTest.java
@@ -139,7 +139,7 @@ class LoggOverlappEksterneYtelserTjenesteTest extends EntityManagerAwareTest {
         var overlappIT = overlappRepository.hentForSaksnummer(behandlingFP.getFagsak().getSaksnummer());
         assertThat(overlappIT).hasSize(1);
         assertThat(overlappIT.getFirst().getPeriode().getTomDato()).isEqualTo(førsteUttaksdatoFp);
-        verify(oppgaveTjenesteMock, times(1)).opprettVurderKonsekvensHosPleiepenger(any(), any(), any());
+        verify(oppgaveTjenesteMock, times(1)).opprettVurderKonsekvensHosPleiepenger(any(), any());
         verifyNoMoreInteractions(oppgaveTjenesteMock);
     }
 
@@ -181,7 +181,7 @@ class LoggOverlappEksterneYtelserTjenesteTest extends EntityManagerAwareTest {
         var overlappIT2 = overlappRepository.hentForSaksnummer(behandlingFP.getFagsak().getSaksnummer());
         assertThat(overlappIT2).hasSize(1);
         assertThat(overlappIT2.getFirst().getPeriode().getTomDato()).isEqualTo(førsteUttaksdatoFp.plusWeeks(4));
-        verify(oppgaveTjenesteMock, times(1)).opprettVurderKonsekvensHosPleiepenger(any(), any(), any());
+        verify(oppgaveTjenesteMock, times(1)).opprettVurderKonsekvensHosPleiepenger(any(), any());
         verifyNoMoreInteractions(oppgaveTjenesteMock);
     }
 
@@ -219,8 +219,8 @@ class LoggOverlappEksterneYtelserTjenesteTest extends EntityManagerAwareTest {
         // Assert
         var overlappIT = overlappRepository.hentForSaksnummer(behandlingFP.getFagsak().getSaksnummer());
         assertThat(overlappIT).hasSize(2);
-        verify(oppgaveTjenesteMock, times(1)).opprettVurderKonsekvensHosPleiepenger(any(), any(), any());
-        verify(oppgaveTjenesteMock, times(1)).opprettVurderKonsekvensHosSykepenger(any(), any(), any());
+        verify(oppgaveTjenesteMock, times(1)).opprettVurderKonsekvensHosPleiepenger(any(), any());
+        verify(oppgaveTjenesteMock, times(1)).opprettVurderKonsekvensHosSykepenger(any(), any());
         verifyNoMoreInteractions(oppgaveTjenesteMock);
     }
 
@@ -259,7 +259,7 @@ class LoggOverlappEksterneYtelserTjenesteTest extends EntityManagerAwareTest {
         // Assert
         var overlappIT = overlappRepository.hentForSaksnummer(behandlingFP.getFagsak().getSaksnummer());
         assertThat(overlappIT).hasSize(3);
-        verify(oppgaveTjenesteMock, times(2)).opprettVurderKonsekvensHosSykepenger(any(), any(), any());
+        verify(oppgaveTjenesteMock, times(2)).opprettVurderKonsekvensHosSykepenger(any(), any());
         verifyNoMoreInteractions(oppgaveTjenesteMock);
     }
 
@@ -299,7 +299,7 @@ class LoggOverlappEksterneYtelserTjenesteTest extends EntityManagerAwareTest {
         var overlappIT = overlappRepository.hentForSaksnummer(behandlingFP.getFagsak().getSaksnummer());
         assertThat(overlappIT).hasSize(1);
         assertThat(overlappIT.getFirst().getPeriode().getTomDato()).isEqualTo(førsteUttaksdatoFp.plusWeeks(3));
-        verify(oppgaveTjenesteMock, times(1)).opprettVurderKonsekvensHosPleiepenger(any(), any(), any());
+        verify(oppgaveTjenesteMock, times(1)).opprettVurderKonsekvensHosPleiepenger(any(), any());
         verifyNoMoreInteractions(oppgaveTjenesteMock);
     }
 
@@ -370,7 +370,7 @@ class LoggOverlappEksterneYtelserTjenesteTest extends EntityManagerAwareTest {
         // Assert
         var overlappIT = overlappRepository.hentForSaksnummer(behandlingFP.getFagsak().getSaksnummer());
         assertThat(overlappIT).hasSize(2);
-        verify(oppgaveTjenesteMock, times(2)).opprettVurderKonsekvensHosPleiepenger(any(), any(), any());
+        verify(oppgaveTjenesteMock, times(2)).opprettVurderKonsekvensHosPleiepenger(any(), any());
         verifyNoMoreInteractions(oppgaveTjenesteMock);
     }
 


### PR DESCRIPTION
Opprette oppgave for å effektuere der KA har delvis omgjort (og sendt resten til Trygderetten).
Setter ikke opprettetAvEnhetsnr for maskinelle oppgaver - for å skille autoopprettet fra manuelt opprettet i metabase.