### PR TITLE
Ikke opprette NØS-oppgave for revurderinger

### DIFF
--- a/domenetjenester/vedtak/src/main/java/no/nav/foreldrepenger/domene/vedtak/OpprettProsessTaskIverksett.java
+++ b/domenetjenester/vedtak/src/main/java/no/nav/foreldrepenger/domene/vedtak/OpprettProsessTaskIverksett.java
@@ -59,7 +59,7 @@ public class OpprettProsessTaskIverksett {
     }
 
     private void leggTilTasksYtelsesBehandling(Behandling behandling, ProsessTaskGruppe taskGruppe) {
-        if (FagsakYtelseType.FORELDREPENGER.equals(behandling.getFagsakYtelseType()) && !behandling.erRevurdering()) {
+        if (FagsakYtelseType.FORELDREPENGER.equals(behandling.getFagsakYtelseType())) {
             taskGruppe.addNesteSekvensiell(ProsessTaskData.forProsessTask(VurderOppgaveArenaTask.class));
         }
         if (!FagsakYtelseType.ENGANGSTØNAD.equals(behandling.getFagsakYtelseType())) {

--- a/domenetjenester/vedtak/src/main/java/no/nav/foreldrepenger/domene/vedtak/OpprettProsessTaskIverksett.java
+++ b/domenetjenester/vedtak/src/main/java/no/nav/foreldrepenger/domene/vedtak/OpprettProsessTaskIverksett.java
@@ -59,7 +59,7 @@ public class OpprettProsessTaskIverksett {
     }
 
     private void leggTilTasksYtelsesBehandling(Behandling behandling, ProsessTaskGruppe taskGruppe) {
-        if (FagsakYtelseType.FORELDREPENGER.equals(behandling.getFagsakYtelseType())) {
+        if (FagsakYtelseType.FORELDREPENGER.equals(behandling.getFagsakYtelseType()) && !behandling.erRevurdering()) {
             taskGruppe.addNesteSekvensiell(ProsessTaskData.forProsessTask(VurderOppgaveArenaTask.class));
         }
         if (!FagsakYtelseType.ENGANGSTØNAD.equals(behandling.getFagsakYtelseType())) {

--- a/domenetjenester/vedtak/src/main/java/no/nav/foreldrepenger/domene/vedtak/ekstern/VurderOppgaveArenaTask.java
+++ b/domenetjenester/vedtak/src/main/java/no/nav/foreldrepenger/domene/vedtak/ekstern/VurderOppgaveArenaTask.java
@@ -54,7 +54,8 @@ public class VurderOppgaveArenaTask extends GenerellProsessTask {
     protected void prosesser(ProsessTaskData prosessTaskData, Long fagsakId, Long behandlingId) {
         var behandling = behandlingRepository.hentBehandling(behandlingId);
         if (behandling.erRevurdering()) {
-            var forrigeBehandlingStartdato = getTidligsteFomDatoMedUtbetaling(behandling.getOriginalBehandlingId().orElseThrow());
+            var forrigeBehandlingStartdato = behandling.getOriginalBehandlingId()
+                .map(this::getTidligsteFomDatoMedUtbetaling).orElse(Tid.TIDENES_ENDE);
             var aktuellBehandlingStartdato = getTidligsteFomDatoMedUtbetaling(behandlingId);
             // Skal bare vurdere oppgave dersom revurdering begynner utbetaling tidligere enn forrige behandling
             if (!aktuellBehandlingStartdato.isBefore(forrigeBehandlingStartdato)) {

--- a/domenetjenester/vedtak/src/main/java/no/nav/foreldrepenger/domene/vedtak/ekstern/VurderOppgaveArenaTask.java
+++ b/domenetjenester/vedtak/src/main/java/no/nav/foreldrepenger/domene/vedtak/ekstern/VurderOppgaveArenaTask.java
@@ -1,17 +1,25 @@
 package no.nav.foreldrepenger.domene.vedtak.ekstern;
 
+import java.time.LocalDate;
+import java.util.Comparator;
+import java.util.List;
+
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import no.nav.foreldrepenger.behandlingslager.behandling.beregning.BeregningsresultatEntitet;
+import no.nav.foreldrepenger.behandlingslager.behandling.beregning.BeregningsresultatPeriode;
+import no.nav.foreldrepenger.behandlingslager.behandling.beregning.BeregningsresultatRepository;
+import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepository;
 import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakProsesstaskRekkefølge;
 import no.nav.foreldrepenger.behandlingslager.task.GenerellProsessTask;
-import no.nav.foreldrepenger.domene.typer.AktørId;
 import no.nav.foreldrepenger.skjæringstidspunkt.SkjæringstidspunktTjeneste;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTask;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTaskData;
+import no.nav.vedtak.konfig.Tid;
 
 @ApplicationScoped
 @ProsessTask(value = "iverksetteVedtak.oppgaveArena", prioritet = 2)
@@ -23,6 +31,8 @@ public class VurderOppgaveArenaTask extends GenerellProsessTask {
     private VurderOmArenaYtelseSkalOpphøre vurdereOmArenaYtelseSkalOpphøre;
 
     private SkjæringstidspunktTjeneste skjæringstidspunktTjeneste;
+    private BehandlingRepository behandlingRepository;
+    private BeregningsresultatRepository beregningsresultatRepository;
 
     VurderOppgaveArenaTask() {
         // for CDI proxy
@@ -30,17 +40,38 @@ public class VurderOppgaveArenaTask extends GenerellProsessTask {
 
     @Inject
     public VurderOppgaveArenaTask(VurderOmArenaYtelseSkalOpphøre vurdereOmArenaYtelseSkalOpphøre,
-                                  SkjæringstidspunktTjeneste skjæringstidspunktTjeneste) {
+                                  SkjæringstidspunktTjeneste skjæringstidspunktTjeneste,
+                                  BehandlingRepository behandlingRepository,
+                                  BeregningsresultatRepository beregningsresultatRepository) {
         super();
         this.skjæringstidspunktTjeneste = skjæringstidspunktTjeneste;
         this.vurdereOmArenaYtelseSkalOpphøre = vurdereOmArenaYtelseSkalOpphøre;
+        this.behandlingRepository = behandlingRepository;
+        this.beregningsresultatRepository = beregningsresultatRepository;
     }
 
     @Override
     protected void prosesser(ProsessTaskData prosessTaskData, Long fagsakId, Long behandlingId) {
-        var aktørId = new AktørId(prosessTaskData.getAktørId());
+        var behandling = behandlingRepository.hentBehandling(behandlingId);
+        if (behandling.erRevurdering()) {
+            var forrigeBehandlingStartdato = getTidligsteFomDatoMedUtbetaling(behandling.getOriginalBehandlingId().orElseThrow());
+            var aktuellBehandlingStartdato = getTidligsteFomDatoMedUtbetaling(behandlingId);
+            // Skal bare vurdere oppgave dersom revurdering begynner utbetaling tidligere enn forrige behandling
+            if (!aktuellBehandlingStartdato.isBefore(forrigeBehandlingStartdato)) {
+                return;
+            }
+        }
+        var aktørId = behandling.getAktørId();
         var skjæringstidspunkt = skjæringstidspunktTjeneste.getSkjæringstidspunkter(behandlingId).getUtledetSkjæringstidspunkt();
         vurdereOmArenaYtelseSkalOpphøre.opprettOppgaveHvisArenaytelseSkalOpphøre(behandlingId, aktørId, skjæringstidspunkt);
         LOG.info("VurderOppgaveArenaTask: Vurderer for behandling: {}", behandlingId);
+    }
+
+    private LocalDate getTidligsteFomDatoMedUtbetaling(Long behandlingId) {
+        return beregningsresultatRepository.hentUtbetBeregningsresultat(behandlingId)
+            .map(BeregningsresultatEntitet::getBeregningsresultatPerioder).orElseGet(List::of).stream()
+            .filter(brp -> brp.getDagsats() > 0)
+            .map(BeregningsresultatPeriode::getBeregningsresultatPeriodeFom)
+            .min(Comparator.naturalOrder()).orElse(Tid.TIDENES_ENDE);
     }
 }


### PR DESCRIPTION
NØS har bedt om at vi ikke lager oppgaver for endringer/revurderinger. De håndterer oppgaven første gang.
Revurderinger som gir tidligere utbetaling enn forrige behandling kan resultere i oppgave