### PR TITLE
Saksnummer som taskparameter overalt, minimer bruk av aktørId

### DIFF
--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/Behandling.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/Behandling.java
@@ -43,6 +43,7 @@ import no.nav.foreldrepenger.behandlingslager.fagsak.Fagsak;
 import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakYtelseType;
 import no.nav.foreldrepenger.behandlingslager.hendelser.StartpunktType;
 import no.nav.foreldrepenger.domene.typer.AktørId;
+import no.nav.foreldrepenger.domene.typer.Saksnummer;
 import no.nav.vedtak.exception.TekniskException;
 import no.nav.vedtak.felles.jpa.converters.BooleanToStringConverter;
 
@@ -313,6 +314,10 @@ public class Behandling extends BaseEntitet {
 
     public Long getFagsakId() {
         return getFagsak().getId();
+    }
+
+    public Saksnummer getSaksnummer() {
+        return getFagsak().getSaksnummer();
     }
 
     public AktørId getAktørId() {

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/events/BehandlingEnhetEvent.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/events/BehandlingEnhetEvent.java
@@ -2,12 +2,12 @@ package no.nav.foreldrepenger.behandlingslager.behandling.events;
 
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingEvent;
-import no.nav.foreldrepenger.domene.typer.AktørId;
+import no.nav.foreldrepenger.domene.typer.Saksnummer;
 
-public record BehandlingEnhetEvent(Long fagsakId, Long behandlingId, AktørId aktørId) implements BehandlingEvent {
+public record BehandlingEnhetEvent(Saksnummer saksnummer, Long fagsakId, Long behandlingId) implements BehandlingEvent {
 
     public BehandlingEnhetEvent(Behandling behandling) {
-        this(behandling.getFagsakId(), behandling.getId(), behandling.getAktørId());
+        this(behandling.getSaksnummer(), behandling.getFagsakId(), behandling.getId());
     }
 
     @Override
@@ -16,8 +16,8 @@ public record BehandlingEnhetEvent(Long fagsakId, Long behandlingId, AktørId ak
     }
 
     @Override
-    public AktørId getAktørId() {
-        return aktørId;
+    public Saksnummer getSaksnummer() {
+        return saksnummer;
     }
 
     @Override

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/events/BehandlingRelasjonEvent.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/events/BehandlingRelasjonEvent.java
@@ -2,12 +2,12 @@ package no.nav.foreldrepenger.behandlingslager.behandling.events;
 
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingEvent;
-import no.nav.foreldrepenger.domene.typer.AktørId;
+import no.nav.foreldrepenger.domene.typer.Saksnummer;
 
-public record BehandlingRelasjonEvent(Long fagsakId, Long behandlingId, AktørId aktørId) implements BehandlingEvent {
+public record BehandlingRelasjonEvent(Saksnummer saksnummer, Long fagsakId, Long behandlingId) implements BehandlingEvent {
 
     public BehandlingRelasjonEvent(Behandling behandling) {
-        this(behandling.getFagsakId(), behandling.getId(), behandling.getAktørId());
+        this(behandling.getSaksnummer(), behandling.getFagsakId(), behandling.getId());
     }
 
     @Override
@@ -16,8 +16,8 @@ public record BehandlingRelasjonEvent(Long fagsakId, Long behandlingId, AktørId
     }
 
     @Override
-    public AktørId getAktørId() {
-        return aktørId;
+    public Saksnummer getSaksnummer() {
+        return saksnummer;
     }
 
     @Override

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/events/BehandlingSaksbehandlerEvent.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/events/BehandlingSaksbehandlerEvent.java
@@ -2,12 +2,12 @@ package no.nav.foreldrepenger.behandlingslager.behandling.events;
 
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingEvent;
-import no.nav.foreldrepenger.domene.typer.AktørId;
+import no.nav.foreldrepenger.domene.typer.Saksnummer;
 
-public record BehandlingSaksbehandlerEvent(Long fagsakId, Long behandlingId, AktørId aktørId) implements BehandlingEvent {
+public record BehandlingSaksbehandlerEvent(Saksnummer saksnummer, Long fagsakId, Long behandlingId) implements BehandlingEvent {
 
     public BehandlingSaksbehandlerEvent(Behandling behandling) {
-        this(behandling.getFagsakId(), behandling.getId(), behandling.getAktørId());
+        this(behandling.getSaksnummer(), behandling.getFagsakId(), behandling.getId());
     }
 
     @Override
@@ -16,8 +16,8 @@ public record BehandlingSaksbehandlerEvent(Long fagsakId, Long behandlingId, Akt
     }
 
     @Override
-    public AktørId getAktørId() {
-        return aktørId;
+    public Saksnummer getSaksnummer() {
+        return saksnummer;
     }
 
     @Override

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/events/BehandlingVedtakEvent.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/events/BehandlingVedtakEvent.java
@@ -4,7 +4,7 @@ import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingEvent;
 import no.nav.foreldrepenger.behandlingslager.behandling.vedtak.BehandlingVedtak;
 import no.nav.foreldrepenger.behandlingslager.behandling.vedtak.IverksettingStatus;
-import no.nav.foreldrepenger.domene.typer.AktørId;
+import no.nav.foreldrepenger.domene.typer.Saksnummer;
 
 public record BehandlingVedtakEvent(BehandlingVedtak vedtak, Behandling behandling) implements BehandlingEvent {
 
@@ -14,8 +14,8 @@ public record BehandlingVedtakEvent(BehandlingVedtak vedtak, Behandling behandli
     }
 
     @Override
-    public AktørId getAktørId() {
-        return behandling.getAktørId();
+    public Saksnummer getSaksnummer() {
+        return behandling.getSaksnummer();
     }
 
     @Override

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/events/FamiliehendelseEvent.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/events/FamiliehendelseEvent.java
@@ -4,23 +4,23 @@ import java.time.LocalDate;
 
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingEvent;
 import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakYtelseType;
-import no.nav.foreldrepenger.domene.typer.AktørId;
+import no.nav.foreldrepenger.domene.typer.Saksnummer;
 
 public class FamiliehendelseEvent  implements BehandlingEvent {
 
     private EventType eventType;
     private Long fagsakId;
     private Long behandlingId;
-    private AktørId aktørId;
+    private Saksnummer saksnummer;
     private FagsakYtelseType ytelseType;
     private LocalDate forrigeBekreftetDato;
     private LocalDate sisteBekreftetDato;
 
 
-    public FamiliehendelseEvent(EventType eventType, AktørId aktørId, Long fagsakId, Long behandlingId,
+    public FamiliehendelseEvent(EventType eventType, Saksnummer saksnummer, Long fagsakId, Long behandlingId,
                                 FagsakYtelseType ytelseType, LocalDate forrigeBekreftetDato, LocalDate sisteBekreftetDato) {
         this.eventType = eventType;
-        this.aktørId = aktørId;
+        this.saksnummer = saksnummer;
         this.fagsakId = fagsakId;
         this.behandlingId = behandlingId;
         this.ytelseType = ytelseType;
@@ -36,8 +36,8 @@ public class FamiliehendelseEvent  implements BehandlingEvent {
 
 
     @Override
-    public AktørId getAktørId() {
-        return aktørId;
+    public Saksnummer getSaksnummer() {
+        return saksnummer;
     }
 
 

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/events/MottattDokumentPersistertEvent.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/events/MottattDokumentPersistertEvent.java
@@ -3,7 +3,7 @@ package no.nav.foreldrepenger.behandlingslager.behandling.events;
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingEvent;
 import no.nav.foreldrepenger.behandlingslager.behandling.MottattDokument;
-import no.nav.foreldrepenger.domene.typer.AktørId;
+import no.nav.foreldrepenger.domene.typer.Saksnummer;
 
 public record MottattDokumentPersistertEvent(MottattDokument mottattDokument, Behandling behandling) implements BehandlingEvent {
 
@@ -13,8 +13,8 @@ public record MottattDokumentPersistertEvent(MottattDokument mottattDokument, Be
     }
 
     @Override
-    public AktørId getAktørId() {
-        return behandling.getAktørId();
+    public Saksnummer getSaksnummer() {
+        return behandling.getSaksnummer();
     }
 
     @Override

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/repository/SatsReguleringRepository.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/repository/SatsReguleringRepository.java
@@ -18,7 +18,7 @@ import no.nav.foreldrepenger.behandlingslager.behandling.vedtak.VedtakResultatTy
 import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakYtelseType;
 import no.nav.foreldrepenger.behandlingslager.uttak.PeriodeResultatType;
 import no.nav.foreldrepenger.behandlingslager.uttak.fp.PeriodeResultatÅrsak;
-import no.nav.foreldrepenger.domene.typer.AktørId;
+import no.nav.foreldrepenger.domene.typer.Saksnummer;
 
 @ApplicationScoped
 public class SatsReguleringRepository {
@@ -37,7 +37,7 @@ public class SatsReguleringRepository {
 
     private EntityManager entityManager;
 
-    public record FagsakIdAktørId(Long fagsakId, AktørId aktørId) { }
+    public record FagsakIdSaksnummer(Long fagsakId, Saksnummer saksnummer) { }
 
     SatsReguleringRepository() {
     }
@@ -52,8 +52,8 @@ public class SatsReguleringRepository {
     }
 
     private static final String REGULERING_SELECT_STD_FP = """
-        SELECT DISTINCT f.id , bru.aktoer_id
-          from Fagsak f join bruker bru on f.bruker_id=bru.id
+        SELECT DISTINCT f.id , f.saksnummer
+          from Fagsak f
           join behandling b on b.fagsak_id=f.id
           join behandling_resultat br on br.behandling_id=b.id
           join behandling_vedtak bv on br.id = bv.behandling_resultat_id
@@ -85,7 +85,7 @@ public class SatsReguleringRepository {
         """;
 
     /** Liste av fagsakId, aktørId for saker som trenger G-regulering over 6G og det ikke finnes åpen behandling */
-    public List<FagsakIdAktørId> finnSakerMedBehovForGrunnbeløpRegulering(LocalDate gjeldendeFom, Long satsmultiplikator) {
+    public List<FagsakIdSaksnummer> finnSakerMedBehovForGrunnbeløpRegulering(LocalDate gjeldendeFom, Long satsmultiplikator) {
         /*
          * Plukker fagsakId, aktørId fra fagsaker som møter disse kriteriene:
          * - Saker som har siste avsluttet behandling med gammel sats, brutto overstiger 6G og har uttak etter gammel sats sin utløpsdato
@@ -104,11 +104,11 @@ public class SatsReguleringRepository {
         setStandardParametersFP(query, gjeldendeFom);
         @SuppressWarnings("unchecked")
         List<Object[]> resultatList = query.getResultList();
-        return resultatList.stream().map(row -> new FagsakIdAktørId(Long.parseLong(row[0].toString()), new AktørId((String) row[1]))).toList();
+        return resultatList.stream().map(row -> new FagsakIdSaksnummer(Long.parseLong(row[0].toString()), new Saksnummer((String) row[1]))).toList();
     }
 
     /** Liste av fagsakId, aktørId for saker som trenger G-regulering (MS under 3G) og det ikke finnes åpen behandling */
-    public List<FagsakIdAktørId> finnSakerMedBehovForMilSivRegulering(LocalDate gjeldendeFom, Long satsmultiplikator) {
+    public List<FagsakIdSaksnummer> finnSakerMedBehovForMilSivRegulering(LocalDate gjeldendeFom, Long satsmultiplikator) {
         /*
          * Plukker fagsakId, aktørId fra fagsaker som møter disse kriteriene:
          * - Saker som har siste avsluttet behandling med gammel sats, status MS, brutto understiger 3G og har uttak etter gammel sats sin utløpsdato
@@ -129,12 +129,12 @@ public class SatsReguleringRepository {
         setStandardParametersFP(query, gjeldendeFom);
         @SuppressWarnings("unchecked")
         List<Object[]> resultatList = query.getResultList();
-        return resultatList.stream().map(row -> new FagsakIdAktørId(Long.parseLong(row[0].toString()), new AktørId((String) row[1]))).toList();
+        return resultatList.stream().map(row -> new FagsakIdSaksnummer(Long.parseLong(row[0].toString()), new Saksnummer((String) row[1]))).toList();
     }
 
     /** Liste av fagsakId, aktørId for saker som trenger G-regulering (SN og kombinasjon) og det ikke finnes åpen behandling */
     @SuppressWarnings("unused")
-    public List<FagsakIdAktørId> finnSakerMedBehovForNæringsdrivendeRegulering(LocalDate gjeldendeFom, Long satsmultiplikator) {
+    public List<FagsakIdSaksnummer> finnSakerMedBehovForNæringsdrivendeRegulering(LocalDate gjeldendeFom, Long satsmultiplikator) {
         /*
          * Plukker fagsakId, aktørId fra fagsaker som møter disse kriteriene:
          * - Saker som har siste avsluttet behandling med gammel sats, status SN/KOMB og har uttak etter gammel sats sin utløpsdato
@@ -149,11 +149,11 @@ public class SatsReguleringRepository {
         setStandardParametersFP(query, gjeldendeFom);
         @SuppressWarnings("unchecked")
         List<Object[]> resultatList = query.getResultList();
-        return resultatList.stream().map(row -> new FagsakIdAktørId(Long.parseLong(row[0].toString()), new AktørId((String) row[1]))).toList();
+        return resultatList.stream().map(row -> new FagsakIdSaksnummer(Long.parseLong(row[0].toString()), new Saksnummer((String) row[1]))).toList();
     }
 
     /** Liste av fagsakId, aktørId for saker som trenger Arena-regulering og det ikke finnes åpen behandling */
-    public List<FagsakIdAktørId> finnSakerMedBehovForArenaRegulering(LocalDate gjeldendeFom, LocalDate nySatsDato) {
+    public List<FagsakIdSaksnummer> finnSakerMedBehovForArenaRegulering(LocalDate gjeldendeFom, LocalDate nySatsDato) {
         /*
          * Plukker fagsakId, aktørId fra fagsaker som møter disse kriteriene:
          * - Saker som er beregnet med AAP/DP og har uttak etter gammel sats sin utløpsdato
@@ -170,7 +170,7 @@ public class SatsReguleringRepository {
         setStandardParametersFP(query, gjeldendeFom);
         @SuppressWarnings("unchecked")
         List<Object[]> resultatList = query.getResultList();
-        return resultatList.stream().map(row -> new FagsakIdAktørId(Long.parseLong(row[0].toString()), new AktørId((String) row[1]))).toList();
+        return resultatList.stream().map(row -> new FagsakIdSaksnummer(Long.parseLong(row[0].toString()), new Saksnummer((String) row[1]))).toList();
     }
 
     private void setStandardParametersFP(Query query, LocalDate gjeldendeFom) {
@@ -186,8 +186,8 @@ public class SatsReguleringRepository {
     }
 
     private static final String REGULERING_SELECT_STD_SVP = """
-        SELECT DISTINCT f.id , bru.aktoer_id
-          from Fagsak f join bruker bru on f.bruker_id=bru.id
+        SELECT DISTINCT f.id , f.saksnummer
+          from Fagsak f
           join behandling b on b.fagsak_id=f.id
           join behandling_resultat br on br.behandling_id=b.id
           join behandling_vedtak bv on br.id = bv.behandling_resultat_id
@@ -226,7 +226,7 @@ public class SatsReguleringRepository {
     }
 
     /** Liste av fagsakId, aktørId for saker som trenger G-regulering over 6G og det ikke finnes åpen behandling */
-    public List<FagsakIdAktørId> finnSakerMedBehovForGrunnbeløpReguleringSVP(LocalDate gjeldendeFom, Long satsmultiplikator) {
+    public List<FagsakIdSaksnummer> finnSakerMedBehovForGrunnbeløpReguleringSVP(LocalDate gjeldendeFom, Long satsmultiplikator) {
         /*
          * Plukker fagsakId, aktørId fra fagsaker som møter disse kriteriene:
          * - Saker som har siste avsluttet behandling med gammel sats, brutto overstiger 6G og har uttak etter gammel sats sin utløpsdato
@@ -245,12 +245,12 @@ public class SatsReguleringRepository {
         setStandardParametersSVP(query, gjeldendeFom);
         @SuppressWarnings("unchecked")
         List<Object[]> resultatList = query.getResultList();
-        return resultatList.stream().map(row -> new FagsakIdAktørId(Long.parseLong(row[0].toString()), new AktørId((String) row[1]))).toList();
+        return resultatList.stream().map(row -> new FagsakIdSaksnummer(Long.parseLong(row[0].toString()), new Saksnummer((String) row[1]))).toList();
     }
 
     /** Liste av fagsakId, aktørId for saker som trenger G-regulering (MS under 3G) og det ikke finnes åpen behandling */
     @SuppressWarnings("unused")
-    public List<FagsakIdAktørId> finnSakerMedBehovForMilSivReguleringSVP(LocalDate gjeldendeFom, Long satsmultiplikator) {
+    public List<FagsakIdSaksnummer> finnSakerMedBehovForMilSivReguleringSVP(LocalDate gjeldendeFom, Long satsmultiplikator) {
         /*
          * Plukker fagsakId, aktørId fra fagsaker som møter disse kriteriene:
          * - Saker som har siste avsluttet behandling med gammel sats, status MS, brutto understiger 3G og har uttak etter gammel sats sin utløpsdato
@@ -271,12 +271,12 @@ public class SatsReguleringRepository {
         setStandardParametersSVP(query, gjeldendeFom);
         @SuppressWarnings("unchecked")
         List<Object[]> resultatList = query.getResultList();
-        return resultatList.stream().map(row -> new FagsakIdAktørId(Long.parseLong(row[0].toString()), new AktørId((String) row[1]))).toList();
+        return resultatList.stream().map(row -> new FagsakIdSaksnummer(Long.parseLong(row[0].toString()), new Saksnummer((String) row[1]))).toList();
     }
 
     /** Liste av fagsakId, aktørId for saker som trenger G-regulering (SN og kombinasjon) og det ikke finnes åpen behandling */
     @SuppressWarnings("unused")
-    public List<FagsakIdAktørId> finnSakerMedBehovForNæringsdrivendeReguleringSVP(LocalDate gjeldendeFom, Long satsmultiplikator) {
+    public List<FagsakIdSaksnummer> finnSakerMedBehovForNæringsdrivendeReguleringSVP(LocalDate gjeldendeFom, Long satsmultiplikator) {
         /*
          * Plukker fagsakId, aktørId fra fagsaker som møter disse kriteriene:
          * - Saker som har siste avsluttet behandling med gammel sats, status SN/KOMB og har uttak etter gammel sats sin utløpsdato
@@ -291,12 +291,12 @@ public class SatsReguleringRepository {
         setStandardParametersSVP(query, gjeldendeFom);
         @SuppressWarnings("unchecked")
         List<Object[]> resultatList = query.getResultList();
-        return resultatList.stream().map(row -> new FagsakIdAktørId(Long.parseLong(row[0].toString()), new AktørId((String) row[1]))).toList();
+        return resultatList.stream().map(row -> new FagsakIdSaksnummer(Long.parseLong(row[0].toString()), new Saksnummer((String) row[1]))).toList();
     }
 
     private static final String REGULERING_SELECT_STD_ES = """
-        SELECT DISTINCT f.id , bru.aktoer_id
-          from fagsak f join bruker bru on f.bruker_id=bru.id
+        SELECT DISTINCT f.id , f.saksnummer
+          from fagsak f
           join behandling b on b.fagsak_id=f.id
           join behandling_resultat br on br.behandling_id=b.id
           join behandling_vedtak bv on br.id = bv.behandling_resultat_id
@@ -330,7 +330,7 @@ public class SatsReguleringRepository {
 
 
     /** Liste av fagsakId, aktørId for saker som potensielt trenger regulering pga endret sats */
-    public List<FagsakIdAktørId> finnSakerMedBehovForEngangsstønadRegulering(LocalDate gjeldendeFom) {
+    public List<FagsakIdSaksnummer> finnSakerMedBehovForEngangsstønadRegulering(LocalDate gjeldendeFom) {
         /*
          * Plukker fagsakId, aktørId fra fagsaker som møter disse kriteriene:
          * - Saker som har siste avsluttet behandling med gammel sats, brutto overstiger 6G og har uttak etter gammel sats sin utløpsdato
@@ -350,7 +350,7 @@ public class SatsReguleringRepository {
             .setParameter("engang", BeregningSatsType.ENGANG.getKode());
         @SuppressWarnings("unchecked")
         List<Object[]> resultatList = query.getResultList();
-        return resultatList.stream().map(row -> new FagsakIdAktørId(Long.parseLong(row[0].toString()), new AktørId((String) row[1]))).toList();
+        return resultatList.stream().map(row -> new FagsakIdSaksnummer(Long.parseLong(row[0].toString()), new Saksnummer((String) row[1]))).toList();
     }
 
 }

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/fagsak/FagsakEvent.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/fagsak/FagsakEvent.java
@@ -1,6 +1,6 @@
 package no.nav.foreldrepenger.behandlingslager.fagsak;
 
-import no.nav.foreldrepenger.domene.typer.AktørId;
+import no.nav.foreldrepenger.domene.typer.Saksnummer;
 
 /**
  * Marker interface for events fyrt på en Fagsak.
@@ -10,6 +10,6 @@ public interface FagsakEvent {
 
     Long getFagsakId();
 
-    AktørId getAktørId();
+    Saksnummer getSaksnummer();
 
 }

--- a/behandlingslager/domene/src/test/java/no/nav/foreldrepenger/behandlingslager/behandling/vedtak/OverlappVedtakRepositoryTest.java
+++ b/behandlingslager/domene/src/test/java/no/nav/foreldrepenger/behandlingslager/behandling/vedtak/OverlappVedtakRepositoryTest.java
@@ -34,7 +34,7 @@ class OverlappVedtakRepositoryTest extends EntityManagerAwareTest {
             LocalDate.of(2019, 5, 1));
         var ytelseInfotrygd = OverlappVedtak.OverlappYtelseType.BS;
         var builder = OverlappVedtak.builder()
-            .medSaksnummer(behandling.getFagsak().getSaksnummer())
+            .medSaksnummer(behandling.getSaksnummer())
             .medBehandlingId(behandling.getId())
             .medPeriode(periodeVL)
             .medHendelse("TEST")
@@ -46,9 +46,9 @@ class OverlappVedtakRepositoryTest extends EntityManagerAwareTest {
         overlappVedtakRepository.lagre(builder);
 
         // Assert
-        var hentet = overlappVedtakRepository.hentForSaksnummer(behandling.getFagsak().getSaksnummer()).get(0);
+        var hentet = overlappVedtakRepository.hentForSaksnummer(behandling.getSaksnummer()).get(0);
         assertThat(hentet.getBehandlingId()).isEqualTo(behandling.getId());
-        assertThat(hentet.getSaksnummer()).isEqualTo(behandling.getFagsak().getSaksnummer());
+        assertThat(hentet.getSaksnummer()).isEqualTo(behandling.getSaksnummer());
         assertThat(hentet.getPeriode()).isEqualTo(periodeVL);
         assertThat(hentet.getYtelse()).isEqualTo(ytelseInfotrygd);
 

--- a/behandlingslager/testutil/src/test/java/no/nav/foreldrepenger/behandlingslager/behandling/BehandlingRepositoryTest.java
+++ b/behandlingslager/testutil/src/test/java/no/nav/foreldrepenger/behandlingslager/behandling/BehandlingRepositoryTest.java
@@ -210,7 +210,7 @@ class BehandlingRepositoryTest extends EntityManagerAwareTest {
         var scenario = ScenarioKlageEngangsstønad.forUtenVurderingResultat(ScenarioMorSøkerEngangsstønad.forAdopsjon());
         var klageBehandling = scenario.lagre(repositoryProvider, klageRepository);
 
-        var alleBehandlinger = behandlingRepository.hentAbsoluttAlleBehandlingerForSaksnummer(klageBehandling.getFagsak().getSaksnummer());
+        var alleBehandlinger = behandlingRepository.hentAbsoluttAlleBehandlingerForSaksnummer(klageBehandling.getSaksnummer());
         assertThat(alleBehandlinger).as("Forventer at alle behandlinger opprettet skal eksistere").hasSize(2);
 
         var sisteBehandling = behandlingRepository.hentSisteYtelsesBehandlingForFagsakId(klageBehandling.getFagsak().getId());
@@ -587,7 +587,7 @@ class BehandlingRepositoryTest extends EntityManagerAwareTest {
         assertThat(behandlinger).hasSize(1).map(Behandling::getId).containsOnly(behandling.getId());
         var beh1 = behandlinger.get(0);
         assertThat(beh1.getFagsak()).isNotNull();
-        assertThat(beh1.getFagsak().getSaksnummer()).isEqualTo(saksnummer);
+        assertThat(beh1.getSaksnummer()).isEqualTo(saksnummer);
 
     }
 

--- a/behandlingsprosess/src/main/java/no/nav/foreldrepenger/behandling/steg/anke/AnkeSteg.java
+++ b/behandlingsprosess/src/main/java/no/nav/foreldrepenger/behandling/steg/anke/AnkeSteg.java
@@ -101,7 +101,7 @@ public class AnkeSteg implements BehandlingSteg {
                 .filter(h -> !KlageHjemmel.UDEFINERT.equals(h))
                 .orElseGet(() -> KlageHjemmel.standardHjemmelForYtelse(behandling.getFagsakYtelseType()));
             var tilKabalTask = ProsessTaskData.forProsessTask(SendTilKabalTask.class);
-            tilKabalTask.setBehandling(behandling.getFagsakId(), behandling.getId(), behandling.getAktørId().getId());
+            tilKabalTask.setBehandling(behandling.getSaksnummer().getVerdi(), behandling.getFagsakId(), behandling.getId());
             tilKabalTask.setCallIdFraEksisterende();
             tilKabalTask.setProperty(SendTilKabalTask.HJEMMEL_KEY, hjemmel.getKode());
             prosessTaskTjeneste.lagre(tilKabalTask);
@@ -138,7 +138,7 @@ public class AnkeSteg implements BehandlingSteg {
                 .orElseGet(() -> aktuelleKlager.stream().max(Comparator.comparing(Behandling::getAvsluttetDato)).orElseThrow());
             return Optional.of(lagrePåanketBehandling(anke, utvalgtKlage));
         }
-        LOG.warn("ANKE steg: kunne ikke utlede klagebehandling automatisk sak {} anke {}", anke.getFagsak().getSaksnummer().getVerdi(), anke.getId());
+        LOG.warn("ANKE steg: kunne ikke utlede klagebehandling automatisk sak {} anke {}", anke.getSaksnummer().getVerdi(), anke.getId());
         return Optional.empty();
     }
 

--- a/behandlingsprosess/src/main/java/no/nav/foreldrepenger/behandling/steg/iverksettevedtak/HenleggBehandlingTjeneste.java
+++ b/behandlingsprosess/src/main/java/no/nav/foreldrepenger/behandling/steg/iverksettevedtak/HenleggBehandlingTjeneste.java
@@ -17,8 +17,8 @@ import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRe
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepositoryProvider;
 import no.nav.foreldrepenger.behandlingslager.behandling.søknad.SøknadRepository;
 import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakYtelseType;
-import no.nav.foreldrepenger.dokumentbestiller.DokumentBestilling;
 import no.nav.foreldrepenger.dokumentbestiller.DokumentBestillerTjeneste;
+import no.nav.foreldrepenger.dokumentbestiller.DokumentBestilling;
 import no.nav.foreldrepenger.dokumentbestiller.DokumentMalType;
 import no.nav.foreldrepenger.historikk.HistorikkInnslagTekstBuilder;
 import no.nav.foreldrepenger.mottak.vedtak.StartBerørtBehandlingTask;
@@ -98,7 +98,7 @@ public class HenleggBehandlingTjeneste {
 
     private void startTaskForDekøingAvBerørtBehandling(Behandling behandling) {
         var taskData = ProsessTaskData.forProsessTask(StartBerørtBehandlingTask.class);
-        taskData.setBehandling(behandling.getFagsakId(), behandling.getId(), behandling.getAktørId().getId());
+        taskData.setBehandling(behandling.getSaksnummer().getVerdi(), behandling.getFagsakId(), behandling.getId());
         taskData.setCallIdFraEksisterende();
         taskTjeneste.lagre(taskData);
     }

--- a/behandlingsprosess/src/main/java/no/nav/foreldrepenger/behandling/steg/klage/VurderFormkrafNkSteg.java
+++ b/behandlingsprosess/src/main/java/no/nav/foreldrepenger/behandling/steg/klage/VurderFormkrafNkSteg.java
@@ -76,7 +76,7 @@ public class VurderFormkrafNkSteg implements BehandlingSteg {
                     KlageHjemmel.standardHjemmelForYtelse(behandling.getFagsakYtelseType()) : klageVurderingResultat.getKlageHjemmel();
 
                 var tilKabalTask = ProsessTaskData.forProsessTask(SendTilKabalTask.class);
-                tilKabalTask.setBehandling(behandling.getFagsakId(), behandling.getId(), behandling.getAktørId().getId());
+                tilKabalTask.setBehandling(behandling.getSaksnummer().getVerdi(), behandling.getFagsakId(), behandling.getId());
                 tilKabalTask.setCallIdFraEksisterende();
                 tilKabalTask.setProperty(SendTilKabalTask.HJEMMEL_KEY, klageHjemmel.getKode());
                 taskTjeneste.lagre(tilKabalTask);

--- a/behandlingsprosess/src/main/java/no/nav/foreldrepenger/behandling/steg/mottatteopplysninger/fp/TilknyttFagsakStegImpl.java
+++ b/behandlingsprosess/src/main/java/no/nav/foreldrepenger/behandling/steg/mottatteopplysninger/fp/TilknyttFagsakStegImpl.java
@@ -120,7 +120,7 @@ public class TilknyttFagsakStegImpl implements TilknyttFagsakSteg {
             if (BehandlingType.FØRSTEGANGSSØKNAD.equals(behandling.getType())) {
                 kobleSakTjeneste.opprettFagsakRelasjon(behandling.getFagsak());
             } else {
-                throw new IllegalStateException("Utviklerfeil: Foreldrepenger revurdering uten relasjon, sak " + behandling.getFagsak().getSaksnummer().getVerdi());
+                throw new IllegalStateException("Utviklerfeil: Foreldrepenger revurdering uten relasjon, sak " + behandling.getSaksnummer().getVerdi());
             }
         } else { // Finnes fagsakrelasjon. Skal ikke endre denne dersom det finnes vedtak. Dersom finnes og det ikke er vedtak - lagre ny (uten DG)
             var harVedtak = behandlingRepository.finnSisteAvsluttedeIkkeHenlagteBehandling(behandling.getFagsakId()).isPresent();

--- a/behandlingsprosess/src/main/java/no/nav/foreldrepenger/behandling/steg/simulering/SimulerOppdragSteg.java
+++ b/behandlingsprosess/src/main/java/no/nav/foreldrepenger/behandling/steg/simulering/SimulerOppdragSteg.java
@@ -242,13 +242,13 @@ public class SimulerOppdragSteg implements BehandlingSteg {
         var harÅpenTilbakekreving = harÅpenTilbakekreving(behandling);
         if (!harÅpenTilbakekreving && SimuleringIntegrasjonTjeneste.harFeilutbetaling(simuleringResultatDto)) {
             LOG.info("Saksnummer {} har ikke åpen tilbakekreving og det er identifisert feilutbetaling. Simuleringsresultat: sumFeilutbetaling={}, sumInntrekk={}, slåttAvInntrekk={}",
-                behandling.getFagsak().getSaksnummer(), simuleringResultatDto.sumFeilutbetaling(), simuleringResultatDto.sumInntrekk(), simuleringResultatDto.slåttAvInntrekk());
+                behandling.getSaksnummer(), simuleringResultatDto.sumFeilutbetaling(), simuleringResultatDto.sumInntrekk(), simuleringResultatDto.slåttAvInntrekk());
         }
         return harÅpenTilbakekreving && simuleringResultatDto.sumFeilutbetaling() != 0;
     }
 
     private boolean harÅpenTilbakekreving(Behandling behandling) {
-        return fptilbakeRestKlient.harÅpenTilbakekrevingsbehandling(behandling.getFagsak().getSaksnummer());
+        return fptilbakeRestKlient.harÅpenTilbakekrevingsbehandling(behandling.getSaksnummer());
     }
 
     private void lagreTilbakekrevingValg(Behandling behandling, TilbakekrevingValg tilbakekrevingValg) {

--- a/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/anke/AnkeStegTest.java
+++ b/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/anke/AnkeStegTest.java
@@ -33,8 +33,8 @@ class AnkeStegTest {
         var ankeRepository = mock(AnkeVurderingTjeneste.class);
         var prosessTaskTjeneste = mock(ProsessTaskTjeneste.class);
         when(ankeRepository.hentAnkeResultatHvisEksisterer(any())).thenReturn(Optional.empty());
-        var kontekst = new BehandlingskontrollKontekst(ankeBehandling.getFagsakId(),
-                ankeBehandling.getAktørId(), new BehandlingLås(ankeBehandling.getId()));
+        var kontekst = new BehandlingskontrollKontekst(ankeBehandling.getSaksnummer(), ankeBehandling.getFagsakId(),
+                new BehandlingLås(ankeBehandling.getId()));
 
         var steg = new AnkeSteg(ankeRepository, mock(KlageRepository.class), prosessTaskTjeneste, rProvider);
 

--- a/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/avklarfakta/fp/KontrollerFaktaRevurderingStegImplTest.java
+++ b/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/avklarfakta/fp/KontrollerFaktaRevurderingStegImplTest.java
@@ -56,7 +56,7 @@ class KontrollerFaktaRevurderingStegImplTest {
         var fagsak = behandling.getFagsak();
         // Arrange
         var lås = behandlingRepository.taSkriveLås(behandling);
-        var kontekst = new BehandlingskontrollKontekst(fagsak.getId(), fagsak.getAktørId(), lås);
+        var kontekst = new BehandlingskontrollKontekst(fagsak.getSaksnummer(), fagsak.getId(), lås);
 
         // Act
         var aksjonspunkter = steg.utførSteg(kontekst).getAksjonspunktListe();
@@ -74,7 +74,7 @@ class KontrollerFaktaRevurderingStegImplTest {
         var fagsak = behandling.getFagsak();
         // Arrange
         var lås = behandlingRepository.taSkriveLås(behandling);
-        var kontekst = new BehandlingskontrollKontekst(fagsak.getId(), fagsak.getAktørId(), lås);
+        var kontekst = new BehandlingskontrollKontekst(fagsak.getSaksnummer(), fagsak.getId(), lås);
 
         // Act
         steg.utførSteg(kontekst).getAksjonspunktListe();
@@ -106,8 +106,8 @@ class KontrollerFaktaRevurderingStegImplTest {
                 .medDefaultOppgittTilknytning()
                 .lagre(repositoryProvider);
 
-        var kontekst = new BehandlingskontrollKontekst(revurdering.getFagsakId(), revurdering.getAktørId(),
-                behandlingRepository.taSkriveLås(revurdering.getId()));
+        var kontekst = new BehandlingskontrollKontekst(revurdering.getSaksnummer(), revurdering.getFagsakId(),
+            behandlingRepository.taSkriveLås(revurdering.getId()));
         steg.utførSteg(kontekst);
 
         var ytelseFordelingAggregat = repositoryProvider.getYtelsesFordelingRepository()
@@ -139,7 +139,7 @@ class KontrollerFaktaRevurderingStegImplTest {
                 .medDefaultOppgittTilknytning()
                 .lagre(repositoryProvider);
 
-        var kontekst = new BehandlingskontrollKontekst(revurdering.getFagsakId(), revurdering.getAktørId(),
+        var kontekst = new BehandlingskontrollKontekst(revurdering.getSaksnummer(), revurdering.getFagsakId(),
                 behandlingRepository.taSkriveLås(revurdering.getId()));
         steg.utførSteg(kontekst);
 
@@ -159,7 +159,7 @@ class KontrollerFaktaRevurderingStegImplTest {
         var fagsak = revurdering.getFagsak();
         // Arrange
         var lås = behandlingRepository.taSkriveLås(revurdering);
-        var kontekst = new BehandlingskontrollKontekst(fagsak.getId(), fagsak.getAktørId(), lås);
+        var kontekst = new BehandlingskontrollKontekst(fagsak.getSaksnummer(), fagsak.getId(), lås);
 
         // Act
         steg.utførSteg(kontekst).getAksjonspunktListe();
@@ -181,7 +181,7 @@ class KontrollerFaktaRevurderingStegImplTest {
         var fagsak = behandling.getFagsak();
         // Arrange
         var lås = behandlingRepository.taSkriveLås(behandling);
-        var kontekst = new BehandlingskontrollKontekst(fagsak.getId(), fagsak.getAktørId(), lås);
+        var kontekst = new BehandlingskontrollKontekst(fagsak.getSaksnummer(), fagsak.getId(), lås);
 
         // Act
         var aksjonspunkter = steg.utførSteg(kontekst).getAksjonspunktListe();
@@ -200,7 +200,7 @@ class KontrollerFaktaRevurderingStegImplTest {
         var fagsak = behandling.getFagsak();
         // Arrange
         var lås = behandlingRepository.taSkriveLås(behandling);
-        var kontekst = new BehandlingskontrollKontekst(fagsak.getId(), fagsak.getAktørId(), lås);
+        var kontekst = new BehandlingskontrollKontekst(fagsak.getSaksnummer(), fagsak.getId(), lås);
         var expectedTransisjon =  TransisjonIdentifikator
             .forId(FellesTransisjoner.SPOLFREM_PREFIX + StartpunktType.TILKJENT_YTELSE.getBehandlingSteg().getKode());
 
@@ -244,7 +244,7 @@ class KontrollerFaktaRevurderingStegImplTest {
         var revurdering = opprettRevurderingPgaBerørtBehandling();
         var fagsak = revurdering.getFagsak();
         var lås = behandlingRepository.taSkriveLås(revurdering);
-        var kontekst = new BehandlingskontrollKontekst(fagsak.getId(), fagsak.getAktørId(), lås);
+        var kontekst = new BehandlingskontrollKontekst(fagsak.getSaksnummer(), fagsak.getId(), lås);
 
         // Act
         steg.utførSteg(kontekst).getAksjonspunktListe();
@@ -262,7 +262,7 @@ class KontrollerFaktaRevurderingStegImplTest {
         endreDekningsgrad(revurdering.getId(), Dekningsgrad._80);
         var fagsak = revurdering.getFagsak();
         var lås = behandlingRepository.taSkriveLås(revurdering);
-        var kontekst = new BehandlingskontrollKontekst(fagsak.getId(), fagsak.getAktørId(), lås);
+        var kontekst = new BehandlingskontrollKontekst(fagsak.getSaksnummer(), fagsak.getId(), lås);
 
         // Act
         steg.utførSteg(kontekst).getAksjonspunktListe();
@@ -289,7 +289,7 @@ class KontrollerFaktaRevurderingStegImplTest {
         endreDekningsgrad(revurdering.getId(), Dekningsgrad._100);
         var fagsak = revurdering.getFagsak();
         var lås = behandlingRepository.taSkriveLås(revurdering);
-        var kontekst = new BehandlingskontrollKontekst(fagsak.getId(), fagsak.getAktørId(), lås);
+        var kontekst = new BehandlingskontrollKontekst(fagsak.getSaksnummer(), fagsak.getId(), lås);
 
         // Act
         steg.utførSteg(kontekst).getAksjonspunktListe();
@@ -313,7 +313,7 @@ class KontrollerFaktaRevurderingStegImplTest {
 
         var fagsak = behandling.getFagsak();
         var lås = behandlingRepository.taSkriveLås(behandling);
-        var kontekst = new BehandlingskontrollKontekst(fagsak.getId(), fagsak.getAktørId(), lås);
+        var kontekst = new BehandlingskontrollKontekst(fagsak.getSaksnummer(), fagsak.getId(), lås);
 
         // Act
         steg.utførSteg(kontekst).getAksjonspunktListe();

--- a/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/avklarfakta/svp/KontrollerFaktaStegImplTest.java
+++ b/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/avklarfakta/svp/KontrollerFaktaStegImplTest.java
@@ -93,7 +93,7 @@ class KontrollerFaktaStegImplTest {
     void skal_utlede_inngangsvilkår_for_svp() {
         var fagsak = behandling.getFagsak();
         var lås = behandlingRepository.taSkriveLås(behandling.getId());
-        var kontekst = new BehandlingskontrollKontekst(fagsak.getId(), fagsak.getAktørId(), lås);
+        var kontekst = new BehandlingskontrollKontekst(fagsak.getSaksnummer(), fagsak.getId(), lås);
 
         // Act
         steg.utførSteg(kontekst);

--- a/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/beregningsgrunnlag/ForeslåBeregningsgrunnlagStegTest.java
+++ b/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/beregningsgrunnlag/ForeslåBeregningsgrunnlagStegTest.java
@@ -55,7 +55,7 @@ class ForeslåBeregningsgrunnlagStegTest {
 
         steg = new ForeslåBeregningsgrunnlagSteg(behandlingRepository, beregningsgrunnlagKopierOgLagreTjeneste, beregningTjeneste);
 
-        iayTjeneste.lagreInntektsmeldinger(behandling.getFagsak().getSaksnummer(), behandling.getId(), List.of());
+        iayTjeneste.lagreInntektsmeldinger(behandling.getSaksnummer(), behandling.getId(), List.of());
     }
 
     @Test

--- a/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/beregningsgrunnlag/fp/KontrollerFaktaBeregningStegTest.java
+++ b/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/beregningsgrunnlag/fp/KontrollerFaktaBeregningStegTest.java
@@ -77,6 +77,6 @@ class KontrollerFaktaBeregningStegTest {
 
     private BehandlingskontrollKontekst lagBehandlingskontrollkontekst(Behandling behandling) {
         var behandlingLås = behandlingRepository.taSkriveLås(behandling.getId());
-        return new BehandlingskontrollKontekst(behandling.getFagsakId(), behandling.getAktørId(), behandlingLås);
+        return new BehandlingskontrollKontekst(behandling.getSaksnummer(), behandling.getFagsakId(), behandlingLås);
     }
 }

--- a/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/foreslåvedtak/ForeslåVedtakStegImplTest.java
+++ b/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/foreslåvedtak/ForeslåVedtakStegImplTest.java
@@ -23,7 +23,7 @@ class ForeslåVedtakStegImplTest {
         // Act
         var fagsak = behandling.getFagsak();
         var behandlingLås = behandlingRepository.taSkriveLås(behandling);
-        var kontekst = new BehandlingskontrollKontekst(fagsak.getId(), fagsak.getAktørId(), behandlingLås);
+        var kontekst = new BehandlingskontrollKontekst(fagsak.getSaksnummer(), fagsak.getId(), behandlingLås);
         steg.utførSteg(kontekst);
 
         // Assert

--- a/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/inngangsvilkår/InngangsvilkårStegImplTest.java
+++ b/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/inngangsvilkår/InngangsvilkårStegImplTest.java
@@ -66,7 +66,7 @@ class InngangsvilkårStegImplTest {
         var repositoryProvider = scenario.mockBehandlingRepositoryProvider();
         Behandlingsresultat.builderEndreEksisterende(behandling.getBehandlingsresultat())
                 .medBehandlingResultatType(BehandlingResultatType.INNVILGET);
-        var kontekst = new BehandlingskontrollKontekst(behandling.getFagsakId(), behandling.getAktørId(),
+        var kontekst = new BehandlingskontrollKontekst(behandling.getSaksnummer(), behandling.getFagsakId(),
                 repositoryProvider.getBehandlingRepository().taSkriveLås(behandling));
 
         var val = new RegelResultat(behandling.getBehandlingsresultat().getVilkårResultat(), emptyList(), emptyMap());
@@ -94,7 +94,7 @@ class InngangsvilkårStegImplTest {
         var repositoryProvider = scenario.mockBehandlingRepositoryProvider();
         Behandlingsresultat.builderEndreEksisterende(behandling.getBehandlingsresultat())
                 .medBehandlingResultatType(BehandlingResultatType.INNVILGET);
-        var kontekst = new BehandlingskontrollKontekst(behandling.getFagsakId(), behandling.getAktørId(),
+        var kontekst = new BehandlingskontrollKontekst(behandling.getSaksnummer(), behandling.getFagsakId(),
                 repositoryProvider.getBehandlingRepository().taSkriveLås(behandling));
 
         var val = lagRegelResultatOpptjening(behandling);
@@ -131,7 +131,7 @@ class InngangsvilkårStegImplTest {
         var repositoryProvider = revurderingsscenario.mockBehandlingRepositoryProvider();
         Behandlingsresultat.builderEndreEksisterende(revurdering.getBehandlingsresultat())
                 .medBehandlingResultatType(BehandlingResultatType.AVSLÅTT);
-        var kontekst = new BehandlingskontrollKontekst(revurdering.getFagsakId(), revurdering.getAktørId(),
+        var kontekst = new BehandlingskontrollKontekst(revurdering.getSaksnummer(), revurdering.getFagsakId(),
                 repositoryProvider.getBehandlingRepository().taSkriveLås(revurdering));
 
         var val = lagRegelResultatOpptjening(revurdering);
@@ -175,7 +175,7 @@ class InngangsvilkårStegImplTest {
         var repositoryProvider = revurderingsscenario.mockBehandlingRepositoryProvider();
         Behandlingsresultat.builderEndreEksisterende(revurdering.getBehandlingsresultat())
                 .medBehandlingResultatType(BehandlingResultatType.INNVILGET);
-        var kontekst = new BehandlingskontrollKontekst(revurdering.getFagsakId(), revurdering.getAktørId(),
+        var kontekst = new BehandlingskontrollKontekst(revurdering.getSaksnummer(), revurdering.getFagsakId(),
                 repositoryProvider.getBehandlingRepository().taSkriveLås(revurdering));
 
         var val = new RegelResultat(revurdering.getBehandlingsresultat().getVilkårResultat(), emptyList(), emptyMap());
@@ -208,7 +208,7 @@ class InngangsvilkårStegImplTest {
         var repositoryProvider = revurderingsscenario.mockBehandlingRepositoryProvider();
         Behandlingsresultat.builderEndreEksisterende(revurdering.getBehandlingsresultat())
                 .medBehandlingResultatType(BehandlingResultatType.INNVILGET);
-        var kontekst = new BehandlingskontrollKontekst(revurdering.getFagsakId(), revurdering.getAktørId(),
+        var kontekst = new BehandlingskontrollKontekst(revurdering.getSaksnummer(), revurdering.getFagsakId(),
                 repositoryProvider.getBehandlingRepository().taSkriveLås(revurdering));
 
         var val = new RegelResultat(revurdering.getBehandlingsresultat().getVilkårResultat(), emptyList(), emptyMap());
@@ -250,7 +250,7 @@ class InngangsvilkårStegImplTest {
         var repositoryProvider = andreRevurderingsscenario.mockBehandlingRepositoryProvider();
         Behandlingsresultat.builderEndreEksisterende(revurdering2.getBehandlingsresultat())
                 .medBehandlingResultatType(BehandlingResultatType.INNVILGET);
-        var kontekst = new BehandlingskontrollKontekst(revurdering2.getFagsakId(), revurdering2.getAktørId(),
+        var kontekst = new BehandlingskontrollKontekst(revurdering2.getSaksnummer(), revurdering2.getFagsakId(),
                 repositoryProvider.getBehandlingRepository().taSkriveLås(revurdering2));
 
         var val = new RegelResultat(revurdering2.getBehandlingsresultat().getVilkårResultat(), emptyList(), emptyMap());
@@ -276,7 +276,7 @@ class InngangsvilkårStegImplTest {
         var repositoryProvider = scenario.mockBehandlingRepositoryProvider();
         Behandlingsresultat.builderEndreEksisterende(behandling.getBehandlingsresultat())
                 .medBehandlingResultatType(BehandlingResultatType.INNVILGET);
-        var kontekst = new BehandlingskontrollKontekst(behandling.getFagsakId(), behandling.getAktørId(),
+        var kontekst = new BehandlingskontrollKontekst(behandling.getSaksnummer(), behandling.getFagsakId(),
                 repositoryProvider.getBehandlingRepository().taSkriveLås(behandling));
         var inngangsvilkårFellesTjeneste = new InngangsvilkårFellesTjeneste(regelOrkestrerer);
         // Act

--- a/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/inngangsvilkår/SamletInngangsvilkårStegImplTest.java
+++ b/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/inngangsvilkår/SamletInngangsvilkårStegImplTest.java
@@ -62,7 +62,7 @@ class SamletInngangsvilkårStegImplTest {
         var repositoryProvider = scenario.mockBehandlingRepositoryProvider();
         Behandlingsresultat.builderEndreEksisterende(behandling.getBehandlingsresultat())
                 .medBehandlingResultatType(BehandlingResultatType.INNVILGET);
-        kontekst = new BehandlingskontrollKontekst(behandling.getFagsakId(), behandling.getAktørId(),
+        kontekst = new BehandlingskontrollKontekst(behandling.getSaksnummer(), behandling.getFagsakId(),
                 repositoryProvider.getBehandlingRepository().taSkriveLås(behandling));
 
         var val = new RegelResultat(behandling.getBehandlingsresultat().getVilkårResultat(), emptyList(), emptyMap());
@@ -93,7 +93,7 @@ class SamletInngangsvilkårStegImplTest {
         var repositoryProvider = scenario.mockBehandlingRepositoryProvider();
         Behandlingsresultat.builderEndreEksisterende(behandling.getBehandlingsresultat())
                 .medBehandlingResultatType(BehandlingResultatType.INNVILGET);
-        kontekst = new BehandlingskontrollKontekst(behandling.getFagsakId(), behandling.getAktørId(),
+        kontekst = new BehandlingskontrollKontekst(behandling.getSaksnummer(), behandling.getFagsakId(),
                 repositoryProvider.getBehandlingRepository().taSkriveLås(behandling));
 
         var val = new RegelResultat(behandling.getBehandlingsresultat().getVilkårResultat(), emptyList(), emptyMap());

--- a/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/inngangsvilkår/medlem/es/VurderMedlemskapvilkårStegTest.java
+++ b/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/inngangsvilkår/medlem/es/VurderMedlemskapvilkårStegTest.java
@@ -53,7 +53,7 @@ class VurderMedlemskapvilkårStegTest {
 
         var behandling = lagre(scenario);
         var fagsak = behandling.getFagsak();
-        var kontekst = new BehandlingskontrollKontekst(fagsak.getId(), fagsak.getAktørId(),
+        var kontekst = new BehandlingskontrollKontekst(fagsak.getSaksnummer(), fagsak.getId(),
             repositoryProvider.getBehandlingLåsRepository().taLås(behandling.getId()));
 
         // Act - vurder vilkåret
@@ -78,7 +78,7 @@ class VurderMedlemskapvilkårStegTest {
 
         var behandling = lagre(scenario);
         var fagsak = behandling.getFagsak();
-        var kontekst = new BehandlingskontrollKontekst(fagsak.getId(), fagsak.getAktørId(),
+        var kontekst = new BehandlingskontrollKontekst(fagsak.getSaksnummer(), fagsak.getId(),
             repositoryProvider.getBehandlingLåsRepository().taLås(behandling.getId()));
 
         // Act - vurder vilkåret
@@ -103,7 +103,7 @@ class VurderMedlemskapvilkårStegTest {
 
         var behandling = lagre(scenario);
         var fagsak = behandling.getFagsak();
-        var kontekst = new BehandlingskontrollKontekst(fagsak.getId(), fagsak.getAktørId(),
+        var kontekst = new BehandlingskontrollKontekst(fagsak.getSaksnummer(), fagsak.getId(),
                 repositoryProvider.getBehandlingLåsRepository().taLås(behandling.getId()));
 
         // Act - vurder vilkåret
@@ -129,7 +129,7 @@ class VurderMedlemskapvilkårStegTest {
 
         var behandling = lagre(scenario);
         var fagsak = behandling.getFagsak();
-        var kontekst = new BehandlingskontrollKontekst(fagsak.getId(), fagsak.getAktørId(),
+        var kontekst = new BehandlingskontrollKontekst(fagsak.getSaksnummer(), fagsak.getId(),
             repositoryProvider.getBehandlingLåsRepository().taLås(behandling.getId()));
 
         // Act - vurder vilkåret

--- a/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/inngangsvilkår/opptjening/fp/VurderOpptjeningsvilkårStegTest.java
+++ b/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/inngangsvilkår/opptjening/fp/VurderOpptjeningsvilkårStegTest.java
@@ -49,7 +49,7 @@ class VurderOpptjeningsvilkårStegTest {
 
         var behandling = lagre(scenario);
         var fagsak = behandling.getFagsak();
-        var kontekst = new BehandlingskontrollKontekst(fagsak.getId(), fagsak.getAktørId(),
+        var kontekst = new BehandlingskontrollKontekst(fagsak.getSaksnummer(), fagsak.getId(),
                 repositoryProvider.getBehandlingLåsRepository().taLås(behandling.getId()));
 
         // Act

--- a/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/inngangsvilkår/opptjening/svp/FastsettOpptjeningsperiodeStegTest.java
+++ b/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/inngangsvilkår/opptjening/svp/FastsettOpptjeningsperiodeStegTest.java
@@ -90,7 +90,7 @@ class FastsettOpptjeningsperiodeStegTest {
         var lås = behandlingRepository.taSkriveLås(behandling.getId());
         // Simulerer at disse vilkårene har blitt opprettet
         opprettVilkår(List.of(OPPTJENINGSPERIODEVILKÅR, OPPTJENINGSVILKÅRET), behandling, lås);
-        var kontekst = new BehandlingskontrollKontekst(fagsak.getId(), fagsak.getAktørId(), lås);
+        var kontekst = new BehandlingskontrollKontekst(fagsak.getSaksnummer(), fagsak.getId(), lås);
 
         // Act
         opptjeningsperiodeSvpSteg.utførSteg(kontekst);
@@ -123,11 +123,11 @@ class FastsettOpptjeningsperiodeStegTest {
         var lås = behandlingRepository.taSkriveLås(behandling.getId());
         // Simulerer at disse vilkårene har blitt opprettet
         opprettVilkår(List.of(OPPTJENINGSPERIODEVILKÅR, OPPTJENINGSVILKÅRET), behandling, lås);
-        var kontekst = new BehandlingskontrollKontekst(fagsak.getId(), fagsak.getAktørId(), lås);
+        var kontekst = new BehandlingskontrollKontekst(fagsak.getSaksnummer(), fagsak.getId(), lås);
         opptjeningsperiodeSvpSteg.utførSteg(kontekst);
 
         var lås2 = behandlingRepository.taSkriveLås(behandling.getId());
-        var kontekst2 = new BehandlingskontrollKontekst(fagsak.getId(), fagsak.getAktørId(), lås2);
+        var kontekst2 = new BehandlingskontrollKontekst(fagsak.getSaksnummer(), fagsak.getId(), lås2);
 
         // Act
         vurderOpptjeningsvilkårSteg.utførSteg(kontekst2);
@@ -155,11 +155,11 @@ class FastsettOpptjeningsperiodeStegTest {
         var lås = behandlingRepository.taSkriveLås(behandling.getId());
         // Simulerer at disse vilkårene har blitt opprettet
         opprettVilkår(List.of(OPPTJENINGSPERIODEVILKÅR, OPPTJENINGSVILKÅRET), behandling, lås);
-        var kontekst = new BehandlingskontrollKontekst(fagsak.getId(), fagsak.getAktørId(), lås);
+        var kontekst = new BehandlingskontrollKontekst(fagsak.getSaksnummer(), fagsak.getId(), lås);
         opptjeningsperiodeSvpSteg.utførSteg(kontekst);
 
         var lås2 = behandlingRepository.taSkriveLås(behandling.getId());
-        var kontekst2 = new BehandlingskontrollKontekst(fagsak.getId(), fagsak.getAktørId(), lås2);
+        var kontekst2 = new BehandlingskontrollKontekst(fagsak.getSaksnummer(), fagsak.getId(), lås2);
 
         // Act
         vurderOpptjeningsvilkårSteg.utførSteg(kontekst2);
@@ -185,11 +185,11 @@ class FastsettOpptjeningsperiodeStegTest {
         var lås = behandlingRepository.taSkriveLås(behandling.getId());
         // Simulerer at disse vilkårene har blitt opprettet
         opprettVilkår(List.of(OPPTJENINGSPERIODEVILKÅR, OPPTJENINGSVILKÅRET), behandling, lås);
-        var kontekst = new BehandlingskontrollKontekst(fagsak.getId(), fagsak.getAktørId(), lås);
+        var kontekst = new BehandlingskontrollKontekst(fagsak.getSaksnummer(), fagsak.getId(), lås);
         opptjeningsperiodeSvpSteg.utførSteg(kontekst);
 
         var lås2 = behandlingRepository.taSkriveLås(behandling.getId());
-        var kontekst2 = new BehandlingskontrollKontekst(fagsak.getId(), fagsak.getAktørId(), lås2);
+        var kontekst2 = new BehandlingskontrollKontekst(fagsak.getSaksnummer(), fagsak.getId(), lås2);
 
         // simuler at aktiviteten har blitt godkjent
         var aktivitetsPeriode = DatoIntervallEntitet.fraOgMedTilOgMed(LocalDate.now().minusMonths(6), LocalDate.now().plusMonths(6));

--- a/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/innsyn/VurderInnsynStegTest.java
+++ b/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/innsyn/VurderInnsynStegTest.java
@@ -41,7 +41,7 @@ class VurderInnsynStegTest extends EntityManagerAwareTest {
         // Act
         var lås = behandlingRepository.taSkriveLås(behandling);
         var fagsak = behandling.getFagsak();
-        var kontekst = new BehandlingskontrollKontekst(fagsak.getId(), fagsak.getAktørId(), lås);
+        var kontekst = new BehandlingskontrollKontekst(fagsak.getSaksnummer(), fagsak.getId(), lås);
         var resultat = steg.utførSteg(kontekst);
         assertThat(resultat.getAksjonspunktListe()).containsOnly(AksjonspunktDefinisjon.VURDER_INNSYN);
     }

--- a/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/iverksettevedtak/IverksetteInnsynVedtakStegFellesTest.java
+++ b/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/iverksettevedtak/IverksetteInnsynVedtakStegFellesTest.java
@@ -30,7 +30,7 @@ class IverksetteInnsynVedtakStegFellesTest {
         var steg = new IverksetteInnsynVedtakStegFelles(dokumentBestillerTjeneste, repositoryProvider, mock(BehandlingEventPubliserer.class));
         var behandling = scenario.getBehandling();
         var fagsak = behandling.getFagsak();
-        var kontekst = new BehandlingskontrollKontekst(fagsak.getId(), fagsak.getAktørId(),
+        var kontekst = new BehandlingskontrollKontekst(fagsak.getSaksnummer(), fagsak.getId(),
                 repositoryProvider.getBehandlingRepository().taSkriveLås(behandling));
         steg.utførSteg(kontekst);
 
@@ -47,7 +47,7 @@ class IverksetteInnsynVedtakStegFellesTest {
         var steg = new IverksetteInnsynVedtakStegFelles(dokumentBestillerTjeneste, repositoryProvider, mock(BehandlingEventPubliserer.class));
         var behandling = scenario.getBehandling();
         var fagsak = behandling.getFagsak();
-        var kontekst = new BehandlingskontrollKontekst(fagsak.getId(), fagsak.getAktørId(),
+        var kontekst = new BehandlingskontrollKontekst(fagsak.getSaksnummer(), fagsak.getId(),
                 repositoryProvider.getBehandlingRepository().taSkriveLås(behandling));
         steg.utførSteg(kontekst);
 
@@ -67,7 +67,7 @@ class IverksetteInnsynVedtakStegFellesTest {
         var steg = new IverksetteInnsynVedtakStegFelles(dokumentBestillerTjeneste, repositoryProvider, mock(BehandlingEventPubliserer.class));
         var behandling = scenario.getBehandling();
         var fagsak = behandling.getFagsak();
-        var kontekst = new BehandlingskontrollKontekst(fagsak.getId(), fagsak.getAktørId(),
+        var kontekst = new BehandlingskontrollKontekst(fagsak.getSaksnummer(), fagsak.getId(),
                 repositoryProvider.getBehandlingRepository().taSkriveLås(behandling));
         steg.utførSteg(kontekst);
 

--- a/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/iverksettevedtak/es/IverksetteVedtakStegFellesTest.java
+++ b/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/iverksettevedtak/es/IverksetteVedtakStegFellesTest.java
@@ -151,7 +151,7 @@ class IverksetteVedtakStegFellesTest extends EntityManagerAwareTest {
 
     private BehandleStegResultat utførSteg(Behandling behandling) {
         var lås = behandlingRepository.taSkriveLås(behandling);
-        return iverksetteVedtakSteg.utførSteg(new BehandlingskontrollKontekst(behandling.getFagsakId(), behandling.getAktørId(), lås));
+        return iverksetteVedtakSteg.utførSteg(new BehandlingskontrollKontekst(behandling.getSaksnummer(), behandling.getFagsakId(), lås));
     }
 
     private Behandling opprettBehandling() {

--- a/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/iverksettevedtak/fp/IverksetteVedtakStegYtelseTest.java
+++ b/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/iverksettevedtak/fp/IverksetteVedtakStegYtelseTest.java
@@ -101,7 +101,7 @@ class IverksetteVedtakStegYtelseTest {
 
     private BehandleStegResultat utførSteg(Behandling behandling) {
         var lås = behandlingRepository.taSkriveLås(behandling);
-        return iverksetteVedtakSteg.utførSteg(new BehandlingskontrollKontekst(behandling.getFagsakId(), behandling.getAktørId(), lås));
+        return iverksetteVedtakSteg.utførSteg(new BehandlingskontrollKontekst(behandling.getSaksnummer(), behandling.getFagsakId(), lås));
     }
 
     private Behandling opprettBehandling() {

--- a/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/klage/KlageNfpStegTest.java
+++ b/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/klage/KlageNfpStegTest.java
@@ -41,7 +41,7 @@ class KlageNfpStegTest {
     void skalOppretteAksjonspunktManuellVurderingAvKlageNfpNårStegKjøres() {
         var scenario = ScenarioKlageEngangsstønad.forMedholdNK(ScenarioMorSøkerEngangsstønad.forFødsel());
         var klageBehandling = scenario.lagMocked();
-        var kontekst = new BehandlingskontrollKontekst(klageBehandling.getFagsakId(), klageBehandling.getAktørId(),
+        var kontekst = new BehandlingskontrollKontekst(klageBehandling.getSaksnummer(), klageBehandling.getFagsakId(),
                 new BehandlingLås(klageBehandling.getId()));
 
         // Act
@@ -62,7 +62,7 @@ class KlageNfpStegTest {
 
         var scenario = ScenarioKlageEngangsstønad.forMedholdNK(ScenarioMorSøkerEngangsstønad.forFødsel());
         var klageBehandling = scenario.lagMocked();
-        var kontekst = new BehandlingskontrollKontekst(klageBehandling.getFagsakId(), klageBehandling.getAktørId(),
+        var kontekst = new BehandlingskontrollKontekst(klageBehandling.getSaksnummer(), klageBehandling.getFagsakId(),
                 new BehandlingLås(klageBehandling.getId()));
         var repositoryProviderMock = scenario.mockBehandlingRepositoryProvider();
         steg = new KlageNfpSteg(repositoryProviderMock.getBehandlingRepository(), behandlendeEnhetTjeneste);

--- a/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/klage/KlageNkStegTest.java
+++ b/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/klage/KlageNkStegTest.java
@@ -17,7 +17,7 @@ class KlageNkStegTest {
         // Arrange
         var scenario = ScenarioKlageEngangsstønad.forAvvistNFP(ScenarioMorSøkerEngangsstønad.forAdopsjon());
         var klageBehandling = scenario.lagMocked();
-        var kontekst = new BehandlingskontrollKontekst(klageBehandling.getFagsakId(), klageBehandling.getAktørId(),
+        var kontekst = new BehandlingskontrollKontekst(klageBehandling.getSaksnummer(), klageBehandling.getFagsakId(),
                 new BehandlingLås(klageBehandling.getId()));
         var klageRepository = scenario.getKlageRepository();
 

--- a/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/mottatteopplysninger/fp/TilknyttFagsakUtlandsAksjonspunktTest.java
+++ b/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/mottatteopplysninger/fp/TilknyttFagsakUtlandsAksjonspunktTest.java
@@ -45,7 +45,7 @@ class TilknyttFagsakUtlandsAksjonspunktTest {
 
         when(kobleSakerTjeneste.finnFagsakRelasjonDersomOpprettet(behandling)).thenReturn(Optional.of(new FagsakRelasjon(behandling.getFagsak(), null,
                 null, Dekningsgrad._100, fødselsdato.plusYears(3))));
-        var kontekst = new BehandlingskontrollKontekst(behandling.getFagsakId(), behandling.getAktørId(),
+        var kontekst = new BehandlingskontrollKontekst(behandling.getSaksnummer(), behandling.getFagsakId(),
             provider.getBehandlingRepository().taSkriveLås(behandling));
 
         var tilknyttFagsakSteg = new TilknyttFagsakStegImpl(provider, kobleSakerTjeneste, mock(BehandlendeEnhetTjeneste.class),

--- a/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/registrersøknad/RegistrerSøknadStegTest.java
+++ b/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/registrersøknad/RegistrerSøknadStegTest.java
@@ -53,9 +53,10 @@ class RegistrerSøknadStegTest extends EntityManagerAwareTest {
     void opprette_registrer_endringssøknad_aksjonspunkt_hvis_mottatt_førstegangssøknad_i_en_revurdering() {
 
         var aktørId = AktørId.dummy();
+        var saksnummer = new Saksnummer("9999");
         var fagsakId = fagsakRepository
                 .opprettNy(
-                        new Fagsak(FagsakYtelseType.FORELDREPENGER, NavBruker.opprettNyNB(aktørId), RelasjonsRolleType.MORA, new Saksnummer("9999")));
+                        new Fagsak(FagsakYtelseType.FORELDREPENGER, NavBruker.opprettNyNB(aktørId), RelasjonsRolleType.MORA, saksnummer));
 
         var fagsak = fagsakRepository.finnEksaktFagsak(fagsakId);
         var forrigeBehandling = Behandling.forFørstegangssøknad(fagsak)
@@ -74,7 +75,7 @@ class RegistrerSøknadStegTest extends EntityManagerAwareTest {
                 .build();
         mottatteDokumentRepository.lagre(mottattDokument);
 
-        var kontekst = new BehandlingskontrollKontekst(fagsakId, aktørId, lås);
+        var kontekst = new BehandlingskontrollKontekst(saksnummer, fagsakId, lås);
         var resultat = steg.utførSteg(kontekst);
 
         assertThat(resultat.getAksjonspunktListe()).containsExactly(AksjonspunktDefinisjon.REGISTRER_PAPIR_ENDRINGSØKNAD_FORELDREPENGER);
@@ -84,9 +85,10 @@ class RegistrerSøknadStegTest extends EntityManagerAwareTest {
     void opprett_registrer_papirsøknad_svangerskapspenger_hvis_fagsaktype_er_svp() {
 
         var aktørId = AktørId.dummy();
+        var saksnummer = new Saksnummer("9999");
         var fagsakId = fagsakRepository
                 .opprettNy(new Fagsak(FagsakYtelseType.SVANGERSKAPSPENGER, NavBruker.opprettNyNB(aktørId), RelasjonsRolleType.MORA,
-                        new Saksnummer("9999")));
+                        saksnummer));
 
         var fagsak = fagsakRepository.finnEksaktFagsak(fagsakId);
         var forrigeBehandling = Behandling.forFørstegangssøknad(fagsak)
@@ -105,7 +107,7 @@ class RegistrerSøknadStegTest extends EntityManagerAwareTest {
                 .build();
         mottatteDokumentRepository.lagre(mottattDokument);
 
-        var kontekst = new BehandlingskontrollKontekst(fagsakId, aktørId, lås);
+        var kontekst = new BehandlingskontrollKontekst(saksnummer, fagsakId, lås);
         var resultat = steg.utførSteg(kontekst);
 
         assertThat(resultat.getAksjonspunktListe()).containsExactly(AksjonspunktDefinisjon.REGISTRER_PAPIRSØKNAD_SVANGERSKAPSPENGER);

--- a/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/simulering/SimulerOppdragStegTest.java
+++ b/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/simulering/SimulerOppdragStegTest.java
@@ -12,8 +12,6 @@ import java.util.Optional;
 
 import jakarta.persistence.EntityManager;
 
-import no.nav.foreldrepenger.behandlingslager.behandling.beregning.BeregningsresultatRepository;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -24,6 +22,7 @@ import no.nav.foreldrepenger.behandlingskontroll.transisjoner.FellesTransisjoner
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingStegType;
 import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.AksjonspunktDefinisjon;
+import no.nav.foreldrepenger.behandlingslager.behandling.beregning.BeregningsresultatRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepositoryProvider;
 import no.nav.foreldrepenger.behandlingslager.behandling.tilbakekreving.TilbakekrevingRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.tilbakekreving.TilbakekrevingValg;
@@ -73,7 +72,7 @@ class SimulerOppdragStegTest {
         beregningsresultatRepository = repositoryProvider.getBeregningsresultatRepository();
         this.entityManager = entityManager;
         behandling = scenario.lagre(repositoryProvider);
-        kontekst = new BehandlingskontrollKontekst(behandling.getFagsakId(), behandling.getAktørId(),
+        kontekst = new BehandlingskontrollKontekst(behandling.getSaksnummer(), behandling.getFagsakId(),
                 behandlingRepository.taSkriveLås(behandling));
     }
 

--- a/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/søknadsfrist/fp/VurderSøknadsfristStegTest.java
+++ b/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/søknadsfrist/fp/VurderSøknadsfristStegTest.java
@@ -101,7 +101,7 @@ class VurderSøknadsfristStegTest extends EntityManagerAwareTest {
         behandlingRepositoryProvider.getSøknadRepository().lagreOgFlush(behandling, søknad);
         var fagsak = behandling.getFagsak();
         // Act
-        var kontekst = new BehandlingskontrollKontekst(fagsak.getId(), fagsak.getAktørId(),
+        var kontekst = new BehandlingskontrollKontekst(fagsak.getSaksnummer(), fagsak.getId(),
                 behandlingRepository.taSkriveLås(behandling));
         var behandleStegResultat = fastsettUttaksgrunnlagOgVurderSøknadsfristSteg.utførSteg(kontekst);
 
@@ -145,7 +145,7 @@ class VurderSøknadsfristStegTest extends EntityManagerAwareTest {
 
         var fagsak = behandling.getFagsak();
         // Act
-        var kontekst = new BehandlingskontrollKontekst(fagsak.getId(), fagsak.getAktørId(),
+        var kontekst = new BehandlingskontrollKontekst(fagsak.getSaksnummer(), fagsak.getId(),
                 behandlingRepository.taSkriveLås(behandling));
         var behandleStegResultat = fastsettUttaksgrunnlagOgVurderSøknadsfristSteg.utførSteg(kontekst);
 

--- a/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/søknadsfrist/svp/VurderSøknadsfristStegTest.java
+++ b/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/søknadsfrist/svp/VurderSøknadsfristStegTest.java
@@ -72,7 +72,7 @@ class VurderSøknadsfristStegTest {
         var fagsak = behandling.getFagsak();
 
         // Act
-        var kontekst = new BehandlingskontrollKontekst(fagsak.getId(), fagsak.getAktørId(),
+        var kontekst = new BehandlingskontrollKontekst(fagsak.getSaksnummer(), fagsak.getId(),
                 behandlingRepository.taSkriveLås(behandling));
         var behandleStegResultat = fastsettUttaksgrunnlagOgVurderSøknadsfristSteg.utførSteg(kontekst);
         em.flush();
@@ -105,8 +105,7 @@ class VurderSøknadsfristStegTest {
         var fagsak = behandling.getFagsak();
 
         // Act
-        var kontekst = new BehandlingskontrollKontekst(fagsak.getId(), fagsak.getAktørId(),
-                behandlingRepository.taSkriveLås(behandling));
+        var kontekst = new BehandlingskontrollKontekst(fagsak.getSaksnummer(), fagsak.getId(), behandlingRepository.taSkriveLås(behandling));
         var behandleStegResultat = fastsettUttaksgrunnlagOgVurderSøknadsfristSteg.utførSteg(kontekst);
         em.flush();
         em.clear();
@@ -138,7 +137,7 @@ class VurderSøknadsfristStegTest {
         var fagsak = behandling.getFagsak();
 
         // Act
-        var kontekst = new BehandlingskontrollKontekst(fagsak.getId(), fagsak.getAktørId(),
+        var kontekst = new BehandlingskontrollKontekst(fagsak.getSaksnummer(), fagsak.getId(),
             behandlingRepository.taSkriveLås(behandling));
         var behandleStegResultat = fastsettUttaksgrunnlagOgVurderSøknadsfristSteg.utførSteg(kontekst);
         em.flush();
@@ -164,7 +163,7 @@ class VurderSøknadsfristStegTest {
         em.flush();
         em.clear();
         // Act
-        var rkontekst = new BehandlingskontrollKontekst(fagsak.getId(), fagsak.getAktørId(),
+        var rkontekst = new BehandlingskontrollKontekst(fagsak.getSaksnummer(), fagsak.getId(),
             behandlingRepository.taSkriveLås(revurdering));
         var rbehandleStegResultat = fastsettUttaksgrunnlagOgVurderSøknadsfristSteg.utførSteg(rkontekst);
         em.flush();

--- a/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/uttak/fp/FaktaLøpendeOmsorgStegTest.java
+++ b/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/uttak/fp/FaktaLøpendeOmsorgStegTest.java
@@ -44,7 +44,7 @@ class FaktaLøpendeOmsorgStegTest {
         var behandling = scenario.lagre(repositoryProvider);
         var fagsak = behandling.getFagsak();
         var lås = repositoryProvider.getBehandlingRepository().taSkriveLås(behandling);
-        var kontekst = new BehandlingskontrollKontekst(fagsak.getId(), fagsak.getAktørId(), lås);
+        var kontekst = new BehandlingskontrollKontekst(fagsak.getSaksnummer(), fagsak.getId(), lås);
 
         var behandleStegResultat = steg.utførSteg(kontekst);
         assertThat(behandleStegResultat.getTransisjon()).isEqualTo(FellesTransisjoner.UTFØRT);

--- a/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/uttak/fp/FaktaUttakDokumentasjonStegTest.java
+++ b/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/uttak/fp/FaktaUttakDokumentasjonStegTest.java
@@ -48,7 +48,7 @@ class FaktaUttakDokumentasjonStegTest {
         var behandling = scenario.lagre(repositoryProvider);
 
         var stegResultat = steg.utførSteg(
-            new BehandlingskontrollKontekst(behandling.getFagsakId(), behandling.getAktørId(), new BehandlingLås(behandling.getId())));
+            new BehandlingskontrollKontekst(behandling.getSaksnummer(), behandling.getFagsakId(), new BehandlingLås(behandling.getId())));
 
         assertThat(stegResultat.getAksjonspunktListe()).containsExactly(AksjonspunktDefinisjon.VURDER_UTTAK_DOKUMENTASJON);
 

--- a/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/uttak/fp/FaktaUttakStegTest.java
+++ b/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/uttak/fp/FaktaUttakStegTest.java
@@ -50,7 +50,7 @@ class FaktaUttakStegTest {
         var behandling = scenario.lagre(repositoryProvider);
 
         var stegResultat = steg.utførSteg(
-            new BehandlingskontrollKontekst(behandling.getFagsakId(), behandling.getAktørId(), new BehandlingLås(behandling.getId())));
+            new BehandlingskontrollKontekst(behandling.getSaksnummer(), behandling.getFagsakId(), new BehandlingLås(behandling.getId())));
 
         assertThat(stegResultat.getAksjonspunktListe()).containsExactly(AksjonspunktDefinisjon.FAKTA_UTTAK_MANUELT_SATT_STARTDATO_ULIK_SØKNAD_STARTDATO);
     }

--- a/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/uttak/fp/UttakStegImplTest.java
+++ b/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/uttak/fp/UttakStegImplTest.java
@@ -156,7 +156,7 @@ class UttakStegImplTest {
     }
 
     private BehandlingskontrollKontekst kontekst(Behandling behandling) {
-        return new BehandlingskontrollKontekst(behandling.getFagsakId(), behandling.getAktørId(), behandlingRepository.taSkriveLås(behandling));
+        return new BehandlingskontrollKontekst(behandling.getSaksnummer(), behandling.getFagsakId(), behandlingRepository.taSkriveLås(behandling));
     }
 
     @Test
@@ -241,7 +241,7 @@ class UttakStegImplTest {
         oppdatereFagsakRelasjonVedVedtak.oppdaterRelasjonVedVedtattBehandling(behandling);
 
         // Act -- behandler fars behandling, skal ikke opprette stønadskontoer på nytt
-        var kontekstForFarsBehandling = new BehandlingskontrollKontekst(fagsak.getId(), fagsak.getAktørId(),
+        var kontekstForFarsBehandling = new BehandlingskontrollKontekst(fagsak.getSaksnummer(), fagsak.getId(),
                 behandlingRepository.taSkriveLås(farsBehandling));
         steg.utførSteg(kontekstForFarsBehandling);
 
@@ -264,7 +264,7 @@ class UttakStegImplTest {
         opprettUttaksperiodegrense(fødselsdato, morsFørstegang);
         opprettPersonopplysninger(morsFørstegang);
         fagsakRelasjonTjeneste.oppdaterDekningsgrad(morsFørstegang.getFagsakId(), Dekningsgrad._80);
-        var førstegangsKontekst = new BehandlingskontrollKontekst(fagsak.getId(), fagsak.getAktørId(),
+        var førstegangsKontekst = new BehandlingskontrollKontekst(fagsak.getSaksnummer(), fagsak.getId(),
                 behandlingRepository.taSkriveLås(morsFørstegang));
 
         // Første versjon av kontoer opprettes
@@ -281,7 +281,7 @@ class UttakStegImplTest {
         var morsRevurdering = opprettRevurdering(morsFørstegang, fødselsdato.minusWeeks(3));
         oppdaterDekningsgrad(morsRevurdering.getId(), Dekningsgrad._100);
 
-        var revurderingKontekst = new BehandlingskontrollKontekst(fagsak.getId(), fagsak.getAktørId(),
+        var revurderingKontekst = new BehandlingskontrollKontekst(fagsak.getSaksnummer(), fagsak.getId(),
                 behandlingRepository.taSkriveLås(morsRevurdering));
         steg.utførSteg(revurderingKontekst);
 
@@ -309,7 +309,7 @@ class UttakStegImplTest {
         opprettUttaksperiodegrense(fødselsdato, morsFørstegang);
         opprettPersonopplysninger(morsFørstegang);
         fagsakRelasjonTjeneste.oppdaterDekningsgrad(fagsak.getId(), dekningsgrad);
-        var førstegangsKontekst = new BehandlingskontrollKontekst(fagsak.getId(), fagsak.getAktørId(),
+        var førstegangsKontekst = new BehandlingskontrollKontekst(fagsak.getSaksnummer(), fagsak.getId(),
             behandlingRepository.taSkriveLås(morsFørstegang));
 
         // Første versjon av kontoer opprettes
@@ -326,7 +326,7 @@ class UttakStegImplTest {
         oppdaterDekningsgrad(morsRevurdering.getId(), dekningsgrad);
 
         nesteSakRepository.lagreNesteSak(morsRevurdering.getId(), new Saksnummer("987"), fødselsdato.plusWeeks(40), fødselsdato.plusWeeks(40));
-        var revurderingKontekst = new BehandlingskontrollKontekst(fagsak.getId(), fagsak.getAktørId(),
+        var revurderingKontekst = new BehandlingskontrollKontekst(fagsak.getSaksnummer(), fagsak.getId(),
             behandlingRepository.taSkriveLås(morsRevurdering));
         steg.utførSteg(revurderingKontekst);
 
@@ -402,8 +402,8 @@ class UttakStegImplTest {
     }
 
     private void kjørSteg(Behandling førstegangsBehandling) {
-        var kontekst = new BehandlingskontrollKontekst(førstegangsBehandling.getFagsakId(),
-                førstegangsBehandling.getAktørId(), behandlingLåsRepository.taLås(førstegangsBehandling.getId()));
+        var kontekst = new BehandlingskontrollKontekst(førstegangsBehandling.getSaksnummer(), førstegangsBehandling.getFagsakId(),
+                behandlingLåsRepository.taLås(førstegangsBehandling.getId()));
         steg.utførSteg(kontekst);
     }
 

--- a/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/vedtak/BehandlingVedtakTjenesteTest.java
+++ b/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/vedtak/BehandlingVedtakTjenesteTest.java
@@ -67,7 +67,7 @@ class BehandlingVedtakTjenesteTest extends EntityManagerAwareTest {
         var behandlingLås = lagreBehandling(revurdering);
         opprettFamilieHendelseGrunnlag(originalBehandling, revurdering);
         var fagsak = revurdering.getFagsak();
-        var revurderingKontekst = new BehandlingskontrollKontekst(fagsak.getId(), fagsak.getAktørId(), behandlingLås);
+        var revurderingKontekst = new BehandlingskontrollKontekst(fagsak.getSaksnummer(), fagsak.getId(), behandlingLås);
         oppdaterMedBehandlingsresultat(revurderingKontekst, BehandlingResultatType.OPPHØR);
         lagUttaksresultatOpphørEtterSkjæringstidspunkt(revurdering);
 
@@ -147,6 +147,6 @@ class BehandlingVedtakTjenesteTest extends EntityManagerAwareTest {
                 .lagre(repositoryProvider);
         Behandlingsresultat.builder().medBehandlingResultatType(BehandlingResultatType.INNVILGET).buildFor(behandling);
         var fagsak = behandling.getFagsak();
-        return new BehandlingskontrollKontekst(fagsak.getId(), fagsak.getAktørId(), behandlingRepository.taSkriveLås(behandling));
+        return new BehandlingskontrollKontekst(fagsak.getSaksnummer(), fagsak.getId(), behandlingRepository.taSkriveLås(behandling));
     }
 }

--- a/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/vedtak/FatteVedtakStegTest.java
+++ b/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/vedtak/FatteVedtakStegTest.java
@@ -215,7 +215,7 @@ class FatteVedtakStegTest {
         var behandlingLås = lagreBehandling(revurdering);
         opprettFamilieHendelseGrunnlag(originalBehandling, revurdering);
         var fagsak = revurdering.getFagsak();
-        var revurderingKontekst = new BehandlingskontrollKontekst(fagsak.getId(), fagsak.getAktørId(), behandlingLås);
+        var revurderingKontekst = new BehandlingskontrollKontekst(fagsak.getSaksnummer(), fagsak.getId(), behandlingLås);
         oppdaterMedBehandlingsresultat(revurderingKontekst, false, antallBarn);
 
         fatteVedtakSteg.utførSteg(revurderingKontekst);
@@ -247,7 +247,7 @@ class FatteVedtakStegTest {
         var behandlingLås = lagreBehandling(revurdering);
         opprettFamilieHendelseGrunnlag(originalBehandling, revurdering);
         var fagsak = revurdering.getFagsak();
-        var revurderingKontekst = new BehandlingskontrollKontekst(fagsak.getId(), fagsak.getAktørId(), behandlingLås);
+        var revurderingKontekst = new BehandlingskontrollKontekst(fagsak.getSaksnummer(), fagsak.getId(), behandlingLås);
         oppdaterMedBehandlingsresultat(revurderingKontekst, true, faktiskAntallBarn);
 
         fatteVedtakSteg.utførSteg(revurderingKontekst);
@@ -279,7 +279,7 @@ class FatteVedtakStegTest {
 
         opprettFamilieHendelseGrunnlag(originalBehandling, revurdering);
         var fagsak = revurdering.getFagsak();
-        var revurderingKontekst = new BehandlingskontrollKontekst(fagsak.getId(), fagsak.getAktørId(), behandlingLås);
+        var revurderingKontekst = new BehandlingskontrollKontekst(fagsak.getSaksnummer(), fagsak.getId(), behandlingLås);
         oppdaterMedBehandlingsresultat(revurderingKontekst, true, antallBarn);
 
         fatteVedtakSteg.utførSteg(revurderingKontekst);
@@ -319,7 +319,7 @@ class FatteVedtakStegTest {
         var behandlingLås = lagreBehandling(revurdering);
         opprettFamilieHendelseGrunnlag(originalBehandling, revurdering);
         var fagsak = revurdering.getFagsak();
-        var revurderingKontekst = new BehandlingskontrollKontekst(fagsak.getId(), fagsak.getAktørId(), behandlingLås);
+        var revurderingKontekst = new BehandlingskontrollKontekst(fagsak.getSaksnummer(), fagsak.getId(), behandlingLås);
         oppdaterMedBehandlingsresultat(revurderingKontekst, false, antallBarn);
 
         fatteVedtakSteg.utførSteg(revurderingKontekst);
@@ -504,7 +504,7 @@ class FatteVedtakStegTest {
         beregningRepository.lagre(beregningResultat, repositoryProvider.getBehandlingRepository().taSkriveLås(behandling));
 
         var fagsak = behandling.getFagsak();
-        return new BehandlingskontrollKontekst(fagsak.getId(), fagsak.getAktørId(), repositoryProvider.getBehandlingRepository().taSkriveLås(behandling));
+        return new BehandlingskontrollKontekst(fagsak.getSaksnummer(), fagsak.getId(), repositoryProvider.getBehandlingRepository().taSkriveLås(behandling));
     }
 
     private void oppdaterMedVedtak(BehandlingskontrollKontekst kontekst) {

--- a/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/abakus/AbakusInntektArbeidYtelseTjeneste.java
+++ b/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/abakus/AbakusInntektArbeidYtelseTjeneste.java
@@ -140,7 +140,7 @@ public class AbakusInntektArbeidYtelseTjeneste implements InntektArbeidYtelseTje
 
     private InntektArbeidYtelseGrunnlagRequest initRequest(Behandling behandling, UUID inntektArbeidYtelseGrunnlagUuid) {
         var request = new InntektArbeidYtelseGrunnlagRequest(new AktørIdPersonident(behandling.getAktørId().getId()));
-        request.medSaksnummer(behandling.getFagsak().getSaksnummer().getVerdi());
+        request.medSaksnummer(behandling.getSaksnummer().getVerdi());
         request.medYtelseType(KodeverkMapper.fraFagsakYtelseType(behandling.getFagsakYtelseType()));
         request.forKobling(behandling.getUuid());
         request.forGrunnlag(inntektArbeidYtelseGrunnlagUuid);
@@ -271,7 +271,7 @@ public class AbakusInntektArbeidYtelseTjeneste implements InntektArbeidYtelseTje
     public void kopierGrunnlagFraEksisterendeBehandling(Long fraBehandlingId, Long tilBehandlingId) {
         var fraBehandling = behandlingRepository.hentBehandling(fraBehandlingId);
         var tilBehandling = behandlingRepository.hentBehandling(tilBehandlingId);
-        var request = new KopierGrunnlagRequest(tilBehandling.getFagsak().getSaksnummer().getVerdi(),
+        var request = new KopierGrunnlagRequest(tilBehandling.getSaksnummer().getVerdi(),
                 tilBehandling.getUuid(),
                 fraBehandling.getUuid(),
                 KodeverkMapper.fraFagsakYtelseType(tilBehandling.getFagsakYtelseType()),
@@ -294,7 +294,7 @@ public class AbakusInntektArbeidYtelseTjeneste implements InntektArbeidYtelseTje
     public void kopierGrunnlagFraEksisterendeBehandlingUtenVurderinger(Long fraBehandlingId, Long tilBehandlingId) {
         var fraBehandling = behandlingRepository.hentBehandling(fraBehandlingId);
         var tilBehandling = behandlingRepository.hentBehandling(tilBehandlingId);
-        var request = new KopierGrunnlagRequest(tilBehandling.getFagsak().getSaksnummer().getVerdi(),
+        var request = new KopierGrunnlagRequest(tilBehandling.getSaksnummer().getVerdi(),
             tilBehandling.getUuid(),
             fraBehandling.getUuid(),
             KodeverkMapper.fraFagsakYtelseType(tilBehandling.getFagsakYtelseType()),
@@ -314,7 +314,7 @@ public class AbakusInntektArbeidYtelseTjeneste implements InntektArbeidYtelseTje
         var oppgittOpptjening = new IAYTilDtoMapper(behandling.getAktørId(),
             KodeverkMapper.fraFagsakYtelseType(behandling.getFagsakYtelseType()),
             null, behandling.getUuid()).mapTilDto(oppgittOpptjeningBuilder);
-        return new OppgittOpptjeningMottattRequest(behandling.getFagsak().getSaksnummer().getVerdi(), behandling.getUuid(), aktør,
+        return new OppgittOpptjeningMottattRequest(behandling.getSaksnummer().getVerdi(), behandling.getUuid(), aktør,
             KodeverkMapper.fraFagsakYtelseType(behandling.getFagsakYtelseType()), oppgittOpptjening);
     }
 
@@ -368,7 +368,7 @@ public class AbakusInntektArbeidYtelseTjeneste implements InntektArbeidYtelseTje
     private InntektArbeidYtelseGrunnlagRequest initRequest(Behandling behandling) {
         var request = new InntektArbeidYtelseGrunnlagRequest(new AktørIdPersonident(behandling.getAktørId().getId()));
         request.medSisteKjenteGrunnlagReferanse(requestCache.getSisteAktiveGrunnlagReferanse(behandling.getUuid()));
-        request.medSaksnummer(behandling.getFagsak().getSaksnummer().getVerdi());
+        request.medSaksnummer(behandling.getSaksnummer().getVerdi());
         request.medYtelseType(KodeverkMapper.fraFagsakYtelseType(behandling.getFagsakYtelseType()));
         request.forKobling(behandling.getUuid());
         request.medDataset(Arrays.asList(Dataset.values()));

--- a/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/arbeidsforhold/InntektsmeldingTjeneste.java
+++ b/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/arbeidsforhold/InntektsmeldingTjeneste.java
@@ -146,7 +146,7 @@ public class InntektsmeldingTjeneste {
     }
 
     public void lagreInntektsmelding(InntektsmeldingBuilder im, Behandling behandling) {
-        var saksnummer = behandling.getFagsak().getSaksnummer();
+        var saksnummer = behandling.getSaksnummer();
         iayTjeneste.lagreInntektsmeldinger(saksnummer, behandling.getId(), List.of(im));
     }
 

--- a/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/fpinntektsmelding/FpInntektsmeldingTjeneste.java
+++ b/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/fpinntektsmelding/FpInntektsmeldingTjeneste.java
@@ -66,7 +66,7 @@ public class FpInntektsmeldingTjeneste {
 
     public void lagForespørselTask(String ag, BehandlingReferanse ref) {
         var taskdata = ProsessTaskData.forTaskType(TaskType.forProsessTask(FpinntektsmeldingTask.class));
-        taskdata.setBehandling(ref.fagsakId(), ref.behandlingId());
+        taskdata.setBehandling(ref.saksnummer().getVerdi(), ref.fagsakId(), ref.behandlingId());
         taskdata.setCallIdFraEksisterende();
         var gruppeId = String.format(GRUPPE_ID, ref.saksnummer().getVerdi());
         taskdata.setGruppe(gruppeId);
@@ -163,16 +163,16 @@ public class FpInntektsmeldingTjeneste {
     public void lagLukkForespørselTask(Behandling behandling, OrgNummer orgNummer, ForespørselStatus status) {
         var behandlingId = behandling.getId();
         var taskdata = ProsessTaskData.forTaskType(TaskType.forProsessTask(LukkForespørslerImTask.class));
-        taskdata.setBehandling(behandling.getFagsakId(), behandlingId);
+        taskdata.setBehandling(behandling.getSaksnummer().getVerdi(), behandling.getFagsakId(), behandlingId);
         taskdata.setCallIdFraEksisterende();
         if (orgNummer != null) {
             taskdata.setProperty(LukkForespørslerImTask.ORG_NUMMER, orgNummer.getId());
         }
-        var gruppeId = String.format(GRUPPE_ID, behandling.getFagsak().getSaksnummer().getVerdi());
+        var gruppeId = String.format(GRUPPE_ID, behandling.getSaksnummer().getVerdi());
         taskdata.setGruppe(gruppeId);
         taskdata.setSekvens(String.valueOf(Instant.now().toEpochMilli()));
         taskdata.setProperty(LukkForespørslerImTask.STATUS, status.name());
-        taskdata.setProperty(LukkForespørslerImTask.SAK_NUMMER, behandling.getFagsak().getSaksnummer().getVerdi());
+        taskdata.setProperty(LukkForespørslerImTask.SAK_NUMMER, behandling.getSaksnummer().getVerdi());
         prosessTaskTjeneste.lagre(taskdata);
     }
 

--- a/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/fpinntektsmelding/LukkForespørselForMottattImEvent.java
+++ b/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/fpinntektsmelding/LukkForespørselForMottattImEvent.java
@@ -3,7 +3,6 @@ package no.nav.foreldrepenger.domene.fpinntektsmelding;
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingEvent;
 import no.nav.foreldrepenger.behandlingslager.virksomhet.OrgNummer;
-import no.nav.foreldrepenger.domene.typer.AktørId;
 import no.nav.foreldrepenger.domene.typer.Saksnummer;
 
 public record LukkForespørselForMottattImEvent(Behandling behandling, OrgNummer orgNummer) implements BehandlingEvent {
@@ -13,16 +12,14 @@ public record LukkForespørselForMottattImEvent(Behandling behandling, OrgNummer
     }
 
     @Override
-    public AktørId getAktørId() {
-        return behandling.getAktørId();
+    public Saksnummer getSaksnummer() {
+        return behandling.getSaksnummer();
     }
 
     @Override
     public Long getBehandlingId() {
         return behandling.getId();
     }
-
-    public Saksnummer getSaksnummer() {return behandling.getFagsak().getSaksnummer();}
 
     public OrgNummer getOrgNummer() {return orgNummer;}
 }

--- a/domenetjenester/arbeidsforhold/src/test/java/no/nav/foreldrepenger/domene/fpinntektsmelding/LukkForespørselObserverTest.java
+++ b/domenetjenester/arbeidsforhold/src/test/java/no/nav/foreldrepenger/domene/fpinntektsmelding/LukkForespørselObserverTest.java
@@ -27,7 +27,6 @@ import no.nav.foreldrepenger.behandlingslager.fagsak.Fagsak;
 import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakRepository;
 import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakYtelseType;
 import no.nav.foreldrepenger.behandlingslager.virksomhet.OrgNummer;
-import no.nav.foreldrepenger.domene.typer.AktørId;
 
 @ExtendWith(MockitoExtension.class)
 class LukkForespørselObserverTest {
@@ -62,12 +61,11 @@ class LukkForespørselObserverTest {
     }
     @Test
     void observer_behandling_avsluttet_event_skal_sette_forespørsel_utgått() {
-        var aktørId = AktørId.dummy();
         var fagsak = Fagsak.opprettNy(FagsakYtelseType.FORELDREPENGER, null);
         var behandling = Behandling.forFørstegangssøknad(fagsak).build();
 
         var behandlingsres = new Behandlingsresultat.Builder().medBehandlingResultatType(BehandlingResultatType.MERGET_OG_HENLAGT).build();
-        BehandlingStatusEvent.BehandlingAvsluttetEvent event = BehandlingStatusEvent.nyEvent(byggKontekst(behandling, fagsak, aktørId), BehandlingStatus.AVSLUTTET);
+        BehandlingStatusEvent.BehandlingAvsluttetEvent event = BehandlingStatusEvent.nyEvent(byggKontekst(behandling, fagsak), BehandlingStatus.AVSLUTTET);
 
         behandling.setBehandlingType(BehandlingType.FØRSTEGANGSSØKNAD);
         when(behandlingRepository.hentBehandling(behandling.getId())).thenReturn(behandling);
@@ -80,12 +78,11 @@ class LukkForespørselObserverTest {
 
     @Test
     void observer_behandling_avsluttet_event_skal_ikke_sette_forespørsel_utgått() {
-        var aktørId = AktørId.dummy();
         var fagsak = Fagsak.opprettNy(FagsakYtelseType.FORELDREPENGER, null);
         var behandling = Behandling.forFørstegangssøknad(fagsak).build();
 
         var behandlingsres = new Behandlingsresultat.Builder().medBehandlingResultatType(BehandlingResultatType.MERGET_OG_HENLAGT).build();
-        BehandlingStatusEvent.BehandlingAvsluttetEvent event = BehandlingStatusEvent.nyEvent(byggKontekst(behandling, fagsak, aktørId), BehandlingStatus.AVSLUTTET);
+        BehandlingStatusEvent.BehandlingAvsluttetEvent event = BehandlingStatusEvent.nyEvent(byggKontekst(behandling, fagsak), BehandlingStatus.AVSLUTTET);
 
         behandling.setBehandlingType(BehandlingType.REVURDERING);
         when(behandlingRepository.hentBehandling(behandling.getId())).thenReturn(behandling);
@@ -96,9 +93,9 @@ class LukkForespørselObserverTest {
         verify(fpInntektsmeldingTjeneste, times(0)).lagLukkForespørselTask(behandling, null, ForespørselStatus.UTGÅTT);
     }
 
-    private BehandlingskontrollKontekst byggKontekst(Behandling behandling, Fagsak fagsak, AktørId aktørId) {
+    private BehandlingskontrollKontekst byggKontekst(Behandling behandling, Fagsak fagsak) {
         var behandlingLås = new BehandlingLås(behandling.getId()) {
         };
-        return new BehandlingskontrollKontekst(fagsak.getId(), aktørId, behandlingLås);
+        return new BehandlingskontrollKontekst(fagsak.getSaksnummer(), fagsak.getId(), behandlingLås);
     }
 }

--- a/domenetjenester/behandling-klage/src/main/java/no/nav/foreldrepenger/behandling/kabal/KabalTjeneste.java
+++ b/domenetjenester/behandling-klage/src/main/java/no/nav/foreldrepenger/behandling/kabal/KabalTjeneste.java
@@ -90,7 +90,7 @@ public class KabalTjeneste {
         var klager = utledKlager(klageBehandling, Optional.of(resultat.getKlageResultat()));
         var sakMottattKaDato = LocalDateTime.now();
         var dokumentReferanser = kabalDokumenter.finnDokumentReferanserForKlage(klageBehandling.getId(),
-            klageBehandling.getFagsak().getSaksnummer(), resultat.getKlageResultat(), brukHjemmel);
+            klageBehandling.getSaksnummer(), resultat.getKlageResultat(), brukHjemmel);
         var request = TilKabalDto.klage(klageBehandling, klager, enhet, dokumentReferanser,
             klageMottattDato, klageMottattDato, sakMottattKaDato, List.of(brukHjemmel.getKabal()), resultat.getBegrunnelse());
         kabalKlient.sendTilKabal(request);

--- a/domenetjenester/behandling-klage/src/main/java/no/nav/foreldrepenger/behandling/kabal/MottaFraKabalTask.java
+++ b/domenetjenester/behandling-klage/src/main/java/no/nav/foreldrepenger/behandling/kabal/MottaFraKabalTask.java
@@ -178,7 +178,7 @@ public class MottaFraKabalTask extends BehandlingProsessTask {
                 kabalTjeneste.lagHistorikkinnslagForHenleggelse(behandlingId, BehandlingResultatType.HENLAGT_ANKE_TRUKKET);
             }
         } else if (KabalUtfall.RETUR.equals(utfall)) {
-            throw new IllegalStateException("KABAL sender ankeutfall RETUR sak " + ankeBehandling.getFagsak().getSaksnummer().getVerdi());
+            throw new IllegalStateException("KABAL sender ankeutfall RETUR sak " + ankeBehandling.getSaksnummer().getVerdi());
         } else {
             kabalTjeneste.lagreAnkeUtfallFraKabal(ankeBehandling, utfall, sendtTrygderetten);
             if (ankeBehandling.isBehandlingPåVent()) { // Autopunkt

--- a/domenetjenester/behandling-klage/src/main/java/no/nav/foreldrepenger/behandling/kabal/TilKabalDto.java
+++ b/domenetjenester/behandling-klage/src/main/java/no/nav/foreldrepenger/behandling/kabal/TilKabalDto.java
@@ -43,7 +43,7 @@ public record TilKabalDto(@NotNull Klager klager,
             brukersHenvendelseMottattNavDato, innsendtTilNav,
             Fagsystem.FPSAK.getOffisiellKode(), behandling.getUuid().toString(), behandling.getUuid().toString(),
             KlageAnke.KLAGE, mapYtelseType(behandling), sakMottattKaTidspunkt, sakMottattKaTidspunkt.toLocalDate(),
-            new Sak(behandling.getFagsak().getSaksnummer().getVerdi(), Fagsystem.FPSAK.getOffisiellKode()),
+            new Sak(behandling.getSaksnummer().getVerdi(), Fagsystem.FPSAK.getOffisiellKode()),
             hjemler, kommentar);
     }
 
@@ -60,7 +60,7 @@ public record TilKabalDto(@NotNull Klager klager,
             brukersHenvendelseMottattNavDato, innsendtTilNav,
             Fagsystem.FPSAK.getOffisiellKode(), kildereferanse, kildereferanse,
             KlageAnke.ANKE, mapYtelseType(behandling), sakMottattKaTidspunkt, sakMottattKaTidspunkt.toLocalDate(),
-            new Sak(behandling.getFagsak().getSaksnummer().getVerdi(), Fagsystem.FPSAK.getOffisiellKode()),
+            new Sak(behandling.getSaksnummer().getVerdi(), Fagsystem.FPSAK.getOffisiellKode()),
             hjemler, "");
     }
 

--- a/domenetjenester/behandling-prosessering/src/main/java/no/nav/foreldrepenger/behandlingsprosess/dagligejobber/gjenopptak/AutomatiskGjenopptagelseTjeneste.java
+++ b/domenetjenester/behandling-prosessering/src/main/java/no/nav/foreldrepenger/behandlingsprosess/dagligejobber/gjenopptak/AutomatiskGjenopptagelseTjeneste.java
@@ -57,7 +57,7 @@ public class AutomatiskGjenopptagelseTjeneste {
     private void opprettProsessTasks(Behandling behandling, String callId, LocalDate dato, LocalTime baseline, int spread) {
         var nesteKjøring = LocalDateTime.of(dato, baseline.plusSeconds(Math.abs(System.nanoTime()) % spread));
         var taskdata = ProsessTaskData.forProsessTask(OpprettGjenopptaTask.class);
-        taskdata.setBehandling(behandling.getFagsakId(), behandling.getId());
+        taskdata.setBehandling(behandling.getSaksnummer().getVerdi(), behandling.getFagsakId(), behandling.getId());
         taskdata.setCallId(callId + "_" + behandling.getId());
         taskdata.setNesteKjøringEtter(nesteKjøring);
         taskTjeneste.lagre(taskdata);

--- a/domenetjenester/behandling-prosessering/src/main/java/no/nav/foreldrepenger/behandlingsprosess/prosessering/BehandlingOpprettingTjeneste.java
+++ b/domenetjenester/behandling-prosessering/src/main/java/no/nav/foreldrepenger/behandlingsprosess/prosessering/BehandlingOpprettingTjeneste.java
@@ -89,7 +89,7 @@ public class BehandlingOpprettingTjeneste {
      */
     public String asynkStartBehandlingsprosess(Behandling behandling) {
         var taskData = ProsessTaskData.forProsessTask(StartBehandlingTask.class);
-        taskData.setBehandling(behandling.getFagsakId(), behandling.getId(), behandling.getAktørId().getId());
+        taskData.setBehandling(behandling.getSaksnummer().getVerdi(), behandling.getFagsakId(), behandling.getId());
         taskData.setCallIdFraEksisterende();
         return taskTjeneste.lagre(taskData);
     }

--- a/domenetjenester/behandling-prosessering/src/main/java/no/nav/foreldrepenger/behandlingsprosess/prosessering/tjeneste/BehandlingProsesseringTjenesteImpl.java
+++ b/domenetjenester/behandling-prosessering/src/main/java/no/nav/foreldrepenger/behandlingsprosess/prosessering/tjeneste/BehandlingProsesseringTjenesteImpl.java
@@ -232,7 +232,7 @@ public class BehandlingProsesseringTjenesteImpl implements BehandlingProsesserin
 
     private ProsessTaskData lagTaskData(TaskType tasktype, Behandling behandling, LocalDateTime nesteKjøringEtter, int prioritet) {
         var taskdata = ProsessTaskData.forTaskType(tasktype);
-        taskdata.setBehandling(behandling.getFagsakId(), behandling.getId(), behandling.getAktørId().getId());
+        taskdata.setBehandling(behandling.getSaksnummer().getVerdi(), behandling.getFagsakId(), behandling.getId());
         taskdata.setCallIdFraEksisterende();
         if (nesteKjøringEtter != null) {
             taskdata.setNesteKjøringEtter(nesteKjøringEtter);

--- a/domenetjenester/behandling-prosessering/src/test/java/no/nav/foreldrepenger/behandlingsprosess/prosessering/GjenopptaBehandlingTaskTest.java
+++ b/domenetjenester/behandling-prosessering/src/test/java/no/nav/foreldrepenger/behandlingsprosess/prosessering/GjenopptaBehandlingTaskTest.java
@@ -17,7 +17,6 @@ import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingL�
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepository;
 import no.nav.foreldrepenger.behandlingslager.testutilities.behandling.ScenarioMorSøkerEngangsstønad;
 import no.nav.foreldrepenger.behandlingsprosess.prosessering.task.GjenopptaBehandlingTask;
-import no.nav.foreldrepenger.domene.typer.AktørId;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTaskData;
 
 @ExtendWith(MockitoExtension.class)
@@ -45,7 +44,7 @@ class GjenopptaBehandlingTaskTest {
         when(mockBehandlingRepository.hentBehandling(any(Long.class))).thenReturn(behandling);
 
         var prosessTaskData = ProsessTaskData.forProsessTask(GjenopptaBehandlingTask.class);
-        prosessTaskData.setBehandling(0L, behandlingId, AktørId.dummy().getId());
+        prosessTaskData.setBehandling("123", 0L, behandlingId);
 
         task.doTask(prosessTaskData);
 

--- a/domenetjenester/behandling-revurdering/src/main/java/no/nav/foreldrepenger/behandling/revurdering/etterkontroll/batch/AutomatiskEtterkontrollBatchTjeneste.java
+++ b/domenetjenester/behandling-revurdering/src/main/java/no/nav/foreldrepenger/behandling/revurdering/etterkontroll/batch/AutomatiskEtterkontrollBatchTjeneste.java
@@ -71,7 +71,7 @@ public class AutomatiskEtterkontrollBatchTjeneste implements BatchTjeneste {
 
     private void opprettEtterkontrollTask(Behandling kandidat, String callId) {
         var prosessTaskData = ProsessTaskData.forProsessTask(AutomatiskEtterkontrollTask.class);
-        prosessTaskData.setBehandling(kandidat.getFagsakId(), kandidat.getId(), kandidat.getAktørId().getId());
+        prosessTaskData.setBehandling(kandidat.getSaksnummer().getVerdi(), kandidat.getFagsakId(), kandidat.getId());
         prosessTaskData.setCallId(callId);
         taskTjeneste.lagre(prosessTaskData);
     }

--- a/domenetjenester/behandling-revurdering/src/main/java/no/nav/foreldrepenger/behandling/revurdering/flytkontroll/TilbakeførTilDekningsgradStegTask.java
+++ b/domenetjenester/behandling-revurdering/src/main/java/no/nav/foreldrepenger/behandling/revurdering/flytkontroll/TilbakeførTilDekningsgradStegTask.java
@@ -66,7 +66,7 @@ public class TilbakeførTilDekningsgradStegTask extends FagsakProsessTask {
             .map(YtelseFordelingAggregat::getGjeldendeDekningsgrad);
         if (fagsakrelDekningsgrad.isEmpty() || behandlingDekningsgrad.isEmpty()) {
             LOG.warn("Burde ikke ha opprettet task på sak {}. Fagsakrel dekningsgrad eller yfa dekningsgrad er {} {}.",
-                behandling.getFagsak().getSaksnummer(), fagsakrelDekningsgrad, behandlingDekningsgrad);
+                behandling.getSaksnummer(), fagsakrelDekningsgrad, behandlingDekningsgrad);
             return;
         }
         if (fagsakrelDekningsgrad.get().equals(behandlingDekningsgrad.get())) {

--- a/domenetjenester/behandling-revurdering/src/main/java/no/nav/foreldrepenger/behandling/revurdering/satsregulering/EngangsstønadFinnSakerTask.java
+++ b/domenetjenester/behandling-revurdering/src/main/java/no/nav/foreldrepenger/behandling/revurdering/satsregulering/EngangsstønadFinnSakerTask.java
@@ -13,7 +13,7 @@ import no.nav.foreldrepenger.behandlingslager.behandling.beregning.BeregningSats
 import no.nav.foreldrepenger.behandlingslager.behandling.beregning.SatsRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.SatsReguleringRepository;
 import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakProsesstaskRekkefølge;
-import no.nav.foreldrepenger.domene.typer.AktørId;
+import no.nav.foreldrepenger.domene.typer.Saksnummer;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTask;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTaskData;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTaskHandler;
@@ -59,7 +59,7 @@ public class EngangsstønadFinnSakerTask implements ProsessTaskHandler {
         var kandidater = satsReguleringRepository.finnSakerMedBehovForEngangsstønadRegulering(esFomDato);
 
         if (revurder) {
-            kandidater.forEach(sak -> opprettReguleringTask(sak.fagsakId(), sak.aktørId(), callIdRoot));
+            kandidater.forEach(sak -> opprettReguleringTask(sak.fagsakId(), sak.saksnummer(), callIdRoot));
         }
         LOG.info("ESregulering finner {} saker til vurdering", kandidater.size());
     }
@@ -74,9 +74,9 @@ public class EngangsstønadFinnSakerTask implements ProsessTaskHandler {
         return gjeldende.getPeriode().getFomDato();
     }
 
-    private void opprettReguleringTask(Long fagsakId, AktørId aktørId, String callId) {
+    private void opprettReguleringTask(Long fagsakId, Saksnummer saksnummer, String callId) {
         var prosessTaskData = ProsessTaskData.forProsessTask(EngangsstønadReguleringTask.class);
-        prosessTaskData.setFagsak(fagsakId, aktørId.getId());
+        prosessTaskData.setFagsak(saksnummer.getVerdi(), fagsakId);
         prosessTaskData.setCallId(callId + fagsakId);
         taskTjeneste.lagre(prosessTaskData);
     }

--- a/domenetjenester/behandling-revurdering/src/main/java/no/nav/foreldrepenger/behandling/revurdering/ytelse/fp/UttakGrunnlagTjeneste.java
+++ b/domenetjenester/behandling-revurdering/src/main/java/no/nav/foreldrepenger/behandling/revurdering/ytelse/fp/UttakGrunnlagTjeneste.java
@@ -158,7 +158,7 @@ public class UttakGrunnlagTjeneste {
             if (harVedtak) {
                 annenPartBehandling = relatertBehandlingTjeneste.hentAnnenPartsGjeldendeBehandlingPåVedtakstidspunkt(behandling);
             } else {
-                annenPartBehandling = relatertBehandlingTjeneste.hentAnnenPartsGjeldendeVedtattBehandling(behandling.getFagsak().getSaksnummer());
+                annenPartBehandling = relatertBehandlingTjeneste.hentAnnenPartsGjeldendeVedtattBehandling(behandling.getSaksnummer());
             }
             if (annenPartBehandling.isPresent()) {
                 var opprettetTidspunkt = Optional.ofNullable(søknadRepository.hentSøknad(annenPartBehandling.get().getId()))

--- a/domenetjenester/behandling-revurdering/src/test/java/no/nav/foreldrepenger/behandling/revurdering/etterkontroll/es/AutomatiskEtterkontrollTaskTest.java
+++ b/domenetjenester/behandling-revurdering/src/test/java/no/nav/foreldrepenger/behandling/revurdering/etterkontroll/es/AutomatiskEtterkontrollTaskTest.java
@@ -98,7 +98,7 @@ class AutomatiskEtterkontrollTaskTest {
                 Collections.emptyList());
 
         var prosessTaskData = ProsessTaskData.forProsessTask(AutomatiskEtterkontrollTask.class);
-        prosessTaskData.setBehandling(behandling.getFagsakId(), behandling.getId(), behandling.getAktørId().getId());
+        prosessTaskData.setBehandling(behandling.getSaksnummer().getVerdi(), behandling.getFagsakId(), behandling.getId());
 
         createTask();
         task.doTask(prosessTaskData);
@@ -142,7 +142,7 @@ class AutomatiskEtterkontrollTaskTest {
                 Collections.emptyList());
 
         var prosessTaskData = ProsessTaskData.forProsessTask(AutomatiskEtterkontrollTask.class);
-        prosessTaskData.setBehandling(behandling.getFagsakId(), behandling.getId(), behandling.getAktørId().getId());
+        prosessTaskData.setBehandling(behandling.getSaksnummer().getVerdi(), behandling.getFagsakId(), behandling.getId());
 
         createTask();
         task.doTask(prosessTaskData);
@@ -159,7 +159,7 @@ class AutomatiskEtterkontrollTaskTest {
         when(personinfoAdapter.innhentAlleFødteForBehandlingIntervaller(any(), any(), any())).thenReturn(barn);
 
         var prosessTaskData = ProsessTaskData.forProsessTask(AutomatiskEtterkontrollTask.class);
-        prosessTaskData.setBehandling(behandling.getFagsakId(), behandling.getId(), behandling.getAktørId().getId());
+        prosessTaskData.setBehandling(behandling.getSaksnummer().getVerdi(), behandling.getFagsakId(), behandling.getId());
 
         createTask();
         task.doTask(prosessTaskData);
@@ -174,7 +174,7 @@ class AutomatiskEtterkontrollTaskTest {
         when(personinfoAdapter.innhentAlleFødteForBehandlingIntervaller(any(), any(), any())).thenReturn(barn);
 
         var prosessTaskData = ProsessTaskData.forProsessTask(AutomatiskEtterkontrollTask.class);
-        prosessTaskData.setBehandling(behandling.getFagsakId(), behandling.getId(), behandling.getAktørId().getId());
+        prosessTaskData.setBehandling(behandling.getSaksnummer().getVerdi(), behandling.getFagsakId(), behandling.getId());
 
         createTask();
         task.doTask(prosessTaskData);
@@ -190,7 +190,7 @@ class AutomatiskEtterkontrollTaskTest {
         when(personinfoAdapter.innhentAlleFødteForBehandlingIntervaller(any(), any(), any())).thenReturn(barn);
 
         var prosessTaskData = ProsessTaskData.forProsessTask(AutomatiskEtterkontrollTask.class);
-        prosessTaskData.setBehandling(behandling.getFagsakId(), behandling.getId(), behandling.getAktørId().getId());
+        prosessTaskData.setBehandling(behandling.getSaksnummer().getVerdi(), behandling.getFagsakId(), behandling.getId());
 
         createTask();
         task.doTask(prosessTaskData);
@@ -205,7 +205,7 @@ class AutomatiskEtterkontrollTaskTest {
         when(personinfoAdapter.innhentAlleFødteForBehandlingIntervaller(any(), any(), any())).thenReturn(barn);
 
         var prosessTaskData = ProsessTaskData.forProsessTask(AutomatiskEtterkontrollTask.class);
-        prosessTaskData.setBehandling(behandling.getFagsakId(), behandling.getId(), behandling.getAktørId().getId());
+        prosessTaskData.setBehandling(behandling.getSaksnummer().getVerdi(), behandling.getFagsakId(), behandling.getId());
 
         createTask();
         task.doTask(prosessTaskData);
@@ -218,7 +218,7 @@ class AutomatiskEtterkontrollTaskTest {
         var behandling = opprettRevurderingsKandidat(0, 2, false, false, false);
 
         var prosessTaskData = ProsessTaskData.forProsessTask(AutomatiskEtterkontrollTask.class);
-        prosessTaskData.setBehandling(behandling.getFagsakId(), behandling.getId(), behandling.getAktørId().getId());
+        prosessTaskData.setBehandling(behandling.getSaksnummer().getVerdi(), behandling.getFagsakId(), behandling.getId());
 
         createTask();
         task.doTask(prosessTaskData);

--- a/domenetjenester/behandling-revurdering/src/test/java/no/nav/foreldrepenger/behandling/revurdering/etterkontroll/fp/AutomatiskEtterkontrollTaskTest.java
+++ b/domenetjenester/behandling-revurdering/src/test/java/no/nav/foreldrepenger/behandling/revurdering/etterkontroll/fp/AutomatiskEtterkontrollTaskTest.java
@@ -261,14 +261,14 @@ class AutomatiskEtterkontrollTaskTest {
         repositoryProvider.getFamilieHendelseRepository().lagre(farsBehandling.getId(), søknadHendelseFar);
 
         var prosessTaskData = ProsessTaskData.forProsessTask(AutomatiskEtterkontrollTask.class);
-        prosessTaskData.setBehandling(morsBehandling.getFagsakId(), morsBehandling.getId(), morsBehandling.getAktørId().getId());
+        prosessTaskData.setBehandling(morsBehandling.getSaksnummer().getVerdi(), morsBehandling.getFagsakId(), morsBehandling.getId());
 
         createTask();
         task.doTask(prosessTaskData);
         assertRevurdering(morsBehandling, BehandlingÅrsakType.RE_MANGLER_FØDSEL);
 
         var prosessTaskDataFar = ProsessTaskData.forProsessTask(AutomatiskEtterkontrollTask.class);
-        prosessTaskDataFar.setBehandling(farsBehandling.getFagsakId(), farsBehandling.getId(), farsBehandling.getAktørId().getId());
+        prosessTaskDataFar.setBehandling(farsBehandling.getSaksnummer().getVerdi(), farsBehandling.getFagsakId(), farsBehandling.getId());
 
         createTask();
         task.doTask(prosessTaskDataFar);
@@ -362,7 +362,7 @@ class AutomatiskEtterkontrollTaskTest {
         repositoryProvider.getFamilieHendelseRepository().lagre(farsBehandling.getId(), søknadHendelseFar);
 
         var prosessTaskDataFar = ProsessTaskData.forProsessTask(AutomatiskEtterkontrollTask.class);
-        prosessTaskDataFar.setBehandling(farsBehandling.getFagsakId(), farsBehandling.getId(), farsBehandling.getAktørId().getId());
+        prosessTaskDataFar.setBehandling(farsBehandling.getSaksnummer().getVerdi(), farsBehandling.getFagsakId(), farsBehandling.getId());
 
         createTask();
         task.doTask(prosessTaskDataFar);
@@ -409,7 +409,7 @@ class AutomatiskEtterkontrollTaskTest {
         when(personinfoAdapter.innhentAlleFødteForBehandlingIntervaller(any(), any(), any())).thenReturn(Collections.emptyList());
 
         var prosessTaskData = ProsessTaskData.forProsessTask(AutomatiskEtterkontrollTask.class);
-        prosessTaskData.setBehandling(behandling.getFagsakId(), behandling.getId(), behandling.getAktørId().getId());
+        prosessTaskData.setBehandling(behandling.getSaksnummer().getVerdi(), behandling.getFagsakId(), behandling.getId());
 
         createTask();
         task.doTask(prosessTaskData);
@@ -423,7 +423,7 @@ class AutomatiskEtterkontrollTaskTest {
         when(personinfoAdapter.innhentAlleFødteForBehandlingIntervaller(any(), any(), any())).thenReturn(Collections.emptyList());
 
         var prosessTaskData = ProsessTaskData.forProsessTask(AutomatiskEtterkontrollTask.class);
-        prosessTaskData.setBehandling(behandling.getFagsakId(), behandling.getId(), behandling.getAktørId().getId());
+        prosessTaskData.setBehandling(behandling.getSaksnummer().getVerdi(), behandling.getFagsakId(), behandling.getId());
 
         createTask();
         task.doTask(prosessTaskData);
@@ -437,7 +437,7 @@ class AutomatiskEtterkontrollTaskTest {
         when(personinfoAdapter.innhentAlleFødteForBehandlingIntervaller(any(), any(), any())).thenReturn(Collections.emptyList());
 
         var prosessTaskData = ProsessTaskData.forProsessTask(AutomatiskEtterkontrollTask.class);
-        prosessTaskData.setBehandling(behandling.getFagsakId(), behandling.getId(), behandling.getAktørId().getId());
+        prosessTaskData.setBehandling(behandling.getSaksnummer().getVerdi(), behandling.getFagsakId(), behandling.getId());
 
         createTask();
         task.doTask(prosessTaskData);
@@ -452,7 +452,7 @@ class AutomatiskEtterkontrollTaskTest {
         when(personinfoAdapter.innhentAlleFødteForBehandlingIntervaller(any(), any(), any())).thenReturn(barn);
 
         var prosessTaskData = ProsessTaskData.forProsessTask(AutomatiskEtterkontrollTask.class);
-        prosessTaskData.setBehandling(behandling.getFagsakId(), behandling.getId(), behandling.getAktørId().getId());
+        prosessTaskData.setBehandling(behandling.getSaksnummer().getVerdi(), behandling.getFagsakId(), behandling.getId());
 
         createTask();
         task.doTask(prosessTaskData);
@@ -468,7 +468,7 @@ class AutomatiskEtterkontrollTaskTest {
         when(personinfoAdapter.innhentAlleFødteForBehandlingIntervaller(any(), any(), any())).thenReturn(barn);
 
         var prosessTaskData = ProsessTaskData.forProsessTask(AutomatiskEtterkontrollTask.class);
-        prosessTaskData.setBehandling(behandling.getFagsakId(), behandling.getId(), behandling.getAktørId().getId());
+        prosessTaskData.setBehandling(behandling.getSaksnummer().getVerdi(), behandling.getFagsakId(), behandling.getId());
 
         createTask();
         task.doTask(prosessTaskData);
@@ -484,7 +484,7 @@ class AutomatiskEtterkontrollTaskTest {
         when(personinfoAdapter.innhentAlleFødteForBehandlingIntervaller(any(), any(), any())).thenReturn(barn);
 
         var prosessTaskData = ProsessTaskData.forProsessTask(AutomatiskEtterkontrollTask.class);
-        prosessTaskData.setBehandling(behandling.getFagsakId(), behandling.getId(), behandling.getAktørId().getId());
+        prosessTaskData.setBehandling(behandling.getSaksnummer().getVerdi(), behandling.getFagsakId(), behandling.getId());
 
         createTask();
         task.doTask(prosessTaskData);
@@ -499,7 +499,7 @@ class AutomatiskEtterkontrollTaskTest {
         when(personinfoAdapter.innhentAlleFødteForBehandlingIntervaller(any(), any(), any())).thenReturn(barn);
 
         var prosessTaskData = ProsessTaskData.forProsessTask(AutomatiskEtterkontrollTask.class);
-        prosessTaskData.setBehandling(behandling.getFagsakId(), behandling.getId(), behandling.getAktørId().getId());
+        prosessTaskData.setBehandling(behandling.getSaksnummer().getVerdi(), behandling.getFagsakId(), behandling.getId());
 
         createTask();
         task.doTask(prosessTaskData);
@@ -515,7 +515,7 @@ class AutomatiskEtterkontrollTaskTest {
         when(personinfoAdapter.innhentAlleFødteForBehandlingIntervaller(any(), any(), any())).thenReturn(barn);
 
         var prosessTaskData = ProsessTaskData.forProsessTask(AutomatiskEtterkontrollTask.class);
-        prosessTaskData.setBehandling(behandling.getFagsakId(), behandling.getId(), behandling.getAktørId().getId());
+        prosessTaskData.setBehandling(behandling.getSaksnummer().getVerdi(), behandling.getFagsakId(), behandling.getId());
 
         createTask();
         task.doTask(prosessTaskData);
@@ -528,7 +528,7 @@ class AutomatiskEtterkontrollTaskTest {
         var behandling = opprettRevurderingsKandidat(0, 2, false, false, false, false);
 
         var prosessTaskData = ProsessTaskData.forProsessTask(AutomatiskEtterkontrollTask.class);
-        prosessTaskData.setBehandling(behandling.getFagsakId(), behandling.getId(), behandling.getAktørId().getId());
+        prosessTaskData.setBehandling(behandling.getSaksnummer().getVerdi(), behandling.getFagsakId(), behandling.getId());
 
         createTask();
         task.doTask(prosessTaskData);

--- a/domenetjenester/behandling-revurdering/src/test/java/no/nav/foreldrepenger/behandling/revurdering/etterkontroll/tjeneste/EtterkontrollEventObserverTest.java
+++ b/domenetjenester/behandling-revurdering/src/test/java/no/nav/foreldrepenger/behandling/revurdering/etterkontroll/tjeneste/EtterkontrollEventObserverTest.java
@@ -70,7 +70,7 @@ class EtterkontrollEventObserverTest {
         etterkontrollRepository.lagre(etterkontroll);
 
         var familiehendelseEvent = new FamiliehendelseEvent(
-                FamiliehendelseEvent.EventType.TERMIN_TIL_FØDSEL, behandling.getAktørId(),
+                FamiliehendelseEvent.EventType.TERMIN_TIL_FØDSEL, behandling.getSaksnummer(),
                 behandling.getFagsakId(), behandling.getId(), FagsakYtelseType.FORELDREPENGER, null, null);
         etterkontrollEventObserver.observerFamiliehendelseEvent(familiehendelseEvent);
 

--- a/domenetjenester/behandling-revurdering/src/test/java/no/nav/foreldrepenger/behandling/revurdering/satsregulering/EngangsstønadReguleringTaskTest.java
+++ b/domenetjenester/behandling-revurdering/src/test/java/no/nav/foreldrepenger/behandling/revurdering/satsregulering/EngangsstønadReguleringTaskTest.java
@@ -12,8 +12,6 @@ import java.util.List;
 
 import jakarta.persistence.EntityManager;
 
-import no.nav.foreldrepenger.behandlingslager.behandling.beregning.SatsRepository;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -28,6 +26,7 @@ import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingStatus;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingÅrsakType;
 import no.nav.foreldrepenger.behandlingslager.behandling.beregning.BeregningSatsType;
 import no.nav.foreldrepenger.behandlingslager.behandling.beregning.LegacyESBeregningRepository;
+import no.nav.foreldrepenger.behandlingslager.behandling.beregning.SatsRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepositoryProvider;
 import no.nav.foreldrepenger.behandlingslager.fagsak.Fagsak;
 import no.nav.foreldrepenger.behandlingsprosess.prosessering.BehandlingProsesseringTjeneste;
@@ -75,7 +74,7 @@ class EngangsstønadReguleringTaskTest {
         var behandling = opprettES(em, BehandlingStatus.AVSLUTTET, cutoff.minusDays(5), gammelSats);
 
         var prosessTaskData = ProsessTaskData.forProsessTask(EngangsstønadReguleringTask.class);
-        prosessTaskData.setBehandling(behandling.getFagsakId(), behandling.getId(), behandling.getAktørId().getId());
+        prosessTaskData.setBehandling(behandling.getSaksnummer().getVerdi(), behandling.getFagsakId(), behandling.getId());
 
         task.doTask(prosessTaskData);
 
@@ -93,7 +92,7 @@ class EngangsstønadReguleringTaskTest {
         lenient().when(personinfoAdapter.innhentAlleFødteForBehandlingIntervaller(any(), any(), any())).thenReturn(List.of(byggBaby(fødselsdato)));
 
         var prosessTaskData = ProsessTaskData.forProsessTask(EngangsstønadReguleringTask.class);
-        prosessTaskData.setBehandling(behandling.getFagsakId(), behandling.getId(), behandling.getAktørId().getId());
+        prosessTaskData.setBehandling(behandling.getSaksnummer().getVerdi(), behandling.getFagsakId(), behandling.getId());
 
         task.doTask(prosessTaskData);
 

--- a/domenetjenester/behandling-revurdering/src/test/java/no/nav/foreldrepenger/behandling/revurdering/satsregulering/GrunnbeløpReguleringTaskTest.java
+++ b/domenetjenester/behandling-revurdering/src/test/java/no/nav/foreldrepenger/behandling/revurdering/satsregulering/GrunnbeløpReguleringTaskTest.java
@@ -95,7 +95,7 @@ class GrunnbeløpReguleringTaskTest {
             .thenReturn(Skjæringstidspunkt.builder().medFørsteUttaksdatoGrunnbeløp(TERMINDATO.minusWeeks(3)).build());
 
         var prosessTaskData = ProsessTaskData.forProsessTask(GrunnbeløpReguleringTask.class);
-        prosessTaskData.setFagsak(behandling.getFagsakId(), behandling.getAktørId().getId());
+        prosessTaskData.setFagsak(behandling.getSaksnummer().getVerdi(), behandling.getFagsakId());
 
         var task = createTask();
         task.doTask(prosessTaskData);
@@ -131,7 +131,7 @@ class GrunnbeløpReguleringTaskTest {
         var behandling = opprettRevurderingsKandidat(BehandlingStatus.UTREDES);
 
         var prosessTaskData = ProsessTaskData.forProsessTask(GrunnbeløpReguleringTask.class);
-        prosessTaskData.setFagsak(behandling.getFagsakId(), behandling.getAktørId().getId());
+        prosessTaskData.setFagsak(behandling.getSaksnummer().getVerdi(), behandling.getFagsakId());
 
         var task = createTask();
         task.doTask(prosessTaskData);
@@ -148,7 +148,7 @@ class GrunnbeløpReguleringTaskTest {
             .thenReturn(Skjæringstidspunkt.builder().medFørsteUttaksdatoGrunnbeløp(TERMINDATO.minusWeeks(3)).build());
 
         var prosessTaskData = ProsessTaskData.forProsessTask(GrunnbeløpReguleringTask.class);
-        prosessTaskData.setFagsak(behandling.getFagsakId(), behandling.getAktørId().getId());
+        prosessTaskData.setFagsak(behandling.getSaksnummer().getVerdi(), behandling.getFagsakId());
 
         var task = createTask();
         task.doTask(prosessTaskData);
@@ -169,7 +169,7 @@ class GrunnbeløpReguleringTaskTest {
                 EKSISTERENDE_G.getVerdi().longValue()));
 
         var prosessTaskData = ProsessTaskData.forProsessTask(GrunnbeløpReguleringTask.class);
-        prosessTaskData.setFagsak(behandling.getFagsakId(), behandling.getAktørId().getId());
+        prosessTaskData.setFagsak(behandling.getSaksnummer().getVerdi(), behandling.getFagsakId());
 
         var task = createTask();
         task.doTask(prosessTaskData);
@@ -183,7 +183,7 @@ class GrunnbeløpReguleringTaskTest {
         when(enhetsTjeneste.finnBehandlendeEnhetFor(any())).thenReturn(new OrganisasjonsEnhet("1234", "Test"));
 
         var prosessTaskData = ProsessTaskData.forProsessTask(GrunnbeløpReguleringTask.class);
-        prosessTaskData.setFagsak(behandling.getFagsakId(), behandling.getAktørId().getId());
+        prosessTaskData.setFagsak(behandling.getSaksnummer().getVerdi(), behandling.getFagsakId());
         prosessTaskData.setProperty(GrunnbeløpReguleringTask.MANUELL_KEY, "true");
 
         var task = createTask();

--- a/domenetjenester/behandling/src/main/java/no/nav/foreldrepenger/behandling/BehandlingReferanse.java
+++ b/domenetjenester/behandling/src/main/java/no/nav/foreldrepenger/behandling/BehandlingReferanse.java
@@ -43,7 +43,7 @@ public record BehandlingReferanse(Saksnummer saksnummer,
      */
     public static BehandlingReferanse fra(Behandling behandling) {
         return new BehandlingReferanse(
-                behandling.getFagsak().getSaksnummer(),
+                behandling.getSaksnummer(),
                 behandling.getFagsakId(),
                 behandling.getFagsakYtelseType(),
                 behandling.getId(),

--- a/domenetjenester/behandling/src/main/java/no/nav/foreldrepenger/behandling/RelatertBehandlingTjeneste.java
+++ b/domenetjenester/behandling/src/main/java/no/nav/foreldrepenger/behandling/RelatertBehandlingTjeneste.java
@@ -59,7 +59,7 @@ public class RelatertBehandlingTjeneste {
     }
 
     public Optional<Behandling> hentAnnenPartsGjeldendeBehandlingPåVedtakstidspunkt(Behandling behandling) {
-        var annenPartsFagsak = hentAnnenPartsFagsak(behandling.getFagsak().getSaksnummer());
+        var annenPartsFagsak = hentAnnenPartsFagsak(behandling.getSaksnummer());
         if (annenPartsFagsak.isEmpty()) {
             return Optional.empty();
         }

--- a/domenetjenester/behandling/src/test/java/no/nav/foreldrepenger/behandling/RelatertBehandlingTjenesteTest.java
+++ b/domenetjenester/behandling/src/test/java/no/nav/foreldrepenger/behandling/RelatertBehandlingTjenesteTest.java
@@ -53,7 +53,7 @@ class RelatertBehandlingTjenesteTest {
     void finnesIngenRelatertFagsakReturnererOptionalEmpty() {
         var farsBehandling = ScenarioFarSøkerForeldrepenger.forFødsel().lagre(repositoryProvider);
         var annenPartsGjeldendeVedtattBehandling = relatertBehandlingTjeneste
-                .hentAnnenPartsGjeldendeVedtattBehandling(farsBehandling.getFagsak().getSaksnummer());
+                .hentAnnenPartsGjeldendeVedtattBehandling(farsBehandling.getSaksnummer());
 
         assertThat(annenPartsGjeldendeVedtattBehandling).isEmpty();
 
@@ -69,7 +69,7 @@ class RelatertBehandlingTjenesteTest {
         fagsakRelasjonTjeneste.kobleFagsaker(morsBehandling.getFagsak(), farsBehandling.getFagsak());
 
         var uttakresultat = relatertBehandlingTjeneste
-                .hentAnnenPartsGjeldendeVedtattBehandling(farsBehandling.getFagsak().getSaksnummer());
+                .hentAnnenPartsGjeldendeVedtattBehandling(farsBehandling.getSaksnummer());
 
         assertThat(uttakresultat).isEmpty();
     }
@@ -93,7 +93,7 @@ class RelatertBehandlingTjenesteTest {
         fagsakRelasjonTjeneste.kobleFagsaker(morsBehandling.getFagsak(), farsBehandling.getFagsak());
 
         var behandling = relatertBehandlingTjeneste
-                .hentAnnenPartsGjeldendeVedtattBehandling(farsBehandling.getFagsak().getSaksnummer());
+                .hentAnnenPartsGjeldendeVedtattBehandling(farsBehandling.getSaksnummer());
 
         assertThat(behandling.get().getId()).isEqualTo(morsBehandling.getId());
     }
@@ -116,7 +116,7 @@ class RelatertBehandlingTjenesteTest {
         fagsakRelasjonTjeneste.kobleFagsaker(morsBehandling.getFagsak(), farsBehandling.getFagsak());
 
         var relatertBehandling = relatertBehandlingTjeneste
-                .hentAnnenPartsGjeldendeVedtattBehandling(farsBehandling.getFagsak().getSaksnummer());
+                .hentAnnenPartsGjeldendeVedtattBehandling(farsBehandling.getSaksnummer());
 
         assertThat(relatertBehandling).isPresent();
         assertThat(relatertBehandling.get().getId()).isEqualTo(morsBehandling.getId());
@@ -154,7 +154,7 @@ class RelatertBehandlingTjenesteTest {
         fagsakRelasjonTjeneste.kobleFagsaker(morsRevurdering.getFagsak(), farsBehandling.getFagsak());
 
         var annenPartsGjeldendeVedtattBehandling = relatertBehandlingTjeneste
-                .hentAnnenPartsGjeldendeVedtattBehandling(farsBehandling.getFagsak().getSaksnummer());
+                .hentAnnenPartsGjeldendeVedtattBehandling(farsBehandling.getSaksnummer());
 
         assertThat(annenPartsGjeldendeVedtattBehandling.get().getId()).isEqualTo(morsRevurdering.getId());
     }
@@ -232,7 +232,7 @@ class RelatertBehandlingTjenesteTest {
         fagsakRelasjonTjeneste.kobleFagsaker(morsRevurdering.getFagsak(), farsBehandling.getFagsak());
 
         var annenPartsGjeldendeVedtattBehandling = relatertBehandlingTjeneste
-                .hentAnnenPartsGjeldendeVedtattBehandling(farsBehandling.getFagsak().getSaksnummer());
+                .hentAnnenPartsGjeldendeVedtattBehandling(farsBehandling.getSaksnummer());
 
         assertThat(annenPartsGjeldendeVedtattBehandling.get().getId()).isEqualTo(morsRevurdering.getId());
     }

--- a/domenetjenester/behandlingskontroll/src/main/java/no/nav/foreldrepenger/behandlingskontroll/BehandlingskontrollKontekst.java
+++ b/domenetjenester/behandlingskontroll/src/main/java/no/nav/foreldrepenger/behandlingskontroll/BehandlingskontrollKontekst.java
@@ -3,7 +3,7 @@ package no.nav.foreldrepenger.behandlingskontroll;
 import java.util.Objects;
 
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingLås;
-import no.nav.foreldrepenger.domene.typer.AktørId;
+import no.nav.foreldrepenger.domene.typer.Saksnummer;
 
 /**
  * Container som holder kontekst under prosessering av {@link BehandlingSteg}.
@@ -11,17 +11,17 @@ import no.nav.foreldrepenger.domene.typer.AktørId;
 public class BehandlingskontrollKontekst {
 
     private BehandlingLås behandlingLås;
-    private AktørId aktørId;
     private Long fagsakId;
+    private Saksnummer saksnummer;
 
     /**
      * NB: Foretrekk {@link BehandlingskontrollTjeneste#initBehandlingskontroll} i
      * stedet for å opprette her direkte.
      */
-    public BehandlingskontrollKontekst(Long fagsakId, AktørId aktørId, BehandlingLås behandlingLås) {
+    public BehandlingskontrollKontekst(Saksnummer saksnummer, Long fagsakId, BehandlingLås behandlingLås) {
         Objects.requireNonNull(behandlingLås, "behandlingLås");
+        this.saksnummer = saksnummer;
         this.fagsakId = fagsakId;
-        this.aktørId = aktørId;
         this.behandlingLås = behandlingLås;
     }
 
@@ -37,8 +37,8 @@ public class BehandlingskontrollKontekst {
         return fagsakId;
     }
 
-    public AktørId getAktørId() {
-        return aktørId;
+    public Saksnummer getSaksnummer() {
+        return saksnummer;
     }
 
     @Override
@@ -50,17 +50,17 @@ public class BehandlingskontrollKontekst {
             return false;
         }
         return Objects.equals(fagsakId, other.fagsakId)
-                && Objects.equals(aktørId, other.aktørId)
+                && Objects.equals(saksnummer, other.saksnummer)
                 && Objects.equals(getBehandlingId(), other.getBehandlingId());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(fagsakId, aktørId, getBehandlingId());
+        return Objects.hash(fagsakId, saksnummer, getBehandlingId());
     }
 
     @Override
     public String toString() {
-        return getClass().getSimpleName() + "<fagsakId=" + fagsakId + ", aktørId=" + aktørId + ", behandlingId=" + getBehandlingId() + ">";
+        return getClass().getSimpleName() + "<fagsakId=" + fagsakId + ", saksnummer=" + saksnummer + ", behandlingId=" + getBehandlingId() + ">";
     }
 }

--- a/domenetjenester/behandlingskontroll/src/main/java/no/nav/foreldrepenger/behandlingskontroll/events/AksjonspunktStatusEvent.java
+++ b/domenetjenester/behandlingskontroll/src/main/java/no/nav/foreldrepenger/behandlingskontroll/events/AksjonspunktStatusEvent.java
@@ -7,7 +7,7 @@ import no.nav.foreldrepenger.behandlingskontroll.BehandlingskontrollKontekst;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingEvent;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingStegType;
 import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.Aksjonspunkt;
-import no.nav.foreldrepenger.domene.typer.AktørId;
+import no.nav.foreldrepenger.domene.typer.Saksnummer;
 
 public class AksjonspunktStatusEvent implements BehandlingEvent {
     private final BehandlingskontrollKontekst kontekst;
@@ -28,8 +28,8 @@ public class AksjonspunktStatusEvent implements BehandlingEvent {
     }
 
     @Override
-    public AktørId getAktørId() {
-        return kontekst.getAktørId();
+    public Saksnummer getSaksnummer() {
+        return kontekst.getSaksnummer();
     }
 
     @Override

--- a/domenetjenester/behandlingskontroll/src/main/java/no/nav/foreldrepenger/behandlingskontroll/events/BehandlingStatusEvent.java
+++ b/domenetjenester/behandlingskontroll/src/main/java/no/nav/foreldrepenger/behandlingskontroll/events/BehandlingStatusEvent.java
@@ -7,7 +7,7 @@ import no.nav.foreldrepenger.behandlingskontroll.BehandlingskontrollTjeneste;
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingEvent;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingStatus;
-import no.nav.foreldrepenger.domene.typer.AktørId;
+import no.nav.foreldrepenger.domene.typer.Saksnummer;
 
 /**
  * Event publiseres av {@link BehandlingskontrollTjeneste} når en
@@ -26,8 +26,8 @@ public class BehandlingStatusEvent implements BehandlingEvent {
     }
 
     @Override
-    public AktørId getAktørId() {
-        return kontekst.getAktørId();
+    public Saksnummer getSaksnummer() {
+        return kontekst.getSaksnummer();
     }
 
     @Override

--- a/domenetjenester/behandlingskontroll/src/main/java/no/nav/foreldrepenger/behandlingskontroll/events/BehandlingStegOvergangEvent.java
+++ b/domenetjenester/behandlingskontroll/src/main/java/no/nav/foreldrepenger/behandlingskontroll/events/BehandlingStegOvergangEvent.java
@@ -9,7 +9,7 @@ import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingEvent;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingStegStatus;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingStegType;
-import no.nav.foreldrepenger.domene.typer.AktørId;
+import no.nav.foreldrepenger.domene.typer.Saksnummer;
 
 /**
  * Event publiseres av {@link BehandlingskontrollTjeneste} når en
@@ -50,8 +50,8 @@ public class BehandlingStegOvergangEvent implements BehandlingEvent {
     }
 
     @Override
-    public AktørId getAktørId() {
-        return kontekst.getAktørId();
+    public Saksnummer getSaksnummer() {
+        return kontekst.getSaksnummer();
     }
 
     @Override

--- a/domenetjenester/behandlingskontroll/src/main/java/no/nav/foreldrepenger/behandlingskontroll/events/BehandlingStegStatusEvent.java
+++ b/domenetjenester/behandlingskontroll/src/main/java/no/nav/foreldrepenger/behandlingskontroll/events/BehandlingStegStatusEvent.java
@@ -6,7 +6,7 @@ import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingEvent;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingStegStatus;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingStegType;
-import no.nav.foreldrepenger.domene.typer.AktørId;
+import no.nav.foreldrepenger.domene.typer.Saksnummer;
 
 /**
  * Event publiseres av {@link BehandlingskontrollTjeneste} når en
@@ -33,8 +33,8 @@ public class BehandlingStegStatusEvent implements BehandlingEvent {
     }
 
     @Override
-    public AktørId getAktørId() {
-        return kontekst.getAktørId();
+    public Saksnummer getSaksnummer() {
+        return kontekst.getSaksnummer();
     }
 
     @Override

--- a/domenetjenester/behandlingskontroll/src/main/java/no/nav/foreldrepenger/behandlingskontroll/events/BehandlingTransisjonEvent.java
+++ b/domenetjenester/behandlingskontroll/src/main/java/no/nav/foreldrepenger/behandlingskontroll/events/BehandlingTransisjonEvent.java
@@ -8,7 +8,7 @@ import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingEvent;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingStegStatus;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingStegTilstand;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingStegType;
-import no.nav.foreldrepenger.domene.typer.AktørId;
+import no.nav.foreldrepenger.domene.typer.Saksnummer;
 
 public class BehandlingTransisjonEvent implements BehandlingEvent {
 
@@ -38,8 +38,8 @@ public class BehandlingTransisjonEvent implements BehandlingEvent {
     }
 
     @Override
-    public AktørId getAktørId() {
-        return kontekst.getAktørId();
+    public Saksnummer getSaksnummer() {
+        return kontekst.getSaksnummer();
     }
 
     public BehandlingskontrollKontekst getKontekst() {

--- a/domenetjenester/behandlingskontroll/src/main/java/no/nav/foreldrepenger/behandlingskontroll/events/BehandlingskontrollEvent.java
+++ b/domenetjenester/behandlingskontroll/src/main/java/no/nav/foreldrepenger/behandlingskontroll/events/BehandlingskontrollEvent.java
@@ -6,7 +6,7 @@ import no.nav.foreldrepenger.behandlingskontroll.BehandlingskontrollTjeneste;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingEvent;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingStegStatus;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingStegType;
-import no.nav.foreldrepenger.domene.typer.AktørId;
+import no.nav.foreldrepenger.domene.typer.Saksnummer;
 
 /**
  * Event som fyres når Behandlingskontroll STARTER å prosessere en behandling,
@@ -30,13 +30,13 @@ public abstract class BehandlingskontrollEvent implements BehandlingEvent {
     }
 
     @Override
-    public AktørId getAktørId() {
-        return kontekst.getAktørId();
+    public Long getFagsakId() {
+        return kontekst.getFagsakId();
     }
 
     @Override
-    public Long getFagsakId() {
-        return kontekst.getFagsakId();
+    public Saksnummer getSaksnummer() {
+        return kontekst.getSaksnummer();
     }
 
     @Override

--- a/domenetjenester/behandlingskontroll/src/main/java/no/nav/foreldrepenger/behandlingskontroll/impl/BehandlingskontrollTjenesteImpl.java
+++ b/domenetjenester/behandlingskontroll/src/main/java/no/nav/foreldrepenger/behandlingskontroll/impl/BehandlingskontrollTjenesteImpl.java
@@ -250,7 +250,7 @@ public class BehandlingskontrollTjenesteImpl implements BehandlingskontrollTjene
         var lås = serviceProvider.taLås(behandlingId);
         // så les
         var behandling = serviceProvider.hentBehandling(behandlingId);
-        return new BehandlingskontrollKontekst(behandling.getFagsakId(), behandling.getAktørId(), lås);
+        return new BehandlingskontrollKontekst(behandling.getSaksnummer(), behandling.getFagsakId(), lås);
     }
 
     @Override
@@ -260,7 +260,7 @@ public class BehandlingskontrollTjenesteImpl implements BehandlingskontrollTjene
         var lås = serviceProvider.taLås(behandlingUuid);
         // så les
         var behandling = serviceProvider.hentBehandling(behandlingUuid);
-        return new BehandlingskontrollKontekst(behandling.getFagsakId(), behandling.getAktørId(), lås);
+        return new BehandlingskontrollKontekst(behandling.getSaksnummer(), behandling.getFagsakId(), lås);
     }
 
     @Override
@@ -270,7 +270,7 @@ public class BehandlingskontrollTjenesteImpl implements BehandlingskontrollTjene
         var lås = serviceProvider.taLås(behandling.getId());
 
         // så les
-        return new BehandlingskontrollKontekst(behandling.getFagsakId(), behandling.getAktørId(), lås);
+        return new BehandlingskontrollKontekst(behandling.getSaksnummer(), behandling.getFagsakId(), lås);
     }
 
     void aksjonspunkterEndretStatus(BehandlingskontrollKontekst kontekst, BehandlingStegType behandlingStegType,
@@ -693,7 +693,7 @@ public class BehandlingskontrollTjenesteImpl implements BehandlingskontrollTjene
         // Oppdater behandling og lagre
         InternalManipulerBehandling.forceOppdaterBehandlingSteg(behandling, revidertStegType, behandlingStegStatus, sluttStatusForAndreÅpneSteg);
         var skriveLås = behandlingRepository.taSkriveLås(behandling);
-        var kontekst = new BehandlingskontrollKontekst(behandling.getFagsakId(), behandling.getAktørId(), skriveLås);
+        var kontekst = new BehandlingskontrollKontekst(behandling.getSaksnummer(), behandling.getFagsakId(), skriveLås);
         behandlingRepository.lagre(behandling, skriveLås);
 
         // Publiser oppdatering

--- a/domenetjenester/behandlingskontroll/src/main/java/no/nav/foreldrepenger/behandlingskontroll/impl/TekniskBehandlingStegVisitor.java
+++ b/domenetjenester/behandlingskontroll/src/main/java/no/nav/foreldrepenger/behandlingskontroll/impl/TekniskBehandlingStegVisitor.java
@@ -1,11 +1,14 @@
 package no.nav.foreldrepenger.behandlingskontroll.impl;
 
+import java.util.Optional;
+
 import no.nav.foreldrepenger.behandlingskontroll.BehandlingModellVisitor;
 import no.nav.foreldrepenger.behandlingskontroll.BehandlingStegModell;
 import no.nav.foreldrepenger.behandlingskontroll.BehandlingskontrollKontekst;
 import no.nav.foreldrepenger.behandlingskontroll.StegProsesseringResultat;
 import no.nav.foreldrepenger.behandlingskontroll.spi.BehandlingskontrollServiceProvider;
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
+import no.nav.foreldrepenger.domene.typer.Saksnummer;
 import no.nav.vedtak.felles.jpa.savepoint.Work;
 import no.nav.vedtak.log.mdc.MdcExtendedLogContext;
 
@@ -33,7 +36,9 @@ public class TekniskBehandlingStegVisitor implements BehandlingModellVisitor {
 
     @Override
     public StegProsesseringResultat prosesser(BehandlingStegModell steg) {
-        LOG_CONTEXT.add("fagsak", kontekst.getFagsakId());
+        var saksreferanse = Optional.ofNullable(kontekst.getSaksnummer()).map(Saksnummer::getVerdi)
+            .orElseGet(() -> kontekst.getFagsakId().toString());
+        LOG_CONTEXT.add("fagsak", saksreferanse);
         LOG_CONTEXT.add("behandling", kontekst.getBehandlingId());
         LOG_CONTEXT.add("steg", steg.getBehandlingStegType().getKode());
 

--- a/domenetjenester/behandlingskontroll/src/test/java/no/nav/foreldrepenger/behandlingskontroll/impl/observer/TilbakehoppTest.java
+++ b/domenetjenester/behandlingskontroll/src/test/java/no/nav/foreldrepenger/behandlingskontroll/impl/observer/TilbakehoppTest.java
@@ -202,7 +202,7 @@ class TilbakehoppTest {
         var fraTilstand = new BehandlingStegTilstandSnapshot(1L, fra.steg(), getBehandlingStegStatus(fra));
         var tilTilstand = new BehandlingStegTilstandSnapshot(2L, til.steg(), getBehandlingStegStatus(til));
         var fagsak = behandling.getFagsak();
-        var kontekst = new BehandlingskontrollKontekst(fagsak.getId(), fagsak.getAktørId(), behandlingLås);
+        var kontekst = new BehandlingskontrollKontekst(fagsak.getSaksnummer(), fagsak.getId(), behandlingLås);
         var event = new BehandlingStegOvergangEvent.BehandlingStegTilbakeføringEvent(
                 kontekst,
                 fraTilstand, tilTilstand);
@@ -218,7 +218,7 @@ class TilbakehoppTest {
         var tilTilstand = new BehandlingStegTilstandSnapshot(2L, til.steg(), getBehandlingStegStatus(til));
 
         var fagsak = behandling.getFagsak();
-        var kontekst = new BehandlingskontrollKontekst(fagsak.getId(), fagsak.getAktørId(), behandlingLås);
+        var kontekst = new BehandlingskontrollKontekst(fagsak.getSaksnummer(), fagsak.getId(), behandlingLås);
         var event = new BehandlingStegOvergangEvent.BehandlingStegTilbakeføringEvent(
                 kontekst,
                 fraTilstand, tilTilstand);

--- a/domenetjenester/behandlingskontroll/src/test/java/no/nav/foreldrepenger/behandlingskontroll/impl/transisjoner/FremoverhoppTest.java
+++ b/domenetjenester/behandlingskontroll/src/test/java/no/nav/foreldrepenger/behandlingskontroll/impl/transisjoner/FremoverhoppTest.java
@@ -161,7 +161,7 @@ class FremoverhoppTest {
         // BehandlingStegTilstand tilTilstand = new BehandlingStegTilstand(behandling,
         // til, BehandlingStegStatus.VENTER);
         var fagsak = behandling.getFagsak();
-        var kontekst = new BehandlingskontrollKontekst(fagsak.getId(), fagsak.getAktørId(), behandlingLås);
+        var kontekst = new BehandlingskontrollKontekst(fagsak.getSaksnummer(), fagsak.getId(), behandlingLås);
         /*
          * BehandlingStegOvergangEvent.BehandlingStegOverhoppEvent behandlingEvent = new
          * BehandlingStegOvergangEvent.BehandlingStegOverhoppEvent(kontekst,

--- a/domenetjenester/beregningsgrunnlag/src/test/java/no/nav/foreldrepenger/domene/prosess/RyddBeregningsgrunnlagTest.java
+++ b/domenetjenester/beregningsgrunnlag/src/test/java/no/nav/foreldrepenger/domene/prosess/RyddBeregningsgrunnlagTest.java
@@ -20,7 +20,6 @@ import no.nav.foreldrepenger.dbstoette.JpaExtension;
 import no.nav.foreldrepenger.domene.entiteter.BeregningsgrunnlagEntitet;
 import no.nav.foreldrepenger.domene.entiteter.BeregningsgrunnlagRepository;
 import no.nav.foreldrepenger.domene.modell.kodeverk.BeregningsgrunnlagTilstand;
-import no.nav.foreldrepenger.domene.typer.AktørId;
 
 @ExtendWith(JpaExtension.class)
 class RyddBeregningsgrunnlagTest {
@@ -35,7 +34,7 @@ class RyddBeregningsgrunnlagTest {
 
         var behandling = ScenarioMorSøkerForeldrepenger.forFødsel().lagre(new BehandlingRepositoryProvider(entityManager));
         referanse = BehandlingReferanse.fra(behandling);
-        var kontekst = new BehandlingskontrollKontekst(referanse.fagsakId(), AktørId.dummy(), new BehandlingLås(referanse.behandlingId()));
+        var kontekst = new BehandlingskontrollKontekst(referanse.saksnummer(), referanse.fagsakId(), new BehandlingLås(referanse.behandlingId()));
         ryddBeregningsgrunnlag = new RyddBeregningsgrunnlag(beregningsgrunnlagRepository, kontekst);
     }
 

--- a/domenetjenester/datavarehus/src/main/java/no/nav/foreldrepenger/datavarehus/tjeneste/BehandlingDvhMapper.java
+++ b/domenetjenester/datavarehus/src/main/java/no/nav/foreldrepenger/datavarehus/tjeneste/BehandlingDvhMapper.java
@@ -64,7 +64,7 @@ public class BehandlingDvhMapper {
             .behandlingType(behandling.getType().getKode())
             .endretAv(CommonDvhMapper.finnEndretAvEllerOpprettetAv(behandling))
             .fagsakId(behandling.getFagsakId())
-            .saksnummer(behandling.getFagsak().getSaksnummer().getVerdi())
+            .saksnummer(behandling.getSaksnummer().getVerdi())
             .aktørId(behandling.getAktørId().getId())
             .ytelseType(behandling.getFagsakYtelseType().getKode())
             .funksjonellTid(LocalDateTime.now())

--- a/domenetjenester/datavarehus/src/main/java/no/nav/foreldrepenger/datavarehus/v2/StønadsstatistikkTjeneste.java
+++ b/domenetjenester/datavarehus/src/main/java/no/nav/foreldrepenger/datavarehus/v2/StønadsstatistikkTjeneste.java
@@ -273,7 +273,7 @@ public class StønadsstatistikkTjeneste {
     }
 
     private List<StønadsstatistikkUttakPeriode> mapForeldrepengerUttaksperioder(Behandling behandling, RettighetType rettighetType) {
-        var logContext = String.format("saksnummer %s behandling %s", behandling.getFagsak().getSaksnummer().getVerdi(), behandling.getUuid().toString());
+        var logContext = String.format("saksnummer %s behandling %s", behandling.getSaksnummer().getVerdi(), behandling.getUuid().toString());
         return foreldrepengerUttakTjeneste.hentHvisEksisterer(behandling.getId(), true)
             .map(u -> StønadsstatistikkUttakPeriodeMapper.mapUttak(behandling.getRelasjonsRolleType(), rettighetType, u.getGjeldendePerioder(), logContext))
             .orElse(List.of());

--- a/domenetjenester/datavarehus/src/test/java/no/nav/foreldrepenger/datavarehus/observer/DatavarehusEventObserverTest.java
+++ b/domenetjenester/datavarehus/src/test/java/no/nav/foreldrepenger/datavarehus/observer/DatavarehusEventObserverTest.java
@@ -78,7 +78,7 @@ class DatavarehusEventObserverTest {
         var behandlingLås = new BehandlingLås(behandling.getId()) {
         };
         var fagsak = behandling.getFagsak();
-        return new BehandlingskontrollKontekst(fagsak.getId(), fagsak.getAktørId(), behandlingLås);
+        return new BehandlingskontrollKontekst(fagsak.getSaksnummer(), fagsak.getId(), behandlingLås);
     }
 
     private Behandling byggBehandling() {

--- a/domenetjenester/datavarehus/src/test/java/no/nav/foreldrepenger/datavarehus/tjeneste/BehandlingDvhMapperTest.java
+++ b/domenetjenester/datavarehus/src/test/java/no/nav/foreldrepenger/datavarehus/tjeneste/BehandlingDvhMapperTest.java
@@ -100,7 +100,7 @@ class BehandlingDvhMapperTest {
         assertThat(dvh.getBehandlingType()).isEqualTo(BehandlingType.FØRSTEGANGSSØKNAD.getKode());
         assertThat(dvh.getEndretAv()).isEqualTo("OpprettetAv");
         assertThat(dvh.getFagsakId()).isEqualTo(behandling.getFagsakId());
-        assertThat(dvh.getSaksnummer()).isEqualTo(behandling.getFagsak().getSaksnummer().getVerdi());
+        assertThat(dvh.getSaksnummer()).isEqualTo(behandling.getSaksnummer().getVerdi());
         assertThat(dvh.getAktørId()).isEqualTo(behandling.getAktørId().getId());
         assertThat(dvh.getYtelseType()).isEqualTo(behandling.getFagsakYtelseType().getKode());
         assertThat(dvh.getFunksjonellTid()).isCloseTo(LocalDateTime.now(), within(5, ChronoUnit.SECONDS));

--- a/domenetjenester/datavarehus/src/test/java/no/nav/foreldrepenger/datavarehus/v2/StønadsstatistikkTjenesteTest.java
+++ b/domenetjenester/datavarehus/src/test/java/no/nav/foreldrepenger/datavarehus/v2/StønadsstatistikkTjenesteTest.java
@@ -131,7 +131,7 @@ class StønadsstatistikkTjenesteTest {
         assertThat(vedtak.getEngangsstønadInnvilget()).isNull();
         assertThat(vedtak.getLovVersjon()).isEqualTo(LovVersjon.FORELDREPENGER_MINSTERETT_2022_08_02);
         assertThat(vedtak.getForrigeBehandlingUuid()).isNull();
-        assertThat(vedtak.getSaksnummer().id()).isEqualTo(behandling.getFagsak().getSaksnummer().getVerdi());
+        assertThat(vedtak.getSaksnummer().id()).isEqualTo(behandling.getSaksnummer().getVerdi());
         assertThat(vedtak.getFagsakId()).isEqualTo(behandling.getFagsak().getId());
         assertThat(vedtak.getSøker().id()).isEqualTo(behandling.getAktørId().getId());
         assertThat(vedtak.getSaksrolle()).isEqualTo(Saksrolle.MOR);
@@ -336,7 +336,7 @@ class StønadsstatistikkTjenesteTest {
         assertThat(vedtak.getLovVersjon()).isEqualTo(LovVersjon.SVANGERSKAPSPENGER_2019_01_01);
         assertThat(vedtak.getForrigeBehandlingUuid()).isNotNull();
         assertThat(vedtak.getRevurderingÅrsak()).isEqualTo(StønadsstatistikkVedtak.RevurderingÅrsak.SØKNAD);
-        assertThat(vedtak.getSaksnummer().id()).isEqualTo(behandling.getFagsak().getSaksnummer().getVerdi());
+        assertThat(vedtak.getSaksnummer().id()).isEqualTo(behandling.getSaksnummer().getVerdi());
         assertThat(vedtak.getFagsakId()).isEqualTo(behandling.getFagsak().getId());
         assertThat(vedtak.getSøker().id()).isEqualTo(behandling.getAktørId().getId());
         assertThat(vedtak.getSaksrolle()).isEqualTo(Saksrolle.MOR);

--- a/domenetjenester/dokumentbestiller/src/main/java/no/nav/foreldrepenger/dokumentbestiller/formidling/DokumentBestiller.java
+++ b/domenetjenester/dokumentbestiller/src/main/java/no/nav/foreldrepenger/dokumentbestiller/formidling/DokumentBestiller.java
@@ -8,8 +8,8 @@ import jakarta.inject.Inject;
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
 import no.nav.foreldrepenger.behandlingslager.behandling.historikk.HistorikkAktør;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepository;
-import no.nav.foreldrepenger.dokumentbestiller.DokumentBestilling;
 import no.nav.foreldrepenger.dokumentbestiller.DokumentBehandlingTjeneste;
+import no.nav.foreldrepenger.dokumentbestiller.DokumentBestilling;
 import no.nav.vedtak.felles.prosesstask.api.CommonTaskProperties;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTaskData;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTaskTjeneste;
@@ -66,7 +66,7 @@ public class DokumentBestiller {
 
         // Brukes kun i logging
         prosessTaskData.setCallIdFraEksisterende();
-        prosessTaskData.setSaksnummer(behandling.getFagsak().getSaksnummer().getVerdi());
+        prosessTaskData.setSaksnummer(behandling.getSaksnummer().getVerdi());
         taskTjeneste.lagre(prosessTaskData);
     }
 }

--- a/domenetjenester/dokumentbestiller/src/main/java/no/nav/foreldrepenger/dokumentbestiller/infobrev/FeilPraksisUtsettelseRepository.java
+++ b/domenetjenester/dokumentbestiller/src/main/java/no/nav/foreldrepenger/dokumentbestiller/infobrev/FeilPraksisUtsettelseRepository.java
@@ -170,7 +170,8 @@ public class FeilPraksisUtsettelseRepository {
      */
     private static final String QUERY_VENTEFRIST_DESEMBER = """
         select * from (
-          select distinct b.FAGSAK_ID, b.ID from fpsak.BEHANDLING b
+          select distinct b.FAGSAK_ID, b.ID, f.saksnummer from fpsak.BEHANDLING b
+                                               join fpsak.FAGSAK f on b.FAGSAK_ID = f.ID
                                                join fpsak.AKSJONSPUNKT a on a.BEHANDLING_ID = b.ID
                                                join fpsak.BEHANDLING_STEG_TILSTAND steg on steg.BEHANDLING_ID = b.ID
                                                join fpsak.BEHANDLING_ARSAK ba on ba.BEHANDLING_ID = b.ID
@@ -192,6 +193,6 @@ public class FeilPraksisUtsettelseRepository {
         return query.getResultList();
     }
 
-    public record BehandlingMedFagsakId(Long fagsakId, Long id) {
+    public record BehandlingMedFagsakId(Long fagsakId, Long id, String saksnummer) {
     }
 }

--- a/domenetjenester/dokumentbestiller/src/main/java/no/nav/foreldrepenger/dokumentbestiller/infobrev/InformasjonPåminnelseData.java
+++ b/domenetjenester/dokumentbestiller/src/main/java/no/nav/foreldrepenger/dokumentbestiller/infobrev/InformasjonPåminnelseData.java
@@ -1,0 +1,5 @@
+package no.nav.foreldrepenger.dokumentbestiller.infobrev;
+
+import no.nav.foreldrepenger.domene.typer.Saksnummer;
+
+public record InformasjonPåminnelseData(Saksnummer saksnummer, Long fagsakId) { }

--- a/domenetjenester/dokumentbestiller/src/main/java/no/nav/foreldrepenger/dokumentbestiller/infobrev/SendInformasjonsbrevBatchTjeneste.java
+++ b/domenetjenester/dokumentbestiller/src/main/java/no/nav/foreldrepenger/dokumentbestiller/infobrev/SendInformasjonsbrevBatchTjeneste.java
@@ -42,7 +42,7 @@ public class SendInformasjonsbrevBatchTjeneste implements BatchTjeneste {
         var saker = informasjonssakRepository.finnSakerMedInnvilgetMaksdatoInnenIntervall(periode.fom(), periode.tom());
         var baseline = LocalTime.now();
         saker.forEach(sak -> {
-            LOG.info("Oppretter informasjonssak-task for {}", sak.getAktørId().getId());
+            LOG.info("Oppretter informasjonssak-task for {}", sak.getAktørId());
             var data = ProsessTaskData.forProsessTask(OpprettInformasjonsFagsakTask.class);
             data.setAktørId(sak.getAktørId().getId());
             data.setCallIdFraEksisterende();

--- a/domenetjenester/dokumentbestiller/src/main/java/no/nav/foreldrepenger/dokumentbestiller/infobrev/SendInformasjonsbrevPåminnelseBatchTjeneste.java
+++ b/domenetjenester/dokumentbestiller/src/main/java/no/nav/foreldrepenger/dokumentbestiller/infobrev/SendInformasjonsbrevPåminnelseBatchTjeneste.java
@@ -42,12 +42,11 @@ public class SendInformasjonsbrevPåminnelseBatchTjeneste implements BatchTjenes
         var saker = informasjonssakRepository.finnSakerDerMedforelderIkkeHarSøktOgBarnetBleFødtInnenforIntervall(periode.fom(), periode.tom());
         var baseline = LocalTime.now();
         saker.forEach(sak -> {
-            LOG.info("Oppretter informasjonsbrev-påminnelse task for {}", sak.getAktørId().getId());
+            LOG.info("Oppretter informasjonsbrev-påminnelse task for {}", sak.saksnummer().getVerdi());
             var data = ProsessTaskData.forProsessTask(SendInformasjonsbrevPåminnelseTask.class);
-            data.setAktørId(sak.getAktørId().getId());
             data.setCallIdFraEksisterende();
             data.setNesteKjøringEtter(LocalDateTime.of(LocalDate.now(), baseline.plusSeconds(LocalDateTime.now().getNano() % 419)));
-            data.setProperty(SendInformasjonsbrevPåminnelseTask.FAGSAK_ID_KEY, sak.getKildeFagsakId().toString());
+            data.setFagsak(sak.saksnummer().getVerdi(), sak.fagsakId());
             taskTjeneste.lagre(data);
         });
         return BATCHNAVN + "-" + saker.size();

--- a/domenetjenester/dokumentbestiller/src/main/java/no/nav/foreldrepenger/dokumentbestiller/infobrev/SendInformasjonsbrevPåminnelseTask.java
+++ b/domenetjenester/dokumentbestiller/src/main/java/no/nav/foreldrepenger/dokumentbestiller/infobrev/SendInformasjonsbrevPåminnelseTask.java
@@ -39,8 +39,6 @@ import no.nav.vedtak.felles.prosesstask.api.ProsessTaskHandler;
 @FagsakProsesstaskRekkefølge(gruppeSekvens = true)
 public class SendInformasjonsbrevPåminnelseTask implements ProsessTaskHandler {
 
-    public static final String FAGSAK_ID_KEY = "fagsakId";
-
     private static final Logger LOG = LoggerFactory.getLogger(SendInformasjonsbrevPåminnelseTask.class);
 
     private BehandlingOpprettingTjeneste behandlingOpprettingTjeneste;
@@ -79,13 +77,13 @@ public class SendInformasjonsbrevPåminnelseTask implements ProsessTaskHandler {
 
     @Override
     public void doTask(ProsessTaskData prosessTaskData) {
-        var aktørId = new AktørId(prosessTaskData.getAktørId());
+        var fagsakFar = fagsakRepository.finnEksaktFagsakReadOnly(prosessTaskData.getFagsakId());
+
+        var aktørId = fagsakFar.getAktørId();
         var bruker = hentPersonInfo(aktørId);
         if (bruker.dødsdato() != null) {
             return; // Unngå brev til død bruker
         }
-
-        var fagsakFar = fagsakRepository.finnEksaktFagsakReadOnly(Long.parseLong(prosessTaskData.getPropertyValue(FAGSAK_ID_KEY)));
 
         //Sjekk at det finnes fedrekvote igjen
         var behandlingMor = relatertBehandlingTjeneste.hentAnnenPartsGjeldendeVedtattBehandling(fagsakFar.getSaksnummer()).orElseThrow();

--- a/domenetjenester/dokumentbestiller/src/test/java/no/nav/foreldrepenger/dokumentbestiller/brevmal/BrevmalTjenesteTest.java
+++ b/domenetjenester/dokumentbestiller/src/test/java/no/nav/foreldrepenger/dokumentbestiller/brevmal/BrevmalTjenesteTest.java
@@ -17,7 +17,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import no.nav.foreldrepenger.behandling.BehandlingReferanse;
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingType;
-import no.nav.foreldrepenger.behandlingslager.fagsak.Fagsak;
 import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakYtelseType;
 import no.nav.foreldrepenger.behandlingslager.virksomhet.Arbeidsgiver;
 import no.nav.foreldrepenger.dokumentbestiller.DokumentBehandlingTjeneste;
@@ -83,9 +82,7 @@ class BrevmalTjenesteTest {
         when(behandling.getFagsakYtelseType()).thenReturn(FagsakYtelseType.FORELDREPENGER);
         when(behandling.getType()).thenReturn(BehandlingType.REVURDERING);
         when(behandling.erManueltOpprettet()).thenReturn(true);
-        var fag = mock(Fagsak.class);
-        when(fag.getSaksnummer()).thenReturn(new Saksnummer("123"));
-        when(behandling.getFagsak()).thenReturn(fag);
+        when(behandling.getSaksnummer()).thenReturn(new Saksnummer("123"));
         var brevmalDtos = brevmalTjeneste.hentBrevmalerFor(behandling);
 
         assertThat(brevmalDtos.stream().map(BrevmalDto::kode).toList()).containsExactlyInAnyOrder(DokumentMalType.VARSEL_OM_REVURDERING.getKode(),
@@ -103,9 +100,7 @@ class BrevmalTjenesteTest {
         when(behandling.getFagsakYtelseType()).thenReturn(FagsakYtelseType.FORELDREPENGER);
         when(behandling.getType()).thenReturn(BehandlingType.REVURDERING);
         when(behandling.erManueltOpprettet()).thenReturn(true);
-        var fag = mock(Fagsak.class);
-        when(fag.getSaksnummer()).thenReturn(new Saksnummer("123"));
-        when(behandling.getFagsak()).thenReturn(fag);
+        when(behandling.getSaksnummer()).thenReturn(new Saksnummer("123"));
         var brevmalDtos = brevmalTjeneste.hentBrevmalerFor(behandling);
 
         assertThat(brevmalDtos.stream().map(BrevmalDto::kode).toList()).containsExactlyInAnyOrder(DokumentMalType.VARSEL_OM_REVURDERING.getKode(),
@@ -128,9 +123,7 @@ class BrevmalTjenesteTest {
         when(behandling.getFagsakYtelseType()).thenReturn(FagsakYtelseType.FORELDREPENGER);
         when(behandling.getType()).thenReturn(BehandlingType.REVURDERING);
         when(behandling.erManueltOpprettet()).thenReturn(true);
-        var fag = mock(Fagsak.class);
-        when(fag.getSaksnummer()).thenReturn(new Saksnummer("123"));
-        when(behandling.getFagsak()).thenReturn(fag);
+        when(behandling.getSaksnummer()).thenReturn(new Saksnummer("123"));
         var brevmalDtos = brevmalTjeneste.hentBrevmalerFor(behandling);
 
         assertThat(brevmalDtos.stream().map(BrevmalDto::kode).toList()).containsExactlyInAnyOrder(DokumentMalType.VARSEL_OM_REVURDERING.getKode(),
@@ -150,9 +143,7 @@ class BrevmalTjenesteTest {
         when(behandling.getFagsakYtelseType()).thenReturn(FagsakYtelseType.FORELDREPENGER);
         when(behandling.getType()).thenReturn(BehandlingType.REVURDERING);
         when(behandling.erManueltOpprettet()).thenReturn(true);
-        var fag = mock(Fagsak.class);
-        when(fag.getSaksnummer()).thenReturn(new Saksnummer("123"));
-        when(behandling.getFagsak()).thenReturn(fag);
+        when(behandling.getSaksnummer()).thenReturn(new Saksnummer("123"));
         when(dokumentBehandlingTjeneste.erDokumentBestilt(anyLong(), eq(DokumentMalType.VARSEL_OM_REVURDERING))).thenReturn(true);
 
         var brevmalDtos = brevmalTjeneste.hentBrevmalerFor(behandling);
@@ -224,9 +215,7 @@ class BrevmalTjenesteTest {
         var behandling = mock(Behandling.class);
         when(behandling.getFagsakYtelseType()).thenReturn(foreldrepenger);
         when(behandling.getType()).thenReturn(BehandlingType.FØRSTEGANGSSØKNAD);
-        var fag = mock(Fagsak.class);
-        when(fag.getSaksnummer()).thenReturn(new Saksnummer("123"));
-        when(behandling.getFagsak()).thenReturn(fag);
+        when(behandling.getSaksnummer()).thenReturn(new Saksnummer("123"));
         return behandling;
     }
 }

--- a/domenetjenester/dokumentbestiller/src/test/java/no/nav/foreldrepenger/dokumentbestiller/infobrev/SendInformasjonsbrevPåminnelseBatchTjenesteTest.java
+++ b/domenetjenester/dokumentbestiller/src/test/java/no/nav/foreldrepenger/dokumentbestiller/infobrev/SendInformasjonsbrevPåminnelseBatchTjenesteTest.java
@@ -31,6 +31,7 @@ import no.nav.foreldrepenger.behandlingslager.uttak.fp.Stønadskontoberegning;
 import no.nav.foreldrepenger.dbstoette.CdiDbAwareTest;
 import no.nav.foreldrepenger.domene.typer.AktørId;
 import no.nav.foreldrepenger.domene.typer.PersonIdent;
+import no.nav.foreldrepenger.domene.typer.Saksnummer;
 import no.nav.foreldrepenger.familiehendelse.FamilieHendelseTjeneste;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTaskTjeneste;
 
@@ -170,7 +171,7 @@ class SendInformasjonsbrevPåminnelseBatchTjenesteTest {
         repositoryProvider.getFagsakRelasjonRepository().opprettRelasjon(behandlingMor.getFagsak());
         repositoryProvider.getFagsakRelasjonRepository().lagre(behandlingMor.getFagsak(), kontoMor.build());
 
-        var fagsakFar = Fagsak.opprettNy(FagsakYtelseType.FORELDREPENGER, NavBruker.opprettNyNB(aktørIdFar));
+        var fagsakFar = Fagsak.opprettNy(FagsakYtelseType.FORELDREPENGER, NavBruker.opprettNyNB(aktørIdFar), new Saksnummer("9999"));
         repositoryProvider.getFagsakRepository().opprettNy(fagsakFar);
         var behandlingFar = Behandling.forFørstegangssøknad(fagsakFar).medBehandlendeEnhet(new OrganisasjonsEnhet("1000", "Enheten")).build();
         lås = behandlingRepository.taSkriveLås(behandlingFar);

--- a/domenetjenester/familie-hendelse/src/main/java/no/nav/foreldrepenger/familiehendelse/event/FamiliehendelseEventPubliserer.java
+++ b/domenetjenester/familie-hendelse/src/main/java/no/nav/foreldrepenger/familiehendelse/event/FamiliehendelseEventPubliserer.java
@@ -29,7 +29,7 @@ public class FamiliehendelseEventPubliserer {
     public void fireEventTerminFødsel(Long behandlingId, LocalDate forrigeBekreftetDato, LocalDate sisteBekreftetDato) {
         var behandling = behandlingRepository.hentBehandling(behandlingId);
         var event = new FamiliehendelseEvent(FamiliehendelseEvent.EventType.TERMIN_TIL_FØDSEL,
-            behandling.getAktørId(), behandling.getFagsakId(), behandling.getId(), behandling.getFagsakYtelseType(),
+            behandling.getSaksnummer(), behandling.getFagsakId(), behandling.getId(), behandling.getFagsakYtelseType(),
             forrigeBekreftetDato, sisteBekreftetDato);
         familiehendelseEvent.fire(event);
     }

--- a/domenetjenester/familie-hendelse/src/test/java/no/nav/foreldrepenger/familiehendelse/kontrollerfakta/adopsjon/AksjonspunktUtlederForForeldrepengerAdopsjonTest.java
+++ b/domenetjenester/familie-hendelse/src/test/java/no/nav/foreldrepenger/familiehendelse/kontrollerfakta/adopsjon/AksjonspunktUtlederForForeldrepengerAdopsjonTest.java
@@ -22,7 +22,6 @@ import no.nav.foreldrepenger.behandlingskontroll.AksjonspunktResultat;
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
 import no.nav.foreldrepenger.behandlingslager.behandling.familiehendelse.FamilieHendelseGrunnlagBuilder;
 import no.nav.foreldrepenger.behandlingslager.behandling.familiehendelse.FamilieHendelseRepository;
-import no.nav.foreldrepenger.behandlingslager.fagsak.Fagsak;
 import no.nav.foreldrepenger.behandlingslager.testutilities.behandling.ScenarioMorSøkerForeldrepenger;
 import no.nav.foreldrepenger.familiehendelse.FamilieHendelseTjeneste;
 
@@ -52,9 +51,7 @@ class AksjonspunktUtlederForForeldrepengerAdopsjonTest {
 
     @Test
     void skal_utlede_aksjonspunkt_basert_på_fakta_om_fp_til_mor() {
-        var fagsakMock = mock(Fagsak.class);
         var behandlingMock = mock(Behandling.class);
-        when(behandlingMock.getFagsak()).thenReturn(fagsakMock);
 
         var aksjonspunkter = aksjonspunktForFakta(behandlingMock);
 
@@ -65,9 +62,7 @@ class AksjonspunktUtlederForForeldrepengerAdopsjonTest {
 
     @Test
     void skal_utlede_aksjonspunkt_basert_på_fakta_om_fp_til_far() {
-        var fagsakMock = mock(Fagsak.class);
         var behandlingMock = mock(Behandling.class);
-        when(behandlingMock.getFagsak()).thenReturn(fagsakMock);
         var aksjonspunkter = aksjonspunktForFakta(behandlingMock);
 
         assertThat(aksjonspunkter).hasSize(2);
@@ -77,9 +72,7 @@ class AksjonspunktUtlederForForeldrepengerAdopsjonTest {
 
     @Test
     void skal_utlede_aksjonspunkt_basert_på_fakta_om_fp_til_medmor() {
-        var fagsakMock = mock(Fagsak.class);
         var behandlingMock = mock(Behandling.class);
-        when(behandlingMock.getFagsak()).thenReturn(fagsakMock);
         var aksjonspunkter = aksjonspunktForFakta(behandlingMock);
 
         assertThat(aksjonspunkter).hasSize(2);

--- a/domenetjenester/inngangsvilkar/src/test/java/no/nav/foreldrepenger/inngangsvilkaar/opptjening/YtelseMaksdatoTjenesteTest.java
+++ b/domenetjenester/inngangsvilkar/src/test/java/no/nav/foreldrepenger/inngangsvilkaar/opptjening/YtelseMaksdatoTjenesteTest.java
@@ -63,7 +63,7 @@ class YtelseMaksdatoTjenesteTest extends EntityManagerAwareTest {
     @Test
     void finnesIngenVedtattBehandlingForMorSkalReturnereOptionalEmpty() {
         var behandling = ScenarioFarSøkerForeldrepenger.forFødsel().lagre(repositoryProvider);
-        var morsMaksdato = ytelseMaksdatoTjeneste.beregnMorsMaksdato(behandling.getFagsak().getSaksnummer(), behandling.getRelasjonsRolleType());
+        var morsMaksdato = ytelseMaksdatoTjeneste.beregnMorsMaksdato(behandling.getSaksnummer(), behandling.getRelasjonsRolleType());
         assertThat(morsMaksdato).isEmpty();
     }
 
@@ -128,7 +128,7 @@ class YtelseMaksdatoTjenesteTest extends EntityManagerAwareTest {
         repositoryProvider.getFagsakRelasjonRepository().kobleFagsaker(morsBehandling.getFagsak(), farsBehandling.getFagsak());
 
         // Act
-        var morsMaksdato = ytelseMaksdatoTjeneste.beregnMorsMaksdato(farsBehandling.getFagsak().getSaksnummer(), farsBehandling.getRelasjonsRolleType());
+        var morsMaksdato = ytelseMaksdatoTjeneste.beregnMorsMaksdato(farsBehandling.getSaksnummer(), farsBehandling.getRelasjonsRolleType());
 
         // Assert
         assertThat(morsMaksdato).isPresent();
@@ -191,7 +191,7 @@ class YtelseMaksdatoTjenesteTest extends EntityManagerAwareTest {
         repositoryProvider.getFagsakRelasjonRepository().kobleFagsaker(morsBehandling.getFagsak(), farsBehandling.getFagsak());
 
         // Act
-        var morsMaksdato = ytelseMaksdatoTjeneste.beregnMorsMaksdato(farsBehandling.getFagsak().getSaksnummer(), farsBehandling.getRelasjonsRolleType());
+        var morsMaksdato = ytelseMaksdatoTjeneste.beregnMorsMaksdato(farsBehandling.getSaksnummer(), farsBehandling.getRelasjonsRolleType());
 
         // Assert
         assertThat(morsMaksdato).isPresent();
@@ -244,7 +244,7 @@ class YtelseMaksdatoTjenesteTest extends EntityManagerAwareTest {
         repositoryProvider.getFagsakRelasjonRepository().kobleFagsaker(morsBehandling.getFagsak(), farsBehandling.getFagsak());
 
         // Act
-        var morsMaksdato = ytelseMaksdatoTjeneste.beregnMorsMaksdato(farsBehandling.getFagsak().getSaksnummer(), farsBehandling.getRelasjonsRolleType());
+        var morsMaksdato = ytelseMaksdatoTjeneste.beregnMorsMaksdato(farsBehandling.getSaksnummer(), farsBehandling.getRelasjonsRolleType());
 
         // Assert
         assertThat(morsMaksdato).isEmpty();

--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/dokumentmottak/SaksbehandlingDokumentmottakTjeneste.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/dokumentmottak/SaksbehandlingDokumentmottakTjeneste.java
@@ -9,6 +9,7 @@ import org.slf4j.LoggerFactory;
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingÅrsakType;
 import no.nav.foreldrepenger.behandlingslager.behandling.MottattDokument;
+import no.nav.foreldrepenger.domene.typer.Saksnummer;
 import no.nav.foreldrepenger.mottak.dokumentmottak.impl.HåndterMottattDokumentTask;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTaskData;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTaskTjeneste;
@@ -32,12 +33,12 @@ public class SaksbehandlingDokumentmottakTjeneste {
         this.mottatteDokumentTjeneste = mottatteDokumentTjeneste;
     }
 
-    public void dokumentAnkommet(MottattDokument mottattDokument, BehandlingÅrsakType behandlingÅrsakType) {
+    public void dokumentAnkommet(MottattDokument mottattDokument, BehandlingÅrsakType behandlingÅrsakType, Saksnummer saksnummer) {
 
         var mottattDokumentId = mottatteDokumentTjeneste.lagreMottattDokumentPåFagsak(mottattDokument);
 
         var prosessTaskData = ProsessTaskData.forProsessTask(HåndterMottattDokumentTask.class);
-        prosessTaskData.setFagsakId(mottattDokument.getFagsakId());
+        prosessTaskData.setFagsak(saksnummer.getVerdi(), mottattDokument.getFagsakId());
         prosessTaskData.setProperty(HåndterMottattDokumentTask.MOTTATT_DOKUMENT_ID_KEY, mottattDokumentId.toString());
         settÅrsakHvisDefinert(behandlingÅrsakType, prosessTaskData);
         prosessTaskData.setCallIdFraEksisterende();
@@ -47,17 +48,17 @@ public class SaksbehandlingDokumentmottakTjeneste {
     public void opprettFraTidligereBehandling(MottattDokument mottattDokument, Behandling behandling, BehandlingÅrsakType behandlingÅrsakType) {
         LOG.info("Oppretter håndtermottattdokumenttask fra tidligere behandling {} fagsak {} dokument {}", behandling.getId(), behandling.getFagsakId(), mottattDokument.getId());
         var prosessTaskData = ProsessTaskData.forProsessTask(HåndterMottattDokumentTask.class);
-        prosessTaskData.setBehandling(behandling.getFagsakId(), behandling.getId(), behandling.getAktørId().getId());
+        prosessTaskData.setBehandling(behandling.getSaksnummer().getVerdi(), behandling.getFagsakId(), behandling.getId());
         prosessTaskData.setProperty(HåndterMottattDokumentTask.MOTTATT_DOKUMENT_ID_KEY, mottattDokument.getId().toString());
         settÅrsakHvisDefinert(behandlingÅrsakType, prosessTaskData);
         prosessTaskData.setCallIdFraEksisterende();
         taskTjeneste.lagre(prosessTaskData);
     }
 
-    public void mottaUbehandletSøknad(MottattDokument mottattDokument, BehandlingÅrsakType behandlingÅrsakType) {
+    public void mottaUbehandletSøknad(MottattDokument mottattDokument, BehandlingÅrsakType behandlingÅrsakType, Saksnummer saksnummer) {
         var prosessTaskData = ProsessTaskData.forProsessTask(HåndterMottattDokumentTask.class);
 
-        prosessTaskData.setFagsakId(mottattDokument.getFagsakId());
+        prosessTaskData.setFagsak(saksnummer.getVerdi(), mottattDokument.getFagsakId());
         prosessTaskData.setProperty(HåndterMottattDokumentTask.MOTTATT_DOKUMENT_ID_KEY, mottattDokument.getId().toString());
         settÅrsakHvisDefinert(behandlingÅrsakType, prosessTaskData);
         prosessTaskData.setCallIdFraEksisterende();

--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/dokumentmottak/impl/DokumentmottakerFelles.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/dokumentmottak/impl/DokumentmottakerFelles.java
@@ -84,7 +84,7 @@ public class DokumentmottakerFelles {
 
     void opprettTaskForÅStarteBehandling(Behandling behandling) {
         var prosessTaskData = ProsessTaskData.forProsessTask(StartBehandlingTask.class);
-        prosessTaskData.setBehandling(behandling.getFagsakId(), behandling.getId(), behandling.getAktørId().getId());
+        prosessTaskData.setBehandling(behandling.getSaksnummer().getVerdi(), behandling.getFagsakId(), behandling.getId());
         prosessTaskData.setCallIdFraEksisterende();
         taskTjeneste.lagre(prosessTaskData);
     }
@@ -96,7 +96,7 @@ public class DokumentmottakerFelles {
             .ifPresent(jpid -> prosessTaskData.setProperty(OpprettOppgaveVurderDokumentTask.KEY_JOURNALPOST_ID, jpid));
         prosessTaskData.setProperty(OpprettOppgaveVurderDokumentTask.KEY_BEHANDLENDE_ENHET, behandlendeEnhetsId);
         prosessTaskData.setProperty(OpprettOppgaveVurderDokumentTask.KEY_DOKUMENT_TYPE, mottattDokument.getDokumentType().getKode());
-        prosessTaskData.setFagsak(fagsak.getId(), fagsak.getAktørId().getId());
+        prosessTaskData.setFagsak(fagsak.getSaksnummer().getVerdi(), fagsak.getId());
         prosessTaskData.setCallIdFraEksisterende();
         taskTjeneste.lagre(prosessTaskData);
     }

--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/hendelser/ForretningshendelseMottak.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/hendelser/ForretningshendelseMottak.java
@@ -161,7 +161,7 @@ public class ForretningshendelseMottak {
         var taskData = ProsessTaskData.forProsessTask(MottaHendelseFagsakTask.class);
         taskData.setProperty(MottaHendelseFagsakTask.PROPERTY_HENDELSE_TYPE, hendelseType.getKode());
         taskData.setProperty(MottaHendelseFagsakTask.PROPERTY_ÅRSAK_TYPE, behandlingÅrsakType.getKode());
-        taskData.setFagsakId(fagsak.getId());
+        taskData.setFagsak(fagsak.getSaksnummer().getVerdi(), fagsak.getId());
         taskData.setCallIdFraEksisterende();
         if (IS_PROD && LocalTime.now().isBefore(OPPDRAG_VÅKNER)) {
             // Porsjoner utover neste 7 min
@@ -198,7 +198,7 @@ public class ForretningshendelseMottak {
 
     private ProsessTaskData opprettOppdaterEnhetTask(Behandling behandling) {
         var prosessTaskData = ProsessTaskData.forProsessTask(OppdaterBehandlendeEnhetTask.class);
-        prosessTaskData.setBehandling(behandling.getFagsakId(), behandling.getId());
+        prosessTaskData.setBehandling(behandling.getSaksnummer().getVerdi(), behandling.getFagsakId(), behandling.getId());
         prosessTaskData.setCallIdFraEksisterende();
         return prosessTaskData;
     }

--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/kabal/KabalHendelseHåndterer.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/kabal/KabalHendelseHåndterer.java
@@ -117,7 +117,7 @@ public class KabalHendelseHåndterer implements KafkaMessageHandler.KafkaStringM
         }
 
         var task = ProsessTaskData.forProsessTask(MottaFraKabalTask.class);
-        task.setBehandling(behandling.getFagsakId(), behandling.getId(), behandling.getAktørId().getId());
+        task.setBehandling(behandling.getSaksnummer().getVerdi(), behandling.getFagsakId(), behandling.getId());
         task.setCallIdFraEksisterende();
         task.setProperty(MottaFraKabalTask.HENDELSETYPE_KEY, mottattHendelse.type().name());
         task.setProperty(MottaFraKabalTask.KABALREF_KEY, mottattHendelse.kabalReferanse());
@@ -157,7 +157,7 @@ public class KabalHendelseHåndterer implements KafkaMessageHandler.KafkaStringM
         opprettOppgave.setProperty(OpprettOppgaveVurderKonsekvensTask.KEY_BESKRIVELSE, beskrivelse);
         opprettOppgave.setProperty(OpprettOppgaveVurderKonsekvensTask.KEY_PRIORITET, OpprettOppgaveVurderKonsekvensTask.PRIORITET_HØY);
         opprettOppgave.setCallIdFraEksisterende();
-        opprettOppgave.setBehandling(behandling.getFagsakId(), behandling.getId(), behandling.getAktørId().getId());
+        opprettOppgave.setBehandling(behandling.getSaksnummer().getVerdi(), behandling.getFagsakId(), behandling.getId());
         taskTjeneste.lagre(opprettOppgave);
     }
 

--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/sakskompleks/BerørtBehandlingKontroller.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/sakskompleks/BerørtBehandlingKontroller.java
@@ -130,7 +130,7 @@ public class BerørtBehandlingKontroller {
         var medforelderDekningsgrad = ytelseFordelingTjeneste.hentAggregat(behandlingMedforelder.getId()).getGjeldendeDekningsgrad();
         var ulikDekningsgrad = !Objects.equals(vedtattDekningsgrad, medforelderDekningsgrad);
         if (avsluttetErEndreDekningsgrad && ulikDekningsgrad) {
-            LOG.warn("Endre dekningsgrad potensiell cascade avsluttet behandlingId {} sak medforelder {}", vedtattBehandling.getId(), behandlingMedforelder.getFagsak().getSaksnummer());
+            LOG.warn("Endre dekningsgrad potensiell cascade avsluttet behandlingId {} sak medforelder {}", vedtattBehandling.getId(), behandlingMedforelder.getSaksnummer());
             return false;
         }
         return ulikDekningsgrad;

--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/sakskompleks/KobleSakerTjeneste.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/sakskompleks/KobleSakerTjeneste.java
@@ -98,7 +98,7 @@ public class KobleSakerTjeneste {
         // Håndter utfall
         if (aktuelleFagsaker.isEmpty()) {
             if (!RelasjonsRolleType.erMor(behandling.getFagsak().getRelasjonsRolleType())) {
-                LOG.info("KobleSak: Finner ikke sak å koble med for ikke-mor i sak {} rolle {}", behandling.getFagsak().getSaksnummer(),
+                LOG.info("KobleSak: Finner ikke sak å koble med for ikke-mor i sak {} rolle {}", behandling.getSaksnummer(),
                     behandling.getFagsak().getRelasjonsRolleType().getKode());
             }
             return Optional.empty();

--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/sakskompleks/KøKontroller.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/sakskompleks/KøKontroller.java
@@ -5,6 +5,7 @@ import java.util.Optional;
 import jakarta.enterprise.context.Dependent;
 import jakarta.inject.Inject;
 
+import no.nav.foreldrepenger.behandling.BehandlingRevurderingTjeneste;
 import no.nav.foreldrepenger.behandling.revurdering.flytkontroll.BehandlingFlytkontroll;
 import no.nav.foreldrepenger.behandlingskontroll.BehandlingskontrollTjeneste;
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
@@ -15,7 +16,6 @@ import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.Aksjonspun
 import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.Venteårsak;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepositoryProvider;
-import no.nav.foreldrepenger.behandling.BehandlingRevurderingTjeneste;
 import no.nav.foreldrepenger.behandlingslager.behandling.søknad.SøknadEntitet;
 import no.nav.foreldrepenger.behandlingslager.behandling.søknad.SøknadRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.YtelsesFordelingRepository;
@@ -188,7 +188,7 @@ public class KøKontroller {
 
     void lagreOppdaterKøetProsesstask(Behandling behandling) {
         var data = ProsessTaskData.forProsessTask(GjenopptaKøetBehandlingTask.class);
-        data.setBehandling(behandling.getFagsakId(), behandling.getId(), behandling.getAktørId().getId());
+        data.setBehandling(behandling.getSaksnummer().getVerdi(), behandling.getFagsakId(), behandling.getId());
         data.setCallIdFraEksisterende();
         taskTjeneste.lagre(data);
     }

--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/vedtak/kafka/VedtaksHendelseHåndterer.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/vedtak/kafka/VedtaksHendelseHåndterer.java
@@ -154,7 +154,7 @@ public class VedtaksHendelseHåndterer implements KafkaMessageHandler.KafkaStrin
         // Kjøretidspunkt tidlig neste virkedag slik at OS har fordøyd oppdrag fra K9Sak men ikke utbetalt ennå
         var nesteFormiddag = LocalDateTime.of(VirkedagUtil.fomVirkedag(LocalDate.now().plusDays(1)), LocalTime.of(7, 35, 1));
         var prosessTaskData = ProsessTaskData.forProsessTask(HåndterOverlappPleiepengerTask.class);
-        prosessTaskData.setFagsak(f.getId(), f.getAktørId().getId());
+        prosessTaskData.setFagsak(f.getSaksnummer().getVerdi(), f.getId());
         // Gi abakus tid til å konsumere samme hendelse så det finnes et grunnlag å hente opp.
         prosessTaskData.setNesteKjøringEtter(nesteFormiddag);
         prosessTaskData.setCallId(callID.toString());

--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/vedtak/observer/MottaKlageAnkeVedtakTask.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/vedtak/observer/MottaKlageAnkeVedtakTask.java
@@ -103,7 +103,7 @@ public class MottaKlageAnkeVedtakTask extends GenerellProsessTask {
         opprettOppgave.setProperty(OpprettOppgaveVurderKonsekvensTask.KEY_BESKRIVELSE, beskrivelse);
         opprettOppgave.setProperty(OpprettOppgaveVurderKonsekvensTask.KEY_PRIORITET, OpprettOppgaveVurderKonsekvensTask.PRIORITET_HØY);
         opprettOppgave.setCallIdFraEksisterende();
-        opprettOppgave.setBehandling(sisteYtelseBehandling.getFagsakId(), sisteYtelseBehandling.getId(), sisteYtelseBehandling.getAktørId().getId());
+        opprettOppgave.setBehandling(sisteYtelseBehandling.getSaksnummer().getVerdi(), sisteYtelseBehandling.getFagsakId(), sisteYtelseBehandling.getId());
         taskTjeneste.lagre(opprettOppgave);
     }
 

--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/vedtak/observer/VedtaksHendelseObserver.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/vedtak/observer/VedtaksHendelseObserver.java
@@ -65,7 +65,7 @@ public class VedtaksHendelseObserver {
 
     void lagreProsesstaskFor(Behandling behandling, TaskType taskType, int delaysecs) {
         var data = ProsessTaskData.forTaskType(taskType);
-        data.setBehandling(behandling.getFagsakId(), behandling.getId(), behandling.getAktørId().getId());
+        data.setBehandling(behandling.getSaksnummer().getVerdi(), behandling.getFagsakId(), behandling.getId());
         data.setCallId(behandling.getUuid().toString());
         data.setNesteKjøringEtter(LocalDateTime.now().plusSeconds(delaysecs));
         taskTjeneste.lagre(data);

--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/vedtak/overlapp/HåndterOpphørAvYtelser.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/vedtak/overlapp/HåndterOpphørAvYtelser.java
@@ -22,6 +22,7 @@ import no.nav.foreldrepenger.behandlingslager.fagsak.Fagsak;
 import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakLåsRepository;
 import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakYtelseType;
 import no.nav.foreldrepenger.behandlingsprosess.prosessering.BehandlingProsesseringTjeneste;
+import no.nav.foreldrepenger.domene.typer.Saksnummer;
 import no.nav.foreldrepenger.mottak.dokumentmottak.impl.Kompletthetskontroller;
 import no.nav.foreldrepenger.mottak.sakskompleks.KøKontroller;
 import no.nav.foreldrepenger.produksjonsstyring.behandlingenhet.BehandlendeEnhetTjeneste;
@@ -106,7 +107,7 @@ public class HåndterOpphørAvYtelser {
 
     private void opprettVurderKonsekvens(Behandling behandling, String beskrivelse) {
         var enhet = utledEnhetFraBehandling(behandling);
-        opprettTaskForÅVurdereKonsekvens(behandling.getFagsakId(), enhet.enhetId(), beskrivelse);
+        opprettTaskForÅVurdereKonsekvens(behandling.getSaksnummer(), behandling.getFagsakId(), enhet.enhetId(), beskrivelse);
     }
 
     private Behandling opprettRevurdering(Fagsak sakRevurdering, BehandlingÅrsakType behandlingÅrsakType, OrganisasjonsEnhet enhet, boolean skalKøes) {
@@ -125,12 +126,12 @@ public class HåndterOpphørAvYtelser {
         return FagsakYtelseType.SVANGERSKAPSPENGER.equals(fagsak.getYtelseType()) ? revurderingTjenesteSVP : revurderingTjenesteFP;
     }
 
-    private void opprettTaskForÅVurdereKonsekvens(Long fagsakId, String behandlendeEnhetsId, String oppgaveBeskrivelse) {
+    private void opprettTaskForÅVurdereKonsekvens(Saksnummer saksnummer, Long fagsakId, String behandlendeEnhetsId, String oppgaveBeskrivelse) {
         var prosessTaskData = ProsessTaskData.forProsessTask(OpprettOppgaveVurderKonsekvensTask.class);
         prosessTaskData.setProperty(OpprettOppgaveVurderKonsekvensTask.KEY_BEHANDLENDE_ENHET, behandlendeEnhetsId);
         prosessTaskData.setProperty(OpprettOppgaveVurderKonsekvensTask.KEY_BESKRIVELSE, oppgaveBeskrivelse);
         prosessTaskData.setProperty(OpprettOppgaveVurderKonsekvensTask.KEY_PRIORITET, OpprettOppgaveVurderKonsekvensTask.PRIORITET_HØY);
-        prosessTaskData.setFagsakId(fagsakId);
+        prosessTaskData.setFagsak(saksnummer.getVerdi(), fagsakId);
         prosessTaskData.setCallIdFraEksisterende();
         taskTjeneste.lagre(prosessTaskData);
     }

--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/vedtak/overlapp/LoggOverlappEksterneYtelserTjeneste.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/vedtak/overlapp/LoggOverlappEksterneYtelserTjeneste.java
@@ -15,8 +15,6 @@ import java.util.Set;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 
-import no.nav.foreldrepenger.behandling.BehandlingReferanse;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -24,6 +22,7 @@ import no.nav.abakus.vedtak.ytelse.Desimaltall;
 import no.nav.abakus.vedtak.ytelse.Kildesystem;
 import no.nav.abakus.vedtak.ytelse.Ytelser;
 import no.nav.abakus.vedtak.ytelse.v1.YtelseV1;
+import no.nav.foreldrepenger.behandling.BehandlingReferanse;
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
 import no.nav.foreldrepenger.behandlingslager.behandling.beregning.BeregningsresultatEntitet;
 import no.nav.foreldrepenger.behandlingslager.behandling.beregning.BeregningsresultatPeriode;
@@ -137,7 +136,7 @@ public class LoggOverlappEksterneYtelserTjeneste {
                 var overlapp = finnGradertOverlapp(fpTimeline, Fagsystem.K9SAK, mapAbakusYtelseType(ytelse),
                     ytelse.getSaksnummer(), ytelseTidslinje);
                 overlapp.stream()
-                    .map(builder -> builder.medSaksnummer(b.getFagsak().getSaksnummer())
+                    .map(builder -> builder.medSaksnummer(b.getSaksnummer())
                         .medBehandlingId(b.getId())
                         .medHendelse(OverlappVedtak.HENDELSE_VEDTAK_OMS))
                     .forEach(overlappRepository::lagre);
@@ -170,7 +169,7 @@ public class LoggOverlappEksterneYtelserTjeneste {
         vurderOmOverlappOMS(ref.aktørId(), tidligsteUttakFP, perioderFpGradert, overlappene);
         vurderOmOverlappSYK(ident, tidligsteUttakFP, perioderFpGradert, overlappene);
         return overlappene.stream()
-            .map(b -> b.medSaksnummer(behandling.getFagsak().getSaksnummer()).medBehandlingId(ref.behandlingId()))
+            .map(b -> b.medSaksnummer(behandling.getSaksnummer()).medBehandlingId(ref.behandlingId()))
             .toList();
     }
 

--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/vedtak/overlapp/VurderOpphørAvYtelser.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/vedtak/overlapp/VurderOpphørAvYtelser.java
@@ -112,7 +112,7 @@ public class VurderOpphørAvYtelser {
 
     private void opprettTaskForÅHåndtereOpphør(Fagsak sakOpphør, Fagsak fersktVedtak) {
         var prosessTaskData = ProsessTaskData.forProsessTask(HåndterOpphørAvYtelserTask.class);
-        prosessTaskData.setFagsakId(sakOpphør.getId());
+        prosessTaskData.setFagsak(sakOpphør.getSaksnummer().getVerdi(), sakOpphør.getId());
         prosessTaskData.setProperty(HåndterOpphørAvYtelserTask.BESKRIVELSE_KEY, String.format("Overlapp identifisert: Vurder saksnr %s vedtak i saksnr %s", sakOpphør.getSaksnummer(), fersktVedtak.getSaksnummer()));
         prosessTaskData.setCallIdFraEksisterende();
         taskTjeneste.lagre(prosessTaskData);
@@ -123,12 +123,12 @@ public class VurderOpphørAvYtelser {
 
         //dersom to tette fødsler skal vi opprette VKY for at SB må ta stilling til eventuelt gjenstående minsterett ellers ikke
         if (toTetteFødsler(sakOpphør, iverksattBehandling) && overlappendeYtelse(sakOpphør, iverksattBehandling)) {
-            prosessTaskData.setProperty(HåndterOpphørAvYtelserTask.BESKRIVELSE_KEY, String.format("Overlapp på sak med minsterett ved tette fødsler identifisert: Vurder om sak %s har brukt opp minsteretten, og skal opphøres pga ny sak %s", sakOpphør.getSaksnummer(), iverksattBehandling.getFagsak().getSaksnummer()));
+            prosessTaskData.setProperty(HåndterOpphørAvYtelserTask.BESKRIVELSE_KEY, String.format("Overlapp på sak med minsterett ved tette fødsler identifisert: Vurder om sak %s har brukt opp minsteretten, og skal opphøres pga ny sak %s", sakOpphør.getSaksnummer(), iverksattBehandling.getSaksnummer()));
         } else {
             prosessTaskData.setProperty(HåndterOpphørAvYtelserTask.BESKRIVELSE_KEY, null);
         }
 
-        prosessTaskData.setFagsakId(sakOpphør.getId());
+        prosessTaskData.setFagsak(sakOpphør.getSaksnummer().getVerdi(), sakOpphør.getId());
         prosessTaskData.setCallIdFraEksisterende();
         taskTjeneste.lagre(prosessTaskData);
     }
@@ -207,7 +207,7 @@ public class VurderOpphørAvYtelser {
         return fagsakRepository.hentForBruker(behandlingIVB.getAktørId())
             .stream()
             .filter(f -> VURDER_OVERLAPP.contains(f.getYtelseType()))
-            .filter(f -> !behandlingIVB.getFagsak().getSaksnummer().equals(f.getSaksnummer()))
+            .filter(f -> !behandlingIVB.getSaksnummer().equals(f.getSaksnummer()))
             .flatMap(f -> sjekkOverlappMotIverksattSvangerskapspenger(f, behandlingIVB, stønadsperiodeIVB).stream())
             .toList();
     }
@@ -217,7 +217,7 @@ public class VurderOpphørAvYtelser {
         var overlapp = stønadsperiodeTjeneste.utbetalingsperiodeEnkeltSak(sjekkFagsak)
             .filter(utbetalingsperiode -> utbetalingsperiode.overlaps(stønadsperiodeIVB));
         if (overlapp.isEmpty()) return Optional.empty();
-        var saksnummer = behandlingIVB.getFagsak().getSaksnummer();
+        var saksnummer = behandlingIVB.getSaksnummer();
         if (FagsakYtelseType.SVANGERSKAPSPENGER.equals(sjekkFagsak.getYtelseType())) {
             LOG.info("Overlapp SVP oppdaget for sak {} med løpende SVP-sak {}. Ingen revurdering opprettet", saksnummer, sjekkFagsak.getSaksnummer());
             return Optional.empty();

--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/vurderfagsystem/VurderFagsystemFellesUtils.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/vurderfagsystem/VurderFagsystemFellesUtils.java
@@ -374,7 +374,7 @@ public class VurderFagsystemFellesUtils {
      */
     private boolean kanFagsakUtenGrunnlagBrukesForDokument(VurderFagsystem vurderFagsystem, Behandling sisteBehandling) {
         var innkommendeReferanseDato = getReferanseDatoFraInnkommendeForVurdering(vurderFagsystem);
-        var alleInntektsmeldinger = inntektsmeldingTjeneste.hentAlleInntektsmeldingerForFagsakInkludertInaktive(sisteBehandling.getFagsak().getSaksnummer());
+        var alleInntektsmeldinger = inntektsmeldingTjeneste.hentAlleInntektsmeldingerForFagsakInkludertInaktive(sisteBehandling.getSaksnummer());
         if (alleInntektsmeldinger.isEmpty()) {
             // Unngå gjenbruk av flere år gamle saker
             var behandlingRefDato = Optional.ofNullable(sisteBehandling.getAvsluttetDato()).map(LocalDateTime::toLocalDate).orElseGet(LocalDate::now);
@@ -452,14 +452,14 @@ public class VurderFagsystemFellesUtils {
             .flatMap(f -> behandlingRepository.hentSisteBehandlingAvBehandlingTypeForFagsakId(f.getId(), BehandlingType.KLAGE).stream())
             .filter(Objects::nonNull)
             .filter(b -> b.getAvsluttetDato() == null || b.getAvsluttetDato().isAfter(LocalDateTime.now().minusYears(2)))
-            .map(b -> b.getFagsak().getSaksnummer())
+            .map(b -> b.getSaksnummer())
             .collect(Collectors.toSet());
 
         // Først sjekk om det finnes saker med diffus klagehistorikk
         if (sakerMedKjenteNyereKlager.size() > 1) {
             LOG.info("VFS-KLAGE flere klager i VL saksnummer {}", sakerMedKjenteNyereKlager);
             return Optional.empty();
-        } else if (sakerMedKjenteNyereKlager.size() == 1 && (behandlinger.isEmpty() || behandlinger.stream().noneMatch(b -> sakerMedKjenteNyereKlager.contains(b.getFagsak().getSaksnummer())))) {
+        } else if (sakerMedKjenteNyereKlager.size() == 1 && (behandlinger.isEmpty() || behandlinger.stream().noneMatch(b -> sakerMedKjenteNyereKlager.contains(b.getSaksnummer())))) {
             LOG.info("VFS-KLAGE eldre klage i VL saksnummer {}", sakerMedKjenteNyereKlager);
             return Optional.empty();
         }
@@ -482,7 +482,7 @@ public class VurderFagsystemFellesUtils {
             LOG.info("VFS-KLAGE flere saker - antall saker {} saker med klage {} saksnummer {}", sakerTilVurdering.size(), sakerMedKlage, saker);
         }
         return behandlinger.size() != 1 ? Optional.empty() :
-            Optional.of(new BehandlendeFagsystem(VEDTAKSLØSNING, behandlinger.get(0).getFagsak().getSaksnummer()));
+            Optional.of(new BehandlendeFagsystem(VEDTAKSLØSNING, behandlinger.get(0).getSaksnummer()));
     }
 
     public static boolean erSøknad(VurderFagsystem vurderFagsystem) {

--- a/domenetjenester/mottak/src/test/java/no/nav/foreldrepenger/mottak/dokumentmottak/api/SaksbehandlingDokumentmottakTjenesteTest.java
+++ b/domenetjenester/mottak/src/test/java/no/nav/foreldrepenger/mottak/dokumentmottak/api/SaksbehandlingDokumentmottakTjenesteTest.java
@@ -19,6 +19,7 @@ import no.nav.foreldrepenger.behandlingslager.behandling.DokumentTypeId;
 import no.nav.foreldrepenger.behandlingslager.behandling.MottattDokument;
 import no.nav.foreldrepenger.domene.typer.AktørId;
 import no.nav.foreldrepenger.domene.typer.JournalpostId;
+import no.nav.foreldrepenger.domene.typer.Saksnummer;
 import no.nav.foreldrepenger.mottak.dokumentmottak.MottatteDokumentTjeneste;
 import no.nav.foreldrepenger.mottak.dokumentmottak.SaksbehandlingDokumentmottakTjeneste;
 import no.nav.foreldrepenger.mottak.dokumentmottak.impl.HåndterMottattDokumentTask;
@@ -63,7 +64,7 @@ class SaksbehandlingDokumentmottakTjenesteTest {
         var captor = ArgumentCaptor.forClass(ProsessTaskData.class);
 
         // Act
-        saksbehandlingDokumentmottakTjeneste.dokumentAnkommet(saksdokument, null);
+        saksbehandlingDokumentmottakTjeneste.dokumentAnkommet(saksdokument, null, new Saksnummer("9999"));
 
         // Assert
         verify(mottatteDokumentTjeneste).lagreMottattDokumentPåFagsak(saksdokument);
@@ -88,7 +89,7 @@ class SaksbehandlingDokumentmottakTjenesteTest {
         var captor = ArgumentCaptor.forClass(ProsessTaskData.class);
 
         // Act
-        saksbehandlingDokumentmottakTjeneste.dokumentAnkommet(saksdokument, null);
+        saksbehandlingDokumentmottakTjeneste.dokumentAnkommet(saksdokument, null, new Saksnummer("9999"));
         verify(mottatteDokumentTjeneste).lagreMottattDokumentPåFagsak(saksdokument);
 
         // Assert
@@ -109,7 +110,7 @@ class SaksbehandlingDokumentmottakTjenesteTest {
         var captor = ArgumentCaptor.forClass(ProsessTaskData.class);
 
         // Act
-        saksbehandlingDokumentmottakTjeneste.mottaUbehandletSøknad(md1, BehandlingÅrsakType.UDEFINERT);
+        saksbehandlingDokumentmottakTjeneste.mottaUbehandletSøknad(md1, BehandlingÅrsakType.UDEFINERT, new Saksnummer("456"));
 
         // Assert
         verify(taskTjeneste).lagre(captor.capture());
@@ -125,6 +126,7 @@ class SaksbehandlingDokumentmottakTjenesteTest {
         var behandling = mock(Behandling.class);
         when(behandling.getId()).thenReturn(789L);
         when(behandling.getFagsakId()).thenReturn(456L);
+        when(behandling.getSaksnummer()).thenReturn(new Saksnummer("456"));
         when(behandling.getAktørId()).thenReturn(new AktørId("0000000000000"));
         var md1 = new MottattDokument.Builder()
             .medJournalPostId(new JournalpostId("123"))

--- a/domenetjenester/mottak/src/test/java/no/nav/foreldrepenger/mottak/dokumentmottak/impl/DokumentmottakerInntektsmeldingTest.java
+++ b/domenetjenester/mottak/src/test/java/no/nav/foreldrepenger/mottak/dokumentmottak/impl/DokumentmottakerInntektsmeldingTest.java
@@ -209,7 +209,7 @@ class DokumentmottakerInntektsmeldingTest {
         when(revurdering.getId()).thenReturn(10L);
         when(revurdering.getFagsakId()).thenReturn(behandling.getFagsakId());
         when(revurdering.getFagsak()).thenReturn(behandling.getFagsak());
-        when(revurdering.getAktørId()).thenReturn(behandling.getAktørId());
+        when(revurdering.getSaksnummer()).thenReturn(behandling.getSaksnummer());
 
         var dokumentTypeId = DokumentTypeId.INNTEKTSMELDING;
         var mottattDokument = DokumentmottakTestUtil.byggMottattDokument(dokumentTypeId, behandling.getFagsakId(), "", now(), true,
@@ -232,7 +232,7 @@ class DokumentmottakerInntektsmeldingTest {
         var dokumentTypeId = DokumentTypeId.INNTEKTSMELDING;
         var mottattDokument = DokumentmottakTestUtil.byggMottattDokument(dokumentTypeId, 123L, "", now(), true, "123");
         var førstegangsbehandling = mock(Behandling.class);
-        when(førstegangsbehandling.getAktørId()).thenReturn(AktørId.dummy());
+        when(førstegangsbehandling.getSaksnummer()).thenReturn(new Saksnummer("9999"));
         when(behandlingsoppretter.opprettFørstegangsbehandling(fagsak, BehandlingÅrsakType.UDEFINERT, Optional.empty()))
                 .thenReturn(førstegangsbehandling);
 
@@ -276,14 +276,15 @@ class DokumentmottakerInntektsmeldingTest {
     void skal_opprette_køet_behandling_og_kjøre_kompletthet_dersom_køet_behandling_ikke_finnes() {
         // Arrange - opprette fagsak uten behandling
         var aktørId = AktørId.dummy();
-        var fagsak = DokumentmottakTestUtil.byggFagsak(aktørId, RelasjonsRolleType.MORA, NavBrukerKjønn.KVINNE, new Saksnummer("9999"),
+        var saksnummer = new Saksnummer("9999");
+        var fagsak = DokumentmottakTestUtil.byggFagsak(aktørId, RelasjonsRolleType.MORA, NavBrukerKjønn.KVINNE, saksnummer,
                 fagsakRepository);
 
         // Arrange - sett opp opprettelse av køet behandling
         var behandling = mock(Behandling.class);
         // doReturn(fagsak.getId()).when(behandling).getFagsakId();
         doReturn(fagsak).when(behandling).getFagsak();
-        doReturn(aktørId).when(behandling).getAktørId();
+        doReturn(saksnummer).when(behandling).getSaksnummer();
         doReturn(behandling).when(behandlingsoppretter).opprettFørstegangsbehandling(fagsak, BehandlingÅrsakType.RE_ENDRET_INNTEKTSMELDING,
                 Optional.empty());
         /*

--- a/domenetjenester/mottak/src/test/java/no/nav/foreldrepenger/mottak/dokumentmottak/impl/DokumentmottakerKlageTest.java
+++ b/domenetjenester/mottak/src/test/java/no/nav/foreldrepenger/mottak/dokumentmottak/impl/DokumentmottakerKlageTest.java
@@ -193,7 +193,7 @@ class DokumentmottakerKlageTest {
                 .medBehandlingStegStart(BehandlingStegType.FATTE_VEDTAK)
                 .lagre(repositoryProvider);
         var fagsak = behandling.getFagsak();
-        var kontekst = new BehandlingskontrollKontekst(fagsak.getId(), fagsak.getAktørId(),
+        var kontekst = new BehandlingskontrollKontekst(fagsak.getSaksnummer(), fagsak.getId(),
                 behandlingRepository.taSkriveLås(behandling));
 
         Behandlingsresultat.builderForInngangsvilkår()

--- a/domenetjenester/mottak/src/test/java/no/nav/foreldrepenger/mottak/dokumentmottak/impl/DokumentmottakerSøknadDefaultTest.java
+++ b/domenetjenester/mottak/src/test/java/no/nav/foreldrepenger/mottak/dokumentmottak/impl/DokumentmottakerSøknadDefaultTest.java
@@ -129,7 +129,7 @@ class DokumentmottakerSøknadDefaultTest extends EntityManagerAwareTest {
         var mottattDokument = DokumentmottakTestUtil.byggMottattDokument(dokumentTypeId, fagsakId, "", now(), true, null);
 
         var behandlingMock = mock(Behandling.class);
-        when(behandlingMock.getAktørId()).thenReturn(fagsak.getAktørId());
+        when(behandlingMock.getSaksnummer()).thenReturn(fagsak.getSaksnummer());
         when(behandlingsoppretter.opprettFørstegangsbehandling(eq(fagsak), any(), any())).thenReturn(behandlingMock);
 
         // Act
@@ -150,7 +150,7 @@ class DokumentmottakerSøknadDefaultTest extends EntityManagerAwareTest {
         var mottattDokument = DokumentmottakTestUtil.byggMottattPapirsøknad(DokumentTypeId.UDEFINERT, fagsakId, "", now(), true, null);
 
         var behandlingMock = mock(Behandling.class);
-        when(behandlingMock.getAktørId()).thenReturn(fagsak.getAktørId());
+        when(behandlingMock.getSaksnummer()).thenReturn(fagsak.getSaksnummer());
         when(behandlingsoppretter.opprettFørstegangsbehandling(any(), any(), any())).thenReturn(behandlingMock);
 
         // Act
@@ -236,7 +236,7 @@ class DokumentmottakerSøknadDefaultTest extends EntityManagerAwareTest {
         var revurdering = mock(Behandling.class);
         when(revurdering.getId()).thenReturn(10L);
         when(revurdering.getFagsakId()).thenReturn(behandling.getFagsakId());
-        when(revurdering.getAktørId()).thenReturn(behandling.getAktørId());
+        when(revurdering.getSaksnummer()).thenReturn(behandling.getSaksnummer());
         doReturn(revurdering).when(behandlingsoppretter).opprettRevurdering(behandling.getFagsak(), BehandlingÅrsakType.RE_ENDRING_FRA_BRUKER);
 
         // Act
@@ -292,7 +292,7 @@ class DokumentmottakerSøknadDefaultTest extends EntityManagerAwareTest {
 
         // Arrange - mock tjenestekall
         var nyBehandling = mock(Behandling.class);
-        doReturn(fagsak.getAktørId()).when(nyBehandling).getAktørId();
+        doReturn(fagsak.getSaksnummer()).when(nyBehandling).getSaksnummer();
         when(behandlingsoppretter.opprettNyFørstegangsbehandlingMedImOgVedleggFraForrige(eq(fagsak), any(), any(), anyBoolean()))
                 .thenReturn(nyBehandling);
         when(behandlingsoppretter.erAvslåttBehandling(behandling)).thenReturn(Boolean.TRUE);
@@ -313,12 +313,13 @@ class DokumentmottakerSøknadDefaultTest extends EntityManagerAwareTest {
     void skal_opprette_køet_førstegangsbehandling_og_kjøre_kompletthet_dersom_køet_behandling_ikke_finnes_og_ingen_tidligere_behandling_finnes() {
         // Arrange - opprette fagsak uten behandling
         var aktørId = AktørId.dummy();
-        var fagsak = DokumentmottakTestUtil.byggFagsak(aktørId, RelasjonsRolleType.MORA, NavBrukerKjønn.KVINNE, new Saksnummer("9999"),
+        var saksnummer = new Saksnummer("9999");
+        var fagsak = DokumentmottakTestUtil.byggFagsak(aktørId, RelasjonsRolleType.MORA, NavBrukerKjønn.KVINNE, saksnummer,
                 fagsakRepository);
 
         // Arrange - mock tjenestekall
         var nyBehandling = mock(Behandling.class);
-        doReturn(aktørId).when(nyBehandling).getAktørId();
+        doReturn(saksnummer).when(nyBehandling).getSaksnummer();
 
         // Act - send inn søknad
         var fagsakId = fagsak.getId();

--- a/domenetjenester/mottak/src/test/java/no/nav/foreldrepenger/mottak/dokumentmottak/impl/HåndterMottattDokumentTaskTest.java
+++ b/domenetjenester/mottak/src/test/java/no/nav/foreldrepenger/mottak/dokumentmottak/impl/HåndterMottattDokumentTaskTest.java
@@ -28,6 +28,7 @@ import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakYtelseType;
 import no.nav.foreldrepenger.dbstoette.EntityManagerAwareTest;
 import no.nav.foreldrepenger.domene.typer.AktørId;
 import no.nav.foreldrepenger.domene.typer.JournalpostId;
+import no.nav.foreldrepenger.domene.typer.Saksnummer;
 import no.nav.foreldrepenger.mottak.dokumentmottak.MottatteDokumentTjeneste;
 import no.nav.foreldrepenger.mottak.dokumentpersiterer.impl.MottattDokumentPersisterer;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTaskData;
@@ -69,7 +70,7 @@ class HåndterMottattDokumentTaskTest extends EntityManagerAwareTest {
     }
 
     private Fagsak opprettFagsak() {
-        var fagsak = Fagsak.opprettNy(FagsakYtelseType.ENGANGSTØNAD, NavBruker.opprettNyNB(AktørId.dummy()));
+        var fagsak = Fagsak.opprettNy(FagsakYtelseType.ENGANGSTØNAD, NavBruker.opprettNyNB(AktørId.dummy()), new Saksnummer("9999"));
         fagsakRepository.opprettNy(fagsak);
         return fagsak;
     }
@@ -91,7 +92,7 @@ class HåndterMottattDokumentTaskTest extends EntityManagerAwareTest {
         var dokumentId = mottatteDokumentTjeneste.lagreMottattDokumentPåFagsak(mottattDokument);
 
         var prosessTask = ProsessTaskData.forProsessTask(HåndterMottattDokumentTask.class);
-        prosessTask.setFagsakId(fagsak.getId());
+        prosessTask.setFagsak(fagsak.getSaksnummer().getVerdi(), fagsak.getId());
         prosessTask.setProperty(HåndterMottattDokumentTask.MOTTATT_DOKUMENT_ID_KEY, dokumentId.toString());
         prosessTask.setProperty(HåndterMottattDokumentTask.BEHANDLING_ÅRSAK_TYPE_KEY, BehandlingÅrsakType.UDEFINERT.getKode());
         var captor = ArgumentCaptor.forClass(MottattDokument.class);
@@ -121,7 +122,7 @@ class HåndterMottattDokumentTaskTest extends EntityManagerAwareTest {
         var dokumentId = mottatteDokumentTjeneste.lagreMottattDokumentPåFagsak(mottattDokument);
 
         var prosessTask = ProsessTaskData.forProsessTask(HåndterMottattDokumentTask.class);
-        prosessTask.setBehandling(fagsak.getId(), behandlingId, AKTØR_ID.getId());
+        prosessTask.setBehandling(fagsak.getSaksnummer().getVerdi(), fagsak.getId(), behandlingId);
         prosessTask.setProperty(HåndterMottattDokumentTask.MOTTATT_DOKUMENT_ID_KEY, dokumentId.toString());
         prosessTask.setProperty(HåndterMottattDokumentTask.BEHANDLING_ÅRSAK_TYPE_KEY, BehandlingÅrsakType.ETTER_KLAGE.getKode());
         var captorBehandling = ArgumentCaptor.forClass(Long.class);

--- a/domenetjenester/mottak/src/test/java/no/nav/foreldrepenger/mottak/kompletthettjeneste/impl/fp/KompletthetssjekkerSøknadRevurderingTest.java
+++ b/domenetjenester/mottak/src/test/java/no/nav/foreldrepenger/mottak/kompletthettjeneste/impl/fp/KompletthetssjekkerSøknadRevurderingTest.java
@@ -219,14 +219,14 @@ class KompletthetssjekkerSøknadRevurderingTest extends EntityManagerAwareTest {
 
         // Matcher med utsettelse:
         var dokumentListe = singleton(DokumentTypeId.DOK_INNLEGGELSE);
-        when(dokumentArkivTjeneste.hentDokumentTypeIdForSak(eq(behandling.getFagsak().getSaksnummer()), eq(søknadsDato))).thenReturn(dokumentListe);
+        when(dokumentArkivTjeneste.hentDokumentTypeIdForSak(eq(behandling.getSaksnummer()), eq(søknadsDato))).thenReturn(dokumentListe);
 
         // Act
         var manglendeVedlegg = kompletthetssjekker.utledManglendeVedleggForSøknad(lagRef(behandling));
 
         // Assert
         assertThat(manglendeVedlegg).isEmpty();
-        verify(dokumentArkivTjeneste).hentDokumentTypeIdForSak(eq(behandling.getFagsak().getSaksnummer()), eq(søknadsDato));
+        verify(dokumentArkivTjeneste).hentDokumentTypeIdForSak(eq(behandling.getSaksnummer()), eq(søknadsDato));
     }
 
     private BehandlingReferanse lagRef(Behandling behandling) {

--- a/domenetjenester/mottak/src/test/java/no/nav/foreldrepenger/mottak/sakskompleks/BerørtBehandlingKontrollerTest.java
+++ b/domenetjenester/mottak/src/test/java/no/nav/foreldrepenger/mottak/sakskompleks/BerørtBehandlingKontrollerTest.java
@@ -257,7 +257,7 @@ class BerørtBehandlingKontrollerTest {
             .medOriginalBehandling(behandling, årsakType, false)
             .medBehandlingType(BehandlingType.REVURDERING);
         scenario.medSøknadHendelse().medFødselsDato(LocalDate.now());
-        scenario.medFagsakId(behandling.getId()).medSaksnummer(behandling.getFagsak().getSaksnummer());
+        scenario.medFagsakId(behandling.getId()).medSaksnummer(behandling.getSaksnummer());
         var revurdering = scenario.lagMocked();
         revurdering.setOpprettetTidspunkt(LocalDateTime.now());
         return revurdering;

--- a/domenetjenester/mottak/src/test/java/no/nav/foreldrepenger/mottak/vedtak/kafka/VedtaksHendelseHåndtererTest.java
+++ b/domenetjenester/mottak/src/test/java/no/nav/foreldrepenger/mottak/vedtak/kafka/VedtaksHendelseHåndtererTest.java
@@ -125,7 +125,7 @@ class VedtaksHendelseHåndtererTest extends EntityManagerAwareTest {
 
         vedtaksHendelseHåndterer.loggVedtakOverlapp(ompYtelse, List.of(svp.getFagsak()));
 
-        assertThat(overlappInfotrygdRepository.hentForSaksnummer(svp.getFagsak().getSaksnummer())).isEmpty();
+        assertThat(overlappInfotrygdRepository.hentForSaksnummer(svp.getSaksnummer())).isEmpty();
     }
 
     @Test
@@ -146,7 +146,7 @@ class VedtaksHendelseHåndtererTest extends EntityManagerAwareTest {
 
         vedtaksHendelseHåndterer.loggVedtakOverlapp(ompYtelse, List.of(svp.getFagsak()));
 
-        var behandlingOverlappInfotrygd = overlappInfotrygdRepository.hentForSaksnummer(svp.getFagsak().getSaksnummer());
+        var behandlingOverlappInfotrygd = overlappInfotrygdRepository.hentForSaksnummer(svp.getSaksnummer());
         assertThat(behandlingOverlappInfotrygd).hasSize(1);
         assertThat(behandlingOverlappInfotrygd.getFirst().getBehandlingId()).isEqualTo(svp.getId());
         assertThat(behandlingOverlappInfotrygd.getFirst().getUtbetalingsprosent()).isEqualTo(200);
@@ -172,7 +172,7 @@ class VedtaksHendelseHåndtererTest extends EntityManagerAwareTest {
 
         vedtaksHendelseHåndterer.loggVedtakOverlapp(ompYtelse, List.of(svp.getFagsak()));
 
-        assertThat(overlappInfotrygdRepository.hentForSaksnummer(svp.getFagsak().getSaksnummer())).isEmpty();
+        assertThat(overlappInfotrygdRepository.hentForSaksnummer(svp.getSaksnummer())).isEmpty();
     }
 
     @Test
@@ -193,7 +193,7 @@ class VedtaksHendelseHåndtererTest extends EntityManagerAwareTest {
 
         vedtaksHendelseHåndterer.loggVedtakOverlapp(ompYtelse, List.of(svp.getFagsak()));
 
-        var behandlingOverlappInfotrygd = overlappInfotrygdRepository.hentForSaksnummer(svp.getFagsak().getSaksnummer());
+        var behandlingOverlappInfotrygd = overlappInfotrygdRepository.hentForSaksnummer(svp.getSaksnummer());
         assertThat(behandlingOverlappInfotrygd).hasSize(1);
         assertThat(behandlingOverlappInfotrygd.getFirst().getBehandlingId()).isEqualTo(svp.getId());
         assertThat(behandlingOverlappInfotrygd.getFirst().getUtbetalingsprosent()).isEqualTo(120);
@@ -242,7 +242,6 @@ class VedtaksHendelseHåndtererTest extends EntityManagerAwareTest {
 
         var task = prosessTaskDataList.getFirst();
         assertThat(task.taskType()).isEqualTo(TaskType.forProsessTask(HåndterOverlappPleiepengerTask.class));
-        assertThat(task.getAktørId()).isEqualTo(aktørFra(fpBehandling).getVerdi());
         assertThat(task.getFagsakId()).isEqualTo(fpBehandling.getFagsak().getId());
     }
 

--- a/domenetjenester/mottak/src/test/java/no/nav/foreldrepenger/mottak/vedtak/overlapp/LoggOverlappEksterneYtelserTjenesteTest.java
+++ b/domenetjenester/mottak/src/test/java/no/nav/foreldrepenger/mottak/vedtak/overlapp/LoggOverlappEksterneYtelserTjenesteTest.java
@@ -136,7 +136,7 @@ class LoggOverlappEksterneYtelserTjenesteTest extends EntityManagerAwareTest {
         overlappendeInfotrygdYtelseTjeneste.loggOverlappForVedtakFPSAK(behandlingFP);
 
         // Assert
-        var overlappIT = overlappRepository.hentForSaksnummer(behandlingFP.getFagsak().getSaksnummer());
+        var overlappIT = overlappRepository.hentForSaksnummer(behandlingFP.getSaksnummer());
         assertThat(overlappIT).hasSize(1);
         assertThat(overlappIT.getFirst().getPeriode().getTomDato()).isEqualTo(førsteUttaksdatoFp);
         verify(oppgaveTjenesteMock, times(1)).opprettVurderKonsekvensHosPleiepenger(any(), any());
@@ -162,7 +162,7 @@ class LoggOverlappEksterneYtelserTjenesteTest extends EntityManagerAwareTest {
         overlappendeInfotrygdYtelseTjeneste.loggOverlappForVedtakFPSAK(behandlingFP);
 
         // Assert
-        var overlappIT = overlappRepository.hentForSaksnummer(behandlingFP.getFagsak().getSaksnummer());
+        var overlappIT = overlappRepository.hentForSaksnummer(behandlingFP.getSaksnummer());
         assertThat(overlappIT).isEmpty();
 
         // Arrange2
@@ -178,7 +178,7 @@ class LoggOverlappEksterneYtelserTjenesteTest extends EntityManagerAwareTest {
         overlappendeInfotrygdYtelseTjeneste.loggOverlappForVedtakFPSAK(behandlingFP);
 
         // Assert
-        var overlappIT2 = overlappRepository.hentForSaksnummer(behandlingFP.getFagsak().getSaksnummer());
+        var overlappIT2 = overlappRepository.hentForSaksnummer(behandlingFP.getSaksnummer());
         assertThat(overlappIT2).hasSize(1);
         assertThat(overlappIT2.getFirst().getPeriode().getTomDato()).isEqualTo(førsteUttaksdatoFp.plusWeeks(4));
         verify(oppgaveTjenesteMock, times(1)).opprettVurderKonsekvensHosPleiepenger(any(), any());
@@ -217,7 +217,7 @@ class LoggOverlappEksterneYtelserTjenesteTest extends EntityManagerAwareTest {
         overlappendeInfotrygdYtelseTjeneste.loggOverlappForVedtakFPSAK(behandlingFP);
 
         // Assert
-        var overlappIT = overlappRepository.hentForSaksnummer(behandlingFP.getFagsak().getSaksnummer());
+        var overlappIT = overlappRepository.hentForSaksnummer(behandlingFP.getSaksnummer());
         assertThat(overlappIT).hasSize(2);
         verify(oppgaveTjenesteMock, times(1)).opprettVurderKonsekvensHosPleiepenger(any(), any());
         verify(oppgaveTjenesteMock, times(1)).opprettVurderKonsekvensHosSykepenger(any(), any());
@@ -257,7 +257,7 @@ class LoggOverlappEksterneYtelserTjenesteTest extends EntityManagerAwareTest {
         overlappendeInfotrygdYtelseTjeneste.loggOverlappForVedtakFPSAK(behandlingFP);
 
         // Assert
-        var overlappIT = overlappRepository.hentForSaksnummer(behandlingFP.getFagsak().getSaksnummer());
+        var overlappIT = overlappRepository.hentForSaksnummer(behandlingFP.getSaksnummer());
         assertThat(overlappIT).hasSize(3);
         verify(oppgaveTjenesteMock, times(2)).opprettVurderKonsekvensHosSykepenger(any(), any());
         verifyNoMoreInteractions(oppgaveTjenesteMock);
@@ -296,7 +296,7 @@ class LoggOverlappEksterneYtelserTjenesteTest extends EntityManagerAwareTest {
         overlappendeInfotrygdYtelseTjeneste.loggOverlappForVedtakFPSAK(behandlingFP);
 
         // Assert
-        var overlappIT = overlappRepository.hentForSaksnummer(behandlingFP.getFagsak().getSaksnummer());
+        var overlappIT = overlappRepository.hentForSaksnummer(behandlingFP.getSaksnummer());
         assertThat(overlappIT).hasSize(1);
         assertThat(overlappIT.getFirst().getPeriode().getTomDato()).isEqualTo(førsteUttaksdatoFp.plusWeeks(3));
         verify(oppgaveTjenesteMock, times(1)).opprettVurderKonsekvensHosPleiepenger(any(), any());
@@ -323,7 +323,7 @@ class LoggOverlappEksterneYtelserTjenesteTest extends EntityManagerAwareTest {
         overlappendeInfotrygdYtelseTjeneste.loggOverlappForVedtakFPSAK(behandlingFP);
 
         // Assert
-        var overlappIT = overlappRepository.hentForSaksnummer(behandlingFP.getFagsak().getSaksnummer());
+        var overlappIT = overlappRepository.hentForSaksnummer(behandlingFP.getSaksnummer());
         assertThat(overlappIT).isEmpty();
         verifyNoInteractions(oppgaveTjenesteMock);
     }
@@ -342,7 +342,7 @@ class LoggOverlappEksterneYtelserTjenesteTest extends EntityManagerAwareTest {
         overlappendeInfotrygdYtelseTjeneste.loggOverlappForVedtakFPSAK(behandlingFP);
 
         // Assert
-        var overlappIT = overlappRepository.hentForSaksnummer(behandlingFP.getFagsak().getSaksnummer());
+        var overlappIT = overlappRepository.hentForSaksnummer(behandlingFP.getSaksnummer());
         assertThat(overlappIT).isEmpty();
         verifyNoInteractions(oppgaveTjenesteMock);
     }
@@ -368,7 +368,7 @@ class LoggOverlappEksterneYtelserTjenesteTest extends EntityManagerAwareTest {
         overlappendeInfotrygdYtelseTjeneste.loggOverlappForVedtakFPSAK(behandlingFP);
 
         // Assert
-        var overlappIT = overlappRepository.hentForSaksnummer(behandlingFP.getFagsak().getSaksnummer());
+        var overlappIT = overlappRepository.hentForSaksnummer(behandlingFP.getSaksnummer());
         assertThat(overlappIT).hasSize(2);
         verify(oppgaveTjenesteMock, times(2)).opprettVurderKonsekvensHosPleiepenger(any(), any());
         verifyNoMoreInteractions(oppgaveTjenesteMock);

--- a/domenetjenester/mottak/src/test/java/no/nav/foreldrepenger/mottak/vedtak/overlapp/VurderOpphørAvYtelserTaskTest.java
+++ b/domenetjenester/mottak/src/test/java/no/nav/foreldrepenger/mottak/vedtak/overlapp/VurderOpphørAvYtelserTaskTest.java
@@ -36,7 +36,7 @@ class VurderOpphørAvYtelserTaskTest {
         var behandling = scenario.lagMocked();
 
         var prosessTaskData = ProsessTaskData.forProsessTask(VurderOpphørAvYtelserTask.class);
-        prosessTaskData.setBehandling(behandling.getFagsakId(), behandling.getId(), behandling.getAktørId().toString());
+        prosessTaskData.setBehandling(behandling.getSaksnummer().getVerdi(), behandling.getFagsakId(), behandling.getId());
 
         vurderOpphørAvYtelserTask.doTask(prosessTaskData);
 

--- a/domenetjenester/mottak/src/test/java/no/nav/foreldrepenger/mottak/vurderfagsystem/impl/VurderFagsystemTjenesteImplForAvlsluttetFagsakOgAvslåttBehandlingTest.java
+++ b/domenetjenester/mottak/src/test/java/no/nav/foreldrepenger/mottak/vurderfagsystem/impl/VurderFagsystemTjenesteImplForAvlsluttetFagsakOgAvslåttBehandlingTest.java
@@ -105,7 +105,7 @@ class VurderFagsystemTjenesteImplForAvlsluttetFagsakOgAvslåttBehandlingTest ext
 
         // Assert
         assertThat(resultat.behandlendeSystem()).isEqualTo(BehandlendeFagsystem.BehandlendeSystem.VEDTAKSLØSNING);
-        assertThat(resultat.getSaksnummer()).isEqualTo(Optional.of(behandling.getFagsak().getSaksnummer()));
+        assertThat(resultat.getSaksnummer()).isEqualTo(Optional.of(behandling.getSaksnummer()));
     }
 
     @Test
@@ -116,14 +116,14 @@ class VurderFagsystemTjenesteImplForAvlsluttetFagsakOgAvslåttBehandlingTest ext
         var vfData = opprettVurderFagsystem(BehandlingTema.ENGANGSSTØNAD_FØDSEL);
         vfData.setDokumentTypeId(DokumentTypeId.DOKUMENTASJON_AV_TERMIN_ELLER_FØDSEL);
         vfData.setStrukturertSøknad(false);
-        vfData.setSaksnummer(behandling.getFagsak().getSaksnummer());
+        vfData.setSaksnummer(behandling.getSaksnummer());
 
         // Act
         var resultat = vurderFagsystemFellesTjeneste.vurderFagsystem(vfData);
 
         // Assert
         assertThat(resultat.behandlendeSystem()).isEqualTo(BehandlendeFagsystem.BehandlendeSystem.VEDTAKSLØSNING);
-        assertThat(resultat.getSaksnummer()).isEqualTo(Optional.of(behandling.getFagsak().getSaksnummer()));
+        assertThat(resultat.getSaksnummer()).isEqualTo(Optional.of(behandling.getSaksnummer()));
     }
 
     @Test
@@ -170,7 +170,7 @@ class VurderFagsystemTjenesteImplForAvlsluttetFagsakOgAvslåttBehandlingTest ext
         // Assert
         assertThat(resultat.behandlendeSystem()).isEqualTo(BehandlendeFagsystem.BehandlendeSystem.VEDTAKSLØSNING);
         assertThat(resultat.getSaksnummer()).isPresent();
-        assertThat(resultat.getSaksnummer()).contains(behandling.getFagsak().getSaksnummer());
+        assertThat(resultat.getSaksnummer()).contains(behandling.getSaksnummer());
     }
 
     private Behandling opprettBehandling(BehandlingType behandlingType, BehandlingResultatType behandlingResultatType, Avslagsårsak avslagsårsak,

--- a/domenetjenester/okonomistotte/src/main/java/no/nav/foreldrepenger/økonomistøtte/oppdrag/postcondition/OppdragPostConditionTjeneste.java
+++ b/domenetjenester/okonomistotte/src/main/java/no/nav/foreldrepenger/økonomistøtte/oppdrag/postcondition/OppdragPostConditionTjeneste.java
@@ -75,7 +75,7 @@ public class OppdragPostConditionTjeneste {
             sammenlignEffektAvOppdragMedTilkjentYtelseOgLoggAvvik(behandling, beregningsresultat);
         } catch (Exception e) {
             LOG.warn("Teknisk feil ved sammenligning av effekt av oppdrag mot tilkjent ytelse for {} behandling {} . Dette bør undersøkes: {}",
-                behandling.getFagsak().getSaksnummer(), behandling.getId(), e.getMessage(), e);
+                behandling.getSaksnummer(), behandling.getId(), e.getMessage(), e);
         }
     }
 
@@ -83,7 +83,7 @@ public class OppdragPostConditionTjeneste {
         var resultat = sammenlignEffektAvOppdragMedTilkjentYtelse(behandling, beregningsresultat);
         var altOk = true;
         for (var entry : resultat.entrySet()) {
-            var feil = konverterTilFeil(behandling.getFagsak().getSaksnummer(), Long.toString(behandling.getId()), entry.getKey(), entry.getValue());
+            var feil = konverterTilFeil(behandling.getSaksnummer(), Long.toString(behandling.getId()), entry.getKey(), entry.getValue());
             if (feil != null) {
                 LOG.warn(feil.getMessage());
                 if ("FP-767898".equals(feil.getKode())) {
@@ -96,7 +96,7 @@ public class OppdragPostConditionTjeneste {
 
     private Map<Betalingsmottaker, TilkjentYtelseDifferanse> sammenlignEffektAvOppdragMedTilkjentYtelse(Behandling behandling,
                                                                                                         BehandlingBeregningsresultatEntitet beregningsresultat) {
-        var saksnummer = behandling.getFagsak().getSaksnummer();
+        var saksnummer = behandling.getSaksnummer();
         var oppdragene = økonomioppdragRepository.finnAlleOppdragForSak(saksnummer);
         var oppdragskjeder = EksisterendeOppdragMapper.tilKjeder(oppdragene);
         var målbilde = beregningsresultat == null ? GruppertYtelse.TOM :

--- a/domenetjenester/okonomistotte/src/test/java/no/nav/foreldrepenger/økonomistøtte/BehandleNegativeKvitteringTjenesteTest.java
+++ b/domenetjenester/okonomistotte/src/test/java/no/nav/foreldrepenger/økonomistøtte/BehandleNegativeKvitteringTjenesteTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import no.nav.foreldrepenger.domene.typer.Saksnummer;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTaskData;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTaskStatus;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTaskTjeneste;
@@ -19,7 +20,7 @@ class BehandleNegativeKvitteringTjenesteTest {
     private final static TaskType TASKTYPE = new TaskType("iverksetteVedtak.oppdragTilØkonomi"); //TODO deps
     private final static Long BEHANDLING_ID = 100010010L;
     private final static Long FAGSAK_ID = 987654301L;
-    private final static String AKTØR_ID = "AA-BB-CC-DD-EE";
+    private static final Saksnummer SAKSNUMMER = new Saksnummer(FAGSAK_ID.toString());
 
     private ProsessTaskTjeneste taskTjeneste;
 
@@ -57,7 +58,7 @@ class BehandleNegativeKvitteringTjenesteTest {
 
     private ProsessTaskData lagØkonomioppragTaskPåVent() {
         var taskData = ProsessTaskData.forTaskType(TASKTYPE);
-        taskData.setBehandling(FAGSAK_ID, BEHANDLING_ID, AKTØR_ID);
+        taskData.setBehandling(SAKSNUMMER.getVerdi(), FAGSAK_ID, BEHANDLING_ID);
         taskData.venterPåHendelse(BehandleØkonomioppdragKvittering.ØKONOMI_OPPDRAG_KVITTERING);
         return taskData;
     }

--- a/domenetjenester/okonomistotte/src/test/java/no/nav/foreldrepenger/økonomistøtte/HentOppdragMedPositivKvitteringTest.java
+++ b/domenetjenester/okonomistotte/src/test/java/no/nav/foreldrepenger/økonomistøtte/HentOppdragMedPositivKvitteringTest.java
@@ -37,7 +37,7 @@ class HentOppdragMedPositivKvitteringTest {
             Fagsak.opprettNy(FagsakYtelseType.ENGANGSTØNAD, NavBruker.opprettNyNB(AktørId.dummy()), new Saksnummer("123456789")),
             BehandlingType.FØRSTEGANGSSØKNAD).build();
         behandling.setId(123L);
-        saksnummer = behandling.getFagsak().getSaksnummer();
+        saksnummer = behandling.getSaksnummer();
 
         oppdragskontroll = oppdragskontrollMedOppdrag(saksnummer, 1L);
         mockRepository(oppdragskontroll);

--- a/domenetjenester/okonomistotte/src/test/java/no/nav/foreldrepenger/økonomistøtte/OppdragInputTjenesteTest.java
+++ b/domenetjenester/okonomistotte/src/test/java/no/nav/foreldrepenger/økonomistøtte/OppdragInputTjenesteTest.java
@@ -113,7 +113,7 @@ class OppdragInputTjenesteTest {
         // Assert
         var brukerKjedde = getBrukerKjeddeNøkkel();
 
-        assertFellesFelter(input, behandling.getFagsak().getSaksnummer());
+        assertFellesFelter(input, behandling.getSaksnummer());
         assertTilkjentYtelse(input, brukerKjedde, LocalDate.now());
 
         // Inger oppdrag fra før.
@@ -125,7 +125,7 @@ class OppdragInputTjenesteTest {
     @DisplayName("Simulering oppdrag input for ES fødsel med en tidligere utbetaling.")
     public void oppdragInputSimuleringESRevurderingMedTidligereOppdrag() {
         // Prepare
-        var saksnummer = behandling.getFagsak().getSaksnummer();
+        var saksnummer = behandling.getSaksnummer();
         when(beregningRepository.getSisteBeregning(behandlingId)).thenReturn(
             Optional.of(new LegacyESBeregning(TILKJENT_YTELSE, 1, TILKJENT_YTELSE, LocalDateTime.now())));
 
@@ -151,7 +151,7 @@ class OppdragInputTjenesteTest {
     @DisplayName("Simulering oppdrag input for ES fødsel med to tidligere utbetalinger.")
     public void oppdragInputSimuleringESRevurderingMedToTidligereOppdrag() {
         // Prepare
-        var saksnummer = behandling.getFagsak().getSaksnummer();
+        var saksnummer = behandling.getSaksnummer();
         when(beregningRepository.getSisteBeregning(behandlingId)).thenReturn(
             Optional.of(new LegacyESBeregning(TILKJENT_YTELSE, 1, TILKJENT_YTELSE, LocalDateTime.now())));
 
@@ -183,7 +183,7 @@ class OppdragInputTjenesteTest {
     @DisplayName("Simulering oppdrag input for ES fødsel med to tidligere utbetalinger men med en positiv kvittering.")
     public void oppdragInputSimuleringESRevurderingMedToTidligereOppdragMenKunEnPositivKvittering() {
         // Prepare
-        var saksnummer = behandling.getFagsak().getSaksnummer();
+        var saksnummer = behandling.getSaksnummer();
         when(beregningRepository.getSisteBeregning(behandlingId)).thenReturn(
             Optional.of(new LegacyESBeregning(TILKJENT_YTELSE, 1, TILKJENT_YTELSE, LocalDateTime.now())));
 

--- a/domenetjenester/produksjonsstyring/src/main/java/no/nav/foreldrepenger/produksjonsstyring/batch/FlyttEnhetTask.java
+++ b/domenetjenester/produksjonsstyring/src/main/java/no/nav/foreldrepenger/produksjonsstyring/batch/FlyttEnhetTask.java
@@ -36,7 +36,7 @@ class FlyttEnhetTask implements ProsessTaskHandler {
         var kandidater = behandlingKandidaterRepository.finnBehandlingerIkkeAvsluttetPåAngittEnhet(enhet);
         kandidater.forEach(beh -> {
             var taskData = ProsessTaskData.forProsessTask(OppdaterBehandlendeEnhetTask.class);
-            taskData.setBehandling(beh.getFagsakId(), beh.getId(), beh.getAktørId().getId());
+            taskData.setBehandling(beh.getSaksnummer().getVerdi(), beh.getFagsakId(), beh.getId());
             taskData.setCallIdFraEksisterende();
             taskTjeneste.lagre(taskData);
         });

--- a/domenetjenester/produksjonsstyring/src/main/java/no/nav/foreldrepenger/produksjonsstyring/behandlinghendelse/BehandlingHendelseHåndterer.java
+++ b/domenetjenester/produksjonsstyring/src/main/java/no/nav/foreldrepenger/produksjonsstyring/behandlinghendelse/BehandlingHendelseHåndterer.java
@@ -108,7 +108,7 @@ public class BehandlingHendelseHåndterer implements KafkaMessageHandler.KafkaSt
         var behandlingRef = String.format("%s_T%s", Fagsystem.FPSAK.getOffisiellKode(), hendelse.getBehandlingUuid().toString());
 
         var prosessTaskData = ProsessTaskData.forProsessTask(OppdaterPersonoversiktTask.class);
-        prosessTaskData.setFagsak(fagsak.getId(), fagsak.getAktørId().getId());
+        prosessTaskData.setFagsak(fagsak.getSaksnummer().getVerdi(), fagsak.getId());
         prosessTaskData.setProperty(OppdaterPersonoversiktTask.PH_REF_KEY, behandlingRef);
         prosessTaskData.setProperty(OppdaterPersonoversiktTask.PH_STATUS_KEY, behandlingStatus.getKode());
         prosessTaskData.setProperty(OppdaterPersonoversiktTask.PH_TID_KEY, hendelse.getTidspunkt().toString());

--- a/domenetjenester/produksjonsstyring/src/main/java/no/nav/foreldrepenger/produksjonsstyring/behandlinghendelse/BehandlingskontrollEventObserver.java
+++ b/domenetjenester/produksjonsstyring/src/main/java/no/nav/foreldrepenger/produksjonsstyring/behandlinghendelse/BehandlingskontrollEventObserver.java
@@ -14,7 +14,7 @@ import no.nav.foreldrepenger.behandlingskontroll.events.BehandlingStatusEvent;
 import no.nav.foreldrepenger.behandlingskontroll.events.BehandlingskontrollEvent;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingEvent;
 import no.nav.foreldrepenger.behandlingslager.behandling.events.BehandlingEnhetEvent;
-import no.nav.foreldrepenger.domene.typer.AktørId;
+import no.nav.foreldrepenger.domene.typer.Saksnummer;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTaskTjeneste;
 
 @ApplicationScoped
@@ -77,11 +77,11 @@ public class BehandlingskontrollEventObserver {
     }
 
     private void opprettProsessTask(BehandlingEvent behandlingEvent, HendelseForBehandling hendelse) {
-        opprettProsessTask(behandlingEvent.getFagsakId(), behandlingEvent.getBehandlingId(), behandlingEvent.getAktørId(), hendelse);
+        opprettProsessTask(behandlingEvent.getSaksnummer(), behandlingEvent.getFagsakId(), behandlingEvent.getBehandlingId(), hendelse);
     }
 
-    private void opprettProsessTask(Long fagsakId, Long behandlingsId, AktørId aktørId, HendelseForBehandling hendelse) {
-        var prosessTaskData = PubliserBehandlingHendelseTask.prosessTask(fagsakId, behandlingsId, aktørId, hendelse);
+    private void opprettProsessTask(Saksnummer saksnummer, Long fagsakId, Long behandlingsId, HendelseForBehandling hendelse) {
+        var prosessTaskData = PubliserBehandlingHendelseTask.prosessTask(saksnummer, fagsakId, behandlingsId, hendelse);
         taskTjeneste.lagre(prosessTaskData);
     }
 }

--- a/domenetjenester/produksjonsstyring/src/main/java/no/nav/foreldrepenger/produksjonsstyring/behandlinghendelse/PubliserBehandlingHendelseTask.java
+++ b/domenetjenester/produksjonsstyring/src/main/java/no/nav/foreldrepenger/produksjonsstyring/behandlinghendelse/PubliserBehandlingHendelseTask.java
@@ -16,7 +16,7 @@ import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.Aksjonspun
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepository;
 import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakProsesstaskRekkefølge;
 import no.nav.foreldrepenger.behandlingslager.task.GenerellProsessTask;
-import no.nav.foreldrepenger.domene.typer.AktørId;
+import no.nav.foreldrepenger.domene.typer.Saksnummer;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTask;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTaskData;
 import no.nav.vedtak.hendelser.behandling.Behandlingstype;
@@ -64,18 +64,18 @@ public class PubliserBehandlingHendelseTask extends GenerellProsessTask {
             .medBehandlingUuid(behandling.getUuid())
             .medKildesystem(Kildesystem.FPSAK)
             .medAktørId(behandling.getAktørId().getId())
-            .medSaksnummer(behandling.getFagsak().getSaksnummer().getVerdi())
+            .medSaksnummer(behandling.getSaksnummer().getVerdi())
             .medBehandlingstype(mapBehandlingstype(behandling))
             .medYtelse(mapYtelse(behandling))
             .medTidspunkt(LocalDateTime.now())
             .build();
-        kafkaProducer.sendJsonMedNøkkel(behandling.getFagsak().getSaksnummer().getVerdi(), DefaultJsonMapper.toJson(hendelse));
+        kafkaProducer.sendJsonMedNøkkel(behandling.getSaksnummer().getVerdi(), DefaultJsonMapper.toJson(hendelse));
         LOG.info("Publiser behandlingshendelse på kafka for behandlingsId: {}", behandling.getId());
     }
 
-    public static ProsessTaskData prosessTask(Long fagsakId, Long behandlingsId, AktørId aktørId, HendelseForBehandling hendelse) {
+    public static ProsessTaskData prosessTask(Saksnummer saksnummer, Long fagsakId, Long behandlingsId, HendelseForBehandling hendelse) {
         var prosessTaskData = ProsessTaskData.forProsessTask(PubliserBehandlingHendelseTask.class);
-        prosessTaskData.setBehandling(fagsakId, behandlingsId, aktørId.getId());
+        prosessTaskData.setBehandling(saksnummer.getVerdi(), fagsakId, behandlingsId);
         prosessTaskData.setProperty(PubliserBehandlingHendelseTask.HENDELSE_TYPE, hendelse.name());
         prosessTaskData.setCallIdFraEksisterende();
         return prosessTaskData;

--- a/domenetjenester/produksjonsstyring/src/main/java/no/nav/foreldrepenger/produksjonsstyring/fagsakstatus/OppdaterFagsakStatusTjeneste.java
+++ b/domenetjenester/produksjonsstyring/src/main/java/no/nav/foreldrepenger/produksjonsstyring/fagsakstatus/OppdaterFagsakStatusTjeneste.java
@@ -76,9 +76,9 @@ public class OppdaterFagsakStatusTjeneste {
     public void lagBehandlingAvsluttetTask(Fagsak fagsak, Long behandlingId) {
         var prosessTaskData = ProsessTaskData.forProsessTask(BehandlingAvsluttetHendelseTask.class);
         if (behandlingId != null) {
-            prosessTaskData.setBehandling(fagsak.getId(), behandlingId, fagsak.getAktørId().getId());
+            prosessTaskData.setBehandling(fagsak.getSaksnummer().getVerdi(), fagsak.getId(), behandlingId);
         } else {
-            prosessTaskData.setFagsak(fagsak.getId(), fagsak.getAktørId().getId());
+            prosessTaskData.setFagsak(fagsak.getSaksnummer().getVerdi(), fagsak.getId());
         }
         prosessTaskData.setCallIdFraEksisterende();
         prosessTaskTjeneste.lagre(prosessTaskData);
@@ -159,7 +159,7 @@ public class OppdaterFagsakStatusTjeneste {
             try {
                 // Bruker AVSLUTTET her for behandling som allerede er avsluttet. Dette er for å trigge ny opphenting av sak i fpoversikt.
                 // Det vil i realiteten være to AVSLUTTET behandling hendelser på siste behandling i avsluttet fagsak.
-                var task = PubliserBehandlingHendelseTask.prosessTask(fagsakId, behandlingId, fagsak.getAktørId(), HendelseForBehandling.AVSLUTTET);
+                var task = PubliserBehandlingHendelseTask.prosessTask(fagsak.getSaksnummer(), fagsakId, behandlingId, HendelseForBehandling.AVSLUTTET);
                 prosessTaskTjeneste.lagre(task);
             } catch (Exception ex) {
                 LOG.warn("Publisering av FagsakAvsluttet feilet ved fagsak avsluttet", ex);

--- a/domenetjenester/produksjonsstyring/src/main/java/no/nav/foreldrepenger/produksjonsstyring/oppgavebehandling/OppgaveTjeneste.java
+++ b/domenetjenester/produksjonsstyring/src/main/java/no/nav/foreldrepenger/produksjonsstyring/oppgavebehandling/OppgaveTjeneste.java
@@ -169,7 +169,7 @@ public class OppgaveTjeneste {
                                                                        AktørId arbeidsgiverAktørId) {
 
         var behandling = behandlingRepository.hentBehandling(behandlingId);
-        var saksnummer = behandling.getFagsak().getSaksnummer();
+        var saksnummer = behandling.getSaksnummer();
         var arbeidsgiverIdent = hentPersonInfo(arbeidsgiverAktørId).getIdent();
 
         var beskrivelse = String.format(

--- a/domenetjenester/produksjonsstyring/src/main/java/no/nav/foreldrepenger/produksjonsstyring/sakogbehandling/OppdaterSakOgBehandlingEventObserver.java
+++ b/domenetjenester/produksjonsstyring/src/main/java/no/nav/foreldrepenger/produksjonsstyring/sakogbehandling/OppdaterSakOgBehandlingEventObserver.java
@@ -64,7 +64,7 @@ public class OppdaterSakOgBehandlingEventObserver {
         }
         var behandlingRef = String.format("%s_%s", Fagsystem.FPSAK.getOffisiellKode(), behandling.getId());
         var prosessTaskData = ProsessTaskData.forProsessTask(OppdaterPersonoversiktTask.class);
-        prosessTaskData.setBehandling(behandling.getFagsakId(), behandling.getId(), behandling.getAktørId().getId());
+        prosessTaskData.setBehandling(behandling.getSaksnummer().getVerdi(), behandling.getFagsakId(), behandling.getId());
         prosessTaskData.setProperty(OppdaterPersonoversiktTask.PH_REF_KEY, behandlingRef);
         prosessTaskData.setProperty(OppdaterPersonoversiktTask.PH_STATUS_KEY, nyStatus.getKode());
         prosessTaskData.setProperty(OppdaterPersonoversiktTask.PH_TID_KEY, LocalDateTime.now().toString());

--- a/domenetjenester/produksjonsstyring/src/test/java/no/nav/foreldrepenger/produksjonsstyring/behandlinghendelse/BehandlingHendelseHåndtererTest.java
+++ b/domenetjenester/produksjonsstyring/src/test/java/no/nav/foreldrepenger/produksjonsstyring/behandlinghendelse/BehandlingHendelseHåndtererTest.java
@@ -25,7 +25,6 @@ import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingType;
 import no.nav.foreldrepenger.behandlingslager.kodeverk.Fagsystem;
 import no.nav.foreldrepenger.behandlingslager.testutilities.behandling.ScenarioMorSøkerEngangsstønad;
 import no.nav.foreldrepenger.domene.json.StandardJsonConfig;
-import no.nav.foreldrepenger.domene.typer.AktørId;
 import no.nav.foreldrepenger.produksjonsstyring.fagsakstatus.OppdaterFagsakStatusTjeneste;
 import no.nav.foreldrepenger.produksjonsstyring.sakogbehandling.OppdaterPersonoversiktTask;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTaskData;
@@ -125,8 +124,7 @@ class BehandlingHendelseHåndtererTest {
     private void verifiserProsessTaskData(ScenarioMorSøkerEngangsstønad scenario, ProsessTaskData prosessTaskData,
                                           BehandlingStatus expectedStatus, BehandlingType expectedType) {
         assertThat(prosessTaskData.taskType()).isEqualTo(TaskType.forProsessTask(OppdaterPersonoversiktTask.class));
-        assertThat(new AktørId(prosessTaskData.getAktørId()))
-                .isEqualTo(scenario.getFagsak().getNavBruker().getAktørId());
+        assertThat(prosessTaskData.getFagsakId()).isEqualTo(scenario.getFagsak().getId());
         assertThat(prosessTaskData.getBehandlingId()).isNull();
         assertThat(prosessTaskData.getPropertyValue(OppdaterPersonoversiktTask.PH_REF_KEY)).contains(Fagsystem.FPSAK.getOffisiellKode() + "_T");
         assertThat(prosessTaskData.getPropertyValue(OppdaterPersonoversiktTask.PH_STATUS_KEY)).isEqualTo(expectedStatus.getKode());

--- a/domenetjenester/produksjonsstyring/src/test/java/no/nav/foreldrepenger/produksjonsstyring/oppgavebehandling/OppgaveTjenesteTest.java
+++ b/domenetjenester/produksjonsstyring/src/test/java/no/nav/foreldrepenger/produksjonsstyring/oppgavebehandling/OppgaveTjenesteTest.java
@@ -75,7 +75,7 @@ class OppgaveTjenesteTest {
                 "bla bla");
 
         var request = captor.getValue();
-        assertThat(request.saksreferanse()).isEqualTo(behandling.getFagsak().getSaksnummer().getVerdi());
+        assertThat(request.saksreferanse()).isEqualTo(behandling.getSaksnummer().getVerdi());
         assertThat(request.oppgavetype()).isEqualTo(Oppgavetype.VURDER_DOKUMENT);
         assertThat(oppgaveId).isEqualTo(OPPGAVE.id().toString());
     }
@@ -106,7 +106,7 @@ class OppgaveTjenesteTest {
         var oppgaveId = tjeneste.opprettVurderKonsekvensBasertPåFagsakId(behandling.getFagsakId(), "2010", "bla bla", false);
 
         var request = captor.getValue();
-        assertThat(request.saksreferanse()).isEqualTo(behandling.getFagsak().getSaksnummer().getVerdi());
+        assertThat(request.saksreferanse()).isEqualTo(behandling.getSaksnummer().getVerdi());
         assertThat(request.oppgavetype()).isEqualTo(Oppgavetype.VURDER_KONSEKVENS_YTELSE);
         assertThat(oppgaveId).isEqualTo(OPPGAVE.id().toString());
     }
@@ -125,7 +125,7 @@ class OppgaveTjenesteTest {
         var oppgaveId = tjeneste.opprettOppgaveStopUtbetalingAvARENAYtelse(behandling.getId(), førsteAugust);
 
         var request = captor.getValue();
-        assertThat(request.saksreferanse()).isEqualTo(behandling.getFagsak().getSaksnummer().getVerdi());
+        assertThat(request.saksreferanse()).isEqualTo(behandling.getSaksnummer().getVerdi());
         assertThat(request.oppgavetype()).isEqualTo(Oppgavetype.SETT_UTBETALING_VENT);
 
         assertThat(request.tema()).isEqualTo("STO");
@@ -152,14 +152,14 @@ class OppgaveTjenesteTest {
                 "Saksnummer: %s," +
                 "Vedtaksdato: %s," +
                 "Dato for første utbetaling: %s," +
-                "Fødselsnummer arbeidsgiver: %s", behandling.getFagsak().getSaksnummer().getVerdi(),
+                "Fødselsnummer arbeidsgiver: %s", behandling.getSaksnummer().getVerdi(),
                 vedtaksdato, førsteUttaksdato, personIdent.getIdent());
 
         var oppgaveId = tjeneste.opprettOppgaveSettUtbetalingPåVentPrivatArbeidsgiver(behandling.getId(),
                 førsteUttaksdato, vedtaksdato, behandling.getAktørId());
 
         var request = captor.getValue();
-        assertThat(request.saksreferanse()).isEqualTo(behandling.getFagsak().getSaksnummer().getVerdi());
+        assertThat(request.saksreferanse()).isEqualTo(behandling.getSaksnummer().getVerdi());
         assertThat(request.oppgavetype().getKode()).isEqualTo(Oppgavetype.SETT_UTBETALING_VENT.getKode());
         assertThat(request.tema()).isEqualTo("STO");
         assertThat(request.fristFerdigstillelse()).isEqualTo(forventetFrist);

--- a/domenetjenester/produksjonsstyring/src/test/java/no/nav/foreldrepenger/produksjonsstyring/oppgavebehandling/OpprettOppgaveVurderDokumentTaskTest.java
+++ b/domenetjenester/produksjonsstyring/src/test/java/no/nav/foreldrepenger/produksjonsstyring/oppgavebehandling/OpprettOppgaveVurderDokumentTaskTest.java
@@ -21,6 +21,7 @@ import no.nav.vedtak.felles.prosesstask.api.ProsessTaskData;
 class OpprettOppgaveVurderDokumentTaskTest {
 
     private static final long FAGSAK_ID = 2L;
+    private static final String SAKSNUMMER = "2";
 
     private OppgaveTjeneste oppgaveTjeneste;
     private BehandlingRepositoryProvider repositoryProvider;
@@ -43,7 +44,7 @@ class OpprettOppgaveVurderDokumentTaskTest {
     void skal_opprette_oppgave_for_å_vurdere_dokument_basert_på_fagsakId() {
         // Arrange
         var prosessTaskData = ProsessTaskData.forProsessTask(OpprettOppgaveVurderDokumentTask.class);
-        prosessTaskData.setFagsakId(FAGSAK_ID);
+        prosessTaskData.setFagsak(SAKSNUMMER, FAGSAK_ID);
         prosessTaskData.setProperty(OpprettOppgaveVurderDokumentTask.KEY_DOKUMENT_TYPE, DokumentTypeId.SØKNAD_ENGANGSSTØNAD_FØDSEL.getKode());
         var fagsakIdCaptor = ArgumentCaptor.forClass(Long.class);
         var fordelingsoppgaveEnhetsIdCaptor = ArgumentCaptor.forClass(String.class);

--- a/domenetjenester/produksjonsstyring/src/test/java/no/nav/foreldrepenger/produksjonsstyring/oppgavebehandling/OpprettOppgaveVurderKonsekvensTaskTest.java
+++ b/domenetjenester/produksjonsstyring/src/test/java/no/nav/foreldrepenger/produksjonsstyring/oppgavebehandling/OpprettOppgaveVurderKonsekvensTaskTest.java
@@ -24,6 +24,7 @@ import no.nav.vedtak.felles.prosesstask.api.ProsessTaskData;
 class OpprettOppgaveVurderKonsekvensTaskTest {
 
     private static final long FAGSAK_ID = 2L;
+    private static final String SAKSNUMMER = "2";
     private OppgaveTjeneste oppgaveTjeneste;
     private OpprettOppgaveVurderKonsekvensTask opprettOppgaveVurderKonsekvensTask;
     private BehandlingRepositoryProvider repositoryProvider;
@@ -48,7 +49,7 @@ class OpprettOppgaveVurderKonsekvensTaskTest {
     void skal_opprette_oppgave_for_å_vurdere_konsekvens_basert_på_fagsakId() {
         // Arrange
         var prosessTaskData = ProsessTaskData.forProsessTask(OpprettOppgaveVurderKonsekvensTask.class);
-        prosessTaskData.setFagsakId(FAGSAK_ID);
+        prosessTaskData.setFagsak(SAKSNUMMER, FAGSAK_ID);
         prosessTaskData.setProperty(OpprettOppgaveVurderKonsekvensTask.KEY_BESKRIVELSE, OpprettOppgaveVurderKonsekvensTask.STANDARD_BESKRIVELSE);
         prosessTaskData.setProperty(OpprettOppgaveVurderKonsekvensTask.KEY_PRIORITET, OpprettOppgaveVurderKonsekvensTask.PRIORITET_NORM);
         var fagsakIdCaptor = ArgumentCaptor.forClass(Long.class);

--- a/domenetjenester/produksjonsstyring/src/test/java/no/nav/foreldrepenger/produksjonsstyring/sakogbehandling/OppdaterPersonoversiktTaskTest.java
+++ b/domenetjenester/produksjonsstyring/src/test/java/no/nav/foreldrepenger/produksjonsstyring/sakogbehandling/OppdaterPersonoversiktTaskTest.java
@@ -53,7 +53,7 @@ class OppdaterPersonoversiktTaskTest {
         var behandling = scenario.lagMocked();
         var fagsak = behandling.getFagsak();
         var task = ProsessTaskData.forProsessTask(OppdaterPersonoversiktTask.class);
-        task.setBehandling(fagsak.getId(), behandling.getId(), fagsak.getAktørId().getId());
+        task.setBehandling(fagsak.getSaksnummer().getVerdi(), fagsak.getId(), behandling.getId());
         task.setProperty(OppdaterPersonoversiktTask.PH_REF_KEY, Fagsystem.FPSAK.getOffisiellKode() + "_" + behandling.getId());
         task.setProperty(OppdaterPersonoversiktTask.PH_STATUS_KEY, behandling.getStatus().getKode());
         task.setProperty(OppdaterPersonoversiktTask.PH_TID_KEY, LocalDateTime.now().toString());
@@ -92,7 +92,7 @@ class OppdaterPersonoversiktTaskTest {
         behandling = repositoryProvider.getBehandlingRepository().hentBehandling(behandling.getId());
         var fagsak =behandling.getFagsak();
         var task = ProsessTaskData.forProsessTask(OppdaterPersonoversiktTask.class);
-        task.setBehandling(fagsak.getId(), behandling.getId(), fagsak.getAktørId().getId());
+        task.setBehandling(fagsak.getSaksnummer().getVerdi(), fagsak.getId(), behandling.getId());
         task.setProperty(OppdaterPersonoversiktTask.PH_REF_KEY, Fagsystem.FPSAK.getOffisiellKode() + "_" + behandling.getId());
         task.setProperty(OppdaterPersonoversiktTask.PH_STATUS_KEY, behandling.getStatus().getKode());
         task.setProperty(OppdaterPersonoversiktTask.PH_TID_KEY, LocalDateTime.now().toString());
@@ -132,7 +132,7 @@ class OppdaterPersonoversiktTaskTest {
         var fagsak =behandling.getFagsak();
         var task = ProsessTaskData.forProsessTask(OppdaterPersonoversiktTask.class);
         var tbkUUID = UUID.randomUUID();
-        task.setFagsak(fagsak.getId(), fagsak.getAktørId().getId());
+        task.setFagsak(fagsak.getSaksnummer().getVerdi(), fagsak.getId());
         task.setProperty(OppdaterPersonoversiktTask.PH_REF_KEY, Fagsystem.FPSAK.getOffisiellKode() + "_T" + tbkUUID);
         task.setProperty(OppdaterPersonoversiktTask.PH_STATUS_KEY, BehandlingStatus.OPPRETTET.getKode());
         task.setProperty(OppdaterPersonoversiktTask.PH_TID_KEY, LocalDateTime.now().toString());
@@ -172,7 +172,7 @@ class OppdaterPersonoversiktTaskTest {
         var fagsak =behandling.getFagsak();
         var task = ProsessTaskData.forProsessTask(OppdaterPersonoversiktTask.class);
         var tbkUUID = UUID.randomUUID();
-        task.setFagsak(fagsak.getId(), fagsak.getAktørId().getId());
+        task.setFagsak(fagsak.getSaksnummer().getVerdi(), fagsak.getId());
         task.setProperty(OppdaterPersonoversiktTask.PH_REF_KEY, Fagsystem.FPSAK.getOffisiellKode() + "_T" + tbkUUID);
         task.setProperty(OppdaterPersonoversiktTask.PH_STATUS_KEY, BehandlingStatus.AVSLUTTET.getKode());
         task.setProperty(OppdaterPersonoversiktTask.PH_TID_KEY, LocalDateTime.now().toString());

--- a/domenetjenester/produksjonsstyring/src/test/java/no/nav/foreldrepenger/produksjonsstyring/sakogbehandling/OppdaterSakOgBehandlingEventObserverTest.java
+++ b/domenetjenester/produksjonsstyring/src/test/java/no/nav/foreldrepenger/produksjonsstyring/sakogbehandling/OppdaterSakOgBehandlingEventObserverTest.java
@@ -22,7 +22,6 @@ import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingStatus;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingType;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepositoryProvider;
 import no.nav.foreldrepenger.behandlingslager.testutilities.behandling.ScenarioMorSøkerEngangsstønad;
-import no.nav.foreldrepenger.domene.typer.AktørId;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTaskData;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTaskTjeneste;
 import no.nav.vedtak.felles.prosesstask.api.TaskType;
@@ -48,8 +47,7 @@ class OppdaterSakOgBehandlingEventObserverTest {
         repositoryProvider = scenario.mockBehandlingRepositoryProvider();
         observer = new OppdaterSakOgBehandlingEventObserver(repositoryProvider, taskTjenesteMock);
 
-        var kontekst = new BehandlingskontrollKontekst(fagsak.getId(), fagsak.getAktørId(),
-                scenario.taSkriveLåsForBehandling());
+        var kontekst = new BehandlingskontrollKontekst(fagsak.getSaksnummer(), fagsak.getId(), scenario.taSkriveLåsForBehandling());
         BehandlingOpprettetEvent event = BehandlingStatusEvent.nyEvent(kontekst, BehandlingStatus.OPPRETTET);
 
         var captor = ArgumentCaptor.forClass(ProsessTaskData.class);
@@ -72,8 +70,7 @@ class OppdaterSakOgBehandlingEventObserverTest {
         repositoryProvider = scenario.mockBehandlingRepositoryProvider();
         observer = new OppdaterSakOgBehandlingEventObserver(repositoryProvider, taskTjenesteMock);
 
-        var kontekst = new BehandlingskontrollKontekst(fagsak.getId(), fagsak.getAktørId(),
-                scenario.taSkriveLåsForBehandling());
+        var kontekst = new BehandlingskontrollKontekst(fagsak.getSaksnummer(), fagsak.getId(), scenario.taSkriveLåsForBehandling());
         BehandlingAvsluttetEvent event = BehandlingStatusEvent.nyEvent(kontekst, BehandlingStatus.AVSLUTTET);
 
         var captor = ArgumentCaptor.forClass(ProsessTaskData.class);
@@ -86,8 +83,7 @@ class OppdaterSakOgBehandlingEventObserverTest {
 
     private void verifiserProsessTaskData(ScenarioMorSøkerEngangsstønad scenario, ProsessTaskData prosessTaskData, BehandlingStatus expected) {
         assertThat(prosessTaskData.taskType()).isEqualTo(TaskType.forProsessTask(OppdaterPersonoversiktTask.class));
-        assertThat(new AktørId(prosessTaskData.getAktørId()))
-                .isEqualTo(scenario.getFagsak().getNavBruker().getAktørId());
+        assertThat(prosessTaskData.getFagsakId()).isEqualTo(scenario.getFagsak().getId());
         assertThat(prosessTaskData.getBehandlingId()).isEqualTo(scenario.getBehandling().getId().toString());
         assertThat(prosessTaskData.getPropertyValue(OppdaterPersonoversiktTask.PH_REF_KEY)).contains(scenario.getBehandling().getId().toString());
         assertThat(prosessTaskData.getPropertyValue(OppdaterPersonoversiktTask.PH_STATUS_KEY)).isEqualTo(expected.getKode());

--- a/domenetjenester/registerinnhenting/src/main/java/no/nav/foreldrepenger/domene/registerinnhenting/RegisterdataInnhenter.java
+++ b/domenetjenester/registerinnhenting/src/main/java/no/nav/foreldrepenger/domene/registerinnhenting/RegisterdataInnhenter.java
@@ -215,7 +215,7 @@ public class RegisterdataInnhenter {
     private void doInnhentIAYIAbakus(Behandling behandling, BehandlingType behandlingType, FagsakYtelseType fagsakYtelseType) {
         LOG.info("Trigger innhenting i abakus for behandling med id={} og uuid={}", behandling.getId(), behandling.getUuid());
         var behandlingUuid = behandling.getUuid();
-        var saksnummer = behandling.getFagsak().getSaksnummer().getVerdi();
+        var saksnummer = behandling.getSaksnummer().getVerdi();
         var ytelseType = KodeverkMapper.fraFagsakYtelseType(fagsakYtelseType);
         var opplysningsperiode = opplysningsPeriodeTjeneste.beregn(behandling.getId(), fagsakYtelseType);
         var periode = new Periode(opplysningsperiode.getFomDato(), opplysningsperiode.getTomDato());

--- a/domenetjenester/registerinnhenting/src/main/java/no/nav/foreldrepenger/domene/registerinnhenting/StønadsperioderInnhenter.java
+++ b/domenetjenester/registerinnhenting/src/main/java/no/nav/foreldrepenger/domene/registerinnhenting/StønadsperioderInnhenter.java
@@ -130,7 +130,7 @@ public class StønadsperioderInnhenter {
         var brukStartdato = forrigeInnvilgetFom.filter(d -> d.isBefore(aktuellAntattFørstedag)).isPresent() ?
             forrigeInnvilgetFom.get() : aktuellAntattFørstedag;
         var fhDato = finnFamilieHendelseDato(behandling);
-        var egenSak = new MuligSak(behandling.getFagsakYtelseType(), behandling.getFagsak().getSaksnummer(),
+        var egenSak = new MuligSak(behandling.getFagsakYtelseType(), behandling.getSaksnummer(),
             SaksForhold.EGEN_SAK, brukStartdato, fhDato.orElse(null));
 
         var egneMuligeSaker = utledEgneMuligeSaker(behandling, egenSak);

--- a/domenetjenester/registerinnhenting/src/test/java/no/nav/foreldrepenger/domene/registerinnhenting/StønadsperiodeInnhenterTest.java
+++ b/domenetjenester/registerinnhenting/src/test/java/no/nav/foreldrepenger/domene/registerinnhenting/StønadsperiodeInnhenterTest.java
@@ -137,7 +137,7 @@ class StønadsperiodeInnhenterTest extends EntityManagerAwareTest {
 
         var muligSak = stønadsperioderInnhenter.finnSenereStønadsperiode(behandling);
         assertThat(muligSak).hasValueSatisfying(v -> {
-            assertThat(v.saksnummer()).isEqualTo(nyereBehandling.getFagsak().getSaksnummer());
+            assertThat(v.saksnummer()).isEqualTo(nyereBehandling.getSaksnummer());
             assertThat(v.startdato()).isEqualTo(FH_DATO_YNGRE);
         });
     }
@@ -161,7 +161,7 @@ class StønadsperiodeInnhenterTest extends EntityManagerAwareTest {
 
         var muligSak = stønadsperioderInnhenter.finnSenereStønadsperiode(nyBehSVPOverlapper);
         assertThat(muligSak).hasValueSatisfying(v -> {
-            assertThat(v.saksnummer()).isEqualTo(avsluttetFPBehMor.getFagsak().getSaksnummer());
+            assertThat(v.saksnummer()).isEqualTo(avsluttetFPBehMor.getSaksnummer());
             assertThat(v.startdato()).isEqualTo(STP_NORMAL);
         });
     }
@@ -187,7 +187,7 @@ class StønadsperiodeInnhenterTest extends EntityManagerAwareTest {
 
         var muligSak = stønadsperioderInnhenter.finnSenereStønadsperiode(behandling);
         assertThat(muligSak).hasValueSatisfying(v -> {
-            assertThat(v.saksnummer()).isEqualTo(nyereBehandling.getFagsak().getSaksnummer());
+            assertThat(v.saksnummer()).isEqualTo(nyereBehandling.getSaksnummer());
             assertThat(v.startdato()).isEqualTo(FH_DATO_YNGRE.minusWeeks(3));
         });
     }
@@ -212,7 +212,7 @@ class StønadsperiodeInnhenterTest extends EntityManagerAwareTest {
 
         var muligSak = stønadsperioderInnhenter.finnSenereStønadsperiode(behandling);
         assertThat(muligSak).hasValueSatisfying(v -> {
-            assertThat(v.saksnummer()).isEqualTo(nyereBehandling.getFagsak().getSaksnummer());
+            assertThat(v.saksnummer()).isEqualTo(nyereBehandling.getSaksnummer());
             assertThat(v.startdato()).isEqualTo(FH_DATO_YNGRE.minusWeeks(3));
         });
     }
@@ -257,7 +257,7 @@ class StønadsperiodeInnhenterTest extends EntityManagerAwareTest {
 
         var muligSak = stønadsperioderInnhenter.finnSenereStønadsperiode(behandling);
         assertThat(muligSak).hasValueSatisfying(v -> {
-            assertThat(v.saksnummer()).isEqualTo(nyereBehandling.getFagsak().getSaksnummer());
+            assertThat(v.saksnummer()).isEqualTo(nyereBehandling.getSaksnummer());
             assertThat(v.startdato()).isEqualTo(FH_DATO_YNGRE.minusWeeks(3));
         });
     }

--- a/domenetjenester/registerinnhenting/src/test/java/no/nav/foreldrepenger/domene/registerinnhenting/impl/RegisterdataOppdatererTaskTest.java
+++ b/domenetjenester/registerinnhenting/src/test/java/no/nav/foreldrepenger/domene/registerinnhenting/impl/RegisterdataOppdatererTaskTest.java
@@ -73,7 +73,7 @@ class RegisterdataOppdatererTaskTest {
         when(mockEnhetsTjeneste.sjekkEnhetEtterEndring(any())).thenReturn(Optional.of(enhet));
 
         var prosessTaskData = ProsessTaskData.forProsessTask(RegisterdataOppdatererTask.class);
-        prosessTaskData.setBehandling(0L, behandlingId, "0");
+        prosessTaskData.setBehandling("123", 0L, behandlingId);
 
         task.doTask(prosessTaskData);
 
@@ -103,7 +103,7 @@ class RegisterdataOppdatererTaskTest {
         var snapshot= EndringsresultatSnapshot.opprett()
             .leggTil(EndringsresultatSnapshot.utenSnapshot(PersonInformasjonEntitet.class));
         var prosessTaskData = ProsessTaskData.forProsessTask(RegisterdataOppdatererTask.class);
-        prosessTaskData.setBehandling(0L, behandlingId, "0");
+        prosessTaskData.setBehandling("123", 0L, behandlingId);
         prosessTaskData.setPayload(StandardJsonConfig.toJson(snapshot));
 
         task.doTask(prosessTaskData);

--- a/domenetjenester/risikoklassifisering/src/main/java/no/nav/foreldrepenger/domene/risikoklassifisering/tjeneste/RisikovurderingTjeneste.java
+++ b/domenetjenester/risikoklassifisering/src/main/java/no/nav/foreldrepenger/domene/risikoklassifisering/tjeneste/RisikovurderingTjeneste.java
@@ -73,7 +73,7 @@ public class RisikovurderingTjeneste {
             if (callId == null || callId.isBlank())
                 callId = MDCOperations.generateCallId();
             var taskData = ProsessTaskData.forProsessTask(RisikoklassifiseringUtførTask.class);
-            taskData.setBehandling(referanse.fagsakId(), referanse.behandlingId(), referanse.aktørId().getId());
+            taskData.setBehandling(referanse.saksnummer().getVerdi(), referanse.fagsakId(), referanse.behandlingId());
             taskData.setCallId(callId);
             prosessTaskTjeneste.lagre(taskData);
         }

--- a/domenetjenester/risikoklassifisering/src/test/java/no/nav/foreldrepenger/domene/risikoklassifisering/task/RisikoklassifiseringUtførTaskTest.java
+++ b/domenetjenester/risikoklassifisering/src/test/java/no/nav/foreldrepenger/domene/risikoklassifisering/task/RisikoklassifiseringUtførTaskTest.java
@@ -29,7 +29,6 @@ import no.nav.foreldrepenger.kontrakter.risk.v1.AnnenPartDto;
 import no.nav.foreldrepenger.kontrakter.risk.v1.RisikovurderingRequestDto;
 import no.nav.foreldrepenger.skjæringstidspunkt.OpplysningsPeriodeTjeneste;
 import no.nav.foreldrepenger.skjæringstidspunkt.SkjæringstidspunktTjeneste;
-import no.nav.vedtak.felles.prosesstask.api.CommonTaskProperties;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTaskData;
 
 @ExtendWith(MockitoExtension.class)
@@ -70,7 +69,7 @@ class RisikoklassifiseringUtførTaskTest {
         var ref = BehandlingReferanse.fra(behandling);
         forberedelse(ref, true);
         var prosessTaskData = ProsessTaskData.forProsessTask(RisikoklassifiseringUtførTask.class);
-                prosessTaskData.setProperty(CommonTaskProperties.BEHANDLING_ID, String.valueOf(BEHANDLING_ID));
+                prosessTaskData.setBehandling("9999", 0L, BEHANDLING_ID);
         risikoklassifiseringUtførTask.doTask(prosessTaskData);
         var request = new RisikovurderingRequestDto(
             new no.nav.foreldrepenger.kontrakter.risk.kodeverk.AktørId(ref.aktørId().getId()), SKJÆRINGSTIDSPUNKT, LocalDate.now(),

--- a/domenetjenester/skjaeringstidspunkt/src/main/java/no/nav/foreldrepenger/skjæringstidspunkt/fp/SkjæringstidspunktTjenesteImpl.java
+++ b/domenetjenester/skjaeringstidspunkt/src/main/java/no/nav/foreldrepenger/skjæringstidspunkt/fp/SkjæringstidspunktTjenesteImpl.java
@@ -138,7 +138,7 @@ public class SkjæringstidspunktTjenesteImpl implements SkjæringstidspunktTjene
                 .build();
         } else {
             Optional<LocalDate> morsMaksdato = UtsettelseCore2021.kreverSammenhengendeUttak(familieHendelseGrunnlag.orElse(null)) ?
-                ytelseMaksdatoTjeneste.beregnMorsMaksdato(behandling.getFagsak().getSaksnummer(), behandling.getFagsak().getRelasjonsRolleType())
+                ytelseMaksdatoTjeneste.beregnMorsMaksdato(behandling.getSaksnummer(), behandling.getFagsak().getRelasjonsRolleType())
                     .filter(UtsettelseCore2021::kreverSammenhengendeUttakMorsMaxdato) : Optional.empty();
             var utledetSkjæringstidspunkt = SkjæringstidspunktUtils.utledSkjæringstidspunktFraBehandling(behandling, førsteUttaksdato,
                 familieHendelseGrunnlag, morsMaksdato, utenMinsterett);

--- a/domenetjenester/uttak/src/test/java/no/nav/foreldrepenger/domene/uttak/uttaksgrunnlag/fp/EndringsdatoRevurderingUtlederTest.java
+++ b/domenetjenester/uttak/src/test/java/no/nav/foreldrepenger/domene/uttak/uttaksgrunnlag/fp/EndringsdatoRevurderingUtlederTest.java
@@ -886,7 +886,7 @@ class EndringsdatoRevurderingUtlederTest {
         var ytelse = ytelselseBuilder.medKilde(Fagsystem.FPSAK)
             .medYtelseType(RelatertYtelseType.FORELDREPENGER)
             .medStatus(RelatertYtelseTilstand.AVSLUTTET)
-            .medSaksnummer(revurdering.getFagsak().getSaksnummer())
+            .medSaksnummer(revurdering.getSaksnummer())
             .medPeriode(
                 DatoIntervallEntitet.fraOgMedTilOgMed(LocalDate.now().minusMonths(3), LocalDate.now().plusMonths(6)));
         aktørYtelseBuilder.leggTilYtelse(ytelse);

--- a/domenetjenester/vedtak/src/main/java/no/nav/foreldrepenger/domene/vedtak/OpprettProsessTaskIverksett.java
+++ b/domenetjenester/vedtak/src/main/java/no/nav/foreldrepenger/domene/vedtak/OpprettProsessTaskIverksett.java
@@ -53,7 +53,7 @@ public class OpprettProsessTaskIverksett {
         }
         // Siste i gruppen
         taskGruppe.addNesteSekvensiell(avsluttBehandling);
-        taskGruppe.setBehandling(behandling.getFagsakId(), behandling.getId(), behandling.getAktørId().getId());
+        taskGruppe.setBehandling(behandling.getSaksnummer().getVerdi(), behandling.getFagsakId(), behandling.getId());
         taskGruppe.setCallIdFraEksisterende();
         taskTjeneste.lagre(taskGruppe);
     }

--- a/domenetjenester/vedtak/src/main/java/no/nav/foreldrepenger/domene/vedtak/batch/AutomatiskFagsakAvslutningTjeneste.java
+++ b/domenetjenester/vedtak/src/main/java/no/nav/foreldrepenger/domene/vedtak/batch/AutomatiskFagsakAvslutningTjeneste.java
@@ -52,7 +52,7 @@ public class AutomatiskFagsakAvslutningTjeneste {
     private ProsessTaskData opprettFagsakAvslutningTask(Fagsak fagsak, String callId, LocalDate dato, LocalTime tid, int spread) {
         var nesteKjøring = LocalDateTime.of(dato, tid.plusSeconds(Math.abs(System.nanoTime()) % spread));
         var prosessTaskData = ProsessTaskData.forProsessTask(AutomatiskFagsakAvslutningTask.class);
-        prosessTaskData.setFagsak(fagsak.getId(), fagsak.getAktørId().getId());
+        prosessTaskData.setFagsak(fagsak.getSaksnummer().getVerdi(), fagsak.getId());
         prosessTaskData.setNesteKjøringEtter(nesteKjøring);
         // unik per task da det er ulike tasks for hver behandling
         prosessTaskData.setCallId(callId);

--- a/domenetjenester/vedtak/src/main/java/no/nav/foreldrepenger/domene/vedtak/batch/AvslutteFagsakerEnkeltOpphørTjeneste.java
+++ b/domenetjenester/vedtak/src/main/java/no/nav/foreldrepenger/domene/vedtak/batch/AvslutteFagsakerEnkeltOpphørTjeneste.java
@@ -122,9 +122,8 @@ public class AvslutteFagsakerEnkeltOpphørTjeneste {
     private ProsessTaskData opprettFagsakAvslutningTask(Fagsak fagsak, String callId, LocalDate dato, LocalTime tid, int spread) {
         var nesteKjøring = LocalDateTime.of(dato, tid.plusSeconds(Math.abs(System.nanoTime()) % spread));
         var prosessTaskData = ProsessTaskData.forProsessTask(AutomatiskFagsakAvslutningTask.class);
-        prosessTaskData.setFagsak(fagsak.getId(), fagsak.getAktørId().getId());
+        prosessTaskData.setFagsak(fagsak.getSaksnummer().getVerdi(), fagsak.getId());
         prosessTaskData.setNesteKjøringEtter(nesteKjøring);
-        prosessTaskData.setSaksnummer(fagsak.getSaksnummer().toString());
         prosessTaskData.setCallId(callId);
         return prosessTaskData;
     }

--- a/domenetjenester/vedtak/src/main/java/no/nav/foreldrepenger/domene/vedtak/observer/PubliserVedtattYtelseHendelseTask.java
+++ b/domenetjenester/vedtak/src/main/java/no/nav/foreldrepenger/domene/vedtak/observer/PubliserVedtattYtelseHendelseTask.java
@@ -54,7 +54,7 @@ public class PubliserVedtattYtelseHendelseTask implements ProsessTaskHandler {
             .flatMap(behandlingRepository::finnUnikBehandlingForBehandlingId)
             .ifPresent(b -> {
                 var payload = generatePayload(b);
-                producer.sendJson(b.getFagsak().getSaksnummer().getVerdi(), payload);
+                producer.sendJson(b.getSaksnummer().getVerdi(), payload);
             });
     }
 

--- a/domenetjenester/vedtak/src/main/java/no/nav/foreldrepenger/domene/vedtak/observer/VedtattYtelseTjeneste.java
+++ b/domenetjenester/vedtak/src/main/java/no/nav/foreldrepenger/domene/vedtak/observer/VedtattYtelseTjeneste.java
@@ -60,7 +60,7 @@ public class VedtattYtelseTjeneste {
         aktør.setVerdi(behandling.getAktørId().getId());
         var ytelse = new YtelseV1();
         ytelse.setKildesystem(Kildesystem.FPSAK);
-        ytelse.setSaksnummer(behandling.getFagsak().getSaksnummer().getVerdi());
+        ytelse.setSaksnummer(behandling.getSaksnummer().getVerdi());
         ytelse.setVedtattTidspunkt(vedtak.getVedtakstidspunkt());
         ytelse.setVedtakReferanse(behandling.getUuid().toString());
         ytelse.setAktør(aktør);

--- a/domenetjenester/vedtak/src/main/java/no/nav/foreldrepenger/domene/vedtak/task/VurderOgSendØkonomiOppdragTask.java
+++ b/domenetjenester/vedtak/src/main/java/no/nav/foreldrepenger/domene/vedtak/task/VurderOgSendØkonomiOppdragTask.java
@@ -87,9 +87,7 @@ public class VurderOgSendØkonomiOppdragTask extends BehandlingProsessTask {
         var sendØkonomiOppdrag = ProsessTaskData.forProsessTask(SendØkonomiOppdragTask.class);
         sendØkonomiOppdrag.setGruppe(hovedProsessTask.getGruppe());
         sendØkonomiOppdrag.setCallIdFraEksisterende();
-        sendØkonomiOppdrag.setBehandling(hovedProsessTask.getFagsakId(),
-            behandlingId,
-            hovedProsessTask.getAktørId());
+        sendØkonomiOppdrag.setBehandling(hovedProsessTask.getSaksnummer(), hovedProsessTask.getFagsakId(), behandlingId);
         taskTjeneste.lagre(sendØkonomiOppdrag);
     }
 

--- a/domenetjenester/vedtak/src/test/java/no/nav/foreldrepenger/domene/vedtak/batch/AutomatiskFagsakAvslutningTjenesteTest.java
+++ b/domenetjenester/vedtak/src/test/java/no/nav/foreldrepenger/domene/vedtak/batch/AutomatiskFagsakAvslutningTjenesteTest.java
@@ -16,7 +16,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import no.nav.foreldrepenger.behandling.FagsakRelasjonTjeneste;
 import no.nav.foreldrepenger.behandlingslager.fagsak.Fagsak;
-import no.nav.foreldrepenger.domene.typer.AktørId;
+import no.nav.foreldrepenger.domene.typer.Saksnummer;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTaskData;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTaskTjeneste;
 
@@ -64,9 +64,8 @@ class AutomatiskFagsakAvslutningTjenesteTest {
 
     private Fagsak lagFagsak() {
         var fagsak = mock(Fagsak.class);
-        var aktørId = mock(AktørId.class);
-        when(aktørId.getId()).thenReturn("1");
-        when(fagsak.getAktørId()).thenReturn(aktørId);
+        var saksnummer = new Saksnummer("9999");
+        when(fagsak.getSaksnummer()).thenReturn(saksnummer);
 
         return fagsak;
     }

--- a/domenetjenester/vedtak/src/test/java/no/nav/foreldrepenger/domene/vedtak/innsyn/InnsynTjenesteTest.java
+++ b/domenetjenester/vedtak/src/test/java/no/nav/foreldrepenger/domene/vedtak/innsyn/InnsynTjenesteTest.java
@@ -69,7 +69,7 @@ class InnsynTjenesteTest {
     void skal_opprette_innsynsbehandling_på_fagsak() {
         // arrange
         var opprinneligBehandling = scenario.lagre(repositoryProvider);
-        var saksnummer = opprinneligBehandling.getFagsak().getSaksnummer();
+        var saksnummer = opprinneligBehandling.getSaksnummer();
 
         // act
         var nyBehandling = innsynTjeneste.opprettManueltInnsyn(saksnummer);
@@ -82,7 +82,7 @@ class InnsynTjenesteTest {
     void skal_ikke_opprette_flere_behandlingsresultat_men_oppdatere_eksisterende_når_det_kommer_endringer() {
         // arrange
         var opprinneligBehandling = scenario.lagre(repositoryProvider);
-        var saksnummer = opprinneligBehandling.getFagsak().getSaksnummer();
+        var saksnummer = opprinneligBehandling.getSaksnummer();
 
         var innsynbehandling = innsynTjeneste.opprettManueltInnsyn(saksnummer);
 

--- a/domenetjenester/vedtak/src/test/java/no/nav/foreldrepenger/domene/vedtak/intern/AvsluttBehandlingTest.java
+++ b/domenetjenester/vedtak/src/test/java/no/nav/foreldrepenger/domene/vedtak/intern/AvsluttBehandlingTest.java
@@ -14,8 +14,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
-import no.nav.foreldrepenger.domene.prosess.BeregningTjeneste;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -42,6 +40,7 @@ import no.nav.foreldrepenger.behandlingslager.behandling.vedtak.VedtakResultatTy
 import no.nav.foreldrepenger.behandlingslager.fagsak.Fagsak;
 import no.nav.foreldrepenger.behandlingslager.testutilities.behandling.ScenarioMorSøkerEngangsstønad;
 import no.nav.foreldrepenger.behandlingsprosess.prosessering.BehandlingProsesseringTjeneste;
+import no.nav.foreldrepenger.domene.prosess.BeregningTjeneste;
 import no.nav.foreldrepenger.domene.vedtak.impl.VurderBehandlingerUnderIverksettelse;
 
 @ExtendWith(MockitoExtension.class)
@@ -85,14 +84,14 @@ class AvsluttBehandlingTest {
             Long behId = invocation.getArgument(0);
             var lås = new BehandlingLås(behId) {
             };
-            return new BehandlingskontrollKontekst(fagsak.getId(), fagsak.getAktørId(), lås);
+            return new BehandlingskontrollKontekst(fagsak.getSaksnummer(), fagsak.getId(), lås);
         });
         when(behandlingskontrollTjeneste.initBehandlingskontroll(Mockito.any(Behandling.class))).thenAnswer(
                 invocation -> {
                     Behandling beh = invocation.getArgument(0);
                     var lås = new BehandlingLås(beh.getId()) {
                     };
-                    return new BehandlingskontrollKontekst(fagsak.getId(), fagsak.getAktørId(), lås);
+                    return new BehandlingskontrollKontekst(fagsak.getSaksnummer(), fagsak.getId(), lås);
                 });
     }
 

--- a/domenetjenester/vedtak/src/test/java/no/nav/foreldrepenger/domene/vedtak/task/VurderOgSendØkonomiOppdragTaskTest.java
+++ b/domenetjenester/vedtak/src/test/java/no/nav/foreldrepenger/domene/vedtak/task/VurderOgSendØkonomiOppdragTaskTest.java
@@ -36,6 +36,7 @@ import no.nav.vedtak.felles.prosesstask.api.ProsessTaskTjeneste;
 class VurderOgSendØkonomiOppdragTaskTest {
 
     private static final Long BEHANDLING_ID = 139L;
+    private static final String SAKSNUMMER = "9999";
 
     private static final Long TASK_ID = 238L;
 
@@ -61,8 +62,8 @@ class VurderOgSendØkonomiOppdragTaskTest {
     @BeforeEach
     public void setUp() {
         when(prosessTaskData.getBehandlingId()).thenReturn(BEHANDLING_ID.toString());
+        lenient().when(prosessTaskData.getSaksnummer()).thenReturn(SAKSNUMMER);
         lenient().when(prosessTaskData.getId()).thenReturn(TASK_ID);
-        lenient().when(prosessTaskData.getAktørId()).thenReturn(AKTØR_ID);
         var repositoryProvider = ScenarioMorSøkerForeldrepenger.forFødsel().mockBehandlingRepositoryProvider();
         lenient().when(repositoryProvider.getBehandlingRepository().hentBehandling(BEHANDLING_ID))
             .thenReturn(Behandling.nyBehandlingFor(Fagsak.opprettNy(FagsakYtelseType.FORELDREPENGER, NavBruker.opprettNy(AktørId.dummy(), Språkkode.NB)), BehandlingType.FØRSTEGANGSSØKNAD).build());

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
         <fp-ytelse-beregn.version>1.0.4</fp-ytelse-beregn.version>
 
         <felles.version>7.3.1</felles.version>
-        <prosesstask.version>5.0.19</prosesstask.version>
+        <prosesstask.version>5.0.20</prosesstask.version>
 
         <fp-kontrakter.version>9.1.22</fp-kontrakter.version>
         <abakus-kontrakt.version>2.1.2</abakus-kontrakt.version>

--- a/web/src/main/java/no/nav/foreldrepenger/jsonfeed/HendelsePublisererTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/jsonfeed/HendelsePublisererTjeneste.java
@@ -204,7 +204,7 @@ public class HendelsePublisererTjeneste {
         innhold.setFoersteStoenadsdag(utbetPeriode.getFomDato());
         innhold.setSisteStoenadsdag(utbetPeriode.getTomDato());
         innhold.setAktoerId(behandling.getAktørId().getId());
-        innhold.setGsakId(behandling.getFagsak().getSaksnummer().getVerdi());
+        innhold.setGsakId(behandling.getSaksnummer().getVerdi());
         innhold.setFnr(fnr.getIdent());
 
         return innhold;
@@ -224,7 +224,7 @@ public class HendelsePublisererTjeneste {
         innhold.setFoersteStoenadsdag(utbetPeriode.getFomDato());
         innhold.setSisteStoenadsdag(utbetPeriode.getTomDato());
         innhold.setAktoerId(behandling.getAktørId().getId());
-        innhold.setGsakId(behandling.getFagsak().getSaksnummer().getVerdi());
+        innhold.setGsakId(behandling.getSaksnummer().getVerdi());
         innhold.setFnr(fnr.getIdent());
 
         return innhold;

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/BehandlingRestTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/BehandlingRestTjeneste.java
@@ -386,7 +386,7 @@ public class BehandlingRestTjeneste {
         var saksnummer = new Saksnummer(s.getVerdi());
 
         return behandlingDtoTjeneste.hentAnnenPartsGjeldendeYtelsesBehandling(saksnummer)
-            .map(behandling -> new AnnenPartBehandlingDto(behandling.getFagsak().getSaksnummer().getVerdi(),
+            .map(behandling -> new AnnenPartBehandlingDto(behandling.getSaksnummer().getVerdi(),
                 behandling.getFagsak().getRelasjonsRolleType(), behandling.getUuid()))
             .map(apDto -> Response.ok().entity(apDto).build()).orElseGet(() -> Response.ok().build());
     }

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/aksjonspunkt/BehandlingsoppretterTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/aksjonspunkt/BehandlingsoppretterTjeneste.java
@@ -84,35 +84,36 @@ public class BehandlingsoppretterTjeneste {
                 throw kanIkkeOppretteNyFørstegangsbehandlingEtterKlage(fagsakId);
             }
             var behandlingÅrsakType = erEtterKlageBehandling ? BehandlingÅrsakType.ETTER_KLAGE : BehandlingÅrsakType.UDEFINERT;
-            doOpprettNyBehandlingIgjennomMottak(fagsakId, behandlingÅrsakType);
+            doOpprettNyBehandlingIgjennomMottak(fagsakId, saksnummer, behandlingÅrsakType);
         } else {
             throw kanIkkeOppretteNyFørstegangsbehandling(fagsakId);
         }
     }
 
-    private void doOpprettNyBehandlingIgjennomMottak(Long fagsakId, BehandlingÅrsakType behandlingÅrsakType) {
+    private void doOpprettNyBehandlingIgjennomMottak(Long fagsakId, Saksnummer saksnummer, BehandlingÅrsakType behandlingÅrsakType) {
         var sisteMottatteSøknad = finnSisteMottatteSøknadPåFagsak(fagsakId);
         if (sisteMottatteSøknad != null) {
-            opprettNyBehandlingFraSøknad(behandlingÅrsakType, sisteMottatteSøknad);
+            opprettNyBehandlingFraSøknad(behandlingÅrsakType, sisteMottatteSøknad, saksnummer);
         } else {
             opprettNyBehandlingFraInntektsmelding(fagsakId, behandlingÅrsakType);
         }
     }
 
     private void opprettNyBehandlingFraSøknad(BehandlingÅrsakType behandlingÅrsakType,
-                                              MottattDokument sisteMottatteSøknad) {
+                                              MottattDokument sisteMottatteSøknad,
+                                              Saksnummer saksnummer) {
         if (sisteMottatteSøknad.getBehandlingId() != null) {
             if (sisteMottatteSøknad.getPayloadXml() == null) {
                 // For å registrere papirsøknad på nytt ....
                 var nyMottatt = new MottattDokument.Builder(sisteMottatteSøknad).build();
-                saksbehandlingDokumentmottakTjeneste.dokumentAnkommet(nyMottatt, behandlingÅrsakType);
+                saksbehandlingDokumentmottakTjeneste.dokumentAnkommet(nyMottatt, behandlingÅrsakType, saksnummer);
             } else {
                 var sisteBehandling = behandlingRepository.hentBehandling(sisteMottatteSøknad.getBehandlingId());
                 saksbehandlingDokumentmottakTjeneste.opprettFraTidligereBehandling(sisteMottatteSøknad, sisteBehandling,
                     behandlingÅrsakType);
             }
         } else {
-            saksbehandlingDokumentmottakTjeneste.mottaUbehandletSøknad(sisteMottatteSøknad, behandlingÅrsakType);
+            saksbehandlingDokumentmottakTjeneste.mottaUbehandletSøknad(sisteMottatteSøknad, behandlingÅrsakType, saksnummer);
         }
     }
 

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/aksjonspunkt/BehandlingsoppretterTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/aksjonspunkt/BehandlingsoppretterTjeneste.java
@@ -132,7 +132,7 @@ public class BehandlingsoppretterTjeneste {
         var behandlinger = behandlingRepository.hentAbsoluttAlleBehandlingerForSaksnummer(saksnummer);
 
         if (harMinstEnÅpenFørstegangsbehandling(behandlinger)) {
-            doOpprettNyBehandlingIgjennomMottak(fagsakId, BehandlingÅrsakType.UDEFINERT);
+            doOpprettNyBehandlingIgjennomMottak(fagsakId, saksnummer, BehandlingÅrsakType.UDEFINERT);
         } else {
             throw kanIkkeHenleggeÅpenBehandlingOgOppretteNyFørstegangsbehandling(fagsakId);
         }

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/aksjonspunkt/BehandlingsprosessTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/aksjonspunkt/BehandlingsprosessTjeneste.java
@@ -172,11 +172,11 @@ public class BehandlingsprosessTjeneste {
         var gruppe = new ProsessTaskGruppe();
 
         var åpneBehandlingForEndringerTask = ProsessTaskData.forProsessTask(ÅpneBehandlingForEndringerTask.class);
-        åpneBehandlingForEndringerTask.setBehandling(behandling.getFagsakId(), behandling.getId(), behandling.getAktørId().getId());
+        åpneBehandlingForEndringerTask.setBehandling(behandling.getSaksnummer().getVerdi(), behandling.getFagsakId(), behandling.getId());
         åpneBehandlingForEndringerTask.setCallIdFraEksisterende();
         gruppe.addNesteSekvensiell(åpneBehandlingForEndringerTask);
         var fortsettBehandlingTask = ProsessTaskData.forProsessTask(FortsettBehandlingTask.class);
-        fortsettBehandlingTask.setBehandling(behandling.getFagsakId(), behandling.getId(), behandling.getAktørId().getId());
+        fortsettBehandlingTask.setBehandling(behandling.getSaksnummer().getVerdi(), behandling.getFagsakId(), behandling.getId());
         fortsettBehandlingTask.setProperty(FortsettBehandlingTask.MANUELL_FORTSETTELSE, String.valueOf(true));
         fortsettBehandlingTask.setCallIdFraEksisterende();
         gruppe.addNesteSekvensiell(fortsettBehandlingTask);

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/dekningsgrad/AvklarDekningsgradFellesTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/dekningsgrad/AvklarDekningsgradFellesTjeneste.java
@@ -65,7 +65,7 @@ public class AvklarDekningsgradFellesTjeneste {
         var fagsakRelasjon = fagsakRelasjonTjeneste.finnRelasjonForHvisEksisterer(fagsakId).orElseThrow();
         fagsakRelasjon.getRelatertFagsakFraId(fagsakId).ifPresent(sak -> {
             var prosessTaskData = ProsessTaskData.forProsessTask(TilbakeførTilDekningsgradStegTask.class);
-            prosessTaskData.setFagsak(sak.getId(), sak.getAktørId().getId());
+            prosessTaskData.setFagsak(sak.getSaksnummer().getVerdi(), sak.getId());
             prosessTaskData.setNesteKjøringEtter(LocalDateTime.now().plusSeconds(5)); //Liten delay her for å hindre samtidighetsproblem i køing inn i uttak
             prosessTaskTjeneste.lagre(prosessTaskData);
         });

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/dto/behandling/BehandlingDtoForBackendTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/dto/behandling/BehandlingDtoForBackendTjeneste.java
@@ -78,7 +78,7 @@ public class BehandlingDtoForBackendTjeneste {
 
         var uuidDto = new UuidDto(behandling.getUuid());
 
-        dto.leggTil(get(FagsakRestTjeneste.FAGSAK_PATH, "fagsak", new SaksnummerDto(behandling.getFagsak().getSaksnummer())));
+        dto.leggTil(get(FagsakRestTjeneste.FAGSAK_PATH, "fagsak", new SaksnummerDto(behandling.getSaksnummer())));
         dto.leggTil(get(PersonRestTjeneste.VERGE_BACKEND_PATH, "verge-backend", uuidDto));
         dto.leggTil(get(PersonRestTjeneste.PERSONOPPLYSNINGER_TILBAKE_PATH, "personopplysninger-tilbake", uuidDto));
         dto.leggTil(get(SøknadRestTjeneste.SOKNAD_BACKEND_PATH, "soknad-backend", uuidDto));

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/dto/behandling/BehandlingDtoTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/dto/behandling/BehandlingDtoTjeneste.java
@@ -268,7 +268,7 @@ public class BehandlingDtoTjeneste {
         var dto = new UtvidetBehandlingDto();
         settStandardfelterUtvidet(behandling, dto, erBehandlingMedGjeldendeVedtak);
 
-        var saksnummerDto = new SaksnummerDto(behandling.getFagsak().getSaksnummer());
+        var saksnummerDto = new SaksnummerDto(behandling.getSaksnummer());
         dto.leggTil(get(FagsakRestTjeneste.FAGSAK_PATH, "fagsak", saksnummerDto));
 
         leggTilLenkerForBehandlingsoperasjoner(behandling, dto);

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/dto/behandling/BehandlingFormidlingDtoTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/dto/behandling/BehandlingFormidlingDtoTjeneste.java
@@ -132,7 +132,7 @@ public class BehandlingFormidlingDtoTjeneste {
         var dto = new BehandlingFormidlingDto();
         settStandardfelterForBrev(behandling, dto);
 
-        var saksnummerDto = new SaksnummerDto(behandling.getFagsak().getSaksnummer());
+        var saksnummerDto = new SaksnummerDto(behandling.getSaksnummer());
         dto.leggTil(get(FagsakRestTjeneste.FAGSAK_PATH, "fagsak", saksnummerDto));
 
         var uuidDto = new UuidDto(behandling.getUuid());
@@ -239,7 +239,7 @@ public class BehandlingFormidlingDtoTjeneste {
     }
 
     private Optional<Uttak> hentUttakAnnenpartForeldrepengerHvisEksisterer(Behandling søkersBehandling) {
-        var annenpartBehandling = relatertBehandlingTjeneste.hentAnnenPartsGjeldendeVedtattBehandling(søkersBehandling.getFagsak().getSaksnummer());
+        var annenpartBehandling = relatertBehandlingTjeneste.hentAnnenPartsGjeldendeVedtattBehandling(søkersBehandling.getSaksnummer());
         return annenpartBehandling.flatMap(ab -> uttakTjeneste.hentHvisEksisterer(ab.getId()));
     }
 

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/uttak/app/UttakPerioderDtoTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/uttak/app/UttakPerioderDtoTjeneste.java
@@ -102,7 +102,7 @@ public class UttakPerioderDtoTjeneste {
             return relatertBehandlingTjeneste.hentAnnenPartsGjeldendeBehandlingPåVedtakstidspunkt(søkersBehandling);
         }
 
-        return relatertBehandlingTjeneste.hentAnnenPartsGjeldendeVedtattBehandling(søkersBehandling.getFagsak().getSaksnummer());
+        return relatertBehandlingTjeneste.hentAnnenPartsGjeldendeVedtattBehandling(søkersBehandling.getSaksnummer());
     }
 
     private boolean harVedtak(Behandling søkersBehandling) {

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/datavarehus/DatavarehusAdminRestTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/datavarehus/DatavarehusAdminRestTjeneste.java
@@ -64,7 +64,7 @@ public class DatavarehusAdminRestTjeneste {
 
         if (lagretVedtak != null) {
             var prosessTaskData = ProsessTaskData.forProsessTask(RegenererVedtaksXmlTask.class);
-            prosessTaskData.setBehandling(behandling.getFagsakId(), behandling.getId(), behandling.getAktørId().getId());
+            prosessTaskData.setBehandling(behandling.getSaksnummer().getVerdi(), behandling.getFagsakId(), behandling.getId());
             prosessTaskData.setCallIdFraEksisterende();
             taskTjeneste.lagre(prosessTaskData);
         } else {

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/fagsak/FagsakRestTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/fagsak/FagsakRestTjeneste.java
@@ -254,7 +254,7 @@ public class FagsakRestTjeneste {
 
     private ProsessTaskData opprettLosProsessTask(Behandling behandling) {
         var prosessTaskData = ProsessTaskData.forProsessTask(PubliserBehandlingHendelseTask.class);
-        prosessTaskData.setBehandling(behandling.getFagsakId(), behandling.getId());
+        prosessTaskData.setBehandling(behandling.getSaksnummer().getVerdi(), behandling.getFagsakId(), behandling.getId());
         prosessTaskData.setProperty(PubliserBehandlingHendelseTask.HENDELSE_TYPE, HendelseForBehandling.AKSJONSPUNKT.name());
         prosessTaskData.setCallIdFraEksisterende();
         return prosessTaskData;
@@ -262,7 +262,7 @@ public class FagsakRestTjeneste {
 
     private ProsessTaskData opprettOppdaterEnhetTask(Behandling behandling) {
         var prosessTaskData = ProsessTaskData.forProsessTask(OppdaterBehandlendeEnhetTask.class);
-        prosessTaskData.setBehandling(behandling.getFagsakId(), behandling.getId());
+        prosessTaskData.setBehandling(behandling.getSaksnummer().getVerdi(), behandling.getFagsakId(), behandling.getId());
         prosessTaskData.setCallIdFraEksisterende();
         return prosessTaskData;
     }

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/fagsak/app/FagsakFullTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/fagsak/app/FagsakFullTjeneste.java
@@ -169,7 +169,7 @@ public class FagsakFullTjeneste {
         return fagsakRelasjonTjeneste.finnRelasjonForHvisEksisterer(fagsak)
             .flatMap(r -> r.getRelatertFagsakFraId(fagsak.getId()))
             .map(Fagsak::getId).flatMap(behandlingRepository::hentSisteYtelsesBehandlingForFagsakId)
-            .map(behandling -> new AnnenPartBehandlingDto(behandling.getFagsak().getSaksnummer().getVerdi(),
+            .map(behandling -> new AnnenPartBehandlingDto(behandling.getSaksnummer().getVerdi(),
                 behandling.getFagsak().getRelasjonsRolleType(), behandling.getUuid()));
     }
 }

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/fordeling/FordelRestTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/fordeling/FordelRestTjeneste.java
@@ -243,8 +243,9 @@ public class FordelRestTjeneste {
             return Response.ok().build();
         }
         ensureCallId();
-        var dokument = mapTilMottattDokument(mottattJournalpost, dokumentTypeId);
-        dokumentmottakTjeneste.dokumentAnkommet(dokument, null);
+        var saksnummer = new Saksnummer(mottattJournalpost.getSaksnummer());
+        var dokument = mapTilMottattDokument(mottattJournalpost, dokumentTypeId, saksnummer);
+        dokumentmottakTjeneste.dokumentAnkommet(dokument, null, saksnummer);
         return Response.ok().build();
     }
 
@@ -343,9 +344,7 @@ public class FordelRestTjeneste {
         return dto;
     }
 
-    private MottattDokument mapTilMottattDokument(AbacJournalpostMottakDto journalpostMottakDto, DokumentTypeId dokumentTypeId) {
-
-        var saksnummer = new Saksnummer(journalpostMottakDto.getSaksnummer());
+    private MottattDokument mapTilMottattDokument(AbacJournalpostMottakDto journalpostMottakDto, DokumentTypeId dokumentTypeId, Saksnummer saksnummer) {
         var fagsak = fagsakTjeneste.finnFagsakGittSaksnummer(saksnummer, false)
             .orElseThrow(() -> new IllegalStateException("Finner ingen fagsak for saksnummer " + saksnummer));
         var dokumentKategori = utledDokumentKategori(journalpostMottakDto.getDokumentKategoriOffisiellKode(), dokumentTypeId);

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/fordeling/OpprettSakTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/fordeling/OpprettSakTjeneste.java
@@ -1,5 +1,7 @@
 package no.nav.foreldrepenger.web.app.tjenester.fordeling;
 
+import java.util.Optional;
+
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 
@@ -13,8 +15,6 @@ import no.nav.foreldrepenger.domene.typer.AktørId;
 import no.nav.foreldrepenger.domene.typer.JournalpostId;
 import no.nav.foreldrepenger.domene.typer.Saksnummer;
 import no.nav.vedtak.exception.TekniskException;
-
-import java.util.Optional;
 
 @ApplicationScoped
 public class OpprettSakTjeneste {

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/forvaltning/ForvaltningBeregningRestTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/forvaltning/ForvaltningBeregningRestTjeneste.java
@@ -28,14 +28,6 @@ import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 
-import no.nav.foreldrepenger.behandling.BehandlingReferanse;
-
-import no.nav.foreldrepenger.behandlingslager.behandling.beregning.SatsRepository;
-
-import no.nav.foreldrepenger.web.app.tjenester.forvaltning.dto.StoppRefusjonDto;
-
-import no.nav.vedtak.sikkerhet.kontekst.KontekstHolder;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -44,12 +36,13 @@ import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import no.nav.foreldrepenger.behandling.BehandlingReferanse;
 import no.nav.foreldrepenger.behandling.revurdering.satsregulering.GrunnbeløpReguleringTask;
-import no.nav.foreldrepenger.domene.mappers.til_kalkulator.BeregningsgrunnlagInputProvider;
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
 import no.nav.foreldrepenger.behandlingslager.behandling.SpesialBehandling;
 import no.nav.foreldrepenger.behandlingslager.behandling.beregning.BeregningSats;
 import no.nav.foreldrepenger.behandlingslager.behandling.beregning.BeregningSatsType;
+import no.nav.foreldrepenger.behandlingslager.behandling.beregning.SatsRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepository;
 import no.nav.foreldrepenger.behandlingslager.fagsak.Fagsak;
 import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakRepository;
@@ -66,6 +59,7 @@ import no.nav.foreldrepenger.domene.iay.modell.InntektsmeldingAggregat;
 import no.nav.foreldrepenger.domene.iay.modell.Inntektspost;
 import no.nav.foreldrepenger.domene.iay.modell.kodeverk.InntektsKilde;
 import no.nav.foreldrepenger.domene.json.StandardJsonConfig;
+import no.nav.foreldrepenger.domene.mappers.til_kalkulator.BeregningsgrunnlagInputProvider;
 import no.nav.foreldrepenger.domene.tid.DatoIntervallEntitet;
 import no.nav.foreldrepenger.domene.typer.Beløp;
 import no.nav.foreldrepenger.domene.typer.Saksnummer;
@@ -73,6 +67,7 @@ import no.nav.foreldrepenger.web.app.tjenester.fagsak.dto.SaksnummerAbacSupplier
 import no.nav.foreldrepenger.web.app.tjenester.fagsak.dto.SaksnummerDto;
 import no.nav.foreldrepenger.web.app.tjenester.forvaltning.dto.BeregningSatsDto;
 import no.nav.foreldrepenger.web.app.tjenester.forvaltning.dto.ForvaltningBehandlingIdDto;
+import no.nav.foreldrepenger.web.app.tjenester.forvaltning.dto.StoppRefusjonDto;
 import no.nav.vedtak.exception.TekniskException;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTaskData;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTaskTjeneste;
@@ -80,6 +75,7 @@ import no.nav.vedtak.sikkerhet.abac.BeskyttetRessurs;
 import no.nav.vedtak.sikkerhet.abac.TilpassetAbacAttributt;
 import no.nav.vedtak.sikkerhet.abac.beskyttet.ActionType;
 import no.nav.vedtak.sikkerhet.abac.beskyttet.ResourceType;
+import no.nav.vedtak.sikkerhet.kontekst.KontekstHolder;
 
 @Path("/forvaltningBeregning")
 @ApplicationScoped
@@ -194,7 +190,7 @@ public class ForvaltningBeregningRestTjeneste {
             return Response.status(Response.Status.BAD_REQUEST).build();
         }
         var prosessTaskData = ProsessTaskData.forProsessTask(GrunnbeløpReguleringTask.class);
-        prosessTaskData.setFagsak(fagsak.getId(), fagsak.getAktørId().getId());
+        prosessTaskData.setFagsak(fagsak.getSaksnummer().getVerdi(), fagsak.getId());
         prosessTaskData.setCallIdFraEksisterende();
         prosessTaskData.setProperty(GrunnbeløpReguleringTask.MANUELL_KEY, "true");
         taskTjeneste.lagre(prosessTaskData);
@@ -224,7 +220,7 @@ public class ForvaltningBeregningRestTjeneste {
             return Response.ok(msg).build();
         }
         var task = ProsessTaskData.forProsessTask(OverstyrInntektsmeldingTask.class);
-        task.setBehandling(behandling.getFagsakId(), behandling.getId(), behandling.getAktørId().getId());
+        task.setBehandling(behandling.getSaksnummer().getVerdi(), behandling.getFagsakId(), behandling.getId());
         task.setCallIdFraEksisterende();
         task.setProperty(OverstyrInntektsmeldingTask.BEHANDLING_ID, behandling.getId().toString());
         task.setProperty(OverstyrInntektsmeldingTask.JOURNALPOST_ID, dto.getJournalpostId());

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/forvaltning/ForvaltningOppdragTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/forvaltning/ForvaltningOppdragTjeneste.java
@@ -206,9 +206,8 @@ class ForvaltningOppdragTjeneste {
         sendØkonomiOppdrag.setGruppe(hovedProsessTask.getGruppe());
         sendØkonomiOppdrag.setCallIdFraEksisterende();
         sendØkonomiOppdrag.setProperty("patchet", hardPatch ? "hardt" : "vanlig"); // for sporing
-        sendØkonomiOppdrag.setBehandling(hovedProsessTask.getFagsakId(),
-            Long.valueOf(hovedProsessTask.getBehandlingId()),
-            hovedProsessTask.getAktørId());
+        sendØkonomiOppdrag.setBehandling(hovedProsessTask.getSaksnummer(), hovedProsessTask.getFagsakId(),
+            Long.valueOf(hovedProsessTask.getBehandlingId()));
         taskTjeneste.lagre(sendØkonomiOppdrag);
     }
 
@@ -216,9 +215,7 @@ class ForvaltningOppdragTjeneste {
         var sendØkonomiOppdrag = ProsessTaskData.forProsessTask(SendØkonomiOppdragTask.class);
         sendØkonomiOppdrag.setCallIdFraEksisterende();
         sendØkonomiOppdrag.setProperty("patchet", "k27rapport"); // for sporing
-        sendØkonomiOppdrag.setBehandling(behandling.getFagsakId(),
-            behandling.getId(),
-            behandling.getAktørId().getId());
+        sendØkonomiOppdrag.setBehandling(behandling.getSaksnummer().getVerdi(), behandling.getFagsakId(), behandling.getId());
         taskTjeneste.lagre(sendØkonomiOppdrag);
     }
 
@@ -255,7 +252,7 @@ class ForvaltningOppdragTjeneste {
     }
 
     private void validerFagsystemId(Behandling behandling, long fagsystemId) {
-        if (!Long.toString(fagsystemId / 1000).equals(behandling.getFagsak().getSaksnummer().getVerdi())) {
+        if (!Long.toString(fagsystemId / 1000).equals(behandling.getSaksnummer().getVerdi())) {
             throw new ForvaltningException("FagsystemId=" + fagsystemId + " passer ikke med saksnummer for behandlingId=" + behandling.getId());
         }
     }

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/forvaltning/ForvaltningOpptjeningRestTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/forvaltning/ForvaltningOpptjeningRestTjeneste.java
@@ -163,7 +163,7 @@ public class ForvaltningOpptjeningRestTjeneste {
             return Response.status(Response.Status.BAD_REQUEST).build();
         }
         var prosessTaskData = ProsessTaskData.forProsessTask(InnhentIAYIAbakusTask.class);
-        prosessTaskData.setBehandling(behandling.getFagsakId(), behandling.getId(), behandling.getAktørId().getId());
+        prosessTaskData.setBehandling(behandling.getSaksnummer().getVerdi(), behandling.getFagsakId(), behandling.getId());
         prosessTaskData.setProperty(InnhentIAYIAbakusTask.OVERSTYR_KEY, InnhentIAYIAbakusTask.OVERSTYR_VALUE);
         prosessTaskData.setCallIdFraEksisterende();
         taskTjeneste.lagre(prosessTaskData);

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/forvaltning/ForvaltningUttrekkRestTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/forvaltning/ForvaltningUttrekkRestTjeneste.java
@@ -176,7 +176,7 @@ public class ForvaltningUttrekkRestTjeneste {
             return;
         }
         var task = ProsessTaskData.forProsessTask(MigrerTilOmsorgRettTask.class);
-        task.setBehandling(behandling.getFagsakId(), behandling.getId(), behandling.getAktørId().getId());
+        task.setBehandling(behandling.getSaksnummer().getVerdi(), behandling.getFagsakId(), behandling.getId());
         task.setCallIdFraEksisterende();
         taskTjeneste.lagre(task);
     }

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/forvaltning/fpoversikt/FpoversiktMigeringBehandlingHendelseTask.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/forvaltning/fpoversikt/FpoversiktMigeringBehandlingHendelseTask.java
@@ -83,8 +83,8 @@ class FpoversiktMigeringBehandlingHendelseTask implements ProsessTaskHandler {
         var hendelse = new BehandlingHendelseV1.Builder()
             .medHendelse(Hendelse.MIGRERING)
             .medHendelseUuid(UUID.randomUUID())
-            .medSaksnummer(behandling.getFagsak().getSaksnummer().getVerdi())
+            .medSaksnummer(behandling.getSaksnummer().getVerdi())
             .build();
-        kafkaProducer.sendJsonMedNøkkel(behandling.getFagsak().getSaksnummer().getVerdi(), DefaultJsonMapper.toJson(hendelse));
+        kafkaProducer.sendJsonMedNøkkel(behandling.getSaksnummer().getVerdi(), DefaultJsonMapper.toJson(hendelse));
     }
 }

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/forvaltning/praksisutsettelse/FeilPraksisForlengVentefristAlleTask.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/forvaltning/praksisutsettelse/FeilPraksisForlengVentefristAlleTask.java
@@ -35,7 +35,7 @@ class FeilPraksisForlengVentefristAlleTask implements ProsessTaskHandler {
 
         var behandlinger = utvalgRepository.finnNesteHundreBehandlingerSomErPåVentTilDesember(fraBehandlingId);
 
-        behandlinger.stream().map(behandling -> opprettTaskForEnkeltSak(behandling.fagsakId(), behandling.id())).forEach(prosessTaskTjeneste::lagre);
+        behandlinger.stream().map(behandling -> opprettTaskForEnkeltSak(behandling.fagsakId(), behandling.id(), behandling.saksnummer())).forEach(prosessTaskTjeneste::lagre);
 
         behandlinger.stream()
             .map(FeilPraksisUtsettelseRepository.BehandlingMedFagsakId::id)
@@ -45,9 +45,9 @@ class FeilPraksisForlengVentefristAlleTask implements ProsessTaskHandler {
 
     }
 
-    public static ProsessTaskData opprettTaskForEnkeltSak(Long fagsakId, Long behandlingId) {
+    public static ProsessTaskData opprettTaskForEnkeltSak(Long fagsakId, Long behandlingId, String saksnummer) {
         var prosessTaskData = ProsessTaskData.forProsessTask(FeilPraksisForlengVentefristSingleTask.class);
-        prosessTaskData.setBehandling(fagsakId, behandlingId);
+        prosessTaskData.setBehandling(saksnummer, fagsakId, behandlingId);
         prosessTaskData.setCallIdFraEksisterende();
         return prosessTaskData;
     }

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/forvaltning/stonadsstatistikk/ForvaltningStønadsstatistikkRestTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/forvaltning/stonadsstatistikk/ForvaltningStønadsstatistikkRestTjeneste.java
@@ -3,7 +3,6 @@ package no.nav.foreldrepenger.web.app.tjenester.forvaltning.stonadsstatistikk;
 import static no.nav.foreldrepenger.web.app.tjenester.forvaltning.stonadsstatistikk.StønadsstatistikkMigreringTask.opprettTaskForDato;
 
 import java.time.LocalDate;
-import java.util.List;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -18,20 +17,14 @@ import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 
-import org.hibernate.jpa.HibernateHints;
-
 import io.swagger.v3.oas.annotations.Operation;
 import no.nav.foreldrepenger.behandling.BehandlingReferanse;
-import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingsresultatRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepository;
-import no.nav.foreldrepenger.datavarehus.v2.SendStønadsstatistikkForVedtakTask;
 import no.nav.foreldrepenger.datavarehus.v2.StønadsstatistikkTjeneste;
 import no.nav.foreldrepenger.datavarehus.v2.StønadsstatistikkVedtak;
 import no.nav.foreldrepenger.skjæringstidspunkt.SkjæringstidspunktTjeneste;
 import no.nav.foreldrepenger.web.app.tjenester.forvaltning.dto.ForvaltningBehandlingIdDto;
-import no.nav.vedtak.felles.prosesstask.api.ProsessTaskData;
-import no.nav.vedtak.felles.prosesstask.api.ProsessTaskGruppe;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTaskTjeneste;
 import no.nav.vedtak.sikkerhet.abac.AbacDataAttributter;
 import no.nav.vedtak.sikkerhet.abac.AbacDto;
@@ -101,41 +94,5 @@ public class ForvaltningStønadsstatistikkRestTjeneste {
         }
         var stp = skjæringstidspunktTjeneste.getSkjæringstidspunkter(behandling.getId());
         return stønadsstatistikkTjeneste.genererVedtak(BehandlingReferanse.fra(behandling), stp);
-    }
-
-    @POST
-    @Path("/migrerStebarnsadopsjonSaker")
-    @Produces(MediaType.APPLICATION_JSON)
-    @Operation(description = "Sender vedtak json på kafka", tags = "FORVALTNING-stønadsstatistikk")
-    @BeskyttetRessurs(actionType = ActionType.READ, resourceType = ResourceType.DRIFT, sporingslogg = false)
-    public Response migrerStebarnsadopsjonSaker() {
-        var taskGruppe = new ProsessTaskGruppe();
-
-        var behandlinger = finnVedtakMedStebarnsadopsjon();
-
-        for (var behandling : behandlinger) {
-            var task = ProsessTaskData.forProsessTask(SendStønadsstatistikkForVedtakTask.class);
-            task.setCallIdFraEksisterende();
-            task.setBehandling(behandling.getFagsak().getId(), behandling.getId());
-            task.setPrioritet(4); // Skal gå som batch
-
-            taskGruppe.addNesteSekvensiell(task);
-        }
-        taskTjeneste.lagre(taskGruppe);
-        return Response.accepted().build();
-    }
-
-    private List<Behandling> finnVedtakMedStebarnsadopsjon() {
-        return entityManager.createNativeQuery("""
-            select b.* from BEHANDLING b
-             join GR_FAMILIE_HENDELSE grfh on grfh.behandling_id = b.id and grfh.aktiv = 'J'
-             join FH_ADOPSJON adop on adop.FAMILIE_HENDELSE_ID = nvl(grfh.OVERSTYRT_FAMILIE_HENDELSE_ID, nvl(grfh.BEKREFTET_FAMILIE_HENDELSE_ID, grfh.SOEKNAD_FAMILIE_HENDELSE_ID))
-             join BEHANDLING_RESULTAT br on br.BEHANDLING_ID = b.ID
-             join BEHANDLING_VEDTAK bv on bv.BEHANDLING_RESULTAT_ID = br.ID
-             where b.BEHANDLING_TYPE in ('BT-002','BT-004')
-             and adop.EKTEFELLES_BARN = 'J'
-            """, Behandling.class)
-            .setHint(HibernateHints.HINT_READ_ONLY, "true")
-            .getResultList();
     }
 }

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/forvaltning/stonadsstatistikk/StønadsstatistikkMigreringTask.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/forvaltning/stonadsstatistikk/StønadsstatistikkMigreringTask.java
@@ -121,7 +121,7 @@ class StønadsstatistikkMigreringTask implements ProsessTaskHandler {
     }
 
     private StønadsstatistikkVedtak lagDto(Behandling behandling, BehandlingVedtak vedtak) {
-        LOG.info("Produserer stønadsstatistikk for sak {} behandling {} vedtak {} fattet {}", behandling.getFagsak().getSaksnummer().getVerdi(), behandling.getId(),
+        LOG.info("Produserer stønadsstatistikk for sak {} behandling {} vedtak {} fattet {}", behandling.getSaksnummer().getVerdi(), behandling.getId(),
             vedtak.getId(), vedtak.getOpprettetTidspunkt());
         var stp = skjæringstidspunktTjeneste.getSkjæringstidspunkter(behandling.getId());
         var generertVedtak = stønadsstatistikkTjeneste.genererVedtak(BehandlingReferanse.fra(behandling), stp);

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/los/LosBehandlingDtoTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/los/LosBehandlingDtoTjeneste.java
@@ -108,7 +108,7 @@ public class LosBehandlingDtoTjeneste {
 
         return new LosBehandlingDto(behandling.getUuid(),
             Kildesystem.FPSAK,
-            behandling.getFagsak().getSaksnummer().getVerdi(),
+            behandling.getSaksnummer().getVerdi(),
             mapYtelse(behandling),
             new AktørId(behandling.getAktørId().getId()),
             mapBehandlingstype(behandling),

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/vedtak/VedtakRestTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/vedtak/VedtakRestTjeneste.java
@@ -108,7 +108,7 @@ public class VedtakRestTjeneste {
             var behandling = behandlingsprosessTjeneste.hentBehandling(b);
             var prosessTaskData = ProsessTaskData.forProsessTask(ValiderOgRegenererVedtaksXmlTask.class);
 
-            prosessTaskData.setBehandling(behandling.getFagsakId(), behandling.getId(), behandling.getAktørId().getId());
+            prosessTaskData.setBehandling(behandling.getSaksnummer().getVerdi(), behandling.getFagsakId(), behandling.getId());
             prosessTaskData.setCallIdFraEksisterende();
             taskTjeneste.lagre(prosessTaskData);
         }

--- a/web/src/test/java/no/nav/foreldrepenger/jsonfeed/HendelsePublisererTjenesteTest.java
+++ b/web/src/test/java/no/nav/foreldrepenger/jsonfeed/HendelsePublisererTjenesteTest.java
@@ -100,7 +100,7 @@ class HendelsePublisererTjenesteTest {
         assertThat(opphørt.getFnr()).isEqualTo(FNR);
         assertThat(opphørt.getFoersteStoenadsdag()).isEqualTo(INNVILGET_PERIODE_FØRSTE_DAG);
         assertThat(opphørt.getSisteStoenadsdag()).isEqualTo(INNVILGET_PERIODE_SISTE_DAG);
-        assertThat(opphørt.getGsakId()).isEqualTo(behandling.getFagsak().getSaksnummer().getVerdi());
+        assertThat(opphørt.getGsakId()).isEqualTo(behandling.getSaksnummer().getVerdi());
     }
 
     private List<FpVedtakUtgåendeHendelse> hentUtgåendeHendelser(AktørId aktørId) {
@@ -132,7 +132,7 @@ class HendelsePublisererTjenesteTest {
         assertThat(innvilget.getFnr()).isEqualTo(FNR);
         assertThat(innvilget.getFoersteStoenadsdag()).isEqualTo(INNVILGET_PERIODE_FØRSTE_DAG);
         assertThat(innvilget.getSisteStoenadsdag()).isEqualTo(INNVILGET_PERIODE_SISTE_DAG);
-        assertThat(innvilget.getGsakId()).isEqualTo(behandling.getFagsak().getSaksnummer().getVerdi());
+        assertThat(innvilget.getGsakId()).isEqualTo(behandling.getSaksnummer().getVerdi());
     }
 
     @Test
@@ -172,7 +172,7 @@ class HendelsePublisererTjenesteTest {
         assertThat(endret.getFnr()).isEqualTo(FNR);
         assertThat(endret.getFoersteStoenadsdag()).isEqualTo(NY_PERIODE_FØRSTE_DAG);
         assertThat(endret.getSisteStoenadsdag()).isEqualTo(NY_PERIODE_SISTE_DAG);
-        assertThat(endret.getGsakId()).isEqualTo(behandling.getFagsak().getSaksnummer().getVerdi());
+        assertThat(endret.getGsakId()).isEqualTo(behandling.getSaksnummer().getVerdi());
     }
 
     @Test
@@ -197,7 +197,7 @@ class HendelsePublisererTjenesteTest {
         assertThat(opphørt.getFnr()).isEqualTo(FNR);
         assertThat(opphørt.getFoersteStoenadsdag()).isEqualTo(INNVILGET_PERIODE_FØRSTE_DAG);
         assertThat(opphørt.getSisteStoenadsdag()).isEqualTo(INNVILGET_PERIODE_SISTE_DAG);
-        assertThat(opphørt.getGsakId()).isEqualTo(behandling.getFagsak().getSaksnummer().getVerdi());
+        assertThat(opphørt.getGsakId()).isEqualTo(behandling.getSaksnummer().getVerdi());
     }
 
     private BehandlingVedtak byggBehandlingVedtakOgBehandling(BehandlingType behandlingTypeOppr,

--- a/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/BehandlingRestTjenesteESTest.java
+++ b/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/BehandlingRestTjenesteESTest.java
@@ -99,7 +99,7 @@ class BehandlingRestTjenesteESTest {
         scenario.medRegisterOpplysninger(personInformasjon);
         scenario.medDefaultBekreftetTerminbekreftelse();
         var behandling = scenario.lagre(repositoryProvider);
-        var saksnummer = behandling.getFagsak().getSaksnummer();
+        var saksnummer = behandling.getSaksnummer();
 
         when(behandlingsutredningTjeneste.hentBehandlingerForSaksnummer(saksnummer)).thenReturn(
             singletonList(behandling));

--- a/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/aksjonspunkt/OpprettNyFørstegangsbehandlingTest.java
+++ b/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/aksjonspunkt/OpprettNyFørstegangsbehandlingTest.java
@@ -205,7 +205,7 @@ class OpprettNyFørstegangsbehandlingTest {
         mockMottatteDokumentRepository(repositoryProvider);
         // Act and expect Exception
         var fagsakId = behandling.getFagsakId();
-        var saksnummer = behandling.getFagsak().getSaksnummer();
+        var saksnummer = behandling.getSaksnummer();
         assertThrows(FunksjonellException.class, () -> behandlingsoppretterTjeneste.opprettNyFørstegangsbehandling(fagsakId, saksnummer, false));
     }
 
@@ -237,7 +237,7 @@ class OpprettNyFørstegangsbehandlingTest {
         repositoryProvider.getBehandlingRepository().lagre(klage, repositoryProvider.getBehandlingRepository().taSkriveLås(klage));
 
         // Act
-        behandlingsoppretterTjeneste.opprettNyFørstegangsbehandling(behandling.getFagsakId(), behandling.getFagsak().getSaksnummer(), true);
+        behandlingsoppretterTjeneste.opprettNyFørstegangsbehandling(behandling.getFagsakId(), behandling.getSaksnummer(), true);
 
         // Assert
         var captor = ArgumentCaptor.forClass(ProsessTaskData.class);
@@ -253,7 +253,7 @@ class OpprettNyFørstegangsbehandlingTest {
         mockMottatteDokumentRepositoryElsokUtenBehandling(repositoryProvider);
 
         // Act
-        behandlingsoppretterTjeneste.opprettNyFørstegangsbehandling(behandling.getFagsakId(), behandling.getFagsak().getSaksnummer(), false);
+        behandlingsoppretterTjeneste.opprettNyFørstegangsbehandling(behandling.getFagsakId(), behandling.getSaksnummer(), false);
 
         // Assert
         var captor = ArgumentCaptor.forClass(ProsessTaskData.class);
@@ -269,7 +269,7 @@ class OpprettNyFørstegangsbehandlingTest {
         mockMottatteDokumentRepositoryElsokMedBehandling(repositoryProvider);
 
         // Act
-        behandlingsoppretterTjeneste.opprettNyFørstegangsbehandling(behandling.getFagsakId(), behandling.getFagsak().getSaksnummer(), false);
+        behandlingsoppretterTjeneste.opprettNyFørstegangsbehandling(behandling.getFagsakId(), behandling.getSaksnummer(), false);
 
         // Assert
         var captor = ArgumentCaptor.forClass(ProsessTaskData.class);
@@ -285,7 +285,7 @@ class OpprettNyFørstegangsbehandlingTest {
         mockMottatteDokumentRepositoryImMedBehandling(repositoryProvider);
 
         // Act
-        behandlingsoppretterTjeneste.opprettNyFørstegangsbehandling(behandling.getFagsakId(), behandling.getFagsak().getSaksnummer(), false);
+        behandlingsoppretterTjeneste.opprettNyFørstegangsbehandling(behandling.getFagsakId(), behandling.getSaksnummer(), false);
 
         // Assert
         var captor = ArgumentCaptor.forClass(ProsessTaskData.class);
@@ -302,7 +302,7 @@ class OpprettNyFørstegangsbehandlingTest {
 
         // Act
         var fagsakId = behandling.getFagsakId();
-        var saksnummer = behandling.getFagsak().getSaksnummer();
+        var saksnummer = behandling.getSaksnummer();
         assertThrows(FunksjonellException.class, () -> behandlingsoppretterTjeneste.opprettNyFørstegangsbehandling(fagsakId, saksnummer, false));
     }
 
@@ -314,7 +314,7 @@ class OpprettNyFørstegangsbehandlingTest {
 
         // Act
         var fagsakId = behandling.getFagsakId();
-        var saksnummer = behandling.getFagsak().getSaksnummer();
+        var saksnummer = behandling.getSaksnummer();
         assertThrows(FunksjonellException.class, () -> behandlingsoppretterTjeneste.opprettNyFørstegangsbehandling(fagsakId, saksnummer, true));
     }
 
@@ -322,7 +322,7 @@ class OpprettNyFørstegangsbehandlingTest {
     void skal_opprette_ny_førstegangsbehandling_når_behandlingen_er_åpen() {
         // Act
         mockMottatteDokumentRepository(repositoryProvider);
-        behandlingsoppretterTjeneste.henleggÅpenFørstegangsbehandlingOgOpprettNy(behandling.getFagsakId(), behandling.getFagsak().getSaksnummer());
+        behandlingsoppretterTjeneste.henleggÅpenFørstegangsbehandlingOgOpprettNy(behandling.getFagsakId(), behandling.getSaksnummer());
 
         // Assert
         var captor = ArgumentCaptor.forClass(ProsessTaskData.class);
@@ -335,7 +335,7 @@ class OpprettNyFørstegangsbehandlingTest {
     void skal_opprette_ny_førstegangsbehandling_når_behandlingen_er_åpen_elektronisk() {
         // Act
         mockMottatteDokumentRepositoryElsokMedBehandling(repositoryProvider);
-        behandlingsoppretterTjeneste.henleggÅpenFørstegangsbehandlingOgOpprettNy(behandling.getFagsakId(), behandling.getFagsak().getSaksnummer());
+        behandlingsoppretterTjeneste.henleggÅpenFørstegangsbehandlingOgOpprettNy(behandling.getFagsakId(), behandling.getSaksnummer());
 
         // Assert
         var captor = ArgumentCaptor.forClass(ProsessTaskData.class);
@@ -352,7 +352,7 @@ class OpprettNyFørstegangsbehandlingTest {
 
         // Act
         var fagsakId = behandling.getFagsakId();
-        var saksnummer = behandling.getFagsak().getSaksnummer();
+        var saksnummer = behandling.getSaksnummer();
         assertThrows(FunksjonellException.class, () -> behandlingsoppretterTjeneste
                 .henleggÅpenFørstegangsbehandlingOgOpprettNy(fagsakId, saksnummer));
 

--- a/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/beregningsgrunnlag/FastsettBeregningsgrunnlagATFLOppdatererTest.java
+++ b/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/beregningsgrunnlag/FastsettBeregningsgrunnlagATFLOppdatererTest.java
@@ -62,7 +62,6 @@ class FastsettBeregningsgrunnlagATFLOppdatererTest {
 
     @BeforeEach
     public void setup() {
-        when(behandling.getFagsak()).thenReturn(fagsak);
         when(behandlingRepository.hentBehandling(behandling.getId())).thenReturn(behandling);
         oppdaterer = new FastsettBeregningsgrunnlagATFLOppdaterer(beregningsgrunnlagTjeneste, historikk,
                 behandlingRepository, historikkKalkulusTjeneste, beregningTjeneste);

--- a/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/innsyn/VurderInnsynOppdatererTest.java
+++ b/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/innsyn/VurderInnsynOppdatererTest.java
@@ -78,7 +78,7 @@ class VurderInnsynOppdatererTest {
         scenario.medDefaultBekreftetTerminbekreftelse();
         var behandling = scenario.lagre(repositoryProvider);
 
-        var innsynbehandling = innsynTjeneste.opprettManueltInnsyn(behandling.getFagsak().getSaksnummer());
+        var innsynbehandling = innsynTjeneste.opprettManueltInnsyn(behandling.getSaksnummer());
         var lås = behandlingRepository.taSkriveLås(innsynbehandling);
         behandlingRepository.lagre(innsynbehandling, lås);
 

--- a/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/klage/KlageFormkravOppdatererTest.java
+++ b/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/klage/KlageFormkravOppdatererTest.java
@@ -121,7 +121,7 @@ class KlageFormkravOppdatererTest extends EntityManagerAwareTest {
         assertThat(klageResultatEntitet.getPåKlagdBehandlingId()).isEmpty();
         assertThat(klageResultatEntitet.getPåKlagdEksternBehandlingUuid()).isEqualTo(Optional.of(TILBAKEKREVING_BEHANDLING_UUID));
 
-        var historikkInnslager = historikkTjenesteAdapter.hentAlleHistorikkInnslagForSak(behandling.getFagsak().getSaksnummer(),
+        var historikkInnslager = historikkTjenesteAdapter.hentAlleHistorikkInnslagForSak(behandling.getSaksnummer(),
             URI.create("http://dummy/dummy")).stream().sorted(Comparator.comparing(HistorikkinnslagDto::getOpprettetTidspunkt)).toList();
         assertThat(historikkInnslager).hasSize(2);
         var historikkinnslagDto = historikkInnslager.get(0);
@@ -171,7 +171,7 @@ class KlageFormkravOppdatererTest extends EntityManagerAwareTest {
         assertThat(klageResultatEntitet.getPåKlagdBehandlingId()).isEmpty();
         assertThat(klageResultatEntitet.getPåKlagdEksternBehandlingUuid()).isEqualTo(Optional.of(nyTilbakekrevingUUID));
 
-        var historikkInnslager = historikkTjenesteAdapter.hentAlleHistorikkInnslagForSak(behandling.getFagsak().getSaksnummer(),
+        var historikkInnslager = historikkTjenesteAdapter.hentAlleHistorikkInnslagForSak(behandling.getSaksnummer(),
             URI.create("http://dummy/dummy")).stream().sorted(Comparator.comparing(HistorikkinnslagDto::getOpprettetTidspunkt)).toList();
         assertThat(historikkInnslager).hasSize(2);
         var historikkinnslagDto = historikkInnslager.get(0);
@@ -214,7 +214,7 @@ class KlageFormkravOppdatererTest extends EntityManagerAwareTest {
         klageFormkravAksjonspunktDto = new KlageFormkravAksjonspunktDto(true, true, true, true, null, "test", false, null, null);
         klageFormkravOppdaterer.oppdater(klageFormkravAksjonspunktDto, aksjonspunktOppdaterParameter);
 
-        var historikkInnslager = historikkTjenesteAdapter.hentAlleHistorikkInnslagForSak(behandling.getFagsak().getSaksnummer(),
+        var historikkInnslager = historikkTjenesteAdapter.hentAlleHistorikkInnslagForSak(behandling.getSaksnummer(),
             URI.create("http://dummy/dummy")).stream().sorted(Comparator.comparing(HistorikkinnslagDto::getOpprettetTidspunkt)).toList();
         assertThat(historikkInnslager).hasSize(2);
         var historikkinnslagDto = historikkInnslager.get(0);
@@ -256,7 +256,7 @@ class KlageFormkravOppdatererTest extends EntityManagerAwareTest {
         klageFormkravAksjonspunktDto = new KlageFormkravAksjonspunktDto(true, true, true, true, behandling.getUuid(), "test", false, null, null);
         klageFormkravOppdaterer.oppdater(klageFormkravAksjonspunktDto, aksjonspunktOppdaterParameter);
 
-        var historikkInnslager = historikkTjenesteAdapter.hentAlleHistorikkInnslagForSak(behandling.getFagsak().getSaksnummer(),
+        var historikkInnslager = historikkTjenesteAdapter.hentAlleHistorikkInnslagForSak(behandling.getSaksnummer(),
             URI.create("http://dummy/dummy")).stream().sorted(Comparator.comparing(HistorikkinnslagDto::getOpprettetTidspunkt)).toList();
         assertThat(historikkInnslager).hasSize(2);
         var historikkinnslagDto = historikkInnslager.get(0);
@@ -322,7 +322,7 @@ class KlageFormkravOppdatererTest extends EntityManagerAwareTest {
     }
 
     private void fellesKlageHistoriskAssert() {
-        var historikkInnslager = historikkTjenesteAdapter.hentAlleHistorikkInnslagForSak(behandling.getFagsak().getSaksnummer(),
+        var historikkInnslager = historikkTjenesteAdapter.hentAlleHistorikkInnslagForSak(behandling.getSaksnummer(),
             URI.create("http://dummy/dummy"));
         assertThat(historikkInnslager).hasSize(1);
         var historikkinnslagDto = historikkInnslager.get(0);

--- a/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/uttak/aksjonspunkt/UttakOverstyringshåndtererTest.java
+++ b/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/uttak/aksjonspunkt/UttakOverstyringshåndtererTest.java
@@ -117,7 +117,7 @@ class UttakOverstyringshåndtererTest {
     }
 
     private BehandlingskontrollKontekst kontekst(Behandling behandling) {
-        return new BehandlingskontrollKontekst(behandling.getFagsakId(), behandling.getAktørId(),
+        return new BehandlingskontrollKontekst(behandling.getSaksnummer(), behandling.getFagsakId(),
             repositoryProvider.getBehandlingLåsRepository().taLås(behandling.getId()));
     }
 

--- a/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/uttak/app/SaldoerDtoTjenesteTest.java
+++ b/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/uttak/app/SaldoerDtoTjenesteTest.java
@@ -950,7 +950,7 @@ class SaldoerDtoTjenesteTest extends EntityManagerAwareTest {
 
         repositoryProvider.getFagsakRelasjonRepository().lagre(behandling.getFagsak(), stønadskontoberegning);
 
-        var saksnummer = behandling.getFagsak().getSaksnummer();
+        var saksnummer = behandling.getSaksnummer();
         var fødselNesteSak = periode.getTom().minusDays(1);
         var nesteSakGrunnlag = NesteSakGrunnlagEntitet.Builder.oppdatere(Optional.empty())
             .medBehandlingId(behandling.getId())

--- a/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/fpoversikt/EsDtoTjenesteTest.java
+++ b/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/fpoversikt/EsDtoTjenesteTest.java
@@ -51,7 +51,7 @@ class EsDtoTjenesteTest {
         repositoryProvider.getMottatteDokumentRepository().lagre(mottattDokument);
 
         var dto = (EsSak) tjeneste.hentSak(behandling.getFagsak());
-        assertThat(dto.saksnummer()).isEqualTo(behandling.getFagsak().getSaksnummer().getVerdi());
+        assertThat(dto.saksnummer()).isEqualTo(behandling.getSaksnummer().getVerdi());
         assertThat(dto.aktørId()).isEqualTo(behandling.getAktørId().getId());
         assertThat(dto.vedtak()).hasSize(1);
         assertThat(dto.avsluttet()).isFalse();
@@ -77,7 +77,7 @@ class EsDtoTjenesteTest {
             .lagre(repositoryProvider);
 
         var dto = (EsSak) tjeneste.hentSak(behandling.getFagsak());
-        assertThat(dto.saksnummer()).isEqualTo(behandling.getFagsak().getSaksnummer().getVerdi());
+        assertThat(dto.saksnummer()).isEqualTo(behandling.getSaksnummer().getVerdi());
         assertThat(dto.aktørId()).isEqualTo(behandling.getAktørId().getId());
         assertThat(dto.aksjonspunkt()).hasSize(1);
         var apDto = dto.aksjonspunkt().stream().findFirst().orElseThrow();

--- a/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/fpoversikt/FpDtoTjenesteTest.java
+++ b/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/fpoversikt/FpDtoTjenesteTest.java
@@ -109,7 +109,7 @@ class FpDtoTjenesteTest {
         repositoryProvider.getFpUttakRepository().lagreOpprinneligUttakResultatPerioder(behandling.getId(), uttak);
 
         var dto = (FpSak) tjeneste.hentSak(behandling.getFagsak());
-        assertThat(dto.saksnummer()).isEqualTo(behandling.getFagsak().getSaksnummer().getVerdi());
+        assertThat(dto.saksnummer()).isEqualTo(behandling.getSaksnummer().getVerdi());
         assertThat(dto.aktørId()).isEqualTo(behandling.getAktørId().getId());
         assertThat(dto.ønskerJustertUttakVedFødsel()).isTrue();
         assertThat(dto.vedtak()).hasSize(1);

--- a/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/fpoversikt/SvpDtoTjenesteTest.java
+++ b/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/fpoversikt/SvpDtoTjenesteTest.java
@@ -12,8 +12,6 @@ import java.util.Optional;
 
 import jakarta.inject.Inject;
 
-import no.nav.foreldrepenger.behandlingslager.behandling.tilrettelegging.SvpOppholdKilde;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
@@ -30,6 +28,7 @@ import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRe
 import no.nav.foreldrepenger.behandlingslager.behandling.tilrettelegging.SvangerskapspengerRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.tilrettelegging.SvpAvklartOpphold;
 import no.nav.foreldrepenger.behandlingslager.behandling.tilrettelegging.SvpGrunnlagEntitet;
+import no.nav.foreldrepenger.behandlingslager.behandling.tilrettelegging.SvpOppholdKilde;
 import no.nav.foreldrepenger.behandlingslager.behandling.tilrettelegging.SvpOppholdÅrsak;
 import no.nav.foreldrepenger.behandlingslager.behandling.tilrettelegging.SvpTilretteleggingEntitet;
 import no.nav.foreldrepenger.behandlingslager.behandling.tilrettelegging.SvpTilretteleggingFomKilde;
@@ -105,7 +104,7 @@ class SvpDtoTjenesteTest extends EntityManagerAwareTest {
 
         var dto = (SvpSak) tjeneste.hentSak(behandling.getFagsak());
 
-        assertThat(dto.saksnummer()).isEqualTo(behandling.getFagsak().getSaksnummer().getVerdi());
+        assertThat(dto.saksnummer()).isEqualTo(behandling.getSaksnummer().getVerdi());
         assertThat(dto.aktørId()).isEqualTo(behandling.getAktørId().getId());
         assertThat(dto.vedtak()).hasSize(1);
         assertThat(dto.avsluttet()).isFalse();


### PR DESCRIPTION
Fjerner aktørId og legger til Saksnummer i BehandlingskontrollKontekst - bruker saksnummer for logkontekst i steg.
Sender inn saksnummer ved taskoppretting, reduserer antall varianter av setBehandling/setFagsak i bruk.
Setter aktørId i task kun der det trengs (Infobrev + Påminnelse)