### PR TITLE
Unngå henlagte for fagsakinfo dersom mulig

### DIFF
--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/repository/BehandlingRepository.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/repository/BehandlingRepository.java
@@ -407,15 +407,20 @@ public class BehandlingRepository {
     }
 
     public Optional<Behandling> finnSisteIkkeHenlagteYtelseBehandlingFor(Long fagsakId) {
-        return finnSisteIkkeHenlagteBehandlingavAvBehandlingTypeForFagsakId(fagsakId, BehandlingType.getYtelseBehandlingTyper());
+        return finnSisteIkkeHenlagteBehandlingavAvBehandlingTypeForFagsakId(fagsakId, false, BehandlingType.getYtelseBehandlingTyper());
+    }
+
+    public Optional<Behandling> finnSisteIkkeHenlagteYtelseBehandlingReadOnlyFor(Long fagsakId) {
+        return finnSisteIkkeHenlagteBehandlingavAvBehandlingTypeForFagsakId(fagsakId, true, BehandlingType.getYtelseBehandlingTyper());
     }
 
     public Optional<Behandling> finnSisteIkkeHenlagteBehandlingavAvBehandlingTypeFor(Long fagsakId, BehandlingType behandlingType) {
         Objects.requireNonNull(behandlingType, "behandlingType");
-        return finnSisteIkkeHenlagteBehandlingavAvBehandlingTypeForFagsakId(fagsakId, Set.of(behandlingType));
+        return finnSisteIkkeHenlagteBehandlingavAvBehandlingTypeForFagsakId(fagsakId, false, Set.of(behandlingType));
     }
 
-    private Optional<Behandling> finnSisteIkkeHenlagteBehandlingavAvBehandlingTypeForFagsakId(Long fagsakId, Set<BehandlingType> behandlingTyper) {
+    private Optional<Behandling> finnSisteIkkeHenlagteBehandlingavAvBehandlingTypeForFagsakId(Long fagsakId, boolean readOnly,
+                                                                                              Set<BehandlingType> behandlingTyper) {
         Objects.requireNonNull(fagsakId, FAGSAK_ID);
 
         var query = entityManager.createQuery(
@@ -430,6 +435,9 @@ public class BehandlingRepository {
         query.setParameter(FAGSAK_ID, fagsakId);
         query.setParameter("behandlingTyper", behandlingTyper);
         query.setParameter("henlagtKoder", BehandlingResultatType.getAlleHenleggelseskoder());
+        if (readOnly) {
+            query.setHint(HibernateHints.HINT_READ_ONLY, "true");
+        }
 
         return optionalFirst(query.getResultList());
     }

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/fagsak/app/FagsakTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/fagsak/app/FagsakTjeneste.java
@@ -152,8 +152,8 @@ public class FagsakTjeneste {
     }
 
     private FagsakBackendDto mapFraFagsakTilFagsakDto(Fagsak fagsak) {
-        var behandling = hentSisteYtelsesBehandling(fagsak);
-        var dekningsgrad = behandling.flatMap(b -> dekningsgradTjeneste.finnGjeldendeDekningsgradHvisEksisterer(BehandlingReferanse.fra(b)))
+        var dekningsgrad = hentSisteYtelsesBehandling(fagsak)
+            .flatMap(b -> dekningsgradTjeneste.finnGjeldendeDekningsgradHvisEksisterer(BehandlingReferanse.fra(b)))
             .map(Dekningsgrad::getVerdi)
             .orElse(null);
         return new FagsakBackendDto(fagsak, dekningsgrad);
@@ -174,12 +174,12 @@ public class FagsakTjeneste {
     }
 
     private Optional<Behandling> hentSisteYtelsesBehandling(Fagsak fagsak) {
-        return behandlingRepository.hentSisteYtelsesBehandlingForFagsakIdReadOnly(fagsak.getId());
+        return behandlingRepository.finnSisteIkkeHenlagteYtelseBehandlingReadOnlyFor(fagsak.getId())
+            .or(() -> behandlingRepository.hentSisteYtelsesBehandlingForFagsakIdReadOnly(fagsak.getId()));
     }
 
     private LocalDate hendelseDato(FamilieHendelseEntitet fh) {
         return Optional.ofNullable(fh.getSkjæringstidspunkt())
             .orElseGet(() -> fh.getTerminbekreftelse().map(TerminbekreftelseEntitet::getTermindato).orElse(null));
     }
-
 }


### PR DESCRIPTION
Prøver seg med siste åpne/vedtatte behandling (unngår henlagte). Dersom ingen slike brukes siste henlagte.
Gjelder feil visning i en sak med feilregistrert søknad - vedtatt avslag for barn født mars, registreres barn født november i en behandling som henlegges. Saksinfo i topplinjen vises da med feil annenpart og barn (det fra november).