### PR TITLE
Ikke lagre til DVH i VTP eller tester med inject

### DIFF
--- a/domenetjenester/datavarehus/src/main/java/no/nav/foreldrepenger/datavarehus/observer/DatavarehusEventObserver.java
+++ b/domenetjenester/datavarehus/src/main/java/no/nav/foreldrepenger/datavarehus/observer/DatavarehusEventObserver.java
@@ -4,9 +4,6 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.event.Observes;
 import jakarta.inject.Inject;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import no.nav.foreldrepenger.behandlingskontroll.events.AksjonspunktStatusEvent;
 import no.nav.foreldrepenger.behandlingskontroll.events.BehandlingStatusEvent;
 import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.Aksjonspunkt;
@@ -17,12 +14,15 @@ import no.nav.foreldrepenger.behandlingslager.behandling.events.BehandlingSaksbe
 import no.nav.foreldrepenger.behandlingslager.behandling.events.BehandlingVedtakEvent;
 import no.nav.foreldrepenger.behandlingslager.behandling.events.MottattDokumentPersistertEvent;
 import no.nav.foreldrepenger.datavarehus.tjeneste.DatavarehusTjeneste;
+import no.nav.foreldrepenger.konfig.Environment;
 
 @ApplicationScoped
 public class DatavarehusEventObserver {
-    protected final Logger LOG = LoggerFactory.getLogger(this.getClass());
+
+    private static final boolean TESTENV = Environment.current().isLocal();
 
     private DatavarehusTjeneste tjeneste;
+    private boolean testObserver;
 
     public DatavarehusEventObserver() {
         //Cool Devices Installed
@@ -30,14 +30,19 @@ public class DatavarehusEventObserver {
 
     @Inject
     public DatavarehusEventObserver(DatavarehusTjeneste datavarehusTjeneste) {
+        this(datavarehusTjeneste, false);
+    }
+
+    public DatavarehusEventObserver(DatavarehusTjeneste datavarehusTjeneste, boolean testObserver) {
         this.tjeneste = datavarehusTjeneste;
+        this.testObserver = testObserver;
     }
 
     public void observerAksjonspunktStatusEvent(@Observes AksjonspunktStatusEvent event) {
         var aksjonspunkter = event.getAksjonspunkter();
         // Utvider behandlingStatus i DVH med VenteKategori
         if (aksjonspunkter.stream().anyMatch(a -> a.erAutopunkt() || (a.erUtført() && gjelderKlage(a)))) {
-            tjeneste.lagreNedBehandling(event.getBehandlingId());
+            lagreNedBehandling(event.getBehandlingId());
         }
     }
 
@@ -47,32 +52,42 @@ public class DatavarehusEventObserver {
     }
 
     public void observerBehandlingEnhetEvent(@Observes BehandlingEnhetEvent event) {
-        tjeneste.lagreNedBehandling(event.getBehandlingId());
+        lagreNedBehandling(event.getBehandlingId());
     }
 
     public void observerBehandlingSaksbehandlerEvent(@Observes BehandlingSaksbehandlerEvent event) {
-        tjeneste.lagreNedBehandling(event.getBehandlingId());
+        lagreNedBehandling(event.getBehandlingId());
     }
 
     public void observerBehandlingRelasjonEvent(@Observes BehandlingRelasjonEvent event) {
-        tjeneste.lagreNedBehandling(event.getBehandlingId());
+        lagreNedBehandling(event.getBehandlingId());
     }
 
     public void observerBehandlingStatusEvent(@Observes BehandlingStatusEvent event) {
-        tjeneste.lagreNedBehandling(event.getBehandlingId());
+        lagreNedBehandling(event.getBehandlingId());
     }
 
     public void observerMottattDokumentPersistert(@Observes MottattDokumentPersistertEvent event) {
         // Lagre behandling med rettighetsdato o.l.
         if (event.getMottattDokument().getDokumentType().erSøknadType() || event.getMottattDokument().getDokumentType().erEndringsSøknadType()) {
-            tjeneste.lagreNedBehandling(event.getBehandlingId());
+            lagreNedBehandling(event.getBehandlingId());
         }
     }
 
     public void observerBehandlingVedtakEvent(@Observes BehandlingVedtakEvent event) {
-        if (event.iverksattVedtak()) {
+        if (event.iverksattVedtak() && skalKalleDatavarehusTjeneste()) {
             tjeneste.lagreNedBehandling(event.behandling(), event.vedtak());
         }
+    }
+
+    private void lagreNedBehandling(Long behandlingId) {
+        if (skalKalleDatavarehusTjeneste()) {
+            tjeneste.lagreNedBehandling(behandlingId);
+        }
+    }
+
+    private boolean skalKalleDatavarehusTjeneste() {
+        return testObserver || !TESTENV;
     }
 
 }

--- a/domenetjenester/datavarehus/src/test/java/no/nav/foreldrepenger/datavarehus/observer/DatavarehusEventObserverTest.java
+++ b/domenetjenester/datavarehus/src/test/java/no/nav/foreldrepenger/datavarehus/observer/DatavarehusEventObserverTest.java
@@ -34,7 +34,7 @@ class DatavarehusEventObserverTest {
 
     @BeforeEach
     public void setUp() {
-        datavarehusEventObserver = new DatavarehusEventObserver(datavarehusTjeneste);
+        datavarehusEventObserver = new DatavarehusEventObserver(datavarehusTjeneste, true);
     }
 
     @Test


### PR DESCRIPTION
Ifm innføring av testcontainers
Denne saken sørger for at det ikke skrives til FPSAK_HIST i VTP eller enhetstester som gjør Inject på noe som trigger observer.
Det skal dekke testene i web-modulen som injecter AksjonspunktTjeneste
@mrsladek har du disablet andre tester for å komme så langt? Tenker da spesielt på  DatavarehusTjenesteImplTest

Autotest ser for tiden ikke på om noe skrives til FPSAK_HIST eller hva som skrives. Det går greit.
