### PR TITLE
TFP-5929 Endring i InaktiveArbeidsforholdUtleder

### DIFF
--- a/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/arbeidsforhold/fp/InntektsmeldingFilterYtelseImpl.java
+++ b/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/arbeidsforhold/fp/InntektsmeldingFilterYtelseImpl.java
@@ -35,8 +35,7 @@ public class InntektsmeldingFilterYtelseImpl implements InntektsmeldingFilterYte
     public Map<Arbeidsgiver, Set<InternArbeidsforholdRef>> aktiveArbeidsforholdFilter(BehandlingReferanse referanse,
                                                                                       Skjæringstidspunkt skjæringstidspunkt,
                                                                                       Optional<InntektArbeidYtelseGrunnlag> inntektArbeidYtelseGrunnlag,
-                                                                                      Map<Arbeidsgiver, Set<InternArbeidsforholdRef>> påkrevde,
-                                                                                      boolean taHensynTilPermisjon) {
-        return InaktiveArbeidsforholdUtleder.finnKunAktive(påkrevde, inntektArbeidYtelseGrunnlag, referanse, skjæringstidspunkt, taHensynTilPermisjon);
+                                                                                      Map<Arbeidsgiver, Set<InternArbeidsforholdRef>> påkrevde) {
+        return InaktiveArbeidsforholdUtleder.finnKunAktive(påkrevde, inntektArbeidYtelseGrunnlag, referanse, skjæringstidspunkt);
     }
 }

--- a/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/arbeidsforhold/impl/InaktiveArbeidsforholdUtleder.java
+++ b/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/arbeidsforhold/impl/InaktiveArbeidsforholdUtleder.java
@@ -46,23 +46,18 @@ public class InaktiveArbeidsforholdUtleder {
 
     public static Map<Arbeidsgiver, Set<InternArbeidsforholdRef>> finnKunAktive(Map<Arbeidsgiver, Set<InternArbeidsforholdRef>> påkrevdeInntektsmeldinger,
                                                                                 Optional<InntektArbeidYtelseGrunnlag> inntektArbeidYtelseGrunnlag,
-                                                                                BehandlingReferanse referanse, Skjæringstidspunkt stp,
-                                                                                boolean taHensynTilPermisjon) {
+                                                                                BehandlingReferanse referanse, Skjæringstidspunkt stp) {
         Map<Arbeidsgiver, Set<InternArbeidsforholdRef>> kunAktiveArbeidsforhold = new HashMap<>();
 
+        var utledetStp = stp.getUtledetSkjæringstidspunkt();
         påkrevdeInntektsmeldinger.forEach((key, value) -> {
-            var erInaktivt = erInaktivt(key, inntektArbeidYtelseGrunnlag, referanse.aktørId(), stp.getUtledetSkjæringstidspunkt(),
+            var erInaktivt = erInaktivt(key, inntektArbeidYtelseGrunnlag, referanse.aktørId(), utledetStp,
                 referanse.saksnummer());
             if (!erInaktivt) {
                 List<InternArbeidsforholdRef> aktiveArbeidsforholdsRef = new ArrayList<>();
                 //Sjekker om hvert arbeidsforhold under virksomheten har registrert permisjon som overlapper skjæringstidspunkt. Fjerne de som har det
-                value.forEach(internArbeidsforholdRef -> {
-                    if (taHensynTilPermisjon) {
-                        if (!erIPermisjonPåStp(key, internArbeidsforholdRef, inntektArbeidYtelseGrunnlag, referanse.aktørId(),
-                            stp.getUtledetSkjæringstidspunkt())) {
-                            aktiveArbeidsforholdsRef.add(internArbeidsforholdRef);
-                        }
-                    } else {
+                value.forEach(internArbeidsforholdRef-> {
+                    if (!erIPermisjonPåStp(key, internArbeidsforholdRef, inntektArbeidYtelseGrunnlag, referanse.aktørId(), utledetStp)) {
                         aktiveArbeidsforholdsRef.add(internArbeidsforholdRef);
                     }
                 });

--- a/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/arbeidsforhold/impl/InntektsmeldingFilterYtelse.java
+++ b/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/arbeidsforhold/impl/InntektsmeldingFilterYtelse.java
@@ -21,6 +21,5 @@ public interface InntektsmeldingFilterYtelse {
     Map<Arbeidsgiver, Set<InternArbeidsforholdRef>> aktiveArbeidsforholdFilter(BehandlingReferanse referanse,
                                                                                Skjæringstidspunkt stp,
                                                                                Optional<InntektArbeidYtelseGrunnlag> inntektArbeidYtelseGrunnlag,
-                                                                               Map<Arbeidsgiver, Set<InternArbeidsforholdRef>> påkrevde,
-                                                                               boolean taHensynTilPermisjon);
+                                                                               Map<Arbeidsgiver, Set<InternArbeidsforholdRef>> påkrevde);
 }

--- a/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/arbeidsforhold/impl/InntektsmeldingRegisterTjeneste.java
+++ b/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/arbeidsforhold/impl/InntektsmeldingRegisterTjeneste.java
@@ -129,7 +129,7 @@ public class InntektsmeldingRegisterTjeneste {
         var inntektArbeidYtelseGrunnlag = inntektArbeidYtelseTjeneste.finnGrunnlag(referanse.behandlingId());
         var påkrevdeInntektsmeldinger = utledPåkrevdeInntektsmeldingerFraGrunnlag(referanse, stp, inntektArbeidYtelseGrunnlag);
         var filtrertHvisSvp = søknadsFilter(referanse, påkrevdeInntektsmeldinger);
-        return aktiveArbeidsforholdFilter(referanse, stp, inntektArbeidYtelseGrunnlag, filtrertHvisSvp, false);
+        return aktiveArbeidsforholdFilter(referanse, stp, inntektArbeidYtelseGrunnlag, filtrertHvisSvp);
     }
 
     private Map<Arbeidsgiver, Set<InternArbeidsforholdRef>> utledPåkrevdeInntektsmeldingerFraGrunnlag(BehandlingReferanse referanse,
@@ -174,7 +174,7 @@ public class InntektsmeldingRegisterTjeneste {
         var påkrevdListeSøkteArbeidsforhold = søknadsFilter(referanse, påkrevdeInntektsmeldinger);
         logInntektsmeldinger(referanse, påkrevdListeSøkteArbeidsforhold, "FILTRERT bort arbeidsforhold det ikke er søkt(svp) for");
 
-        var påkrevdListeAktiveArbeidsforhold = aktiveArbeidsforholdFilter(referanse, stp, inntektArbeidYtelseGrunnlag, påkrevdListeSøkteArbeidsforhold, true);
+        var påkrevdListeAktiveArbeidsforhold = aktiveArbeidsforholdFilter(referanse, stp, inntektArbeidYtelseGrunnlag, påkrevdListeSøkteArbeidsforhold);
         filtrerUtMottatteInntektsmeldinger(referanse, stp, påkrevdListeAktiveArbeidsforhold, (a, i) -> i);
         logInntektsmeldinger(referanse, påkrevdListeAktiveArbeidsforhold, "FILTRERT bort inaktive arbeidsforhold, og arbeidsforhold vi har mottatt inntektsmelding på");
 
@@ -282,11 +282,10 @@ public class InntektsmeldingRegisterTjeneste {
 
     public Map<Arbeidsgiver, Set<InternArbeidsforholdRef>> aktiveArbeidsforholdFilter(BehandlingReferanse referanse,
                                                                                       Skjæringstidspunkt stp,
-                                                                                      Optional<InntektArbeidYtelseGrunnlag> inntektArbeidYtelseGrunnlag, Map<Arbeidsgiver, Set<InternArbeidsforholdRef>> påkrevdeInntektsmeldinger,
-                                                                                      boolean tahensynTilPermisjon) {
+                                                                                      Optional<InntektArbeidYtelseGrunnlag> inntektArbeidYtelseGrunnlag, Map<Arbeidsgiver, Set<InternArbeidsforholdRef>> påkrevdeInntektsmeldinger) {
         var filter = FagsakYtelseTypeRef.Lookup.find(inntektsmeldingFiltere, referanse.fagsakYtelseType())
                 .orElseThrow(
                         () -> new IllegalStateException("Ingen implementasjoner funnet for ytelse: " + referanse.fagsakYtelseType().getKode()));
-        return filter.aktiveArbeidsforholdFilter(referanse, stp, inntektArbeidYtelseGrunnlag, påkrevdeInntektsmeldinger, tahensynTilPermisjon);
+        return filter.aktiveArbeidsforholdFilter(referanse, stp, inntektArbeidYtelseGrunnlag, påkrevdeInntektsmeldinger);
     }
 }

--- a/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/arbeidsforhold/svp/InntektsmeldingFilterYtelseImpl.java
+++ b/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/arbeidsforhold/svp/InntektsmeldingFilterYtelseImpl.java
@@ -67,9 +67,8 @@ public class InntektsmeldingFilterYtelseImpl implements InntektsmeldingFilterYte
     public Map<Arbeidsgiver, Set<InternArbeidsforholdRef>> aktiveArbeidsforholdFilter(BehandlingReferanse referanse,
                                                                                       Skjæringstidspunkt stp,
                                                                                       Optional<InntektArbeidYtelseGrunnlag> inntektArbeidYtelseGrunnlag,
-                                                                                      Map<Arbeidsgiver, Set<InternArbeidsforholdRef>> påkrevde,
-                                                                                      boolean taHensynTilPermisjon) {
-        var kunAktive = InaktiveArbeidsforholdUtleder.finnKunAktive(påkrevde, inntektArbeidYtelseGrunnlag, referanse, stp, true);
+                                                                                      Map<Arbeidsgiver, Set<InternArbeidsforholdRef>> påkrevde) {
+        var kunAktive = InaktiveArbeidsforholdUtleder.finnKunAktive(påkrevde, inntektArbeidYtelseGrunnlag, referanse, stp);
 
         // Legger inn alle arbeidsforhold det er søkt tilrettelegging i
         var arbeidsforholdFraSøknad = getArbeidsforholdSøktTilretteleggingI(referanse);

--- a/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/fpinntektsmelding/FpInntektsmeldingTjeneste.java
+++ b/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/fpinntektsmelding/FpInntektsmeldingTjeneste.java
@@ -118,8 +118,7 @@ public class FpInntektsmeldingTjeneste {
             .map(arbeidsgiver -> new OrganisasjonsnummerDto(arbeidsgiver.getOrgnr()))
             .toList();
         if (arbeidsgivereViManglerInntektsmeldingFra.isEmpty()) {
-            //Burde ikke skje - men kan skje om inntektsmeldinger kommer fra LPS eller altinn før vi rekker å opprette oppgave - logger warn inntil vi vet om dette er feil eller ok
-            LOG.warn("FpInntektsmeldingTjeneste:lagForespørsel: Ingen inntektsmeldinger mangler for sak {} og behandlingId {}", ref.saksnummer(), ref.behandlingId());
+            LOG.info("FpInntektsmeldingTjeneste:lagForespørsel: Ingen inntektsmeldinger mangler for sak {} og behandlingId {}", ref.saksnummer(), ref.behandlingId());
             return;
         }
         var skjæringstidspunkt = stp.getUtledetSkjæringstidspunkt();


### PR DESCRIPTION
Fjernet flagget taHensynTilPermisjon da det alltid var true for både fp og svp slik koden var implementert. Dersom det er søkt svangerskapspenger i et arbeidsforhol med gyldig permisjon vil vi uansett kreve inntektsmelding/behandle det som et aktivt arbeidsforhold.