### PR TITLE
Forenkle Anke-steg siden kun Kabal-anker

### DIFF
--- a/behandlingsprosess/src/main/java/no/nav/foreldrepenger/behandling/steg/anke/AnkeSteg.java
+++ b/behandlingsprosess/src/main/java/no/nav/foreldrepenger/behandling/steg/anke/AnkeSteg.java
@@ -1,8 +1,5 @@
 package no.nav.foreldrepenger.behandling.steg.anke;
 
-import java.util.Comparator;
-import java.util.Optional;
-
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 
@@ -10,7 +7,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import no.nav.foreldrepenger.behandling.anke.AnkeVurderingTjeneste;
-import no.nav.foreldrepenger.behandling.kabal.SendTilKabalTask;
 import no.nav.foreldrepenger.behandlingskontroll.AksjonspunktResultat;
 import no.nav.foreldrepenger.behandlingskontroll.BehandleStegResultat;
 import no.nav.foreldrepenger.behandlingskontroll.BehandlingSteg;
@@ -20,23 +16,13 @@ import no.nav.foreldrepenger.behandlingskontroll.BehandlingskontrollKontekst;
 import no.nav.foreldrepenger.behandlingskontroll.FagsakYtelseTypeRef;
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingStegType;
-import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingType;
-import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingsresultatRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.AksjonspunktDefinisjon;
 import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.Venteårsak;
 import no.nav.foreldrepenger.behandlingslager.behandling.anke.AnkeResultatEntitet;
 import no.nav.foreldrepenger.behandlingslager.behandling.anke.AnkeVurdering;
 import no.nav.foreldrepenger.behandlingslager.behandling.anke.AnkeVurderingResultatEntitet;
-import no.nav.foreldrepenger.behandlingslager.behandling.klage.KlageHjemmel;
-import no.nav.foreldrepenger.behandlingslager.behandling.klage.KlageRepository;
-import no.nav.foreldrepenger.behandlingslager.behandling.klage.KlageResultatEntitet;
-import no.nav.foreldrepenger.behandlingslager.behandling.klage.KlageVurdering;
-import no.nav.foreldrepenger.behandlingslager.behandling.klage.KlageVurderingResultat;
-import no.nav.foreldrepenger.behandlingslager.behandling.klage.KlageVurdertAv;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepositoryProvider;
-import no.nav.vedtak.felles.prosesstask.api.ProsessTaskData;
-import no.nav.vedtak.felles.prosesstask.api.ProsessTaskTjeneste;
 
 @BehandlingStegRef(BehandlingStegType.ANKE)
 @BehandlingTypeRef
@@ -46,10 +32,7 @@ public class AnkeSteg implements BehandlingSteg {
 
     private static final Logger LOG = LoggerFactory.getLogger(AnkeSteg.class);
 
-    private KlageRepository klageRepository;
     private BehandlingRepository behandlingRepository;
-    private BehandlingsresultatRepository behandlingsresultatRepository;
-    private ProsessTaskTjeneste prosessTaskTjeneste;
     private AnkeVurderingTjeneste ankeVurderingTjeneste;
 
     public AnkeSteg() {
@@ -57,12 +40,8 @@ public class AnkeSteg implements BehandlingSteg {
     }
 
     @Inject
-    public AnkeSteg(AnkeVurderingTjeneste ankeVurderingTjeneste, KlageRepository klageRepository, ProsessTaskTjeneste prosessTaskTjeneste,
-                    BehandlingRepositoryProvider behandlingRepositoryProvider ) {
-        this.klageRepository = klageRepository;
+    public AnkeSteg(AnkeVurderingTjeneste ankeVurderingTjeneste, BehandlingRepositoryProvider behandlingRepositoryProvider ) {
         this.behandlingRepository = behandlingRepositoryProvider.getBehandlingRepository();
-        this.behandlingsresultatRepository = behandlingRepositoryProvider.getBehandlingsresultatRepository();
-        this.prosessTaskTjeneste = prosessTaskTjeneste;
         this.ankeVurderingTjeneste = ankeVurderingTjeneste;
     }
 
@@ -71,16 +50,12 @@ public class AnkeSteg implements BehandlingSteg {
         /*
          * Ved første besøk kan anke være opprettet manuelt i VL eller pga opprettet-anke-hendelse fra KABAL med referanse
          * Ved senere besøk kan hoppet tilbake, ta av kabal-vent uten resultat, eller avsluttet-anke-hendelse fra KABAL med referanse
-         * - Anke opprettet i VL, uten kabalhendelse -> overfør til kabal manuelt/automatisk/begge - tenk steg + oppdaterer. Sett på vent
          * - Anke opprettet i KABAL og behandling i VL med referanse -> settes på vent til behandling i Kabal avsluttet
          * - Anke avsluttet / trukket -> henlegges utenfor steg
          * - Anke avsluttet / retur -> ukjent betydning, exception utenfor steg
          * - Anke avsluttet / andre utfall -> fortsett/avslutt uten flere AP.
         */
         var behandling = behandlingRepository.hentBehandling(kontekst.getBehandlingId());
-        var klageId = ankeVurderingTjeneste.hentAnkeResultatHvisEksisterer(behandling)
-            .flatMap(AnkeResultatEntitet::getPåAnketKlageBehandlingId)
-            .or(() -> utledLagrePåanketKlageBehandling(behandling));
         var kabalReferanse = ankeVurderingTjeneste.hentAnkeResultatHvisEksisterer(behandling)
             .map(AnkeResultatEntitet::erBehandletAvKabal).orElse(false);
         var harVentKabal = behandling.harAksjonspunktMedType(AksjonspunktDefinisjon.AUTO_VENT_PÅ_KABAL_ANKE);
@@ -95,16 +70,6 @@ public class AnkeSteg implements BehandlingSteg {
             }
         }
 
-        if (!harVentKabal) { // Har ikke vært sent til kabal, send over.
-            var hjemmel = klageId.flatMap(k -> klageRepository.hentKlageVurderingResultat(k, KlageVurdertAv.NFP))
-                .map(KlageVurderingResultat::getKlageHjemmel)
-                .filter(h -> !KlageHjemmel.UDEFINERT.equals(h))
-                .orElseGet(() -> KlageHjemmel.standardHjemmelForYtelse(behandling.getFagsakYtelseType()));
-            var tilKabalTask = ProsessTaskData.forProsessTask(SendTilKabalTask.class);
-            tilKabalTask.setBehandling(behandling.getSaksnummer().getVerdi(), behandling.getFagsakId(), behandling.getId());
-            tilKabalTask.setProperty(SendTilKabalTask.HJEMMEL_KEY, hjemmel.getKode());
-            prosessTaskTjeneste.lagre(tilKabalTask);
-        }
         return BehandleStegResultat.utførtMedAksjonspunktResultat(ventPåKabal());
     }
 
@@ -117,28 +82,6 @@ public class AnkeSteg implements BehandlingSteg {
         return ankeVurdering.isEmpty() || ankeVurdering.map(AnkeVurderingResultatEntitet::getAnkeVurdering)
             .filter(AnkeVurdering.UDEFINERT::equals)
             .isPresent();
-    }
-
-    private Optional<Long> utledLagrePåanketKlageBehandling(Behandling anke) {
-        var aktuelleKlager = behandlingRepository.hentAbsoluttAlleBehandlingerForFagsak(anke.getFagsakId()).stream()
-            .filter(b -> BehandlingType.KLAGE.equals(b.getType()))
-            .filter(Behandling::erSaksbehandlingAvsluttet)
-            .filter(b -> behandlingsresultatRepository.hentHvisEksisterer(b.getId()).filter(br -> !br.isBehandlingHenlagt()).isPresent())
-            .toList();
-        if (aktuelleKlager.size() == 1) {
-            return Optional.of(lagrePåanketBehandling(anke, aktuelleKlager.get(0)));
-        } else if (aktuelleKlager.size() > 1) {
-            var utvalgtKlage = aktuelleKlager.stream()
-                .filter(k -> klageRepository.hentKlageResultatHvisEksisterer(k.getId()).filter(KlageResultatEntitet::erBehandletAvKabal).isPresent())
-                .max(Comparator.comparing(Behandling::getAvsluttetDato))
-                .or(() -> aktuelleKlager.stream()
-                    .filter(k -> klageRepository.hentGjeldendeKlageVurderingResultat(k).filter(kvr -> KlageVurdering.STADFESTE_YTELSESVEDTAK.equals(kvr.getKlageVurdering())).isPresent())
-                    .max(Comparator.comparing(Behandling::getAvsluttetDato)))
-                .orElseGet(() -> aktuelleKlager.stream().max(Comparator.comparing(Behandling::getAvsluttetDato)).orElseThrow());
-            return Optional.of(lagrePåanketBehandling(anke, utvalgtKlage));
-        }
-        LOG.warn("ANKE steg: kunne ikke utlede klagebehandling automatisk sak {} anke {}", anke.getSaksnummer().getVerdi(), anke.getId());
-        return Optional.empty();
     }
 
     private Long lagrePåanketBehandling(Behandling anke, Behandling klage) {

--- a/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/anke/AnkeStegTest.java
+++ b/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/anke/AnkeStegTest.java
@@ -3,8 +3,6 @@ package no.nav.foreldrepenger.behandling.steg.anke;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.Optional;
@@ -15,28 +13,27 @@ import no.nav.foreldrepenger.behandling.anke.AnkeVurderingTjeneste;
 import no.nav.foreldrepenger.behandlingskontroll.BehandlingskontrollKontekst;
 import no.nav.foreldrepenger.behandlingskontroll.transisjoner.FellesTransisjoner;
 import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.AksjonspunktDefinisjon;
-import no.nav.foreldrepenger.behandlingslager.behandling.klage.KlageRepository;
+import no.nav.foreldrepenger.behandlingslager.behandling.anke.AnkeResultatEntitet;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingLås;
 import no.nav.foreldrepenger.behandlingslager.testutilities.behandling.ScenarioAnkeEngangsstønad;
 import no.nav.foreldrepenger.behandlingslager.testutilities.behandling.ScenarioMorSøkerEngangsstønad;
-import no.nav.vedtak.felles.prosesstask.api.ProsessTaskData;
-import no.nav.vedtak.felles.prosesstask.api.ProsessTaskTjeneste;
 
 class AnkeStegTest {
 
     @Test
-    void skalOppretteAksjonspunktManuellAvAnkeNårStegKjøres() {
+    void skalOppretteAksjonspunktVentKabalNårStegKjøres() {
         // Arrange
         var scenario = ScenarioAnkeEngangsstønad.forAvvistAnke(ScenarioMorSøkerEngangsstønad.forAdopsjon());
         var ankeBehandling = scenario.lagMocked();
         var rProvider = scenario.mockBehandlingRepositoryProvider();
         var ankeRepository = mock(AnkeVurderingTjeneste.class);
-        var prosessTaskTjeneste = mock(ProsessTaskTjeneste.class);
-        when(ankeRepository.hentAnkeResultatHvisEksisterer(any())).thenReturn(Optional.empty());
+        var mockAnkeresultat = mock(AnkeResultatEntitet.class);
+        when(mockAnkeresultat.erBehandletAvKabal()).thenReturn(Boolean.TRUE);
+        when(ankeRepository.hentAnkeResultatHvisEksisterer(any())).thenReturn(Optional.of(mockAnkeresultat));
         var kontekst = new BehandlingskontrollKontekst(ankeBehandling.getSaksnummer(), ankeBehandling.getFagsakId(),
                 new BehandlingLås(ankeBehandling.getId()));
 
-        var steg = new AnkeSteg(ankeRepository, mock(KlageRepository.class), prosessTaskTjeneste, rProvider);
+        var steg = new AnkeSteg(ankeRepository, rProvider);
 
         // Act
         var behandlingStegResultat = steg.utførSteg(kontekst);
@@ -46,11 +43,7 @@ class AnkeStegTest {
         assertThat(behandlingStegResultat.getTransisjon()).isEqualTo(FellesTransisjoner.UTFØRT);
         assertThat(behandlingStegResultat.getAksjonspunktListe()).hasSize(1);
 
-        // Sendt til kabl
-        verify(prosessTaskTjeneste, times(1)).lagre(any(ProsessTaskData.class));
-
         var aksjonspunktDefinisjon = behandlingStegResultat.getAksjonspunktListe().get(0);
         assertThat(aksjonspunktDefinisjon).isEqualTo(AksjonspunktDefinisjon.AUTO_VENT_PÅ_KABAL_ANKE);
-
     }
 }

--- a/domenetjenester/behandling-klage/src/main/java/no/nav/foreldrepenger/behandling/kabal/KabalTjeneste.java
+++ b/domenetjenester/behandling-klage/src/main/java/no/nav/foreldrepenger/behandling/kabal/KabalTjeneste.java
@@ -95,27 +95,6 @@ public class KabalTjeneste {
         kabalKlient.sendTilKabal(request);
     }
 
-    public void sendAnkeTilKabal(Behandling ankeBehandling, KlageHjemmel hjemmel) {
-        if (!BehandlingType.ANKE.equals(ankeBehandling.getType())) {
-            throw new IllegalArgumentException("Utviklerfeil: Prøver sende noe annet enn klage/anke til Kabal!");
-        }
-        var ankeResultat = ankeVurderingTjeneste.hentAnkeResultat(ankeBehandling);
-        var klageBehandling = ankeResultat.getPåAnketKlageBehandlingId().map(behandlingRepository::hentBehandling);
-        var klageResultat = klageBehandling.flatMap(kb -> klageVurderingTjeneste.hentKlageResultatHvisEksisterer(kb));
-        var brukHjemmel = Optional.ofNullable(hjemmel)
-            .orElseGet(() -> KlageHjemmel.standardHjemmelForYtelse(ankeBehandling.getFagsakYtelseType()));
-        var enhet = utledEnhet(ankeBehandling.getFagsak());
-        var ankeMottattDato  = kabalDokumenter.utledDokumentMottattDato(ankeBehandling);
-        var klager = utledKlager(ankeBehandling, klageResultat);
-        var bleKlageBehandletKabal = klageResultat.filter(KlageResultatEntitet::erBehandletAvKabal).isPresent();
-        var kildereferanse = klageBehandling.filter(k -> bleKlageBehandletKabal).orElse(ankeBehandling).getUuid().toString();
-        var sakMottattKaDato = ankeBehandling.getOpprettetTidspunkt();
-        var dokumentReferanser = kabalDokumenter.finnDokumentReferanserForAnke(ankeBehandling.getId(), ankeResultat, bleKlageBehandletKabal);
-        var request = TilKabalDto.anke(ankeBehandling, kildereferanse, klager, enhet, dokumentReferanser,
-            ankeMottattDato, ankeMottattDato, sakMottattKaDato, List.of(brukHjemmel.getKabal()));
-        kabalKlient.sendTilKabal(request);
-    }
-
     public void lagreKlageUtfallFraKabal(Behandling behandling, KabalUtfall utfall) {
         var builder = klageVurderingTjeneste.hentKlageVurderingResultatBuilder(behandling, KlageVurdertAv.NK)
             .medKlageVurdering(klageVurderingFraUtfall(utfall))

--- a/domenetjenester/behandling-klage/src/main/java/no/nav/foreldrepenger/behandling/kabal/SendTilKabalTask.java
+++ b/domenetjenester/behandling-klage/src/main/java/no/nav/foreldrepenger/behandling/kabal/SendTilKabalTask.java
@@ -1,10 +1,12 @@
 package no.nav.foreldrepenger.behandling.kabal;
 
+import java.util.Objects;
 import java.util.Optional;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 
+import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingType;
 import no.nav.foreldrepenger.behandlingslager.behandling.klage.KlageHjemmel;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepositoryProvider;
@@ -43,10 +45,10 @@ public class SendTilKabalTask extends BehandlingProsessTask {
             .map(KlageHjemmel::fraKode).orElse(null);
         var behandling = behandlingRepository.hentBehandling(behandlingId);
 
-        switch (behandling.getType()) {
-            case KLAGE -> kabalTjeneste.sendKlageTilKabal(behandling, klagehjemmel);
-            case ANKE -> kabalTjeneste.sendAnkeTilKabal(behandling, klagehjemmel);
-            default -> throw new IllegalArgumentException("Utviklerfeil: Forsøker sende annen behandlingtype til KABAL");
+        if (BehandlingType.KLAGE.equals(behandling.getType())) {
+            kabalTjeneste.sendKlageTilKabal(behandling, klagehjemmel);
+        } else {
+            throw new IllegalArgumentException("Utviklerfeil: Forsøker sende annen behandlingtype til KABAL");
         }
     }
 }

--- a/domenetjenester/behandling-klage/src/main/java/no/nav/foreldrepenger/behandling/kabal/TilKabalDto.java
+++ b/domenetjenester/behandling-klage/src/main/java/no/nav/foreldrepenger/behandling/kabal/TilKabalDto.java
@@ -47,24 +47,7 @@ public record TilKabalDto(@NotNull Klager klager,
             hjemler, kommentar);
     }
 
-    public static TilKabalDto anke(Behandling behandling,
-                                   String kildereferanse,
-                                   @NotNull Klager klager,
-                                   @NotNull String forrigeBehandlendeEnhet, // Førsteinstans
-                                   @NotNull List<DokumentReferanse> tilknyttedeJournalposter,
-                                   @NotNull LocalDate brukersHenvendelseMottattNavDato, // Required Mottattdato?
-                                   @NotNull LocalDate innsendtTilNav, // Innsendingsdato?
-                                   @NotNull LocalDateTime sakMottattKaTidspunkt, // Tidspunkt KA skal ha fått vite om behandlingen
-                                   List<String> hjemler) {
-        return new TilKabalDto(klager, forrigeBehandlendeEnhet, tilknyttedeJournalposter,
-            brukersHenvendelseMottattNavDato, innsendtTilNav,
-            Fagsystem.FPSAK.getOffisiellKode(), kildereferanse, kildereferanse,
-            KlageAnke.ANKE, mapYtelseType(behandling), sakMottattKaTidspunkt, sakMottattKaTidspunkt.toLocalDate(),
-            new Sak(behandling.getSaksnummer().getVerdi(), Fagsystem.FPSAK.getOffisiellKode()),
-            hjemler, "");
-    }
-
-    public static record Sak(@NotNull String fagsakId, @NotNull String fagsystem) {}
+    public record Sak(@NotNull String fagsakId, @NotNull String fagsystem) {}
 
     public record Part(@NotNull PartsType type, @NotNull String verdi) {}
 


### PR DESCRIPTION
Har ikke lenger støtte for å opprette anker i FP-sak. Alle stammer fra Kabal.
Det er derfor ikke lenger behov for å sende anker til Kabal. Alle våre er migrert og bestanden er avstemt.
Forenkling av siste steg (ankemerknader) må vente til en gammel, migrert anke er ferdigbehandlet i trygderetten