### PR TITLE
TFP-5900: Identifisere og opprette revurdering på saker med feil avslått uttak med ny behandlingårsak og brevkode

### DIFF
--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/BehandlingÅrsakType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/BehandlingÅrsakType.java
@@ -74,6 +74,7 @@ public enum BehandlingÅrsakType implements Kodeverdi {
 
     // Håndtering av diverse feilsituaqsjoner
     FEIL_PRAKSIS_UTSETTELSE("FEIL_PRAKSIS_UTSETTELSE", "Feil praksis utsettelse"),
+    FEIL_IVERKSETTELSE_FRI_UTSETTELSE("FEIL_IVERKSETTELSE_FRI_UTSETTELSE", "Feil iverksettelse fri utsettelse"),
 
     // Skille klageområder
     KLAGE_TILBAKEBETALING("KLAGE_TILBAKE", "Tilbakebetaling"),

--- a/behandlingsprosess/src/main/java/no/nav/foreldrepenger/behandling/steg/foreslåvedtak/ForeslåVedtakTjeneste.java
+++ b/behandlingsprosess/src/main/java/no/nav/foreldrepenger/behandling/steg/foreslåvedtak/ForeslåVedtakTjeneste.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -128,7 +129,7 @@ class ForeslåVedtakTjeneste {
         if (behandling.harNoenBehandlingÅrsaker(BehandlingÅrsakType.årsakerRelatertTilDød())) {
             return true;
         }
-        if (behandling.harBehandlingÅrsak(BehandlingÅrsakType.FEIL_PRAKSIS_UTSETTELSE) ||
+        if (behandling.harNoenBehandlingÅrsaker(Set.of(BehandlingÅrsakType.FEIL_PRAKSIS_UTSETTELSE, BehandlingÅrsakType.FEIL_IVERKSETTELSE_FRI_UTSETTELSE)) ||
             fagsakEgenskapRepository.harFagsakMarkering(behandling.getFagsakId(), FagsakMarkering.PRAKSIS_UTSETTELSE)) {
             return true;
         }

--- a/behandlingsprosess/src/main/java/no/nav/foreldrepenger/behandling/steg/registrersøknad/RegistrerSøknadSteg.java
+++ b/behandlingsprosess/src/main/java/no/nav/foreldrepenger/behandling/steg/registrersøknad/RegistrerSøknadSteg.java
@@ -1,23 +1,7 @@
 package no.nav.foreldrepenger.behandling.steg.registrersøknad;
 
-import static java.util.Collections.singletonList;
-import static no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.AksjonspunktDefinisjon.REGISTRER_PAPIRSØKNAD_ENGANGSSTØNAD;
-import static no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.AksjonspunktDefinisjon.REGISTRER_PAPIRSØKNAD_FORELDREPENGER;
-import static no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.AksjonspunktDefinisjon.REGISTRER_PAPIRSØKNAD_SVANGERSKAPSPENGER;
-import static no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.AksjonspunktDefinisjon.REGISTRER_PAPIR_ENDRINGSØKNAD_FORELDREPENGER;
-import static no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.AksjonspunktDefinisjon.VENT_PÅ_SØKNAD;
-
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.Month;
-import java.time.Period;
-import java.util.Comparator;
-import java.util.List;
-import java.util.Set;
-
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
-
 import no.nav.foreldrepenger.behandling.BehandlingReferanse;
 import no.nav.foreldrepenger.behandling.steg.iverksettevedtak.HenleggBehandlingTjeneste;
 import no.nav.foreldrepenger.behandlingskontroll.AksjonspunktResultat;
@@ -44,13 +28,28 @@ import no.nav.foreldrepenger.kompletthet.Kompletthetsjekker;
 import no.nav.foreldrepenger.mottak.dokumentmottak.MottatteDokumentTjeneste;
 import no.nav.foreldrepenger.produksjonsstyring.behandlingenhet.RegistrerFagsakEgenskaper;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.Month;
+import java.time.Period;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Set;
+
+import static java.util.Collections.singletonList;
+import static no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.AksjonspunktDefinisjon.REGISTRER_PAPIRSØKNAD_ENGANGSSTØNAD;
+import static no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.AksjonspunktDefinisjon.REGISTRER_PAPIRSØKNAD_FORELDREPENGER;
+import static no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.AksjonspunktDefinisjon.REGISTRER_PAPIRSØKNAD_SVANGERSKAPSPENGER;
+import static no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.AksjonspunktDefinisjon.REGISTRER_PAPIR_ENDRINGSØKNAD_FORELDREPENGER;
+import static no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.AksjonspunktDefinisjon.VENT_PÅ_SØKNAD;
+
 @BehandlingStegRef(BehandlingStegType.REGISTRER_SØKNAD)
 @BehandlingTypeRef
 @FagsakYtelseTypeRef
 @ApplicationScoped
 public class RegistrerSøknadSteg implements BehandlingSteg {
     private static final Period VENT_PÅ_SØKNAD_PERIODE = Period.parse("P4W");
-    private static final LocalDate FRIST_PRAKSIS_UTSETTELSE = LocalDate.of(2024, Month.AUGUST, 25); // TODO: Sett på vent til når?
+    private static final LocalDate FRIST_PRAKSIS_UTSETTELSE = LocalDate.of(2026, Month.APRIL, 20);
     private BehandlingRepository behandlingRepository;
     private MottatteDokumentTjeneste mottatteDokumentTjeneste;
     private RegistrerFagsakEgenskaper registrerFagsakEgenskaper;

--- a/behandlingsprosess/src/main/java/no/nav/foreldrepenger/behandling/steg/registrersøknad/RegistrerSøknadSteg.java
+++ b/behandlingsprosess/src/main/java/no/nav/foreldrepenger/behandling/steg/registrersøknad/RegistrerSøknadSteg.java
@@ -13,6 +13,7 @@ import java.time.Month;
 import java.time.Period;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Set;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -49,7 +50,7 @@ import no.nav.foreldrepenger.produksjonsstyring.behandlingenhet.RegistrerFagsakE
 @ApplicationScoped
 public class RegistrerSøknadSteg implements BehandlingSteg {
     private static final Period VENT_PÅ_SØKNAD_PERIODE = Period.parse("P4W");
-    private static final LocalDate FRIST_PRAKSIS_UTSETTELSE = LocalDate.of(2024, Month.AUGUST, 25);
+    private static final LocalDate FRIST_PRAKSIS_UTSETTELSE = LocalDate.of(2024, Month.AUGUST, 25); // TODO: Sett på vent til når?
     private BehandlingRepository behandlingRepository;
     private MottatteDokumentTjeneste mottatteDokumentTjeneste;
     private RegistrerFagsakEgenskaper registrerFagsakEgenskaper;
@@ -93,8 +94,7 @@ public class RegistrerSøknadSteg implements BehandlingSteg {
             return evaluerSøknadMottattUoppfylt(behandling, søknadMottatt, VENT_PÅ_SØKNAD);
         }
 
-        if (behandling.harBehandlingÅrsak(BehandlingÅrsakType.FEIL_PRAKSIS_UTSETTELSE) &&
-            !behandling.harBehandlingÅrsak(BehandlingÅrsakType.RE_ENDRING_FRA_BRUKER)) {
+        if (behandling.harNoenBehandlingÅrsaker(Set.of(BehandlingÅrsakType.FEIL_PRAKSIS_UTSETTELSE, BehandlingÅrsakType.FEIL_IVERKSETTELSE_FRI_UTSETTELSE)) && !behandling.harBehandlingÅrsak(BehandlingÅrsakType.RE_ENDRING_FRA_BRUKER)) {
             if (henleggBehandling(behandling)) {
                 henleggBehandlingTjeneste.lagHistorikkInnslagForHenleggelseFraSteg(behandling, BehandlingResultatType.HENLAGT_SØKNAD_MANGLER,
                     null);

--- a/domenetjenester/datavarehus/src/main/java/no/nav/foreldrepenger/datavarehus/tjeneste/BehandlingDvhMapper.java
+++ b/domenetjenester/datavarehus/src/main/java/no/nav/foreldrepenger/datavarehus/tjeneste/BehandlingDvhMapper.java
@@ -6,6 +6,7 @@ import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 import java.util.function.Function;
 
@@ -202,7 +203,7 @@ public class BehandlingDvhMapper {
             return null;
         }
         // Midlertidig
-        if (behandling.harBehandlingÅrsak(BehandlingÅrsakType.FEIL_PRAKSIS_UTSETTELSE) || fagsakMarkering.contains(FagsakMarkering.PRAKSIS_UTSETTELSE)) {
+        if (behandling.harNoenBehandlingÅrsaker(Set.of(BehandlingÅrsakType.FEIL_PRAKSIS_UTSETTELSE, BehandlingÅrsakType.FEIL_IVERKSETTELSE_FRI_UTSETTELSE)) || fagsakMarkering.contains(FagsakMarkering.PRAKSIS_UTSETTELSE)) {
             return RevurderingÅrsak.PRAKSISUTSETTELSE;
         }
         if (behandling.harBehandlingÅrsak(BehandlingÅrsakType.RE_ENDRING_FRA_BRUKER)) {

--- a/domenetjenester/datavarehus/src/main/java/no/nav/foreldrepenger/datavarehus/v2/StønadsstatistikkTjeneste.java
+++ b/domenetjenester/datavarehus/src/main/java/no/nav/foreldrepenger/datavarehus/v2/StønadsstatistikkTjeneste.java
@@ -520,7 +520,7 @@ public class StønadsstatistikkTjeneste {
             return null;
         }
         // MIdlertidig
-        if (behandling.harBehandlingÅrsak(BehandlingÅrsakType.FEIL_PRAKSIS_UTSETTELSE) || fagsakMarkering.contains(FagsakMarkering.PRAKSIS_UTSETTELSE)) {
+        if (behandling.harNoenBehandlingÅrsaker(Set.of(BehandlingÅrsakType.FEIL_PRAKSIS_UTSETTELSE, BehandlingÅrsakType.FEIL_IVERKSETTELSE_FRI_UTSETTELSE)) || fagsakMarkering.contains(FagsakMarkering.PRAKSIS_UTSETTELSE)) {
             return StønadsstatistikkVedtak.RevurderingÅrsak.PRAKSIS_UTSETTELSE;
         }
         if (behandling.harBehandlingÅrsak(BehandlingÅrsakType.RE_ENDRING_FRA_BRUKER)) {

--- a/domenetjenester/dokumentbestiller/src/main/java/no/nav/foreldrepenger/dokumentbestiller/DokumentMalType.java
+++ b/domenetjenester/dokumentbestiller/src/main/java/no/nav/foreldrepenger/dokumentbestiller/DokumentMalType.java
@@ -1,13 +1,12 @@
 package no.nav.foreldrepenger.dokumentbestiller;
 
+import com.fasterxml.jackson.annotation.JsonValue;
+import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
+
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-
-import com.fasterxml.jackson.annotation.JsonValue;
-
-import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
 
 public enum DokumentMalType implements Kodeverdi {
 

--- a/domenetjenester/dokumentbestiller/src/main/java/no/nav/foreldrepenger/dokumentbestiller/autopunkt/SendBrevForAutopunkt.java
+++ b/domenetjenester/dokumentbestiller/src/main/java/no/nav/foreldrepenger/dokumentbestiller/autopunkt/SendBrevForAutopunkt.java
@@ -1,11 +1,7 @@
 package no.nav.foreldrepenger.dokumentbestiller.autopunkt;
 
-import static no.nav.foreldrepenger.behandlingslager.behandling.BehandlingÅrsakType.INFOBREV_OPPHOLD;
-import static no.nav.foreldrepenger.behandlingslager.behandling.BehandlingÅrsakType.INFOBREV_PÅMINNELSE;
-
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
-
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingÅrsakType;
 import no.nav.foreldrepenger.behandlingslager.behandling.RevurderingVarslingÅrsak;
@@ -15,6 +11,11 @@ import no.nav.foreldrepenger.dokumentbestiller.DokumentBehandlingTjeneste;
 import no.nav.foreldrepenger.dokumentbestiller.DokumentBestillerTjeneste;
 import no.nav.foreldrepenger.dokumentbestiller.DokumentBestilling;
 import no.nav.foreldrepenger.dokumentbestiller.DokumentMalType;
+
+import java.util.Set;
+
+import static no.nav.foreldrepenger.behandlingslager.behandling.BehandlingÅrsakType.INFOBREV_OPPHOLD;
+import static no.nav.foreldrepenger.behandlingslager.behandling.BehandlingÅrsakType.INFOBREV_PÅMINNELSE;
 
 @ApplicationScoped
 public class SendBrevForAutopunkt {
@@ -41,7 +42,7 @@ public class SendBrevForAutopunkt {
         if (behandling.harBehandlingÅrsak(BehandlingÅrsakType.INFOBREV_BEHANDLING)
             || behandling.harBehandlingÅrsak(INFOBREV_OPPHOLD) || behandling.harBehandlingÅrsak(INFOBREV_PÅMINNELSE)) {
             dokumentMal = DokumentMalType.FORELDREPENGER_INFO_TIL_ANNEN_FORELDER;
-        } else if (behandling.harBehandlingÅrsak(BehandlingÅrsakType.FEIL_PRAKSIS_UTSETTELSE)) {
+        } else if (behandling.harNoenBehandlingÅrsaker(Set.of(BehandlingÅrsakType.FEIL_PRAKSIS_UTSETTELSE, BehandlingÅrsakType.FEIL_IVERKSETTELSE_FRI_UTSETTELSE))) {
             dokumentMal = DokumentMalType.FORELDREPENGER_FEIL_PRAKSIS_UTSETTELSE_INFOBREV;
             // Akkurat denne skal ikke sendes flere ganger for en sak.
             if (dokumentBehandlingTjeneste.erDokumentBestiltForFagsak(behandling.getFagsakId(), dokumentMal)) {

--- a/domenetjenester/dokumentbestiller/src/main/java/no/nav/foreldrepenger/dokumentbestiller/infobrev/FeilPraksisUtsettelseRepository.java
+++ b/domenetjenester/dokumentbestiller/src/main/java/no/nav/foreldrepenger/dokumentbestiller/infobrev/FeilPraksisUtsettelseRepository.java
@@ -136,7 +136,7 @@ public class FeilPraksisUtsettelseRepository {
 
     public List<Long> finnNesteHundreSakerSomErMerketFeilIverksettelseFriUtsettelse(Long fraFagsakId) {
         var query = entityManager.createNativeQuery(QUERY_MERKET)
-            .setParameter(FRA_FAGSAK_ID, fraFagsakId == null ? 0 : fraFagsakId)
+            .setParameter("fraFagsakId", fraFagsakId == null ? 0 : fraFagsakId)
             .setParameter("feilp", BehandlingÅrsakType.FEIL_PRAKSIS_UTSETTELSE.getKode())
             .setHint(HibernateHints.HINT_READ_ONLY, "true");
         @SuppressWarnings("unchecked")

--- a/domenetjenester/dokumentbestiller/src/main/java/no/nav/foreldrepenger/dokumentbestiller/infobrev/FeilPraksisUtsettelseRepository.java
+++ b/domenetjenester/dokumentbestiller/src/main/java/no/nav/foreldrepenger/dokumentbestiller/infobrev/FeilPraksisUtsettelseRepository.java
@@ -1,14 +1,12 @@
 package no.nav.foreldrepenger.dokumentbestiller.infobrev;
 
-import java.util.List;
-
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.persistence.EntityManager;
-
+import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingÅrsakType;
 import org.hibernate.jpa.HibernateHints;
 
-import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingÅrsakType;
+import java.util.List;
 
 /**
  * Spesialmetoder for å hente opp saker og personer som er kandidat for å sende
@@ -17,8 +15,6 @@ import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingÅrsakType;
 
 @ApplicationScoped
 public class FeilPraksisUtsettelseRepository {
-
-    private static final String FRA_FAGSAK_ID = "fraFagsakId";
 
     private EntityManager entityManager;
 
@@ -31,54 +27,43 @@ public class FeilPraksisUtsettelseRepository {
         this.entityManager = entityManager;
     }
 
+    /*
+     *  MOR: Avslag utsettelse perioder etter 1/10-21
+     */
     private static final String QUERY_MERKING_MOR = """
-        select * from (
-        select f.id fid
-        from fagsak f
-           join behandling b on fagsak_id = f.id
-           join behandling_resultat br  on b.id = br.behandling_id
-           join behandling_vedtak bv on bv.behandling_resultat_id = br.id
-           join (select beh.fagsak_id fsmax, max(bvsq.opprettet_tid) maxbr from behandling beh
-                join behandling_resultat brsq on brsq.behandling_id=beh.id
-                join behandling_vedtak bvsq on bvsq.behandling_resultat_id = brsq.id
-                where beh.behandling_type in ('BT-002','BT-004') and beh.behandling_status in ('AVSLU', 'IVED')
-                group by beh.fagsak_id) on (fsmax=b.fagsak_id and bv.opprettet_tid = maxbr)
-           join uttak_resultat ur on (ur.behandling_resultat_id = br.id and ur.aktiv='J')
+        select distinct f.id from fagsak f
+        join behandling b on fagsak_id = f.id
+        join behandling_resultat br  on b.id = br.behandling_id
+        join behandling_vedtak bv on bv.behandling_resultat_id = br.id
+        join (select beh.fagsak_id fsmax, max(bvsq.opprettet_tid) maxbr from behandling beh
+            join behandling_resultat brsq on brsq.behandling_id=beh.id
+            join behandling_vedtak bvsq on bvsq.behandling_resultat_id = brsq.id
+            where beh.behandling_type in ('BT-002','BT-004') and beh.behandling_status in ('AVSLU', 'IVED')
+            group by beh.fagsak_id) on (fsmax=b.fagsak_id and bv.opprettet_tid = maxbr)
+        join uttak_resultat ur on (ur.behandling_resultat_id = br.id and ur.aktiv='J')
+        join uttak_resultat_periode peri on uttak_resultat_perioder_id = nvl(ur.overstyrt_perioder_id, ur.opprinnelig_perioder_id)
+        join uttak_resultat_periode_akt peria on peria.uttak_resultat_periode_id = peri.id
         where 1=1
-           and b.behandling_type in ('BT-002','BT-004') and b.behandling_status in ('AVSLU', 'IVED')
-           and nvl(ur.overstyrt_perioder_id, ur.opprinnelig_perioder_id) in (
-              select uttak_resultat_perioder_id from uttak_resultat_periode peri
-              where (peri.gradering_avslag_AARSAK = '4501' and samtidig_uttaksprosent is null
-                     and exists (select * from uttak_resultat_periode_akt peria
-                          where peria.uttak_resultat_periode_id = peri.id and utbetalingsprosent < 100)
-              ) or (peri.PERIODE_RESULTAT_AARSAK in ( '4005','4081','4082')
-                    and exists (select * from uttak_resultat_periode_akt peria
-                          where peria.uttak_resultat_periode_id = peri.id and utbetalingsprosent = 0 and trekkdager_desimaler > 0)
-              )
-           )
-           and bruker_rolle = 'MORA'
-           and ytelse_type='FP'
-           and til_infotrygd = 'N'
-           and (bv.vedtak_resultat_type = 'INNVILGET' or (bv.vedtak_resultat_type = 'OPPHØR'
-                and exists (select * from  br_resultat_behandling ty
-                       join br_periode brp on brp.BEREGNINGSRESULTAT_FP_ID = nvl(UTBET_BEREGNINGSRESULTAT_FP_ID,BG_BEREGNINGSRESULTAT_FP_ID)
-                       join br_andel ba on ba.br_periode_id = brp.id
-                       where ty.behandling_id=b.id and ty.aktiv='J' and dagsats > 0)))
-           and f.id not in (select fagsak_id from fagsak_egenskap where egenskap_value = 'PRAKSIS_UTSETTELSE' and aktiv='J')
-           and f.id >:fraFagsakId
-           order by fid
-        ) where ROWNUM <= 100
+            and b.behandling_type in ('BT-002','BT-004') and b.behandling_status in ('AVSLU', 'IVED')
+            and peri.tom >= '01.10.2021'
+            and uttak_utsettelse_type <> '-'
+            and (utbetalingsprosent is null or utbetalingsprosent = 0)
+            and trekkdager_desimaler > 0
+            and trekkonto <> 'FORELDREPENGER_FØR_FØDSEL'
+            and periode_resultat_aarsak not in ( '4030', '4031', '4071', '4072', '4077', '4103', '4104', '4110', '4111', '4112', '4115', '4116', '4117' )
+            and bruker_rolle = 'MORA'
+            and ytelse_type='FP'
+            and til_infotrygd = 'N'
+            and (bv.vedtak_resultat_type = 'INNVILGET' or (bv.vedtak_resultat_type = 'OPPHØR'
+            and exists (select * from  br_resultat_behandling ty
+                      join br_periode brp on brp.BEREGNINGSRESULTAT_FP_ID = nvl(UTBET_BEREGNINGSRESULTAT_FP_ID,BG_BEREGNINGSRESULTAT_FP_ID)
+                      join br_andel ba on ba.br_periode_id = brp.id
+                      where ty.behandling_id=b.id and ty.aktiv='J' and dagsats > 0)))
+            and f.id not in (select fagsak_id from fagsak_egenskap where egenskap_value = 'PRAKSIS_UTSETTELSE' and aktiv='J')
         """;
 
-    public List<Long> finnNesteHundreSakerForMerkingMor(Long fraFagsakId) {
-        /*
-         * Plukker fagsakId, aktørId fra fagsaker som møter disse kriteriene: - Saker
-         * (Foreldrepenger, Mors sak, Ikke Stengt) med avsluttet behandling som har max
-         * uttaksdato i gitt intervall - Begrenset til ikke aleneomsorg - Begrenset til
-         * levende barn - Begrenset til at det er oppgitt annen part
-         */
+    public List<Long> alleSakerMorAvslagUtsettelse() {
         var query = entityManager.createNativeQuery(QUERY_MERKING_MOR)
-            .setParameter(FRA_FAGSAK_ID, fraFagsakId == null ? 0 : fraFagsakId)
             .setHint(HibernateHints.HINT_READ_ONLY, "true");
         @SuppressWarnings("unchecked")
         var resultat = query.getResultList();
@@ -86,59 +71,51 @@ public class FeilPraksisUtsettelseRepository {
     }
 
     /*
-     * OBS: Her er avslag med.
+     * FAR/MEDMOR - begge rett eller aleneomsorg
      */
     private static final String QUERY_MERKING_FAR_BEGGE_ALENE = """
-        select * from (
-           select f.id fid
-           from fagsak f
-              join behandling b on fagsak_id = f.id
-              join behandling_resultat br  on b.id = br.behandling_id
-              join behandling_vedtak bv on bv.behandling_resultat_id = br.id
-              join (select beh.fagsak_id fsmax, max(bvsq.opprettet_tid) maxbr from behandling beh
-                   join behandling_resultat brsq on brsq.behandling_id=beh.id
-                   join behandling_vedtak bvsq on bvsq.behandling_resultat_id = brsq.id
-                   where beh.behandling_type in ('BT-002','BT-004') and beh.behandling_status in ('AVSLU', 'IVED')
-                   group by beh.fagsak_id) on (fsmax=b.fagsak_id and bv.opprettet_tid = maxbr)
-              join uttak_resultat ur on (ur.behandling_resultat_id = br.id and ur.aktiv='J')
-              join gr_ytelses_fordeling gy on (gy.behandling_id = b.id and gy.aktiv='J')
-              left outer join so_rettighet soro on soro.id = gy.overstyrt_rettighet_id
-           where 1=1
-              and b.behandling_type in ('BT-002','BT-004') and b.behandling_status in ('AVSLU', 'IVED')
-              and nvl(ur.overstyrt_perioder_id, ur.opprinnelig_perioder_id) in (
-                 select uttak_resultat_perioder_id from uttak_resultat_periode peri
-                 where (peri.gradering_avslag_AARSAK = '4501' and samtidig_uttaksprosent is null
-                        and exists (select * from uttak_resultat_periode_akt peria
-                             where peria.uttak_resultat_periode_id = peri.id and utbetalingsprosent < 100)
-                 ) or (peri.PERIODE_RESULTAT_AARSAK in ( '4005','4081','4082')
-                       and exists (select * from uttak_resultat_periode_akt peria
-                             where peria.uttak_resultat_periode_id = peri.id  and utbetalingsprosent = 0 and trekkdager_desimaler > 0)
-                 )
-              )
-              and bruker_rolle <> 'MORA'
-              and (soro.aleneomsorg = 'J' or
-                 f.id not in (select fagsak_en_id from fagsak_relasjon join STOENADSKONTO  on STOENADSKONTOBEREGNING_ID = nvl(OVERSTYRT_KONTO_BEREGNING_ID, KONTO_BEREGNING_ID)
-                               where aktiv='J' and stoenadskontotype = 'FORELDREPENGER'
-                               UNION
-                               select fagsak_to_id from fagsak_relasjon join STOENADSKONTO  on STOENADSKONTOBEREGNING_ID = nvl(OVERSTYRT_KONTO_BEREGNING_ID, KONTO_BEREGNING_ID)
-                               where aktiv='J' and stoenadskontotype = 'FORELDREPENGER' and fagsak_to_id is not null)
-                )
-              and ytelse_type='FP'
-              and til_infotrygd = 'N'
-              and (bv.vedtak_resultat_type in ('INNVILGET', 'AVSLAG') or (bv.vedtak_resultat_type = 'OPPHØR'
-                   and exists (select * from  br_resultat_behandling ty
-                          join br_periode brp on brp.BEREGNINGSRESULTAT_FP_ID = nvl(UTBET_BEREGNINGSRESULTAT_FP_ID,BG_BEREGNINGSRESULTAT_FP_ID)
-                          join br_andel ba on ba.br_periode_id = brp.id
-                          where ty.behandling_id=b.id and ty.aktiv='J' and dagsats > 0)))
-              and f.id not in (select fagsak_id from fagsak_egenskap where egenskap_value = 'PRAKSIS_UTSETTELSE' and aktiv='J')
-           and f.id >:fraFagsakId
-           order by fid
-        ) where ROWNUM <= 100
+        select distinct f.id from fagsak f
+        join behandling b on fagsak_id = f.id
+        join behandling_resultat br  on b.id = br.behandling_id
+        join behandling_vedtak bv on bv.behandling_resultat_id = br.id
+        join (select beh.fagsak_id fsmax, max(bvsq.opprettet_tid) maxbr from behandling beh
+              join behandling_resultat brsq on brsq.behandling_id=beh.id
+              join behandling_vedtak bvsq on bvsq.behandling_resultat_id = brsq.id
+              where beh.behandling_type in ('BT-002','BT-004') and beh.behandling_status in ('AVSLU', 'IVED')
+              group by beh.fagsak_id) on (fsmax=b.fagsak_id and bv.opprettet_tid = maxbr)
+        join uttak_resultat ur on (ur.behandling_resultat_id = br.id and ur.aktiv='J')
+        join uttak_resultat_periode peri on uttak_resultat_perioder_id = nvl(ur.overstyrt_perioder_id, ur.opprinnelig_perioder_id)
+        join uttak_resultat_periode_akt peria on peria.uttak_resultat_periode_id = peri.id
+        join gr_ytelses_fordeling gy on (gy.behandling_id = b.id and gy.aktiv='J')
+        left outer join so_rettighet soro on soro.id = gy.overstyrt_rettighet_id
+        where 1=1
+          and b.behandling_type in ('BT-002','BT-004') and b.behandling_status in ('AVSLU', 'IVED')
+          and peri.tom >= '01.10.2021'
+          and uttak_utsettelse_type <> '-'
+          and (utbetalingsprosent is null or utbetalingsprosent = 0)
+          and trekkdager_desimaler > 0
+          and trekkonto <> 'FORELDREPENGER_FØR_FØDSEL'
+          and periode_resultat_aarsak not in ( '4030', '4031', '4071', '4072', '4077', '4103', '4104', '4110', '4111', '4112', '4115', '4116', '4117' )
+          and bruker_rolle <> 'MORA'
+          --and soro.aleneomsorg = 'J'
+          and f.id not in
+              (select fagsak_en_id from fagsak_relasjon join STOENADSKONTO  on STOENADSKONTOBEREGNING_ID = nvl(OVERSTYRT_KONTO_BEREGNING_ID, KONTO_BEREGNING_ID)
+               where aktiv='J' and stoenadskontotype = 'FORELDREPENGER'
+               UNION
+               select fagsak_to_id from fagsak_relasjon join STOENADSKONTO  on STOENADSKONTOBEREGNING_ID = nvl(OVERSTYRT_KONTO_BEREGNING_ID, KONTO_BEREGNING_ID)
+               where aktiv='J' and stoenadskontotype = 'FORELDREPENGER' and fagsak_to_id is not null)
+          and ytelse_type='FP'
+          and til_infotrygd = 'N'
+          and (bv.vedtak_resultat_type in ('INNVILGET', 'AVSLAG') or (bv.vedtak_resultat_type = 'OPPHØR'
+          and exists (select * from  br_resultat_behandling ty
+                      join br_periode brp on brp.BEREGNINGSRESULTAT_FP_ID = nvl(UTBET_BEREGNINGSRESULTAT_FP_ID,BG_BEREGNINGSRESULTAT_FP_ID)
+                      join br_andel ba on ba.br_periode_id = brp.id
+                      where ty.behandling_id=b.id and ty.aktiv='J' and dagsats > 0)))
+          and f.id not in (select fagsak_id from fagsak_egenskap where egenskap_value = 'PRAKSIS_UTSETTELSE' and aktiv='J')
         """;
 
-    public List<Long> finnNesteHundreSakerForMerkingFarBeggeEllerAlene(Long fraFagsakId) {
+    public List<Long> alleSakerFarBeggeEllerAleneUtsettelse() {
         var query = entityManager.createNativeQuery(QUERY_MERKING_FAR_BEGGE_ALENE)
-            .setParameter(FRA_FAGSAK_ID, fraFagsakId == null ? 0 : fraFagsakId)
             .setHint(HibernateHints.HINT_READ_ONLY, "true");
         @SuppressWarnings("unchecked")
         var resultat = query.getResultList();
@@ -157,7 +134,7 @@ public class FeilPraksisUtsettelseRepository {
         ) where ROWNUM <= 100
         """;
 
-    public List<Long> finnNesteHundreSakerSomErMerketPraksisUtsettelse(Long fraFagsakId) {
+    public List<Long> finnNesteHundreSakerSomErMerketFeilIverksettelseFriUtsettelse(Long fraFagsakId) {
         var query = entityManager.createNativeQuery(QUERY_MERKET)
             .setParameter(FRA_FAGSAK_ID, fraFagsakId == null ? 0 : fraFagsakId)
             .setParameter("feilp", BehandlingÅrsakType.FEIL_PRAKSIS_UTSETTELSE.getKode())

--- a/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/uttaksgrunnlag/fp/EndringsdatoRevurderingUtleder.java
+++ b/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/uttaksgrunnlag/fp/EndringsdatoRevurderingUtleder.java
@@ -202,7 +202,8 @@ public class EndringsdatoRevurderingUtleder {
         var ref = input.getBehandlingReferanse();
         var fpGrunnlag = (ForeldrepengerGrunnlag) input.getYtelsespesifiktGrunnlag();
         if (input.isBehandlingManueltOpprettet() || fpGrunnlag.isDødsfall() || arbeidsforholdRelevantForUttakErEndret(input) ||
-            endretDekningsgrad(ref) || input.harBehandlingÅrsak(BehandlingÅrsakType.FEIL_PRAKSIS_UTSETTELSE)) {
+            endretDekningsgrad(ref) || input.harBehandlingÅrsak(BehandlingÅrsakType.FEIL_PRAKSIS_UTSETTELSE) ||
+            input.harBehandlingÅrsak(BehandlingÅrsakType.FEIL_IVERKSETTELSE_FRI_UTSETTELSE)) {
 
             return Optional.of(EndringsdatoType.FØRSTE_UTTAKSDATO_GJELDENDE_VEDTAK);
         }

--- a/domenetjenester/uttak/src/test/java/no/nav/foreldrepenger/domene/uttak/uttaksgrunnlag/fp/EndringsdatoRevurderingUtlederTest.java
+++ b/domenetjenester/uttak/src/test/java/no/nav/foreldrepenger/domene/uttak/uttaksgrunnlag/fp/EndringsdatoRevurderingUtlederTest.java
@@ -1,6 +1,7 @@
 package no.nav.foreldrepenger.domene.uttak.uttaksgrunnlag.fp;
 
 import static no.nav.foreldrepenger.behandlingslager.behandling.BehandlingÅrsakType.BERØRT_BEHANDLING;
+import static no.nav.foreldrepenger.behandlingslager.behandling.BehandlingÅrsakType.FEIL_IVERKSETTELSE_FRI_UTSETTELSE;
 import static no.nav.foreldrepenger.behandlingslager.behandling.BehandlingÅrsakType.FEIL_PRAKSIS_UTSETTELSE;
 import static no.nav.foreldrepenger.behandlingslager.behandling.BehandlingÅrsakType.OPPHØR_YTELSE_NYTT_BARN;
 import static no.nav.foreldrepenger.behandlingslager.behandling.BehandlingÅrsakType.RE_ENDRET_INNTEKTSMELDING;
@@ -803,6 +804,26 @@ class EndringsdatoRevurderingUtlederTest {
     void skal_utlede_at_endringsdato_er_første_uttaksdato_fra_vedtak_når_revurdering_er_pga_feil_praksis_utsettelse_og_endringssøknad_mottatt() {
         var revurdering = testUtil.opprettRevurdering(FEIL_PRAKSIS_UTSETTELSE);
         var input = lagInput(revurdering).medBehandlingÅrsaker(Set.of(FEIL_PRAKSIS_UTSETTELSE, RE_ENDRING_FRA_BRUKER));
+
+        var endringsdato = utleder.utledEndringsdato(input);
+
+        assertThat(endringsdato).isEqualTo(FØRSTE_UTTAKSDATO_GJELDENDE_VEDTAK);
+    }
+
+    @Test
+    void skal_utlede_at_endringsdato_er_første_uttaksdato_fra_vedtak_når_revurdering_er_pga_feil_iverksettelse_fri_utsettelse() {
+        var revurdering = testUtil.opprettRevurdering(FEIL_IVERKSETTELSE_FRI_UTSETTELSE);
+        var input = lagInput(revurdering).medBehandlingÅrsaker(Set.of(FEIL_IVERKSETTELSE_FRI_UTSETTELSE));
+
+        var endringsdato = utleder.utledEndringsdato(input);
+
+        assertThat(endringsdato).isEqualTo(FØRSTE_UTTAKSDATO_GJELDENDE_VEDTAK);
+    }
+
+    @Test
+    void skal_utlede_at_endringsdato_er_første_uttaksdato_fra_vedtak_når_revurdering_er_pga_feil_iverksettelse_fri_utsettelse_og_endringssøknad_mottatt() {
+        var revurdering = testUtil.opprettRevurdering(FEIL_IVERKSETTELSE_FRI_UTSETTELSE);
+        var input = lagInput(revurdering).medBehandlingÅrsaker(Set.of(FEIL_IVERKSETTELSE_FRI_UTSETTELSE, RE_ENDRING_FRA_BRUKER));
 
         var endringsdato = utleder.utledEndringsdato(input);
 

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/forvaltning/praksisutsettelse/FeilPraksisOpprettBehandlingTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/forvaltning/praksisutsettelse/FeilPraksisOpprettBehandlingTjeneste.java
@@ -134,6 +134,7 @@ public class FeilPraksisOpprettBehandlingTjeneste {
         if (behandlingRepository.hentAbsoluttAlleBehandlingerForFagsak(fagsak.getId()).stream()
                 .anyMatch(b -> b.harBehandlingÅrsak(BehandlingÅrsakType.FEIL_PRAKSIS_UTSETTELSE))) {
             LOG.info("FeilPraksisUtsettelse: Har allerede hatt feil praksis revurdering for sak {}", fagsak.getSaksnummer());
+            return;
         }
 
         if (!dryrun) {
@@ -144,12 +145,10 @@ public class FeilPraksisOpprettBehandlingTjeneste {
         }
 
         LOG.info("FeilPraksisUtsettelse: Opprettet revurdering med saksnummer {}", fagsak.getSaksnummer());
-
     }
 
     private static Trekkdager tapteDager(List<UttakResultatPeriodeEntitet> perioder) {
         var trekkdagerPrAktivitet = new LinkedHashMap<>(tapteDagerUtsettelse(perioder));
-        tapteDagerGradering(perioder).forEach((k,v) -> trekkdagerPrAktivitet.put(k, trekkdagerPrAktivitet.getOrDefault(k, Trekkdager.ZERO).add(v)));
         return trekkdagerPrAktivitet.values().stream().max(Comparator.naturalOrder()).orElse(Trekkdager.ZERO);
     }
 

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/forvaltning/praksisutsettelse/FeilPraksisSaksmerkingAlleTask.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/forvaltning/praksisutsettelse/FeilPraksisSaksmerkingAlleTask.java
@@ -1,18 +1,15 @@
 package no.nav.foreldrepenger.web.app.tjenester.forvaltning.praksisutsettelse;
 
-import java.time.LocalDateTime;
-import java.util.Comparator;
-import java.util.Optional;
-
 import jakarta.enterprise.context.Dependent;
 import jakarta.inject.Inject;
-
 import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakProsesstaskRekkefølge;
 import no.nav.foreldrepenger.dokumentbestiller.infobrev.FeilPraksisUtsettelseRepository;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTask;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTaskData;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTaskHandler;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTaskTjeneste;
+
+import java.time.LocalDateTime;
 
 @Dependent
 @ProsessTask(value = "behandling.saksmerkepraksisutsettelse.alle", prioritet = 4, maxFailedRuns = 1)
@@ -35,20 +32,19 @@ class FeilPraksisSaksmerkingAlleTask implements ProsessTaskHandler {
 
     @Override
     public void doTask(ProsessTaskData prosessTaskData) {
-        var fagsakIdProperty = prosessTaskData.getPropertyValue(FRA_FAGSAK_ID);
-        var fraFagsakId = fagsakIdProperty == null ? null : Long.valueOf(fagsakIdProperty);
-        var utvalg = Optional.ofNullable(prosessTaskData.getPropertyValue(UTVALG))
-            .map(Utvalg::valueOf).orElseThrow();
-
-        var saker = switch (utvalg) {
-            case MOR -> utvalgRepository.finnNesteHundreSakerForMerkingMor(fraFagsakId);
-            case FAR_BEGGE_RETT -> utvalgRepository.finnNesteHundreSakerForMerkingFarBeggeEllerAlene(fraFagsakId);
-        };
-        saker.stream().map(FeilPraksisSaksmerkingAlleTask::opprettTaskForEnkeltSak).forEach(prosessTaskTjeneste::lagre);
-
-        saker.stream().max(Comparator.naturalOrder())
-            .map(maxfid -> opprettTaskForNesteUtvalg(maxfid, utvalg))
-            .ifPresent(prosessTaskTjeneste::lagre);
+//        var fagsakIdProperty = prosessTaskData.getPropertyValue(FRA_FAGSAK_ID);
+//        var fraFagsakId = fagsakIdProperty == null ? null : Long.valueOf(fagsakIdProperty);
+//        var utvalg = Optional.ofNullable(prosessTaskData.getPropertyValue(UTVALG))
+//            .map(Utvalg::valueOf).orElseThrow();
+//        var saker = switch (utvalg) {
+//            case MOR -> utvalgRepository.finnNesteHundreSakerForMerkingMor(fraFagsakId);
+//            case FAR_BEGGE_RETT -> utvalgRepository.finnNesteHundreSakerForMerkingFarBeggeEllerAlene(fraFagsakId);
+//        };
+//        saker.stream().map(FeilPraksisSaksmerkingAlleTask::opprettTaskForEnkeltSak).forEach(prosessTaskTjeneste::lagre);
+//
+//        saker.stream().max(Comparator.naturalOrder())
+//            .map(maxfid -> opprettTaskForNesteUtvalg(maxfid, utvalg))
+//            .ifPresent(prosessTaskTjeneste::lagre);
 
     }
 

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/forvaltning/praksisutsettelse/FeilPraksisUtsettelseAlleTask.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/forvaltning/praksisutsettelse/FeilPraksisUtsettelseAlleTask.java
@@ -34,7 +34,7 @@ class FeilPraksisUtsettelseAlleTask implements ProsessTaskHandler {
         var fagsakIdProperty = prosessTaskData.getPropertyValue(FRA_FAGSAK_ID);
         var fraFagsakId = fagsakIdProperty == null ? null : Long.valueOf(fagsakIdProperty);
 
-        var saker = utvalgRepository.finnNesteHundreSakerSomErMerketPraksisUtsettelse(fraFagsakId);
+        var saker = utvalgRepository.finnNesteHundreSakerSomErMerketFeilIverksettelseFriUtsettelse(fraFagsakId);
 
         saker.stream().map(FeilPraksisUtsettelseAlleTask::opprettTaskForEnkeltSak).forEach(prosessTaskTjeneste::lagre);
 

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/forvaltning/praksisutsettelse/FeilPraksisUtsettelseIkrafttredelseAlleTask.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/forvaltning/praksisutsettelse/FeilPraksisUtsettelseIkrafttredelseAlleTask.java
@@ -1,0 +1,57 @@
+package no.nav.foreldrepenger.web.app.tjenester.forvaltning.praksisutsettelse;
+
+import jakarta.enterprise.context.Dependent;
+import jakarta.inject.Inject;
+import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakProsesstaskRekkefølge;
+import no.nav.foreldrepenger.dokumentbestiller.infobrev.FeilPraksisUtsettelseRepository;
+import no.nav.vedtak.felles.prosesstask.api.ProsessTask;
+import no.nav.vedtak.felles.prosesstask.api.ProsessTaskData;
+import no.nav.vedtak.felles.prosesstask.api.ProsessTaskHandler;
+import no.nav.vedtak.felles.prosesstask.api.ProsessTaskTjeneste;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Optional;
+
+import static no.nav.foreldrepenger.web.app.tjenester.forvaltning.praksisutsettelse.FeilPraksisUtsettelseIkrafttredelseSingleTask.DRY_RUN;
+
+@Dependent
+@ProsessTask(value = "behandling.friutsettelse.ikrafttredelse.alle", prioritet = 4, maxFailedRuns = 1)
+@FagsakProsesstaskRekkefølge(gruppeSekvens = false)
+class FeilPraksisUtsettelseIkrafttredelseAlleTask implements ProsessTaskHandler {
+    private static final Logger LOG = LoggerFactory.getLogger(FeilPraksisUtsettelseIkrafttredelseAlleTask.class);
+
+    private static final String UTVALG = "utvalg";
+    private final FeilPraksisUtsettelseRepository utvalgRepository;
+    private final ProsessTaskTjeneste prosessTaskTjeneste;
+
+    public enum Utvalg { MOR, FAR }
+
+    @Inject
+    public FeilPraksisUtsettelseIkrafttredelseAlleTask(FeilPraksisUtsettelseRepository utvalgRepository,
+                                                       ProsessTaskTjeneste prosessTaskTjeneste) {
+        this.utvalgRepository = utvalgRepository;
+        this.prosessTaskTjeneste = prosessTaskTjeneste;
+    }
+
+    @Override
+    public void doTask(ProsessTaskData prosessTaskData) {
+        var dryRun = Optional.ofNullable(prosessTaskData.getPropertyValue(DRY_RUN)).filter("false"::equalsIgnoreCase).isEmpty();
+        var utvalg = Optional.ofNullable(prosessTaskData.getPropertyValue(UTVALG))
+                .map(Utvalg::valueOf)
+                .orElseThrow();
+        var saker = switch (utvalg) {
+            case MOR -> utvalgRepository.alleSakerMorAvslagUtsettelse();
+            case FAR -> utvalgRepository.alleSakerFarBeggeEllerAleneUtsettelse();
+        };
+        LOG.info("Hentet {} saker for utvalg {}", saker.size(), utvalg);
+        saker.stream().map((Long fagsakId) -> opprettTaskForEnkeltSak(fagsakId, dryRun)).forEach(prosessTaskTjeneste::lagre);
+    }
+
+    private static ProsessTaskData opprettTaskForEnkeltSak(Long fagsakId, boolean dryRun) {
+        var prosessTaskData = ProsessTaskData.forProsessTask(FeilPraksisUtsettelseIkrafttredelseSingleTask.class);
+        prosessTaskData.setProperty(FeilPraksisUtsettelseIkrafttredelseSingleTask.FAGSAK_ID, String.valueOf(fagsakId));
+        prosessTaskData.setProperty(DRY_RUN, String.valueOf(dryRun));
+        return prosessTaskData;
+    }
+}

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/forvaltning/praksisutsettelse/FeilPraksisUtsettelseIkrafttredelseSingleTask.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/forvaltning/praksisutsettelse/FeilPraksisUtsettelseIkrafttredelseSingleTask.java
@@ -1,0 +1,74 @@
+package no.nav.foreldrepenger.web.app.tjenester.forvaltning.praksisutsettelse;
+
+import jakarta.enterprise.context.Dependent;
+import jakarta.inject.Inject;
+import no.nav.foreldrepenger.behandlingslager.behandling.historikk.HistorikkAktør;
+import no.nav.foreldrepenger.behandlingslager.behandling.historikk.Historikkinnslag;
+import no.nav.foreldrepenger.behandlingslager.behandling.historikk.HistorikkinnslagRepository;
+import no.nav.foreldrepenger.behandlingslager.fagsak.Fagsak;
+import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakEgenskapRepository;
+import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakProsesstaskRekkefølge;
+import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakRepository;
+import no.nav.foreldrepenger.behandlingslager.fagsak.egenskaper.FagsakMarkering;
+import no.nav.vedtak.felles.prosesstask.api.ProsessTask;
+import no.nav.vedtak.felles.prosesstask.api.ProsessTaskData;
+import no.nav.vedtak.felles.prosesstask.api.ProsessTaskHandler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Optional;
+
+@Dependent
+@ProsessTask(value = "behandling.friutsettelse.ikrafttredelse.single", prioritet = 4, maxFailedRuns = 1)
+@FagsakProsesstaskRekkefølge(gruppeSekvens = false)
+class FeilPraksisUtsettelseIkrafttredelseSingleTask implements ProsessTaskHandler {
+
+    private static final Logger LOG = LoggerFactory.getLogger(FeilPraksisUtsettelseIkrafttredelseSingleTask.class);
+    static final String FAGSAK_ID = "fagsakId";
+    static final String DRY_RUN = "dryRun";
+
+    private final FeilPraksisOpprettBehandlingTjeneste feilPraksisOpprettBehandlingTjeneste;
+    private final HistorikkinnslagRepository historikkinnslagRepository;
+    private final FagsakRepository fagsakRepository;
+    private final FagsakEgenskapRepository fagsakEgenskapRepository;
+
+    @Inject
+    public FeilPraksisUtsettelseIkrafttredelseSingleTask(FeilPraksisOpprettBehandlingTjeneste feilPraksisOpprettBehandlingTjeneste,
+                                                         HistorikkinnslagRepository historikkinnslagRepository,
+                                                         FagsakRepository fagsakRepository,
+                                                         FagsakEgenskapRepository fagsakEgenskapRepository) {
+        this.feilPraksisOpprettBehandlingTjeneste = feilPraksisOpprettBehandlingTjeneste;
+        this.historikkinnslagRepository = historikkinnslagRepository;
+        this.fagsakRepository = fagsakRepository;
+        this.fagsakEgenskapRepository = fagsakEgenskapRepository;
+    }
+
+    @Override
+    public void doTask(ProsessTaskData prosessTaskData) {
+        var dryRun = Optional.ofNullable(prosessTaskData.getPropertyValue(DRY_RUN)).filter("false"::equalsIgnoreCase).isEmpty();
+        var fagsak = Optional.ofNullable(prosessTaskData.getPropertyValue(FAGSAK_ID))
+            .map(fid -> fagsakRepository.finnEksaktFagsak(Long.parseLong(fid)))
+            .orElseThrow();
+        if (fagsakEgenskapRepository.finnFagsakMarkeringer(fagsak.getId()).contains(FagsakMarkering.PRAKSIS_UTSETTELSE)) {
+            LOG.info("Fagsak {} har allerede saksmerking {}", fagsak.getSaksnummer(), FagsakMarkering.PRAKSIS_UTSETTELSE);
+            return;
+        }
+
+        if (!dryRun) {
+            fagsakEgenskapRepository.leggTilFagsakMarkering(fagsak.getId(), FagsakMarkering.PRAKSIS_UTSETTELSE);
+            lagHistorikkInnslag(fagsak, FagsakMarkering.PRAKSIS_UTSETTELSE);
+        }
+        feilPraksisOpprettBehandlingTjeneste.opprettBehandling(fagsak, dryRun);
+    }
+
+    private void lagHistorikkInnslag(Fagsak fagsak, FagsakMarkering ny) {
+        var historikkinnslag = new Historikkinnslag.Builder()
+            .medAktør(HistorikkAktør.VEDTAKSLØSNINGEN)
+            .medFagsakId(fagsak.getId())
+            .medTittel("Fakta er endret")
+            .addLinje(String.format("Saksmerkering %s er lagt til", ny.getNavn()))
+            .build();
+        historikkinnslagRepository.lagre(historikkinnslag);
+    }
+
+}

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/forvaltning/praksisutsettelse/FeilPraksisUtsettelseSingleTask.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/forvaltning/praksisutsettelse/FeilPraksisUtsettelseSingleTask.java
@@ -1,13 +1,7 @@
 package no.nav.foreldrepenger.web.app.tjenester.forvaltning.praksisutsettelse;
 
-import java.util.Optional;
-
 import jakarta.enterprise.context.Dependent;
 import jakarta.inject.Inject;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakEgenskapRepository;
 import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakProsesstaskRekkefølge;
 import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakRepository;
@@ -15,6 +9,10 @@ import no.nav.foreldrepenger.behandlingslager.fagsak.egenskaper.FagsakMarkering;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTask;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTaskData;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTaskHandler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Optional;
 
 @Dependent
 @ProsessTask(value = "behandling.feilpraksisutsettelse.single", prioritet = 4, maxFailedRuns = 1)
@@ -43,7 +41,7 @@ class FeilPraksisUtsettelseSingleTask implements ProsessTaskHandler {
             .map(fid -> fagsakRepository.finnEksaktFagsak(Long.parseLong(fid)))
             .orElseThrow();
         if (fagsakEgenskapRepository.harFagsakMarkering(sak.getId(), FagsakMarkering.PRAKSIS_UTSETTELSE)) {
-            feilPraksisOpprettBehandlingTjeneste.opprettBehandling(sak);
+            feilPraksisOpprettBehandlingTjeneste.opprettBehandling(sak, true);
         } else {
             LOG.info("FeilPraksisUtsettelse: Mangler saksmerking praksis utsettelse, oppretter ikke revurdering for {} som har merking {}",
                 sak.getSaksnummer(), fagsakEgenskapRepository.finnFagsakMarkeringer(sak.getId()));


### PR DESCRIPTION
1. Markere samtlige med FEIL_PRAKSISK saksmerkering
2. Oppretter revurdering med behandlingårsak  FEIL_IVERKSETTELSE_FRI_UTSETTELSE
3. Revurdering settes på vent til X?
4. Gjenbruker samme brevkode som før, men må da endre på brevet som finnes i dokgen.

