### PR TITLE
Failsafe henting av agnavn fra gamle simuleringer

### DIFF
--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/arbeidsforhold/InntektArbeidYtelseRestTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/arbeidsforhold/InntektArbeidYtelseRestTjeneste.java
@@ -237,8 +237,13 @@ public class InntektArbeidYtelseRestTjeneste {
         });
 
         if (behandling.erAvsluttet() || behandlingskontrollTjeneste.erIStegEllerSenereSteg(behandling.getId(), BehandlingStegType.SIMULER_OPPDRAG)) {
-            var simuleringResultatDto = fpOppdragRestKlient.hentSimuleringResultatMedOgUtenInntrekk(behandling.getId());
-            arbeidsgivere.addAll(simuleringResultatDto.map(this::finnArbeidsgivereFraSimulering).orElse(Collections.emptySet()));
+            try {
+                var simuleringResultatDto = fpOppdragRestKlient.hentSimuleringResultatMedOgUtenInntrekk(behandling.getId());
+                arbeidsgivere.addAll(simuleringResultatDto.map(this::finnArbeidsgivereFraSimulering).orElse(Collections.emptySet()));
+            } catch (Exception e) {
+                // Do nothing
+            }
+
         }
 
         if (!overstyrtNavn.isEmpty()) {


### PR DESCRIPTION
Fjerner en del av loggstøyen og rødlinje for saksbehandler.
Vil fortsatt logges feil i fpoppdrag - men man får opp saken.