### PR TITLE
TFP-5981 forbedre startpunkt medlemsrelatert

### DIFF
--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/RegisterdataDiffsjekker.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/RegisterdataDiffsjekker.java
@@ -2,6 +2,7 @@ package no.nav.foreldrepenger.behandlingslager.behandling;
 
 import java.util.Collection;
 import java.util.Map;
+import java.util.function.Predicate;
 
 import no.nav.foreldrepenger.behandlingslager.TraverseEntityGraphFactory;
 import no.nav.foreldrepenger.behandlingslager.diff.DiffEntity;
@@ -24,6 +25,17 @@ public class RegisterdataDiffsjekker {
 
     public  <T> boolean erForskjellPå(Collection<T> list1, Collection<T> list2) {
         return list1.size() != list2.size() || !finnForskjellerPåLister(list1, list2).isEmpty();
+    }
+
+    public  <T> boolean erForskjellPåFiltrert(Collection<T> list1, Collection<T> list2, Predicate<Map.Entry<Node, Pair>> filter) {
+        if (list1.size() != list2.size()) {
+            return true;
+        }
+        var forskjeller = finnForskjellerPåLister(list1, list2);
+        if (forskjeller.isEmpty()) {
+            return false;
+        }
+        return forskjeller.entrySet().stream().anyMatch(filter);
     }
 
     private  <T> Map<Node, Pair> finnForskjellerPåLister(Collection<T> list1, Collection<T> list2) {

--- a/domenetjenester/person/src/main/java/no/nav/foreldrepenger/domene/person/pdl/AnnetPeriodisertMapper.java
+++ b/domenetjenester/person/src/main/java/no/nav/foreldrepenger/domene/person/pdl/AnnetPeriodisertMapper.java
@@ -2,7 +2,6 @@ package no.nav.foreldrepenger.domene.person.pdl;
 
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
-import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -66,12 +65,7 @@ public class AnnetPeriodisertMapper {
     private static PersonstatusPeriode mapPersonstatus(Folkeregisterpersonstatus status) {
         var ajourFom = status.getFolkeregistermetadata().getAjourholdstidspunkt();
         var gyldigFom = status.getFolkeregistermetadata().getGyldighetstidspunkt();
-        Date brukFom;
-        if (ajourFom != null && gyldigFom != null) {
-            brukFom = ajourFom.before(gyldigFom) ? ajourFom : gyldigFom;
-        } else {
-            brukFom = gyldigFom != null ? gyldigFom : ajourFom;
-        }
+        var brukFom = gyldigFom != null ? gyldigFom : ajourFom;
         var periode = Gyldighetsperiode.fraDates(brukFom, status.getFolkeregistermetadata().getOpphoerstidspunkt());
         return new PersonstatusPeriode(periode, PersonstatusType.fraFregPersonstatus(status.getStatus()));
     }

--- a/domenetjenester/person/src/main/java/no/nav/foreldrepenger/domene/personopplysning/PersonopplysningGrunnlagDiff.java
+++ b/domenetjenester/person/src/main/java/no/nav/foreldrepenger/domene/personopplysning/PersonopplysningGrunnlagDiff.java
@@ -134,6 +134,9 @@ public class PersonopplysningGrunnlagDiff {
         if (Optional.ofNullable(entry.getKey().getLocalName()).orElse("").contains("adresselinje3")) {
             var al3 = entry.getValue();
             return al3 != null && al3.getElement1() != null && al3.getElement2() != null;
+        } else if (Optional.ofNullable(entry.getKey().getLocalName()).orElse("").contains("adresselinje4")) {
+            var al4 = entry.getValue();
+            return al4 != null && al4.getElement1() != null && al4.getElement2() != null;
         } else {
             return true;
         }

--- a/domenetjenester/person/src/test/java/no/nav/foreldrepenger/domene/personopplysning/PersonAdresseEndringIdentifisererTest.java
+++ b/domenetjenester/person/src/test/java/no/nav/foreldrepenger/domene/personopplysning/PersonAdresseEndringIdentifisererTest.java
@@ -18,6 +18,7 @@ import no.nav.foreldrepenger.behandlingslager.behandling.personopplysning.Person
 import no.nav.foreldrepenger.behandlingslager.behandling.personopplysning.PersonopplysningGrunnlagBuilder;
 import no.nav.foreldrepenger.behandlingslager.behandling.personopplysning.PersonopplysningGrunnlagEntitet;
 import no.nav.foreldrepenger.behandlingslager.behandling.personopplysning.PersonopplysningVersjonType;
+import no.nav.foreldrepenger.behandlingslager.geografisk.Landkoder;
 import no.nav.foreldrepenger.domene.tid.DatoIntervallEntitet;
 import no.nav.foreldrepenger.domene.typer.AktørId;
 
@@ -27,74 +28,86 @@ class PersonAdresseEndringIdentifisererTest {
 
     @Test
     void testPersonAdresseUendret() {
-        var postnummer = "2040";
-        var personopplysningGrunnlag1 = opprettPersonopplysningGrunnlag(List.of(postnummer));
-        var personopplysningGrunnlag2 = opprettPersonopplysningGrunnlag(List.of(postnummer));
+        var utlandkode = Landkoder.SWE;
+        var personopplysningGrunnlag1 = opprettPersonopplysningGrunnlag(List.of(utlandkode));
+        var personopplysningGrunnlag2 = opprettPersonopplysningGrunnlag(List.of(utlandkode));
         var differ = new PersonopplysningGrunnlagDiff(AKTØRID, personopplysningGrunnlag1, personopplysningGrunnlag2);
 
-        var erEndret = differ.erAdresserEndretIPeriode(DatoIntervallEntitet.fraOgMed(LocalDate.now()));
+        var erEndret = differ.erSøkersUtlandsAdresserEndretIPeriode(DatoIntervallEntitet.fraOgMed(LocalDate.now()));
         assertThat(erEndret).as("Forventer at adresse er uendret").isFalse();
     }
 
     @Test
-    void testPersonAdresseUendret_flere_postnummer() {
-        var personopplysningGrunnlag1 = opprettPersonopplysningGrunnlag(List.of("2040", "2050"));
-        var personopplysningGrunnlag2 = opprettPersonopplysningGrunnlag(List.of("2040", "2050"));
+    void testPersonAdresseUendret_flere_land() {
+        var utlandkode = List.of(Landkoder.SWE, Landkoder.DNK);
+        var personopplysningGrunnlag1 = opprettPersonopplysningGrunnlag(utlandkode);
+        var personopplysningGrunnlag2 = opprettPersonopplysningGrunnlag(utlandkode);
         var differ = new PersonopplysningGrunnlagDiff(AKTØRID, personopplysningGrunnlag1, personopplysningGrunnlag2);
 
-        var erEndret = differ.erAdresserEndretIPeriode(DatoIntervallEntitet.fraOgMed(LocalDate.now()));
+        var erEndret = differ.erSøkersUtlandsAdresserEndretIPeriode(DatoIntervallEntitet.fraOgMed(LocalDate.now()));
         assertThat(erEndret).as("Forventer at adresse er uendret").isFalse();
     }
 
     @Test
     void testPersonAdresseUendret_men_rekkefølge_er_endret() {
-        var personopplysningGrunnlag1 = opprettPersonopplysningGrunnlag(List.of("2050", "2040"));
+        var utlandkode = List.of(Landkoder.SWE, Landkoder.DNK);
+        var personopplysningGrunnlag1 = opprettPersonopplysningGrunnlag(utlandkode);
         var personopplysningGrunnlag2 = opprettPersonopplysningGrunnlagMotstattRekkefølge(
                 personopplysningGrunnlag1.getRegisterVersjon().map(PersonInformasjonEntitet::getAdresser).orElse(Collections.emptyList()));
         var differ = new PersonopplysningGrunnlagDiff(AKTØRID, personopplysningGrunnlag1, personopplysningGrunnlag2);
 
-        var erEndret = differ.erAdresserEndretIPeriode(DatoIntervallEntitet.fraOgMed(LocalDate.now()));
+        var erEndret = differ.erSøkersUtlandsAdresserEndretIPeriode(DatoIntervallEntitet.fraOgMed(LocalDate.now()));
         assertThat(erEndret).as("Forventer at adresse er uendret").isFalse();
     }
 
     @Test
     void testPersonAdresseEndret() {
-        var personopplysningGrunnlag1 = opprettPersonopplysningGrunnlag(List.of("2040"));
-        var personopplysningGrunnlag2 = opprettPersonopplysningGrunnlag(List.of("2050"));
+        var personopplysningGrunnlag1 = opprettPersonopplysningGrunnlag(List.of(Landkoder.DNK));
+        var personopplysningGrunnlag2 = opprettPersonopplysningGrunnlag(List.of(Landkoder.SWE));
         var differ = new PersonopplysningGrunnlagDiff(AKTØRID, personopplysningGrunnlag1, personopplysningGrunnlag2);
 
-        var erEndret = differ.erAdresserEndretIPeriode(DatoIntervallEntitet.fraOgMed(LocalDate.now()));
+        var erEndret = differ.erSøkersUtlandsAdresserEndretIPeriode(DatoIntervallEntitet.fraOgMed(LocalDate.now()));
         assertThat(erEndret).as("Forventer at endring i adresse blir detektert.").isTrue();
     }
 
     @Test
     void testPersonAdresseEndretNår() {
-        var personopplysningGrunnlag1 = opprettPersonopplysningGrunnlag(List.of("2040"));
-        var personopplysningGrunnlag2 = opprettPersonopplysningGrunnlag(List.of("2050"));
+        var personopplysningGrunnlag1 = opprettPersonopplysningGrunnlag(List.of(Landkoder.DNK));
+        var personopplysningGrunnlag2 = opprettPersonopplysningGrunnlag(List.of(Landkoder.SWE));
         var differ = new PersonopplysningGrunnlagDiff(AKTØRID, personopplysningGrunnlag1, personopplysningGrunnlag2);
 
-        var erEndret = differ.erAdresserEndretIPeriode(DatoIntervallEntitet.fraOgMed(LocalDate.now()));
+        var erEndret = differ.erSøkersUtlandsAdresserEndretIPeriode(DatoIntervallEntitet.fraOgMed(LocalDate.now()));
         assertThat(erEndret).as("Forventer at endring i adresse blir detektert.").isTrue();
     }
 
     @Test
-    void testPersonAdresseEndret_flere_postnummer() {
-        var personopplysningGrunnlag1 = opprettPersonopplysningGrunnlag(List.of("2040", "2050"));
-        var personopplysningGrunnlag2 = opprettPersonopplysningGrunnlag(List.of("2040", "2060"));
+    void testPersonAdresseEndret_flere_land() {
+        var personopplysningGrunnlag1 = opprettPersonopplysningGrunnlag(List.of(Landkoder.DNK, Landkoder.SWE));
+        var personopplysningGrunnlag2 = opprettPersonopplysningGrunnlag(List.of(Landkoder.DNK, Landkoder.ALA));
         var differ = new PersonopplysningGrunnlagDiff(AKTØRID, personopplysningGrunnlag1, personopplysningGrunnlag2);
 
-        var erEndret = differ.erAdresserEndretIPeriode(DatoIntervallEntitet.fraOgMed(LocalDate.now()));
+        var erEndret = differ.erSøkersUtlandsAdresserEndretIPeriode(DatoIntervallEntitet.fraOgMed(LocalDate.now()));
         assertThat(erEndret).as("Forventer at endring i adresse blir detektert.").isTrue();
     }
 
     @Test
-    void testPersonAdresseEndret_ekstra_postnummer_lagt_til() {
-        var personopplysningGrunnlag1 = opprettPersonopplysningGrunnlag(List.of("2040", "2050"));
-        var personopplysningGrunnlag2 = opprettPersonopplysningGrunnlag(List.of("2040", "2050", "9046"));
+    void testPersonAdresseEndret_ekstra_land_lagt_til() {
+        var personopplysningGrunnlag1 = opprettPersonopplysningGrunnlag(List.of(Landkoder.DNK, Landkoder.SWE));
+        var personopplysningGrunnlag2 = opprettPersonopplysningGrunnlag(List.of(Landkoder.DNK, Landkoder.ALA, Landkoder.FIN));
         var differ = new PersonopplysningGrunnlagDiff(AKTØRID, personopplysningGrunnlag1, personopplysningGrunnlag2);
 
-        var erEndret = differ.erAdresserEndretIPeriode(DatoIntervallEntitet.fraOgMed(LocalDate.now()));
+        var erEndret = differ.erSøkersUtlandsAdresserEndretIPeriode(DatoIntervallEntitet.fraOgMed(LocalDate.now()));
         assertThat(erEndret).as("Forventer at endring i adresse blir detektert.").isTrue();
+    }
+
+    @Test
+    void testPersonAdresseEndret_landkode_adresselinje3_gir_uendret() {
+        var personopplysningGrunnlag1 = opprettPersonopplysningGrunnlagLinje3(List.of(Landkoder.DNK, Landkoder.SWE), true);
+        var personopplysningGrunnlag2 = opprettPersonopplysningGrunnlagLinje3(List.of(Landkoder.DNK, Landkoder.SWE), false);
+        var differ = new PersonopplysningGrunnlagDiff(AKTØRID, personopplysningGrunnlag1, personopplysningGrunnlag2);
+
+        var erEndret = differ.erSøkersUtlandsAdresserEndretIPeriode(DatoIntervallEntitet.fraOgMed(LocalDate.now()));
+        assertThat(erEndret).as("Forventer at endring i adresse blir detektert.").isFalse();
     }
 
     private PersonopplysningGrunnlagEntitet opprettPersonopplysningGrunnlagMotstattRekkefølge(List<PersonAdresseEntitet> personadresser) {
@@ -104,20 +117,32 @@ class PersonAdresseEndringIdentifisererTest {
         new LinkedList<>(personadresser)
                 .descendingIterator()
                 .forEachRemaining(a -> builder1
-                        .leggTil(builder1.getAdresseBuilder(AKTØRID, a.getPeriode(), a.getAdresseType()).medPostnummer(a.getPostnummer())));
+                        .leggTil(builder1.getAdresseBuilder(AKTØRID, a.getPeriode(), a.getAdresseType()).medLand(a.getLand())));
         return PersonopplysningGrunnlagBuilder.oppdatere(Optional.empty()).medRegistrertVersjon(builder1).build();
     }
 
-    private PersonopplysningGrunnlagEntitet opprettPersonopplysningGrunnlag(List<String> postnummer) {
+    private PersonopplysningGrunnlagEntitet opprettPersonopplysningGrunnlag(List<Landkoder> land) {
         var builder1 = PersonInformasjonBuilder.oppdater(Optional.empty(), PersonopplysningVersjonType.REGISTRERT);
-        builder1
-                .leggTil(builder1.getPersonopplysningBuilder(AKTØRID));
-        // Opprett adresser med forskjellig fra og med dato. Går 1 mnd tilbake for hver
-        // adresse. Endrer kun postnummer i denne testen
-        IntStream.range(0, postnummer.size()).forEach(i -> builder1.leggTil(
-                builder1.getAdresseBuilder(AKTØRID, DatoIntervallEntitet.fraOgMed(LocalDate.now().minusMonths(i)), AdresseType.POSTADRESSE)
-                        .medPostnummer(postnummer.get(i))
-                        .medAdresseType(AdresseType.POSTADRESSE)));
+        builder1.leggTil(builder1.getPersonopplysningBuilder(AKTØRID));
+        // Opprett adresser med forskjellig fra og med dato. Går 1 mnd tilbake for hver adresse. Endrer kun land i denne testen
+        IntStream.range(0, land.size()).forEach(i -> builder1.leggTil(
+                builder1.getAdresseBuilder(AKTØRID, DatoIntervallEntitet.fraOgMed(LocalDate.now().minusMonths(i)), AdresseType.POSTADRESSE_UTLAND)
+                        .medLand(land.get(i))
+                        .medAdresseType(AdresseType.POSTADRESSE_UTLAND)));
+        return PersonopplysningGrunnlagBuilder.oppdatere(Optional.empty()).medRegistrertVersjon(builder1).build();
+    }
+
+    private PersonopplysningGrunnlagEntitet opprettPersonopplysningGrunnlagLinje3(List<Landkoder> land, boolean landLinje3) {
+        var builder1 = PersonInformasjonBuilder.oppdater(Optional.empty(), PersonopplysningVersjonType.REGISTRERT);
+        builder1.leggTil(builder1.getPersonopplysningBuilder(AKTØRID));
+        // Opprett adresser med forskjellig fra og med dato. Går 1 mnd tilbake for hver adresse. Endrer kun land i denne testen
+        IntStream.range(0, land.size()).forEach(i -> builder1.leggTil(
+            builder1.getAdresseBuilder(AKTØRID, DatoIntervallEntitet.fraOgMed(LocalDate.now().minusMonths(i)), AdresseType.POSTADRESSE_UTLAND)
+                .medAdresselinje1("1st street")
+                .medAdresselinje2("101")
+                .medAdresselinje3(landLinje3 ? land.get(i).getKode() : null)
+                .medLand(land.get(i))
+                .medAdresseType(AdresseType.POSTADRESSE_UTLAND)));
         return PersonopplysningGrunnlagBuilder.oppdatere(Optional.empty()).medRegistrertVersjon(builder1).build();
     }
 }

--- a/domenetjenester/person/src/test/java/no/nav/foreldrepenger/domene/personopplysning/PersonstatusEndringIdentifisererTest.java
+++ b/domenetjenester/person/src/test/java/no/nav/foreldrepenger/domene/personopplysning/PersonstatusEndringIdentifisererTest.java
@@ -31,7 +31,7 @@ class PersonstatusEndringIdentifisererTest {
         var personopplysningGrunnlag2 = opprettPersonopplysningGrunnlag(List.of(PersonstatusType.FOSV));
         var differ = new PersonopplysningGrunnlagDiff(AKTØRID, personopplysningGrunnlag1, personopplysningGrunnlag2);
 
-        var erEndret = differ.erPersonstatusEndretForSøkerPeriode(DatoIntervallEntitet.fraOgMed(LocalDate.now()));
+        var erEndret = differ.erPersonstatusIkkeBosattEndretForSøkerPeriode(DatoIntervallEntitet.fraOgMed(LocalDate.now()));
         assertThat(erEndret).as("Forventer at personstatus er uendret").isFalse();
     }
 
@@ -43,7 +43,7 @@ class PersonstatusEndringIdentifisererTest {
                 List.of(PersonstatusType.FOSV, PersonstatusType.BOSA));
         var differ = new PersonopplysningGrunnlagDiff(AKTØRID, personopplysningGrunnlag1, personopplysningGrunnlag2);
 
-        var erEndret = differ.erPersonstatusEndretForSøkerPeriode(DatoIntervallEntitet.fraOgMed(LocalDate.now()));
+        var erEndret = differ.erPersonstatusIkkeBosattEndretForSøkerPeriode(DatoIntervallEntitet.fraOgMed(LocalDate.now()));
         assertThat(erEndret).as("Forventer at personstatus er uendret").isFalse();
     }
 
@@ -55,7 +55,7 @@ class PersonstatusEndringIdentifisererTest {
                 List.of(PersonstatusType.FOSV, PersonstatusType.BOSA, PersonstatusType.UREG));
         var differ = new PersonopplysningGrunnlagDiff(AKTØRID, personopplysningGrunnlag1, personopplysningGrunnlag2);
 
-        var erEndret = differ.erPersonstatusEndretForSøkerPeriode(DatoIntervallEntitet.fraOgMed(LocalDate.now()));
+        var erEndret = differ.erPersonstatusIkkeBosattEndretForSøkerPeriode(DatoIntervallEntitet.fraOgMed(LocalDate.now()));
         assertThat(erEndret).as("Forventer at endring i personstatus blir detektert.").isTrue();
     }
 
@@ -67,7 +67,7 @@ class PersonstatusEndringIdentifisererTest {
                 List.of(PersonstatusType.UREG, PersonstatusType.FOSV));
         var differ = new PersonopplysningGrunnlagDiff(AKTØRID, personopplysningGrunnlag1, personopplysningGrunnlag2);
 
-        var erEndret = differ.erPersonstatusEndretForSøkerPeriode(DatoIntervallEntitet.fraOgMed(LocalDate.now()));
+        var erEndret = differ.erPersonstatusIkkeBosattEndretForSøkerPeriode(DatoIntervallEntitet.fraOgMed(LocalDate.now()));
         assertThat(erEndret).as("Forventer at endring i personstatus blir detektert.").isTrue();
     }
 
@@ -79,8 +79,30 @@ class PersonstatusEndringIdentifisererTest {
                 personopplysningGrunnlag1.getRegisterVersjon().map(PersonInformasjonEntitet::getPersonstatus).orElse(Collections.emptyList()));
         var differ = new PersonopplysningGrunnlagDiff(AKTØRID, personopplysningGrunnlag1, personopplysningGrunnlag2);
 
-        var erEndret = differ.erPersonstatusEndretForSøkerPeriode(DatoIntervallEntitet.fraOgMed(LocalDate.now()));
+        var erEndret = differ.erPersonstatusIkkeBosattEndretForSøkerPeriode(DatoIntervallEntitet.fraOgMed(LocalDate.now()));
         assertThat(erEndret).as("Forventer at endring i rekkefølge ikke skal detektere endring.").isFalse();
+    }
+
+    @Test
+    void testPersonstatusEndret_dnr_til_bosatt() {
+        var personopplysningGrunnlag1 = opprettPersonopplysningGrunnlag(
+            List.of(PersonstatusType.ADNR));
+        var personopplysningGrunnlag2 = opprettPersonopplysningGrunnlag(
+            List.of(PersonstatusType.ADNR, PersonstatusType.BOSA));
+        var differ = new PersonopplysningGrunnlagDiff(AKTØRID, personopplysningGrunnlag1, personopplysningGrunnlag2);
+
+        var erEndret = differ.erPersonstatusIkkeBosattEndretForSøkerPeriode(DatoIntervallEntitet.fraOgMed(LocalDate.now()));
+        assertThat(erEndret).as("Forventer at endring i personstatus ikke blir detektert.").isFalse();
+    }
+
+    @Test
+    void testPersonstatusEndret_bosatt_til_utflyttet() {
+        var personopplysningGrunnlag1 = opprettPersonopplysningGrunnlag(List.of(PersonstatusType.BOSA));
+        var personopplysningGrunnlag2 = opprettPersonopplysningGrunnlag(List.of(PersonstatusType.BOSA, PersonstatusType.UTVA));
+        var differ = new PersonopplysningGrunnlagDiff(AKTØRID, personopplysningGrunnlag1, personopplysningGrunnlag2);
+
+        var erEndret = differ.erPersonstatusIkkeBosattEndretForSøkerPeriode(DatoIntervallEntitet.fraOgMed(LocalDate.now()));
+        assertThat(erEndret).as("Forventer at endring i personstatus blir detektert.").isTrue();
     }
 
     private PersonopplysningGrunnlagEntitet opprettPersonopplysningGrunnlagMotstattRekkefølge(List<PersonstatusEntitet> personstatuser) {


### PR DESCRIPTION
Endrer noe på periodisering av personstatus. Selv om det frarådes å lage en tidslinje - så ville det blitt mye endringer i revurderinger.
Diffsjekker regner dnr som OK, mens den ikke reagerer på omlegging av adresselinje3 (+4) (tidlligere lå det landkode der)
Utbedrer tester så de treffer koden som brukes i dag.
