### PR TITLE
TFP-5977 ettersendt vedlegg skal ta ES-behandlinger av vent

### DIFF
--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/dokumentmottak/impl/DokumentmottakerVedlegg.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/dokumentmottak/impl/DokumentmottakerVedlegg.java
@@ -7,13 +7,11 @@ import jakarta.inject.Inject;
 
 import no.nav.foreldrepenger.behandling.BehandlingRevurderingTjeneste;
 import no.nav.foreldrepenger.behandlingskontroll.FagsakYtelseTypeRef;
-import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingÅrsakType;
 import no.nav.foreldrepenger.behandlingslager.behandling.DokumentTypeId;
 import no.nav.foreldrepenger.behandlingslager.behandling.MottattDokument;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepository;
 import no.nav.foreldrepenger.behandlingslager.fagsak.Fagsak;
-import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakYtelseType;
 
 @ApplicationScoped
 @FagsakYtelseTypeRef
@@ -47,7 +45,7 @@ class DokumentmottakerVedlegg implements Dokumentmottaker {
         if (åpenAnnenBehandling.isPresent()) { // Klage, anke, etc
             dokumentmottakerFelles.opprettTaskForÅVurdereDokument(fagsak, åpenAnnenBehandling.get(), mottattDokument);
         } else if (åpenBehandling.isPresent()) {
-            håndterÅpenBehandling(fagsak, åpenBehandling.get(), mottattDokument);
+            kompletthetskontroller.persisterDokumentOgVurderKompletthet(åpenBehandling.get(), mottattDokument);
         } else if (skalOppretteNyFørstegangsBehandlingSomFølgerAvVedlegget(mottattDokument, fagsak)) { //#V3
             dokumentmottakerFelles.opprettFørstegangsbehandlingMedHistorikkinslagOgKopiAvDokumenter(mottattDokument, fagsak, behandlingÅrsakType);
         } else {
@@ -80,13 +78,5 @@ class DokumentmottakerVedlegg implements Dokumentmottaker {
     private boolean mottattDokumentHarTypeAnnetEllerUdefinert(MottattDokument mottattDokument) {
         var fraDokument = mottattDokument.getDokumentType();
         return fraDokument.erAnnenDokType() || DokumentTypeId.UDEFINERT.equals(fraDokument);
-    }
-
-    private void håndterÅpenBehandling(Fagsak fagsak, Behandling behandling, MottattDokument mottattDokument) { //#V2
-        if (FagsakYtelseType.ENGANGSTØNAD.equals(fagsak.getYtelseType())) {
-            dokumentmottakerFelles.opprettTaskForÅVurdereDokument(fagsak, behandling, mottattDokument);
-        } else {
-            kompletthetskontroller.persisterDokumentOgVurderKompletthet(behandling, mottattDokument);
-        }
     }
 }

--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/dokumentmottak/impl/Kompletthetskontroller.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/dokumentmottak/impl/Kompletthetskontroller.java
@@ -79,8 +79,13 @@ public class Kompletthetskontroller {
         }
         if (kompletthetResultat.erOppfylt() && (kompletthetModell.erKompletthetssjekkEllerPassert(behandlingId)
             || behandling.isBehandlingPåVent() || mottattDokument.getDokumentType().erSøknadType() || mottattDokument.getDokumentType().erEndringsSøknadType())) {
-            spolKomplettBehandlingTilStartpunkt(behandling, grunnlagSnapshot);
-            if (kompletthetModell.erKompletthetssjekkPassert(behandlingId)) {
+            if (behandling.isBehandlingPåVent()) {
+                behandlingProsesseringTjeneste.taBehandlingAvVent(behandling);
+            }
+            if (kompletthetModell.erKompletthetssjekkPassert(behandling.getId())) {
+                // Reposisjoner basert på grunnlagsendring i nylig mottatt dokument. Videre reposisjonering gjøres i task etter registeroppdatering
+                behandlingProsesseringTjeneste.utledDiffOgReposisjonerBehandlingVedEndringer(behandling, grunnlagSnapshot);
+                behandlingProsesseringTjeneste.tvingInnhentingRegisteropplysninger(behandling);
                 behandlingProsesseringTjeneste.opprettTasksForGjenopptaOppdaterFortsett(behandling, LocalDateTime.now());
             } else {
                 behandlingProsesseringTjeneste.opprettTasksForFortsettBehandling(behandling);
@@ -122,17 +127,6 @@ public class Kompletthetskontroller {
             behandlingProsesseringTjeneste.opprettTasksForFortsettBehandling(behandling);
         } else if (BehandlingÅrsakType.RE_HENDELSE_FØDSEL.equals(behandlingÅrsakType) && behandling.harÅpentAksjonspunktMedType(AksjonspunktDefinisjon.VENT_PGA_FOR_TIDLIG_SØKNAD)) {
             behandlingProsesseringTjeneste.opprettTasksForFortsettBehandling(behandling);
-        }
-    }
-
-    void spolKomplettBehandlingTilStartpunkt(Behandling behandling, EndringsresultatSnapshot grunnlagSnapshot) {
-        // Behandling er komplett - nullstill venting
-        if (behandling.isBehandlingPåVent()) {
-            behandlingProsesseringTjeneste.taBehandlingAvVent(behandling);
-        }
-        if (kompletthetModell.erKompletthetssjekkPassert(behandling.getId())) {
-            // Reposisjoner basert på grunnlagsendring i nylig mottatt dokument. Videre reposisjonering gjøres i task etter registeroppdatering
-            behandlingProsesseringTjeneste.utledDiffOgReposisjonerBehandlingVedEndringer(behandling, grunnlagSnapshot);
         }
     }
 


### PR DESCRIPTION
Tar ES av vent når det kommer vedlegg. 
Oppdaterer en test og fjerner en som ikke lenger er relevant (fordel lager oppgave for KA/scanning).
Tetter et smutthull i kompletthet.