### PR TITLE
TFP-5990 sjekk sammenheng termin/fødsel

### DIFF
--- a/domenetjenester/datavarehus/src/main/java/no/nav/foreldrepenger/datavarehus/v2/StønadsstatistikkVedtak.java
+++ b/domenetjenester/datavarehus/src/main/java/no/nav/foreldrepenger/datavarehus/v2/StønadsstatistikkVedtak.java
@@ -276,7 +276,7 @@ public class StønadsstatistikkVedtak {
 
         // minsterett - kun for far har rett, uføre (mors aktivitet er ikke et krav i disse tilfeller)
 
-        record Trekkdager(@JsonValue @Min(0) @Max(530) @NotNull BigDecimal antall) {
+        record Trekkdager(@JsonValue @Min(0) @Max(720) @NotNull BigDecimal antall) {
             public Trekkdager(int antall) {
                 this(BigDecimal.valueOf(antall).setScale(1, RoundingMode.DOWN));
             }

--- a/domenetjenester/familie-hendelse/src/main/java/no/nav/foreldrepenger/familiehendelse/aksjonspunkt/SjekkManglendeFødselOppdaterer.java
+++ b/domenetjenester/familie-hendelse/src/main/java/no/nav/foreldrepenger/familiehendelse/aksjonspunkt/SjekkManglendeFødselOppdaterer.java
@@ -118,7 +118,7 @@ public class SjekkManglendeFødselOppdaterer implements AksjonspunktOppdaterer<S
         var barn = brukAntallBarnISøknad ? konverterBarn(dto.getUidentifiserteBarn()) : bekreftetVersjon.map(FamilieHendelseEntitet::getBarna)
             .orElse(List.of());
         if (barn.isEmpty()) {
-            throw new FunksjonellException("FP-076346", "Ingen barn funnet", "Overstyr fødselsvilkåret for å avslå");
+            throw new FunksjonellException("FP-076346", "Ingen barn funnet", "Legg inn fødselsdato og overstyr fødselsvilkåret for å avslå");
         }
         if (barn.stream().anyMatch(b -> null == b.getFødselsdato())) {
             throw kanIkkeUtledeGjeldendeFødselsdato();


### PR DESCRIPTION
Mer sanity-checks ved "sjekk manglende fødsel"
* Må ha 1 barn en dato (eller krasjer det senere)
* Må ha passe avstand fødsel/termin

Øker max stønadsdager for å slippe gjennom tilfelle og nærme seg teoretisk max (689 dager)