### PR TITLE
TFP-5990 tilpasning til gjeldende konvensjon - bruk PDL-barn

### DIFF
--- a/domenetjenester/familie-hendelse/src/main/java/no/nav/foreldrepenger/familiehendelse/aksjonspunkt/SjekkManglendeFødselOppdaterer.java
+++ b/domenetjenester/familie-hendelse/src/main/java/no/nav/foreldrepenger/familiehendelse/aksjonspunkt/SjekkManglendeFødselOppdaterer.java
@@ -117,13 +117,11 @@ public class SjekkManglendeFødselOppdaterer implements AksjonspunktOppdaterer<S
         var brukAntallBarnISøknad = dto.getDokumentasjonForeligger() && !dto.isBrukAntallBarnITps();
         var barn = brukAntallBarnISøknad ? konverterBarn(dto.getUidentifiserteBarn()) : bekreftetVersjon.map(FamilieHendelseEntitet::getBarna)
             .orElse(List.of());
-        if (barn.isEmpty()) {
-            throw new FunksjonellException("FP-076346", "Ingen barn funnet", "Legg inn fødselsdato og overstyr fødselsvilkåret for å avslå");
-        }
         if (barn.stream().anyMatch(b -> null == b.getFødselsdato())) {
             throw kanIkkeUtledeGjeldendeFødselsdato();
         }
-        var fødselsdato = barn.stream().map(UidentifisertBarn::getFødselsdato).min(Comparator.naturalOrder()).orElseThrow();
+        var fødselsdato = barn.stream().map(UidentifisertBarn::getFødselsdato).min(Comparator.naturalOrder())
+            .orElseGet(() -> grunnlag.getGjeldendeVersjon().getSkjæringstidspunkt());
         if (termindato.isPresent()) {
             var fødselsintervall = FamilieHendelseTjeneste.intervallForTermindato(termindato.get());
             if (!fødselsintervall.encloses(fødselsdato)) {

--- a/domenetjenester/familie-hendelse/src/main/java/no/nav/foreldrepenger/familiehendelse/aksjonspunkt/SjekkManglendeFødselOppdaterer.java
+++ b/domenetjenester/familie-hendelse/src/main/java/no/nav/foreldrepenger/familiehendelse/aksjonspunkt/SjekkManglendeFødselOppdaterer.java
@@ -120,11 +120,10 @@ public class SjekkManglendeFødselOppdaterer implements AksjonspunktOppdaterer<S
         if (barn.stream().anyMatch(b -> null == b.getFødselsdato())) {
             throw kanIkkeUtledeGjeldendeFødselsdato();
         }
-        var fødselsdato = barn.stream().map(UidentifisertBarn::getFødselsdato).min(Comparator.naturalOrder())
-            .orElseGet(() -> grunnlag.getGjeldendeVersjon().getSkjæringstidspunkt());
-        if (termindato.isPresent()) {
+        var fødselsdato = barn.stream().map(UidentifisertBarn::getFødselsdato).min(Comparator.naturalOrder());
+        if (termindato.isPresent() && fødselsdato.isPresent()) {
             var fødselsintervall = FamilieHendelseTjeneste.intervallForTermindato(termindato.get());
-            if (!fødselsintervall.encloses(fødselsdato)) {
+            if (!fødselsintervall.encloses(fødselsdato.get())) {
                 throw new FunksjonellException("FP-076346", "For stort avvik termin/fødsel", "Sjekk datoer eller meld sak i Porten");
             }
         }


### PR DESCRIPTION
Beholder konvensjon om at "bruk fra Folkeregisteret" - som kan ha 0 barn.
Oppdaterer hele panelet senere + feil som kan oppstå når antall barn er satt til 0. Tar det i STP-PR