### PR TITLE
TFP-5985 ikke tilrettelegging før registerinnhenting

### DIFF
--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/dto/behandling/BehandlingDtoTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/dto/behandling/BehandlingDtoTjeneste.java
@@ -285,7 +285,7 @@ public class BehandlingDtoTjeneste {
         dto.setAksjonspunkt(aksjonspunkt);
 
         // FIXME hvorfor ytelsspesifikk url her?  Bør kun ha en tilrettelegging url
-        if (FagsakYtelseType.SVANGERSKAPSPENGER.equals(behandling.getFagsakYtelseType())) {
+        if (FagsakYtelseType.SVANGERSKAPSPENGER.equals(behandling.getFagsakYtelseType()) && behandlingRepository.hentSistOppdatertTidspunkt(behandling.getId()).isPresent()) {
             dto.leggTil(get(SvangerskapspengerRestTjeneste.TILRETTELEGGING_V2_PATH, "svangerskapspenger-tilrettelegging", uuidDto));
         }
 


### PR DESCRIPTION
Det første forsøket klarte ikke vise tilretteleggingspanelet - det bare spinner. Kommer en OK Dto - men det rendres ikke. Kanskje @pekern ser hva som er problemet i frontend - prøv den andre branchen og en autotest (break før IM).

Dette er et tristere alternativ: Ikke vise tilretteleggingspanel før det er innhentet registerdata. Det er ikke heldig siden vi da ikke kan vise søknadsdata. Denne må også testes lokalt fordi vi ikke vet hvordan ting ser ut når lenken ikke er med.