### PR TITLE
TFP-5732 test av ES-botid overgang riktig dato

### DIFF
--- a/domenetjenester/medlem/src/test/java/no/nav/foreldrepenger/domene/medlem/MedlemskapVurderingPeriodeTjenesteTest.java
+++ b/domenetjenester/medlem/src/test/java/no/nav/foreldrepenger/domene/medlem/MedlemskapVurderingPeriodeTjenesteTest.java
@@ -44,7 +44,7 @@ class MedlemskapVurderingPeriodeTjenesteTest {
 
         // Act/Assert
         assertThat(new MedlemskapVurderingPeriodeTjeneste(BOTID_CORE).bosattVurderingsintervall(ref, stp))
-            .isEqualTo(new LocalDateInterval(LocalDate.now().minus(BOSATT_TILBAKE), termindato));
+            .isEqualTo(new LocalDateInterval(termindato.minus(BOSATT_TILBAKE), termindato));
         assertThat(new MedlemskapVurderingPeriodeTjeneste(BOTID_CORE).lovligOppholdVurderingsintervall(ref, stp))
             .isEqualTo(new LocalDateInterval(termindato, termindato));
     }


### PR DESCRIPTION
Skal beholde gammel funksjonalitet etter overgangen. Nå er det botid for alle.