### PR TITLE
TFP-6004: fiks resursslenke for dokumentliste

### DIFF
--- a/web/src/main/java/no/nav/foreldrepenger/web/app/rest/ResourceLink.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/rest/ResourceLink.java
@@ -6,11 +6,9 @@ import java.util.Objects;
 
 import jakarta.validation.constraints.NotNull;
 
-import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
  * Representerer en link til en resource/action i en HATEOAS response.
@@ -87,41 +85,8 @@ public class ResourceLink {
         return new ResourceLink(href, rel, HttpMethod.GET, null);
     }
 
-    public static ResourceLink get(String href, String rel, Object queryParams) {
-        var uri = new StringBuilder();
-        uri.append(href);
-        if (queryParams != null) {
-            uri.append("?");
-            uri.append(convertObjectToQueryString(queryParams));
-        }
-        return new ResourceLink(uri.toString(), rel, HttpMethod.GET, null);
-    }
-
     public static ResourceLink post(String href, String rel, Object requestPayload) {
         return new ResourceLink(href, rel, HttpMethod.POST, requestPayload);
-    }
-
-    private static String convertObjectToQueryString(Object object) {
-        var mapper = new ObjectMapper();
-        return mapper.convertValue(object, UriFormat.class).toString();
-    }
-
-    private static class UriFormat {
-
-        private final StringBuilder builder = new StringBuilder();
-
-        @JsonAnySetter
-        public void addToUri(String name, Object property) {
-            if (builder.length() > 0) {
-                builder.append("&");
-            }
-            builder.append(name).append("=").append(property);
-        }
-
-        @Override
-        public String toString() {
-            return builder.toString();
-        }
     }
 
     @Override

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/rest/ResourceLinks.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/rest/ResourceLinks.java
@@ -1,5 +1,8 @@
 package no.nav.foreldrepenger.web.app.rest;
 
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import no.nav.foreldrepenger.konfig.Environment;
 import no.nav.foreldrepenger.web.app.konfig.ApiConfig;
 
@@ -14,23 +17,53 @@ public final class ResourceLinks {
         return get(path, rel, null);
     }
 
-    public static ResourceLink get(String path, String rel, Object dto) {
-        var href = href(path);
-        return ResourceLink.get(href, rel, dto);
+    public static ResourceLink get(String path, String rel, Object queryParams) {
+        var href = addPathPrefix(path);
+        var query = toQuery(queryParams);
+        return ResourceLink.get(href + query, rel);
     }
 
     public static ResourceLink post(String path, String rel) {
         return post(path, rel, null);
     }
 
-    public static ResourceLink post(String path, String rel, Object dto) {
-        var href = href(path);
-        return ResourceLink.post(href, rel, dto);
+    public static ResourceLink post(String path, String rel, Object requestPayload) {
+        var href = addPathPrefix(path);
+        return ResourceLink.post(href, rel, requestPayload);
     }
 
-    private static String href(String path) {
-        var contextPath = ENV.getProperty("context.path","/fpsak");
+    public static String addPathPrefix(String path) {
+        var contextPath = ENV.getProperty("context.path", "/fpsak");
         var apiUri = ApiConfig.API_URI;
         return contextPath + apiUri + path;
+    }
+
+    public static String toQuery(Object queryParams) {
+        if (queryParams != null) {
+            var mapper = new ObjectMapper();
+            var mappedQueryParams = mapper.convertValue(queryParams, UriFormat.class).toString();
+            if (!mappedQueryParams.isEmpty()) {
+                return String.join("?", mappedQueryParams);
+            }
+        }
+        return "";
+    }
+
+    private static class UriFormat {
+
+        private final StringBuilder builder = new StringBuilder();
+
+        @JsonAnySetter
+        public void addToUri(String name, Object property) {
+            if (builder.length() > 0) {
+                builder.append("&");
+            }
+            builder.append(name).append("=").append(property);
+        }
+
+        @Override
+        public String toString() {
+            return builder.toString();
+        }
     }
 }

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/dto/behandling/BehandlingDtoTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/dto/behandling/BehandlingDtoTjeneste.java
@@ -1,8 +1,5 @@
 package no.nav.foreldrepenger.web.app.tjenester.behandling.dto.behandling;
 
-import static no.nav.foreldrepenger.web.app.rest.ResourceLinks.get;
-import static no.nav.foreldrepenger.web.app.rest.ResourceLinks.post;
-
 import java.time.LocalDate;
 import java.util.Collections;
 import java.util.List;
@@ -91,6 +88,9 @@ import no.nav.foreldrepenger.web.app.tjenester.dokument.DokumentRestTjeneste;
 import no.nav.foreldrepenger.web.app.tjenester.fagsak.FagsakRestTjeneste;
 import no.nav.foreldrepenger.web.app.tjenester.fagsak.dto.SaksnummerDto;
 import no.nav.foreldrepenger.web.app.tjenester.familiehendelse.FamiliehendelseRestTjeneste;
+
+import static no.nav.foreldrepenger.web.app.rest.ResourceLinks.get;
+import static no.nav.foreldrepenger.web.app.rest.ResourceLinks.post;
 
 /**
  * Bygger et sammensatt resultat av BehandlingDto ved å samle data fra ulike tjenester, for å kunne levere dette ut på en REST tjeneste.
@@ -317,9 +317,8 @@ public class BehandlingDtoTjeneste {
     }
 
     private UtvidetBehandlingDto utvideBehandlingDtoForInnsyn(Behandling behandling, UtvidetBehandlingDto dto) {
-        var uuidDto = new UuidDto(behandling.getUuid());
-        dto.leggTil(get(InnsynRestTjeneste.INNSYN_PATH, "innsyn", uuidDto));
-        dto.leggTil(get(DokumentRestTjeneste.DOKUMENTER_PATH, "dokumenter", uuidDto));
+        dto.leggTil(get(InnsynRestTjeneste.INNSYN_PATH, "innsyn", new UuidDto(behandling.getUuid())));
+        dto.leggTil(get(DokumentRestTjeneste.DOKUMENTER_PATH, "dokumenter", new SaksnummerDto(behandling.getSaksnummer())));
         return dto;
     }
 


### PR DESCRIPTION
Ressurslenke for hent-dokumentliste sendes ned med feil query parameter.
Denne endringen fikser det, og utbedrer testen i BehandlingDtoTjenesteTest slik forskjeller mellom ressurslenker og annoterte endepunkt fanges opp i fremtiden

ref:  https://github.com/navikt/fp-frontend/blob/b291700ee0aaee07c70e9bb449214bb3d7b45f8a/apps/fp-frontend-app/src/data/behandlingApi.ts#L228