### PR TITLE
TFP-6005 prosess går videre selv om EØS-aksjonspunkt åpent

### DIFF
--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/aksjonspunkt/AksjonspunktDefinisjon.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/aksjonspunkt/AksjonspunktDefinisjon.java
@@ -186,7 +186,7 @@ public enum AksjonspunktDefinisjon implements Kodeverdi {
     AUTOMATISK_MARKERING_AV_UTENLANDSSAK(
             AksjonspunktKodeDefinisjon.AUTOMATISK_MARKERING_AV_UTENLANDSSAK_KODE, AksjonspunktType.MANUELL,
             "Innhent dokumentasjon fra utenlandsk trygdemyndighet",
-            BehandlingStegType.VURDER_KOMPLETT_TIDLIG, VurderingspunktType.INN, UTEN_VILKÅR, UTEN_SKJERMLENKE, ENTRINN, EnumSet.of(ES, FP, SVP)),
+            BehandlingStegType.INREG_AVSL, VurderingspunktType.UT, UTEN_VILKÅR, UTEN_SKJERMLENKE, ENTRINN, EnumSet.of(ES, FP, SVP)),
     FAKTA_UTTAK_INGEN_PERIODER(AksjonspunktKodeDefinisjon.FAKTA_UTTAK_INGEN_PERIODER_KODE,
         AksjonspunktType.MANUELL, "Ingen perioder å vurdere. Vurder om behandlingen er feilopprettet og kan henlegges", BehandlingStegType.FAKTA_UTTAK, VurderingspunktType.UT, UTEN_VILKÅR,
         SkjermlenkeType.FAKTA_UTTAK, TOTRINN, EnumSet.of(FP)),

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/aksjonspunkt/AksjonspunktDtoMapper.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/aksjonspunkt/AksjonspunktDtoMapper.java
@@ -88,6 +88,10 @@ public class AksjonspunktDtoMapper {
         if (AksjonspunktDefinisjon.AVKLAR_VERGE.equals(def) && !AksjonspunktStatus.UTFØRT.equals(status)) {
             return true;
         }
+        //Spesialbehandling av EØS-sjekk fordi det oppstår tidlig og underliggende prosess bør kunne gå videre (inntektsmelding, mm)
+        if (AksjonspunktDefinisjon.AUTOMATISK_MARKERING_AV_UTENLANDSSAK.equals(def) && AksjonspunktStatus.OPPRETTET.equals(status)) {
+            return true;
+        }
         if (def.erAutopunkt()) {
             return false;
         }


### PR DESCRIPTION
Fikset denne i går ved å sette VP til VurderSøktForTidlig / INN. Noen behandlinger var allerede gått forbi dette.
Imidlertid bør prosessen med å hente IM kunne gå videre uavhengig av når man vurderer behov for SED - så man ikke akkumulerer ventetid.
Sørger derfor for at aksjonspunktet kan løses så lenge det er opprettet og før man går til KontrollerArbeidsforhold. 
Potensielt kunne den gått til opptjening, uttak eller helt til vedtak.