### PR TITLE
Redusere antall loggfeil fra tomme uttak

### DIFF
--- a/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/arbeidInntektsmelding/HåndterePermisjoner.java
+++ b/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/arbeidInntektsmelding/HåndterePermisjoner.java
@@ -12,7 +12,6 @@ import java.util.List;
 import java.util.Optional;
 
 import no.nav.foreldrepenger.behandling.BehandlingReferanse;
-import no.nav.foreldrepenger.behandling.Skjæringstidspunkt;
 import no.nav.foreldrepenger.domene.arbeidInntektsmelding.dto.PermisjonOgMangelDto;
 import no.nav.foreldrepenger.domene.arbeidsforhold.impl.AksjonspunktÅrsak;
 import no.nav.foreldrepenger.domene.iay.modell.InntektArbeidYtelseGrunnlag;
@@ -29,11 +28,10 @@ public class HåndterePermisjoner {
     }
 
     public static List<ArbeidsforholdMangel> finnArbForholdMedPermisjonUtenSluttdatoMangel(BehandlingReferanse behandlingReferanse,
-                                                                                           Skjæringstidspunkt skjæringstidspunkt,
+                                                                                           LocalDate stp,
                                                                                            InntektArbeidYtelseGrunnlag iayGrunnlag) {
         List<ArbeidsforholdMangel> arbForholdMedPermUtenSluttdato = new ArrayList<>();
 
-        var stp = skjæringstidspunkt.getUtledetSkjæringstidspunkt();
         var aktørId = behandlingReferanse.aktørId();
         var filter = new YrkesaktivitetFilter(iayGrunnlag.getArbeidsforholdInformasjon(), iayGrunnlag.getAktørArbeidFraRegister(aktørId)).før(stp);
 

--- a/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/arbeidsforhold/InntektsmeldingTjeneste.java
+++ b/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/arbeidsforhold/InntektsmeldingTjeneste.java
@@ -233,6 +233,9 @@ public class InntektsmeldingTjeneste {
     }
 
     private boolean kanInntektsmeldingBrukesForSkjæringstidspunkt(Inntektsmelding inntektsmelding, LocalDate skjæringstidspunkt) {
+        if (skjæringstidspunkt == null) {
+            return true; // Ikke definert skjæringstidspunkt så alle inntektsmeldinger er kandidater inntil videre
+        }
         var tidligsteDato = skjæringstidspunkt.minusWeeks(4).minusDays(1);
         var sisteBeregningMåned = YearMonth.from(skjæringstidspunkt.minusMonths(1));
         var imdato = inntektsmelding.getInnsendingstidspunkt().toLocalDate();

--- a/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/arbeidsforhold/aksjonspunkt/AksjonspunktUtlederForArbForholdMedPermisjoner.java
+++ b/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/arbeidsforhold/aksjonspunkt/AksjonspunktUtlederForArbForholdMedPermisjoner.java
@@ -50,7 +50,7 @@ public class AksjonspunktUtlederForArbForholdMedPermisjoner {
             var referanse = param.getRef();
             var erEndringssøknad = erEndringssøknad(referanse);
             if (!erEndringssøknad) {
-                var arbForholdMedPermisjonUtenSluttdato = finnArbForholdMedPermisjonUtenSluttdatoMangel(referanse, param.getSkjæringstidspunkt(), iayGrunnlag);
+                var arbForholdMedPermisjonUtenSluttdato = finnArbForholdMedPermisjonUtenSluttdatoMangel(referanse, param.getSkjæringstidspunkt().getUtledetSkjæringstidspunkt(), iayGrunnlag);
 
                 if (!arbForholdMedPermisjonUtenSluttdato.isEmpty()) {
                     return opprettListeForAksjonspunkt(AksjonspunktDefinisjon.VURDER_PERMISJON_UTEN_SLUTTDATO);

--- a/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/opptjening/dto/OpptjeningDtoTjeneste.java
+++ b/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/opptjening/dto/OpptjeningDtoTjeneste.java
@@ -10,7 +10,6 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 
 import no.nav.foreldrepenger.behandling.BehandlingReferanse;
-import no.nav.foreldrepenger.behandling.Skjæringstidspunkt;
 import no.nav.foreldrepenger.behandlingslager.behandling.opptjening.Opptjening;
 import no.nav.foreldrepenger.behandlingslager.behandling.opptjening.OpptjeningAktivitetType;
 import no.nav.foreldrepenger.behandlingslager.virksomhet.OrganisasjonsNummerValidator;
@@ -24,11 +23,13 @@ import no.nav.foreldrepenger.domene.opptjening.VurderingsStatus;
 import no.nav.foreldrepenger.domene.opptjening.aksjonspunkt.MapYrkesaktivitetTilOpptjeningsperiodeTjeneste;
 import no.nav.foreldrepenger.domene.typer.InternArbeidsforholdRef;
 import no.nav.foreldrepenger.domene.typer.Stillingsprosent;
+import no.nav.foreldrepenger.skjæringstidspunkt.SkjæringstidspunktTjeneste;
 
 @ApplicationScoped
 public class OpptjeningDtoTjeneste {
     private OpptjeningsperioderTjeneste forSaksbehandlingTjeneste;
     private ArbeidsgiverTjeneste arbeidsgiverTjeneste;
+    private SkjæringstidspunktTjeneste skjæringstidspunktTjeneste;
 
     OpptjeningDtoTjeneste() {
         // CDI
@@ -36,12 +37,14 @@ public class OpptjeningDtoTjeneste {
 
     @Inject
     public OpptjeningDtoTjeneste(OpptjeningsperioderTjeneste forSaksbehandlingTjeneste,
-            ArbeidsgiverTjeneste arbeidsgiverTjeneste) {
+                                 ArbeidsgiverTjeneste arbeidsgiverTjeneste,
+                                 SkjæringstidspunktTjeneste skjæringstidspunktTjeneste) {
         this.forSaksbehandlingTjeneste = forSaksbehandlingTjeneste;
         this.arbeidsgiverTjeneste = arbeidsgiverTjeneste;
+        this.skjæringstidspunktTjeneste = skjæringstidspunktTjeneste;
     }
 
-    public Optional<OpptjeningDto> mapFra(BehandlingReferanse ref, Skjæringstidspunkt stp) {
+    public Optional<OpptjeningDto> mapFra(BehandlingReferanse ref) {
         var behandlingId = ref.behandlingId();
         var fastsattOpptjening = forSaksbehandlingTjeneste.hentOpptjeningHvisFinnes(behandlingId);
 
@@ -51,6 +54,7 @@ public class OpptjeningDtoTjeneste {
                 mapFastsattOpptjening(fastsatt), MergeOverlappendePeriodeHjelp.mergeOverlappenePerioder(fastsatt.getOpptjeningAktivitet()))));
 
         if (fastsattOpptjening.isPresent()) {
+            var stp = skjæringstidspunktTjeneste.getSkjæringstidspunkter(ref.behandlingId());
 
             resultat.setOpptjeningAktivitetList(
                     forSaksbehandlingTjeneste.hentRelevanteOpptjeningAktiveterForSaksbehandling(ref, stp)

--- a/domenetjenester/arbeidsforhold/src/test/java/no/nav/foreldrepenger/domene/arbeidInntektsmelding/HåndterePermisjonerTest.java
+++ b/domenetjenester/arbeidsforhold/src/test/java/no/nav/foreldrepenger/domene/arbeidInntektsmelding/HåndterePermisjonerTest.java
@@ -16,7 +16,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import no.nav.foreldrepenger.behandling.BehandlingReferanse;
-import no.nav.foreldrepenger.behandling.Skjæringstidspunkt;
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
 import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakYtelseType;
 import no.nav.foreldrepenger.behandlingslager.virksomhet.ArbeidType;
@@ -268,10 +267,7 @@ class HåndterePermisjonerTest {
         return BehandlingReferanse.fra(behandling);
     }
 
-    private Skjæringstidspunkt lagStp(Behandling behandling) {
-        return Skjæringstidspunkt.builder()
-                .medUtledetSkjæringstidspunkt(SKJÆRINGSTIDSPUNKT)
-                .medSkjæringstidspunktOpptjening(SKJÆRINGSTIDSPUNKT)
-                .build();
+    private LocalDate lagStp(Behandling behandling) {
+        return SKJÆRINGSTIDSPUNKT;
     }
 }

--- a/domenetjenester/beregningsgrunnlag/src/main/java/no/nav/foreldrepenger/domene/fp/SykemeldingVentTjeneste.java
+++ b/domenetjenester/beregningsgrunnlag/src/main/java/no/nav/foreldrepenger/domene/fp/SykemeldingVentTjeneste.java
@@ -36,6 +36,6 @@ public class SykemeldingVentTjeneste {
 
         var iayGrunnlag = inntektArbeidYtelseTjeneste.hentGrunnlag(referanse.behandlingUuid());
         var filter = new YtelseFilter(iayGrunnlag.getAktørYtelseFraRegister(referanse.aktørId()));
-        return VentPåSykemelding.utledVenteFrist(filter, stp.getSkjæringstidspunktOpptjening(), LocalDate.now());
+        return VentPåSykemelding.utledVenteFrist(filter, stp.getUtledetSkjæringstidspunkt(), LocalDate.now());
     }
 }

--- a/domenetjenester/medlem/src/test/java/no/nav/foreldrepenger/domene/medlem/MedlemskapVurderingPeriodeTjenesteTest.java
+++ b/domenetjenester/medlem/src/test/java/no/nav/foreldrepenger/domene/medlem/MedlemskapVurderingPeriodeTjenesteTest.java
@@ -134,9 +134,9 @@ class MedlemskapVurderingPeriodeTjenesteTest {
 
         // Act/Assert
         assertThat(new MedlemskapVurderingPeriodeTjeneste(BOTID_CORE).bosattVurderingsintervall(ref, stp))
-            .isEqualTo(new LocalDateInterval(LocalDate.now().minus(ES_MEDLEMSKAP), termindato));
+            .isEqualTo(new LocalDateInterval(termindato.minus(ES_MEDLEMSKAP), termindato));
         assertThat(new MedlemskapVurderingPeriodeTjeneste(BOTID_CORE).lovligOppholdVurderingsintervall(ref, stp))
-            .isEqualTo(new LocalDateInterval(LocalDate.now().minus(ES_MEDLEMSKAP), termindato));
+            .isEqualTo(new LocalDateInterval(termindato.minus(ES_MEDLEMSKAP), termindato));
     }
 
     @Test
@@ -157,9 +157,9 @@ class MedlemskapVurderingPeriodeTjenesteTest {
 
         // Act/Assert
         assertThat(new MedlemskapVurderingPeriodeTjeneste(BOTID_CORE).bosattVurderingsintervall(ref, stp))
-            .isEqualTo(new LocalDateInterval(LocalDate.now().minus(ES_MEDLEMSKAP), termindato));
+            .isEqualTo(new LocalDateInterval(termindato.minus(ES_MEDLEMSKAP), termindato));
         assertThat(new MedlemskapVurderingPeriodeTjeneste(BOTID_CORE).lovligOppholdVurderingsintervall(ref, stp))
-            .isEqualTo(new LocalDateInterval(LocalDate.now().minus(ES_MEDLEMSKAP), termindato));
+            .isEqualTo(new LocalDateInterval(termindato.minus(ES_MEDLEMSKAP), termindato));
     }
 
     @Test

--- a/domenetjenester/registerinnhenting/src/main/java/no/nav/foreldrepenger/domene/registerinnhenting/impl/startpunkt/StartpunktUtlederInntektArbeidYtelse.java
+++ b/domenetjenester/registerinnhenting/src/main/java/no/nav/foreldrepenger/domene/registerinnhenting/impl/startpunkt/StartpunktUtlederInntektArbeidYtelse.java
@@ -153,7 +153,7 @@ class StartpunktUtlederInntektArbeidYtelse implements StartpunktUtleder {
     }
 
     private boolean sjekkOmMåVurderePermisjonerUtenSluttdato(BehandlingReferanse ref, Skjæringstidspunkt stp, InntektArbeidYtelseGrunnlag inntektArbeidYtelseGrunnlag) {
-        return !HåndterePermisjoner.finnArbForholdMedPermisjonUtenSluttdatoMangel(ref, stp, inntektArbeidYtelseGrunnlag).isEmpty();
+        return !HåndterePermisjoner.finnArbForholdMedPermisjonUtenSluttdatoMangel(ref, stp.getUtledetSkjæringstidspunkt(), inntektArbeidYtelseGrunnlag).isEmpty();
     }
 
     /*

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/opptjening/OpptjeningRestTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/opptjening/OpptjeningRestTjeneste.java
@@ -23,7 +23,6 @@ import no.nav.foreldrepenger.domene.opptjening.dto.OpptjeningDto;
 import no.nav.foreldrepenger.domene.opptjening.dto.OpptjeningDtoTjeneste;
 import no.nav.foreldrepenger.domene.opptjening.dto.OpptjeningIUtlandDokStatusDto;
 import no.nav.foreldrepenger.domene.opptjening.dto.OpptjeningIUtlandDokStatusDtoTjeneste;
-import no.nav.foreldrepenger.skjæringstidspunkt.SkjæringstidspunktTjeneste;
 import no.nav.foreldrepenger.web.app.tjenester.behandling.dto.BehandlingAbacSuppliers;
 import no.nav.foreldrepenger.web.app.tjenester.behandling.dto.UuidDto;
 import no.nav.vedtak.sikkerhet.abac.BeskyttetRessurs;
@@ -45,7 +44,7 @@ public class OpptjeningRestTjeneste {
 
     private BehandlingRepository behandlingRepository;
     private OpptjeningDtoTjeneste dtoMapper;
-    private SkjæringstidspunktTjeneste skjæringstidspunktTjeneste;
+
     private OpptjeningIUtlandDokStatusDtoTjeneste opptjeningIUtlandDokStatusDtoTjeneste;
 
     public OpptjeningRestTjeneste() {
@@ -54,10 +53,9 @@ public class OpptjeningRestTjeneste {
 
     @Inject
     public OpptjeningRestTjeneste(BehandlingRepository behandlingRepository,
-            SkjæringstidspunktTjeneste skjæringstidspunktTjeneste,
-            OpptjeningDtoTjeneste dtoMapper, OpptjeningIUtlandDokStatusDtoTjeneste opptjeningIUtlandDokStatusDtoTjeneste) {
+                                  OpptjeningDtoTjeneste dtoMapper,
+                                  OpptjeningIUtlandDokStatusDtoTjeneste opptjeningIUtlandDokStatusDtoTjeneste) {
         this.behandlingRepository = behandlingRepository;
-        this.skjæringstidspunktTjeneste = skjæringstidspunktTjeneste;
         this.dtoMapper = dtoMapper;
         this.opptjeningIUtlandDokStatusDtoTjeneste = opptjeningIUtlandDokStatusDtoTjeneste;
     }
@@ -89,7 +87,6 @@ public class OpptjeningRestTjeneste {
 
     private OpptjeningDto getOpptjeningFraBehandling(Behandling behandling) {
         var behandlingReferanse = BehandlingReferanse.fra(behandling);
-        var skjæringstidspunkt = skjæringstidspunktTjeneste.getSkjæringstidspunkter(behandling.getId());
-        return dtoMapper.mapFra(behandlingReferanse, skjæringstidspunkt).orElse(null);
+        return dtoMapper.mapFra(behandlingReferanse).orElse(null);
     }
 }

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/svp/SvangerskapspengerTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/svp/SvangerskapspengerTjeneste.java
@@ -113,7 +113,7 @@ public class SvangerskapspengerTjeneste {
             finnSaksbehandletHvisEksisterer(aktørId, iay)));
         var stp = skjæringstidspunktTjeneste.getSkjæringstidspunkter(behandlingId);
         var inntektsmeldinger = inntektsmeldingTjeneste.hentInntektsmeldinger(BehandlingReferanse.fra(behandling),
-                stp.getSkjæringstidspunktOpptjening());
+                stp.getUtledetSkjæringstidspunkt());
         var iayOverstyringer = iayGrunnlag.map(InntektArbeidYtelseGrunnlag::getArbeidsforholdOverstyringer).orElseGet(List::of);
 
         gjeldendeTilrettelegginger.forEach(tilr -> {

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/søknad/SøknadDtoTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/søknad/SøknadDtoTjeneste.java
@@ -211,17 +211,21 @@ public class SøknadDtoTjeneste {
     }
 
     private Optional<LocalDate> hentOppgittStartdatoForPermisjon(Long behandlingId, RelasjonsRolleType rolleType) {
-        var skjæringstidspunkter = skjæringstidspunktTjeneste.getSkjæringstidspunkter(behandlingId);
+        try {
+            var skjæringstidspunkter = skjæringstidspunktTjeneste.getSkjæringstidspunkter(behandlingId);
 
-        var oppgittStartdato = skjæringstidspunkter.getFørsteUttaksdatoHvisFinnes()
-            .or(skjæringstidspunkter::getSkjæringstidspunktHvisUtledet);
-        if (RelasjonsRolleType.MORA.equals(rolleType) && skjæringstidspunkter.gjelderFødsel()) {
-            var evFødselFørOppgittStartdato = familieHendelseRepository.hentAggregat(behandlingId)
-                .getGjeldendeBekreftetVersjon().flatMap(FamilieHendelseEntitet::getFødselsdato).map(VirkedagUtil::fomVirkedag)
-                .filter(fødselsdatoUkedag -> fødselsdatoUkedag.isBefore(oppgittStartdato.orElse(LocalDate.MAX)));
-            return evFødselFørOppgittStartdato.or(() -> oppgittStartdato);
+            var oppgittStartdato = skjæringstidspunkter.getFørsteUttaksdatoHvisFinnes()
+                .or(skjæringstidspunkter::getSkjæringstidspunktHvisUtledet);
+            if (RelasjonsRolleType.MORA.equals(rolleType) && skjæringstidspunkter.gjelderFødsel()) {
+                var evFødselFørOppgittStartdato = familieHendelseRepository.hentAggregat(behandlingId)
+                    .getGjeldendeBekreftetVersjon().flatMap(FamilieHendelseEntitet::getFødselsdato).map(VirkedagUtil::fomVirkedag)
+                    .filter(fødselsdatoUkedag -> fødselsdatoUkedag.isBefore(oppgittStartdato.orElse(LocalDate.MAX)));
+                return evFødselFørOppgittStartdato.or(() -> oppgittStartdato);
+            }
+            return oppgittStartdato;
+        } catch (Exception e) {
+            return Optional.empty();
         }
-        return oppgittStartdato;
     }
 
 }

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/fpoversikt/SvpDtoTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/fpoversikt/SvpDtoTjeneste.java
@@ -242,7 +242,7 @@ public class SvpDtoTjeneste {
     private Optional<Inntektsmelding> finnIMForArbforhold(Behandling behandling, no.nav.foreldrepenger.behandlingslager.virksomhet.Arbeidsgiver arbeidsgiver, InternArbeidsforholdRef internArbeidsforholdRef) {
         var skjæringstidspunkter = skjæringstidspunktTjeneste.getSkjæringstidspunkter(behandling.getId());
         var ref = BehandlingReferanse.fra(behandling);
-        return inntektsmeldingTjeneste.hentInntektsmeldinger(ref, skjæringstidspunkter.getSkjæringstidspunktOpptjening()).stream()
+        return inntektsmeldingTjeneste.hentInntektsmeldinger(ref, skjæringstidspunkter.getUtledetSkjæringstidspunkt()).stream()
             .filter(inntektsmelding -> inntektsmelding.getArbeidsgiver().equals(arbeidsgiver) && (internArbeidsforholdRef == null || inntektsmelding.getArbeidsforholdRef().gjelderFor(internArbeidsforholdRef)))
             .findFirst();
     }


### PR DESCRIPTION
Denne adresserer noen av feilene vi har sett i loggen siste tiden. Typisk når man åpner en behandling med tomt uttak.
Det som gjenstår er ARBEID_OG_INNTEKTSMELDING_PART_PATH - her er det et par alternativ
* Bruke dagens dato som utledetSTP (evt FHdato+3år) - krever at hele Inntektsmeldingstjeneste-greia går fra STP til LocalDate
* Returnere en redusert DTO - kan ta med IM (filter tar med alle dersom stpdato == null) - men mer usikkert med arbeid+inntekt
