### PR TITLE
TFP-5957: endre ressurslenke til formidling på om det finnes verge

### DIFF
--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/dto/behandling/BehandlingDtoTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/dto/behandling/BehandlingDtoTjeneste.java
@@ -31,7 +31,6 @@ import no.nav.foreldrepenger.behandlingslager.behandling.søknad.SøknadReposito
 import no.nav.foreldrepenger.behandlingslager.behandling.tilbakekreving.TilbakekrevingRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.vedtak.BehandlingVedtak;
 import no.nav.foreldrepenger.behandlingslager.behandling.vedtak.BehandlingVedtakRepository;
-import no.nav.foreldrepenger.behandlingslager.behandling.verge.VergeAggregat;
 import no.nav.foreldrepenger.behandlingslager.behandling.verge.VergeRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.AvklarteUttakDatoerEntitet;
 import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.YtelseFordelingAggregat;
@@ -325,14 +324,14 @@ public class BehandlingDtoTjeneste {
         var uuidDto = new UuidDto(behandling.getUuid());
         dto.leggTil(get(KlageRestTjeneste.KLAGE_V2_PATH, "klage-vurdering", uuidDto));
         dto.leggTil(get(KlageRestTjeneste.MOTTATT_KLAGEDOKUMENT_V2_PATH, "mottatt-klagedokument", uuidDto));
-        leggTilVergeHvisAksjonspunkt(behandling, dto, uuidDto);
+        leggTilVergeHvisFinnes(behandling, dto, uuidDto);
         return dto;
     }
 
     private UtvidetBehandlingDto utvideBehandlingDtoAnke(Behandling behandling, UtvidetBehandlingDto dto) {
         var uuidDto = new UuidDto(behandling.getUuid());
         dto.leggTil(get(AnkeRestTjeneste.ANKEVURDERING_V2_PATH, "anke-vurdering", uuidDto));
-        leggTilVergeHvisAksjonspunkt(behandling, dto, uuidDto);
+        leggTilVergeHvisFinnes(behandling, dto, uuidDto);
         return dto;
     }
 
@@ -360,7 +359,7 @@ public class BehandlingDtoTjeneste {
         dto.leggTil(get(FamiliehendelseRestTjeneste.FAMILIEHENDELSE_V2_PATH, "familiehendelse-v2", uuidDto));
         dto.leggTil(get(PersonRestTjeneste.PERSONOVERSIKT_PATH, "behandling-personoversikt", uuidDto));
         dto.leggTil(get(PersonRestTjeneste.MEDLEMSKAP_V3_PATH, "soeker-medlemskap-v3", uuidDto));
-        leggTilVergeHvisAksjonspunkt(behandling, dto, uuidDto);
+        leggTilVergeHvisFinnes(behandling, dto, uuidDto);
         dto.leggTil(get(InntektArbeidYtelseRestTjeneste.INNTEKT_ARBEID_YTELSE_PATH, "inntekt-arbeid-ytelse", uuidDto));
         dto.leggTil(get(InntektArbeidYtelseRestTjeneste.ARBEIDSGIVERE_OPPLYSNINGER_PATH, "arbeidsgivere-oversikt", uuidDto));
         dto.leggTil(get(ArbeidOgInntektsmeldingRestTjeneste.HENT_ALLE_INNTEKTSMELDINGER_PATH, "inntektsmeldinger", uuidDto));
@@ -536,11 +535,10 @@ public class BehandlingDtoTjeneste {
         return behandlingsresultatRepository.hentHvisEksisterer(behandlingId).orElse(null);
     }
 
-    private void leggTilVergeHvisAksjonspunkt(Behandling behandling, UtvidetBehandlingDto dto, UuidDto uuidDto) {
+    private void leggTilVergeHvisFinnes(Behandling behandling, UtvidetBehandlingDto dto, UuidDto uuidDto) {
         var vergeFinnes = vergeRepository.hentAggregat(behandling.getId()).isPresent();
         if (behandling.harÅpentAksjonspunktMedType(AksjonspunktDefinisjon.AVKLAR_VERGE) || vergeFinnes) {
             dto.leggTil(get(PersonRestTjeneste.VERGE_PATH, "soeker-verge", uuidDto));
-            dto.leggTil(get(PersonRestTjeneste.VERGE_BACKEND_PATH, "verge-backend", uuidDto));
         }
     }
 }

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/dto/behandling/BehandlingDtoUtil.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/dto/behandling/BehandlingDtoUtil.java
@@ -94,14 +94,14 @@ final class BehandlingDtoUtil {
         dto.setGjeldendeVedtak(erBehandlingMedGjeldendeVedtak);
     }
 
-    static Optional<BehandlingÅrsakDto> førsteÅrsak(Behandling behandling) {
+    private static Optional<BehandlingÅrsakDto> førsteÅrsak(Behandling behandling) {
         return behandling.getBehandlingÅrsaker().stream()
             .sorted(Comparator.comparing(BaseEntitet::getOpprettetTidspunkt))
             .map(BehandlingDtoUtil::map)
             .findFirst();
     }
 
-    static boolean erAktivPapirsøknad(Behandling behandling) {
+    private static boolean erAktivPapirsøknad(Behandling behandling) {
         var kriterier = Arrays.asList(
             AksjonspunktDefinisjon.REGISTRER_PAPIRSØKNAD_ENGANGSSTØNAD,
             AksjonspunktDefinisjon.REGISTRER_PAPIRSØKNAD_FORELDREPENGER,


### PR DESCRIPTION
formidling bruker ressurslenke til å bestemme om det finnes verge i en sak. om det ikke finnes en lenke antar den at det ikke er verge. Nå som verge kan lagres direkte må betingelsen for om lenke skal legges til i dto endres.

formidling: https://github.com/navikt/fp-formidling/blob/8bb53cb053fc38c61943c79e11bc9e6b1774314b/src/main/java/no/nav/foreldrepenger/fpformidling/integrasjon/fpsak/Behandlinger.java#L54