### PR TITLE
TFP-5957: utbedre testing av ressurslenker

### DIFF
--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/dto/behandling/BehandlingFormidlingDtoTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/dto/behandling/BehandlingFormidlingDtoTjeneste.java
@@ -107,10 +107,6 @@ public class BehandlingFormidlingDtoTjeneste {
         // for CDI proxy
     }
 
-    public BehandlingFormidlingDto lagDtoForFormidling(Behandling behandling) {
-        return lagDto(behandling);
-    }
-
     private Språkkode getSpråkkode(Behandling behandling) {
         if (!behandling.erYtelseBehandling()) {
             return behandlingRepository.finnSisteIkkeHenlagteYtelseBehandlingFor(behandling.getFagsakId())
@@ -133,7 +129,7 @@ public class BehandlingFormidlingDtoTjeneste {
         dto.setBehandlingsresultat(behandlingsresultatDto.orElse(null));
     }
 
-    private BehandlingFormidlingDto lagDto(Behandling behandling) {
+    public BehandlingFormidlingDto lagDtoForFormidling(Behandling behandling) {
         var dto = new BehandlingFormidlingDto();
         settStandardfelterForBrev(behandling, dto);
 

--- a/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/dto/behandling/BehandlingDtoForBackendTjenesteTest.java
+++ b/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/dto/behandling/BehandlingDtoForBackendTjenesteTest.java
@@ -1,4 +1,4 @@
-package no.nav.foreldrepenger.web.app.tjenester.behandling;
+package no.nav.foreldrepenger.web.app.tjenester.behandling.dto.behandling;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -30,7 +30,6 @@ import no.nav.foreldrepenger.behandlingslager.geografisk.Språkkode;
 import no.nav.foreldrepenger.dbstoette.EntityManagerAwareTest;
 import no.nav.foreldrepenger.domene.typer.AktørId;
 import no.nav.foreldrepenger.domene.typer.Saksnummer;
-import no.nav.foreldrepenger.web.app.tjenester.behandling.dto.behandling.BehandlingDtoForBackendTjeneste;
 
 class BehandlingDtoForBackendTjenesteTest extends EntityManagerAwareTest {
 

--- a/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/dto/behandling/BehandlingDtoForBackendTjenesteTest.java
+++ b/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/dto/behandling/BehandlingDtoForBackendTjenesteTest.java
@@ -109,7 +109,8 @@ class BehandlingDtoForBackendTjenesteTest extends EntityManagerAwareTest {
         lagBehandligVedtak(innsyn);
         avsluttBehandling(innsyn);
 
-        var utvidetBehandlingDto = behandlingDtoForBackendTjeneste.lagBehandlingDto(innsyn, null, Optional.of(new OrganisasjonsEnhet("9000", "Spesifikk")));
+        var utvidetBehandlingDto = behandlingDtoForBackendTjeneste.lagBehandlingDto(innsyn, null,
+            Optional.of(new OrganisasjonsEnhet("9000", "Spesifikk")));
 
         assertThat(utvidetBehandlingDto.getAnsvarligSaksbehandler()).isEqualTo(ANSVARLIG_SAKSBEHANDLER);
         assertThat(utvidetBehandlingDto.getBehandlingÅrsaker()).isNotEmpty();
@@ -119,6 +120,21 @@ class BehandlingDtoForBackendTjenesteTest extends EntityManagerAwareTest {
         assertThat(utvidetBehandlingDto.getLinks()).isNotEmpty();
     }
 
+    @Test
+    void alle_ressurslenker_skal_matche_annotert_restmetode() {
+        var behandlinger = BehandlingDtoLenkeTestUtils.lagOgLagreBehandlinger(repositoryProvider);
+
+        var routes = BehandlingDtoLenkeTestUtils.getRoutes();
+        for (var behandling : behandlinger) {
+            for (var dtoLink : behandlingDtoForBackendTjeneste.lagBehandlingDto(behandling, null, Optional.empty()).getLinks()) {
+                assertThat(dtoLink).isNotNull();
+                assertThat(routes.stream().anyMatch(route -> route.hasSameHttpMethod(dtoLink) && route.matchesUrlTemplate(dtoLink))).withFailMessage(
+                    "Route " + dtoLink + " does not exist.").isTrue();
+            }
+        }
+    }
+
+
     private Fagsak byggFagsak(AktørId aktørId, Saksnummer saksnummer) {
         var navBruker = NavBruker.opprettNyNB(aktørId);
         var fagsak = Fagsak.opprettNy(FagsakYtelseType.FORELDREPENGER, navBruker, RelasjonsRolleType.MORA, saksnummer);
@@ -127,13 +143,11 @@ class BehandlingDtoForBackendTjenesteTest extends EntityManagerAwareTest {
     }
 
     private SøknadEntitet lagSøknadMedNynorskSpråk() {
-        return new SøknadEntitet.Builder()
-            .medSøknadsdato(LocalDate.now())
+        return new SøknadEntitet.Builder().medSøknadsdato(LocalDate.now())
             .medMottattDato(LocalDate.now().minusWeeks(3))
             .medElektroniskRegistrert(true)
             .medSpråkkode(Språkkode.NN)
             .build();
-
     }
 
     private Behandling lagBehandling(Fagsak fagsak, BehandlingType behandlingType) {
@@ -142,9 +156,7 @@ class BehandlingDtoForBackendTjenesteTest extends EntityManagerAwareTest {
             .medBehandlendeEnhet(new OrganisasjonsEnhet("9999", "Generisk"))
             .medBehandlingÅrsak(BehandlingÅrsak.builder(BEHANDLING_ÅRSAK_TYPE))
             .build();
-        var behandlingsresultat = Behandlingsresultat.builder()
-            .medBehandlingResultatType(BEHANDLING_RESULTAT_TYPE)
-            .build();
+        var behandlingsresultat = Behandlingsresultat.builder().medBehandlingResultatType(BEHANDLING_RESULTAT_TYPE).build();
 
         behandling.setBehandlingresultat(behandlingsresultat);
         behandling.setAnsvarligSaksbehandler(ANSVARLIG_SAKSBEHANDLER);
@@ -156,12 +168,14 @@ class BehandlingDtoForBackendTjenesteTest extends EntityManagerAwareTest {
     }
 
     private void lagBehandligVedtak(Behandling behandling) {
-        var behandlingVedtak = BehandlingVedtak.builder().medVedtakResultatType(VedtakResultatType.INNVILGET)
+        var behandlingVedtak = BehandlingVedtak.builder()
+            .medVedtakResultatType(VedtakResultatType.INNVILGET)
             .medAnsvarligSaksbehandler(ANSVARLIG_SAKSBEHANDLER)
             .medBehandlingsresultat(behandling.getBehandlingsresultat())
             .medIverksettingStatus(IverksettingStatus.IVERKSATT)
             .medVedtakstidspunkt(now)
-            .medBeslutning(true).build();
+            .medBeslutning(true)
+            .build();
         var behandlingLås = behandlingRepository.taSkriveLås(behandling);
         repositoryProvider.getBehandlingVedtakRepository().lagre(behandlingVedtak, behandlingLås);
     }

--- a/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/dto/behandling/BehandlingDtoLenkeTestUtils.java
+++ b/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/dto/behandling/BehandlingDtoLenkeTestUtils.java
@@ -1,0 +1,162 @@
+package no.nav.foreldrepenger.web.app.tjenester.behandling.dto.behandling;
+
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.QueryParam;
+
+import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
+import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingType;
+import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingÅrsakType;
+import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepositoryProvider;
+import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.periode.OppgittFordelingEntitet;
+import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.periode.OppgittPeriodeBuilder;
+import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.periode.UttakPeriodeType;
+import no.nav.foreldrepenger.behandlingslager.testutilities.behandling.ScenarioMorSøkerEngangsstønad;
+import no.nav.foreldrepenger.behandlingslager.testutilities.behandling.ScenarioMorSøkerForeldrepenger;
+import no.nav.foreldrepenger.behandlingslager.testutilities.behandling.ScenarioMorSøkerSvangerskapspenger;
+import no.nav.foreldrepenger.web.app.rest.ResourceLink;
+import no.nav.foreldrepenger.web.app.rest.ResourceLinks;
+import no.nav.foreldrepenger.web.app.tjenester.RestImplementationClasses;
+
+import org.glassfish.jersey.uri.UriTemplate;
+
+import java.lang.reflect.InvocationTargetException;
+import java.time.LocalDate;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class BehandlingDtoLenkeTestUtils {
+    private static final LocalDate now = LocalDate.now();
+
+    static Set<Behandling> lagOgLagreBehandlinger(BehandlingRepositoryProvider repositoryProvider) {
+        var orginalFP = lagFPBehandling().medBehandlingType(BehandlingType.FØRSTEGANGSSØKNAD).lagre(repositoryProvider);
+        var orginalSVP = lagSVPBehandling().medBehandlingType(BehandlingType.FØRSTEGANGSSØKNAD).lagre(repositoryProvider);
+        var orginalES = lagESBehandling().medBehandlingType(BehandlingType.FØRSTEGANGSSØKNAD).lagre(repositoryProvider);
+
+        return Set.of(orginalFP,
+            lagFPBehandling().medBehandlingType(BehandlingType.REVURDERING).medOriginalBehandling(orginalFP, BehandlingÅrsakType.RE_ANNET).lagre(repositoryProvider),
+            lagFPBehandling().medBehandlingType(BehandlingType.KLAGE).medOriginalBehandling(orginalFP,BehandlingÅrsakType.KLAGE_TILBAKEBETALING).lagre(repositoryProvider),
+            lagFPBehandling().medBehandlingType(BehandlingType.ANKE).medOriginalBehandling(orginalFP, BehandlingÅrsakType.ETTER_KLAGE).lagre(repositoryProvider),
+            lagFPBehandling().medBehandlingType(BehandlingType.INNSYN).lagre(repositoryProvider),
+
+            orginalSVP,
+            lagSVPBehandling().medBehandlingType(BehandlingType.REVURDERING).medOriginalBehandling(orginalSVP, BehandlingÅrsakType.RE_ANNET).lagre(repositoryProvider),
+            lagSVPBehandling().medBehandlingType(BehandlingType.KLAGE).medOriginalBehandling(orginalSVP,BehandlingÅrsakType.KLAGE_TILBAKEBETALING).lagre(repositoryProvider),
+            lagSVPBehandling().medBehandlingType(BehandlingType.ANKE).medOriginalBehandling(orginalSVP, BehandlingÅrsakType.ETTER_KLAGE).lagre(repositoryProvider),
+            lagSVPBehandling().medBehandlingType(BehandlingType.INNSYN).lagre(repositoryProvider),
+
+            orginalES,
+            lagESBehandling().medBehandlingType(BehandlingType.REVURDERING).medOriginalBehandling(orginalES, BehandlingÅrsakType.RE_ANNET).lagre(repositoryProvider),
+            lagESBehandling().medBehandlingType(BehandlingType.KLAGE).medOriginalBehandling(orginalES,BehandlingÅrsakType.KLAGE_TILBAKEBETALING).lagre(repositoryProvider),
+            lagESBehandling().medBehandlingType(BehandlingType.ANKE).medOriginalBehandling(orginalES, BehandlingÅrsakType.ETTER_KLAGE).lagre(repositoryProvider),
+            lagESBehandling().medBehandlingType(BehandlingType.INNSYN).lagre(repositoryProvider)
+            );
+
+    }
+
+    static ScenarioMorSøkerEngangsstønad lagESBehandling() {
+        var scenario = ScenarioMorSøkerEngangsstønad.forFødsel();
+        scenario.medSøknadHendelse().erFødsel().build();
+        return scenario;
+    }
+
+    static ScenarioMorSøkerSvangerskapspenger lagSVPBehandling() {
+        return ScenarioMorSøkerSvangerskapspenger.forSvangerskapspenger();
+    }
+
+    static ScenarioMorSøkerForeldrepenger lagFPBehandling() {
+        return ScenarioMorSøkerForeldrepenger.forFødsel()
+            .medDefaultSøknadTerminbekreftelse()
+            .medDefaultBekreftetTerminbekreftelse()
+            .medFordeling(new OppgittFordelingEntitet(Collections.singletonList(
+                OppgittPeriodeBuilder.ny().medPeriodeType(UttakPeriodeType.FEDREKVOTE).medPeriode(now.plusWeeks(8), now.plusWeeks(12)).build()),
+                true));
+
+    }
+
+    static Collection<AnnotatedRoute> getRoutes() {
+        Set<AnnotatedRoute> routes = new HashSet<>();
+        var restClasses = RestImplementationClasses.getImplementationClasses();
+        for (var aClass : restClasses) {
+            var pathFromClass = getClassAnnotationValue(aClass, Path.class, "value");
+            var methods = aClass.getMethods();
+            for (var aMethod : methods) {
+                ResourceLink.HttpMethod method = null;
+                if (aMethod.getAnnotation(POST.class) != null) {
+                    method = ResourceLink.HttpMethod.POST;
+                }
+                if (aMethod.getAnnotation(GET.class) != null) {
+                    method = ResourceLink.HttpMethod.GET;
+                }
+                if (aMethod.getAnnotation(PUT.class) != null) {
+                    method = ResourceLink.HttpMethod.PUT;
+                }
+                if (aMethod.getAnnotation(DELETE.class) != null) {
+                    method = ResourceLink.HttpMethod.DELETE;
+                }
+                if (method != null) {
+                    var pathFromMethod = "";
+                    if (aMethod.getAnnotation(Path.class) != null) {
+                        pathFromMethod = aMethod.getAnnotation(Path.class).value();
+                    }
+
+                    List<String> queryParameters = Arrays.stream(aMethod.getParameters())
+                        .map(p -> p.getDeclaredAnnotation(QueryParam.class))
+                        .filter(Objects::nonNull)
+                        .map(QueryParam::value)
+                        .toList();
+
+                    var path = pathFromClass + pathFromMethod;
+                    routes.add(new AnnotatedRoute(method, path, queryParameters));
+                }
+            }
+        }
+        return routes;
+    }
+
+    public static String getClassAnnotationValue(Class<?> aClass, @SuppressWarnings("rawtypes") Class annotationClass, String name) {
+        @SuppressWarnings("unchecked") var aClassAnnotation = aClass.getAnnotation(annotationClass);
+        if (aClassAnnotation != null) {
+            var type = aClassAnnotation.annotationType();
+            for (var method : type.getDeclaredMethods()) {
+                try {
+                    var value = method.invoke(aClassAnnotation);
+                    if (method.getName().equals(name)) {
+                        return value.toString();
+                    }
+                } catch (InvocationTargetException | IllegalAccessException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        }
+        return null;
+    }
+
+    public record AnnotatedRoute(ResourceLink.HttpMethod method, String path, List<String> queryParameters) {
+        public String getUri() {
+            var q = queryParameters.isEmpty() ? null : queryParameters.stream().collect(Collectors.toMap(v -> v, v -> String.format("{%s}", v)));
+            return ResourceLinks.addPathPrefix(path) + ResourceLinks.toQuery(q);
+        }
+
+        public boolean hasSameHttpMethod(ResourceLink resource) {
+            return method().equals(resource.getType());
+        }
+
+        public boolean matchesUrlTemplate(ResourceLink resource) {
+            UriTemplate uriTemplate = new UriTemplate(getUri());
+            var extractedTemplateValues = new HashMap<String, String>();
+            return uriTemplate.match(resource.getHref().toString(), extractedTemplateValues) && extractedTemplateValues.keySet()
+                .containsAll(queryParameters());
+        }
+    }
+}

--- a/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/dto/behandling/BehandlingDtoTjenesteTest.java
+++ b/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/dto/behandling/BehandlingDtoTjenesteTest.java
@@ -1,4 +1,4 @@
-package no.nav.foreldrepenger.web.app.tjenester.behandling;
+package no.nav.foreldrepenger.web.app.tjenester.behandling.dto.behandling;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
@@ -59,8 +59,6 @@ import no.nav.foreldrepenger.skjæringstidspunkt.SkjæringstidspunktTjeneste;
 import no.nav.foreldrepenger.web.app.rest.ResourceLink;
 import no.nav.foreldrepenger.web.app.tjenester.RestImplementationClasses;
 import no.nav.foreldrepenger.web.app.tjenester.behandling.dto.UuidDto;
-import no.nav.foreldrepenger.web.app.tjenester.behandling.dto.behandling.BehandlingDtoTjeneste;
-import no.nav.foreldrepenger.web.app.tjenester.behandling.dto.behandling.UtvidetBehandlingDto;
 import no.nav.foreldrepenger.web.app.tjenester.behandling.tilbakekreving.TilbakekrevingRestTjeneste;
 import no.nav.foreldrepenger.web.app.tjenester.behandling.uttak.dokumentasjon.DokumentasjonVurderingBehovDtoTjeneste;
 import no.nav.foreldrepenger.web.app.tjenester.behandling.uttak.fakta.FaktaUttakPeriodeDtoTjeneste;

--- a/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/dto/behandling/BehandlingDtoTjenesteTest.java
+++ b/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/dto/behandling/BehandlingDtoTjenesteTest.java
@@ -3,52 +3,26 @@ package no.nav.foreldrepenger.web.app.tjenester.behandling.dto.behandling;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
-import java.lang.reflect.InvocationTargetException;
 import java.net.URI;
-import java.time.LocalDate;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Objects;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 import jakarta.inject.Inject;
-import jakarta.ws.rs.DELETE;
-import jakarta.ws.rs.GET;
-import jakarta.ws.rs.POST;
-import jakarta.ws.rs.PUT;
-import jakarta.ws.rs.Path;
-
-import jakarta.ws.rs.QueryParam;
 
 import no.nav.foreldrepenger.behandlingslager.behandling.verge.VergeRepository;
 
 import no.nav.foreldrepenger.web.app.rest.ResourceLinks;
 
-import org.glassfish.jersey.uri.UriTemplate;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import no.nav.foreldrepenger.behandling.DekningsgradTjeneste;
 import no.nav.foreldrepenger.behandling.FagsakRelasjonTjeneste;
-import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
-import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingType;
+
 import no.nav.foreldrepenger.behandlingslager.behandling.dokument.BehandlingDokumentRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepositoryProvider;
 import no.nav.foreldrepenger.behandlingslager.behandling.tilbakekreving.TilbakekrevingRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.tilbakekreving.TilbakekrevingValg;
 import no.nav.foreldrepenger.behandlingslager.behandling.tilbakekreving.TilbakekrevingVidereBehandling;
-import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.periode.OppgittFordelingEntitet;
-import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.periode.OppgittPeriodeBuilder;
-import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.periode.UttakPeriodeType;
-import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakYtelseType;
-import no.nav.foreldrepenger.behandlingslager.testutilities.behandling.ScenarioMorSøkerEngangsstønad;
-import no.nav.foreldrepenger.behandlingslager.testutilities.behandling.ScenarioMorSøkerForeldrepenger;
-import no.nav.foreldrepenger.behandlingslager.testutilities.behandling.ScenarioMorSøkerSvangerskapspenger;
 import no.nav.foreldrepenger.dbstoette.CdiDbAwareTest;
 import no.nav.foreldrepenger.domene.prosess.BeregningTjeneste;
 import no.nav.foreldrepenger.domene.uttak.ForeldrepengerUttakTjeneste;
@@ -57,7 +31,6 @@ import no.nav.foreldrepenger.domene.uttak.beregnkontoer.UtregnetStønadskontoTje
 import no.nav.foreldrepenger.domene.vedtak.TotrinnTjeneste;
 import no.nav.foreldrepenger.skjæringstidspunkt.SkjæringstidspunktTjeneste;
 import no.nav.foreldrepenger.web.app.rest.ResourceLink;
-import no.nav.foreldrepenger.web.app.tjenester.RestImplementationClasses;
 import no.nav.foreldrepenger.web.app.tjenester.behandling.dto.UuidDto;
 import no.nav.foreldrepenger.web.app.tjenester.behandling.tilbakekreving.TilbakekrevingRestTjeneste;
 import no.nav.foreldrepenger.web.app.tjenester.behandling.uttak.dokumentasjon.DokumentasjonVurderingBehovDtoTjeneste;
@@ -104,8 +77,6 @@ class BehandlingDtoTjenesteTest {
 
     private BehandlingDtoTjeneste tjeneste;
 
-    private final LocalDate now = LocalDate.now();
-
     @BeforeEach
     public void setUp() {
         tjeneste = new BehandlingDtoTjeneste(repositoryProvider, beregningTjeneste, uttakTjeneste, tilbakekrevingRepository,
@@ -116,7 +87,7 @@ class BehandlingDtoTjenesteTest {
 
     @Test
     void skal_ha_med_tilbakekrevings_link_når_det_finnes_et_resultat() {
-        var behandling = lagBehandling();
+        var behandling = BehandlingDtoLenkeTestUtils.lagFPBehandling().lagre(repositoryProvider);
 
         tilbakekrevingRepository.lagre(behandling,
             TilbakekrevingValg.utenMulighetForInntrekk(TilbakekrevingVidereBehandling.OPPRETT_TILBAKEKREVING, "varsel"));
@@ -130,7 +101,7 @@ class BehandlingDtoTjenesteTest {
 
     @Test
     void skal_ikke_ha_med_tilbakekrevings_link_når_det_ikke_finnes_et_resultat() {
-        var behandling = lagBehandling();
+        var behandling = BehandlingDtoLenkeTestUtils.lagFPBehandling().lagre(repositoryProvider);
 
         var dto = tjeneste.lagUtvidetBehandlingDto(behandling, null);
         var link = ResourceLinks.get(TilbakekrevingRestTjeneste.VALG_PATH, "", new UuidDto(dto.getUuid()));
@@ -139,16 +110,10 @@ class BehandlingDtoTjenesteTest {
     }
 
     @Test
-    void alle_paths_skal_eksistere() {
-        Set<Behandling> behandlinger = new HashSet<>();
-        behandlinger.add(lagBehandling());
-        behandlinger.add(lagBehandling(BehandlingType.KLAGE));
-        behandlinger.add(lagBehandling(BehandlingType.ANKE));
-        behandlinger.add(lagBehandling(BehandlingType.INNSYN));
-        behandlinger.add(lagBehandling(FagsakYtelseType.ENGANGSTØNAD));
-        behandlinger.add(lagBehandling(FagsakYtelseType.SVANGERSKAPSPENGER));
+    void alle_ressurslenker_skal_matche_annotert_restmetode() {
+        var behandlinger = BehandlingDtoLenkeTestUtils.lagOgLagreBehandlinger(repositoryProvider);
 
-        var routes = getRoutes();
+        var routes = BehandlingDtoLenkeTestUtils.getRoutes();
         for (var behandling : behandlinger) {
             for (var dtoLink : tjeneste.lagUtvidetBehandlingDto(behandling, null).getLinks()) {
                 assertThat(dtoLink).isNotNull();
@@ -158,122 +123,11 @@ class BehandlingDtoTjenesteTest {
         }
     }
 
-
-    private Behandling lagBehandling() {
-        return ScenarioMorSøkerForeldrepenger.forFødsel()
-                .medDefaultSøknadTerminbekreftelse()
-                .medDefaultBekreftetTerminbekreftelse()
-                .medFordeling(new OppgittFordelingEntitet(Collections.singletonList(OppgittPeriodeBuilder.ny()
-                        .medPeriodeType(UttakPeriodeType.FEDREKVOTE)
-                        .medPeriode(now.plusWeeks(8), now.plusWeeks(12))
-                        .build()), true))
-                .lagre(repositoryProvider);
-    }
-
-    private Behandling lagBehandling(BehandlingType behandlingType) {
-        return ScenarioMorSøkerForeldrepenger.forFødsel()
-                .medDefaultSøknadTerminbekreftelse()
-                .medDefaultBekreftetTerminbekreftelse()
-                .medFordeling(new OppgittFordelingEntitet(Collections.singletonList(OppgittPeriodeBuilder.ny()
-                        .medPeriodeType(UttakPeriodeType.FEDREKVOTE)
-                        .medPeriode(now.plusWeeks(8), now.plusWeeks(12))
-                        .build()), true))
-                .medBehandlingType(behandlingType)
-                .lagre(repositoryProvider);
-    }
-
-    private Behandling lagBehandling(FagsakYtelseType fagsakYtelseType) {
-        if (fagsakYtelseType.equals(FagsakYtelseType.SVANGERSKAPSPENGER)) {
-            return ScenarioMorSøkerSvangerskapspenger.forSvangerskapspenger().lagre(repositoryProvider);
-        }
-        if (fagsakYtelseType.equals(FagsakYtelseType.ENGANGSTØNAD)) {
-            var scenario = ScenarioMorSøkerEngangsstønad.forFødsel();
-            scenario.medSøknadHendelse().erFødsel().build();
-            return scenario.lagre(repositoryProvider);
-        }
-        return null;
-    }
-
     private List<URI> getLinkHref(UtvidetBehandlingDto dto) {
         return dto.getLinks().stream().map(ResourceLink::getHref).toList();
     }
 
     private List<String> getLinkRel(UtvidetBehandlingDto dto) {
         return dto.getLinks().stream().map(ResourceLink::getRel).toList();
-    }
-
-    public Collection<AnnotatedRoute> getRoutes() {
-        Set<AnnotatedRoute> routes = new HashSet<>();
-        var restClasses = RestImplementationClasses.getImplementationClasses();
-        for (var aClass : restClasses) {
-            var pathFromClass = getClassAnnotationValue(aClass, Path.class, "value");
-            var methods = aClass.getMethods();
-            for (var aMethod : methods) {
-                ResourceLink.HttpMethod method = null;
-                if (aMethod.getAnnotation(POST.class) != null) {
-                    method = ResourceLink.HttpMethod.POST;
-                }
-                if (aMethod.getAnnotation(GET.class) != null) {
-                    method = ResourceLink.HttpMethod.GET;
-                }
-                if (aMethod.getAnnotation(PUT.class) != null) {
-                    method = ResourceLink.HttpMethod.PUT;
-                }
-                if (aMethod.getAnnotation(DELETE.class) != null) {
-                    method = ResourceLink.HttpMethod.DELETE;
-                }
-                if (method != null) {
-                    var pathFromMethod = "";
-                    if (aMethod.getAnnotation(Path.class) != null) {
-                        pathFromMethod = aMethod.getAnnotation(Path.class).value();
-                    }
-
-                    List<String> queryParameters = Arrays.stream(aMethod.getParameters())
-                        .map(p -> p.getDeclaredAnnotation(QueryParam.class))
-                        .filter(Objects::nonNull)
-                        .map(QueryParam::value)
-                        .toList();
-
-                    var path = pathFromClass + pathFromMethod;
-                    routes.add(new AnnotatedRoute(method, path, queryParameters));
-                }
-            }
-        }
-        return routes;
-    }
-
-    public static String getClassAnnotationValue(Class<?> aClass, @SuppressWarnings("rawtypes") Class annotationClass, String name) {
-        @SuppressWarnings("unchecked") var aClassAnnotation = aClass.getAnnotation(annotationClass);
-        if (aClassAnnotation != null) {
-            var type = aClassAnnotation.annotationType();
-            for (var method : type.getDeclaredMethods()) {
-                try {
-                    var value = method.invoke(aClassAnnotation);
-                    if (method.getName().equals(name)) {
-                        return value.toString();
-                    }
-                } catch (InvocationTargetException | IllegalAccessException e) {
-                    throw new RuntimeException(e);
-                }
-            }
-        }
-        return null;
-    }
-
-    public record AnnotatedRoute(ResourceLink.HttpMethod method, String path, List<String> queryParameters) {
-        public String getUri() {
-            var q = queryParameters.isEmpty() ? null : queryParameters.stream().collect(Collectors.toMap(v -> v, v -> String.format("{%s}", v)));
-            return ResourceLinks.addPathPrefix(path) + ResourceLinks.toQuery(q);
-        }
-
-        public boolean hasSameHttpMethod(ResourceLink resource) {
-            return method().equals(resource.getType());
-        }
-
-        public boolean matchesUrlTemplate(ResourceLink resource) {
-            UriTemplate uriTemplate = new UriTemplate(getUri());
-            var extractedTemplateValues = new HashMap<String, String>();
-            return uriTemplate.match(resource.getHref().toString(), extractedTemplateValues) && extractedTemplateValues.keySet().containsAll(queryParameters());
-        }
     }
 }

--- a/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/dto/behandling/BehandlingFormidlingDtoTjenesteTest.java
+++ b/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/dto/behandling/BehandlingFormidlingDtoTjenesteTest.java
@@ -1,0 +1,81 @@
+package no.nav.foreldrepenger.web.app.tjenester.behandling.dto.behandling;
+
+import jakarta.inject.Inject;
+
+import no.nav.foreldrepenger.behandling.DekningsgradTjeneste;
+import no.nav.foreldrepenger.behandling.RelatertBehandlingTjeneste;
+import no.nav.foreldrepenger.behandlingslager.behandling.dokument.BehandlingDokumentRepository;
+import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepositoryProvider;
+import no.nav.foreldrepenger.behandlingslager.behandling.verge.VergeRepository;
+import no.nav.foreldrepenger.dbstoette.CdiDbAwareTest;
+import no.nav.foreldrepenger.domene.medlem.MedlemTjeneste;
+import no.nav.foreldrepenger.domene.prosess.BeregningTjeneste;
+import no.nav.foreldrepenger.domene.uttak.UttakTjeneste;
+import no.nav.foreldrepenger.domene.uttak.beregnkontoer.UtregnetStønadskontoTjeneste;
+import no.nav.foreldrepenger.skjæringstidspunkt.SkjæringstidspunktTjeneste;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+@CdiDbAwareTest
+class BehandlingFormidlingDtoTjenesteTest {
+
+    @Inject
+    private BehandlingRepositoryProvider repositoryProvider;
+
+    @Inject
+    private BeregningTjeneste beregningTjeneste;
+
+    @Inject
+    private SkjæringstidspunktTjeneste skjæringstidspunktTjeneste;
+
+    @Inject
+    private BehandlingDokumentRepository behandlingDokumentRepository;
+
+    @Inject
+    private RelatertBehandlingTjeneste relatertBehandlingTjeneste;
+
+    @Inject
+    private DekningsgradTjeneste dekningsgradTjeneste;
+
+    @Inject
+    private UttakTjeneste uttakTjeneste;
+
+    @Inject
+    private UtregnetStønadskontoTjeneste utregnetStønadskontoTjeneste;
+
+    @Inject
+    private MedlemTjeneste medlemTjeneste;
+
+    @Inject
+    private VergeRepository vergeRepository;
+
+    private BehandlingFormidlingDtoTjeneste tjeneste;
+
+    @BeforeEach
+    public void setUp() {
+        tjeneste = new BehandlingFormidlingDtoTjeneste(repositoryProvider, beregningTjeneste, skjæringstidspunktTjeneste,
+            behandlingDokumentRepository, relatertBehandlingTjeneste, uttakTjeneste, dekningsgradTjeneste, utregnetStønadskontoTjeneste,
+            medlemTjeneste, vergeRepository);
+    }
+
+
+    @Test
+    void alle_ressurslenker_skal_matche_annotert_restmetode() {
+        var behandlinger = BehandlingDtoLenkeTestUtils.lagOgLagreBehandlinger(repositoryProvider);
+
+        var routes = BehandlingDtoLenkeTestUtils.getRoutes();
+        for (var behandling : behandlinger) {
+            for (var dtoLink : tjeneste.lagDtoForFormidling(behandling).getLinks()) {
+                assertThat(dtoLink).isNotNull();
+                assertThat(routes.stream().anyMatch(route -> route.hasSameHttpMethod(dtoLink) && route.matchesUrlTemplate(dtoLink))).withFailMessage(
+                    "Route " + dtoLink + " does not exist.").isTrue();
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
Vi har tre behandlingsDtoer som brukes til å sende ressurslenker til ulike tjenester: BehandlingDto(web), BehandlingFormidlingDto (formidling), og UtvidetBehandlingDto (andre backendtjenester). 

For å standarisere måten vi tester at alle ressurslenkene vi lager i `BehandlingDtoTjeneste`, `BehandlingFormidlingDtoTjeneste` og `BehandlingDtoForBackendTjeneste` er definert riktig i forhold til den  annoterte metoden i rest-tjenesten så har jeg samlet denne logikken i `BehandlingDtoLenkeTestUtils`