### PR TITLE
TFP-5957: rydding i vergetjenester

### DIFF
--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/dto/behandling/BehandlingDtoForBackendTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/dto/behandling/BehandlingDtoForBackendTjeneste.java
@@ -23,6 +23,7 @@ import no.nav.foreldrepenger.web.app.tjenester.behandling.oppdrag.OppdragRestTje
 import no.nav.foreldrepenger.web.app.tjenester.behandling.personopplysning.PersonRestTjeneste;
 import no.nav.foreldrepenger.web.app.tjenester.behandling.søknad.SøknadRestTjeneste;
 import no.nav.foreldrepenger.web.app.tjenester.behandling.tilbakekreving.TilbakekrevingRestTjeneste;
+import no.nav.foreldrepenger.web.app.tjenester.behandling.verge.VergeRestTjeneste;
 import no.nav.foreldrepenger.web.app.tjenester.fagsak.FagsakRestTjeneste;
 import no.nav.foreldrepenger.web.app.tjenester.fagsak.dto.SaksnummerDto;
 
@@ -79,7 +80,7 @@ public class BehandlingDtoForBackendTjeneste {
         var uuidDto = new UuidDto(behandling.getUuid());
 
         dto.leggTil(get(FagsakRestTjeneste.FAGSAK_PATH, "fagsak", new SaksnummerDto(behandling.getSaksnummer())));
-        dto.leggTil(get(PersonRestTjeneste.VERGE_BACKEND_PATH, "verge-backend", uuidDto));
+        dto.leggTil(get(VergeRestTjeneste.VERGE_BACKEND_PATH, "verge-backend", uuidDto));
         dto.leggTil(get(PersonRestTjeneste.PERSONOPPLYSNINGER_TILBAKE_PATH, "personopplysninger-tilbake", uuidDto));
         dto.leggTil(get(SøknadRestTjeneste.SOKNAD_BACKEND_PATH, "soknad-backend", uuidDto));
         dto.leggTil(get(TilbakekrevingRestTjeneste.VARSELTEKST_PATH, "tilbakekrevingsvarsel-fritekst", uuidDto));

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/dto/behandling/BehandlingDtoTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/dto/behandling/BehandlingDtoTjeneste.java
@@ -269,9 +269,6 @@ public class BehandlingDtoTjeneste {
             dto.leggTil(post(VergeRestTjeneste.VERGE_OPPRETT_PATH, "verge-opprett", new NyVergeDto(), uuidDto));
         }
 
-        dto.leggTil(post(VergeRestTjeneste.VERGE_OPPRETT_PATH_DEPRECATED, "opprett-verge", new BehandlingIdVersjonDto()));
-        dto.leggTil(post(VergeRestTjeneste.VERGE_FJERN_PATH_DEPRECATED, "fjern-verge", new BehandlingIdVersjonDto()));
-
         if (behandling.erYtelseBehandling()) {
             dto.leggTil(post(BehandlingRestTjeneste.OPNE_FOR_ENDRINGER_PATH, "opne-for-endringer", new ReåpneBehandlingDto()));
             dto.leggTil(
@@ -539,7 +536,7 @@ public class BehandlingDtoTjeneste {
     private void leggTilVergeHvisFinnes(Behandling behandling, UtvidetBehandlingDto dto, UuidDto uuidDto) {
         var vergeFinnes = vergeRepository.hentAggregat(behandling.getId()).isPresent();
         if (behandling.harÅpentAksjonspunktMedType(AksjonspunktDefinisjon.AVKLAR_VERGE) || vergeFinnes) {
-            dto.leggTil(get(PersonRestTjeneste.VERGE_PATH, "soeker-verge", uuidDto));
+            dto.leggTil(get(VergeRestTjeneste.BASE_PATH, "soeker-verge", uuidDto));
         }
     }
 }

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/dto/behandling/BehandlingFormidlingDtoTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/dto/behandling/BehandlingFormidlingDtoTjeneste.java
@@ -42,9 +42,9 @@ import no.nav.foreldrepenger.web.app.tjenester.behandling.beregningsresultat.Ber
 import no.nav.foreldrepenger.web.app.tjenester.behandling.dto.UuidDto;
 import no.nav.foreldrepenger.web.app.tjenester.behandling.innsyn.InnsynRestTjeneste;
 import no.nav.foreldrepenger.web.app.tjenester.behandling.klage.KlageRestTjeneste;
-import no.nav.foreldrepenger.web.app.tjenester.behandling.personopplysning.PersonRestTjeneste;
 import no.nav.foreldrepenger.web.app.tjenester.behandling.søknad.SøknadRestTjeneste;
 import no.nav.foreldrepenger.web.app.tjenester.behandling.uttak.UttakRestTjeneste;
+import no.nav.foreldrepenger.web.app.tjenester.behandling.verge.VergeRestTjeneste;
 import no.nav.foreldrepenger.web.app.tjenester.behandling.ytelsefordeling.YtelsefordelingRestTjeneste;
 import no.nav.foreldrepenger.web.app.tjenester.brev.BrevRestTjeneste;
 import no.nav.foreldrepenger.web.app.tjenester.dokument.DokumentRestTjeneste;
@@ -299,7 +299,7 @@ public class BehandlingFormidlingDtoTjeneste {
 
     private void leggTilVergeHvisFinnes(BehandlingFormidlingDto dto, Behandling behandling, UuidDto uuidDto) {
         vergeRepository.hentAggregat(behandling.getId())
-            .ifPresent(v -> dto.leggTil(get(PersonRestTjeneste.VERGE_BACKEND_PATH, "verge-backend", uuidDto)));
+            .ifPresent(v -> dto.leggTil(get(VergeRestTjeneste.VERGE_BACKEND_PATH, "verge-backend", uuidDto)));
     }
 
     private Behandlingsresultat getBehandlingsresultat(Long behandlingId) {

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/personopplysning/PersonRestTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/personopplysning/PersonRestTjeneste.java
@@ -21,7 +21,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import no.nav.foreldrepenger.behandlingslager.behandling.verge.VergeRepository;
 import no.nav.foreldrepenger.domene.person.verge.VergeDtoTjeneste;
 import no.nav.foreldrepenger.domene.person.verge.dto.VergeBackendDto;
-import no.nav.foreldrepenger.domene.person.verge.dto.VergeDto;
 import no.nav.foreldrepenger.web.app.tjenester.behandling.aksjonspunkt.BehandlingsprosessTjeneste;
 import no.nav.foreldrepenger.web.app.tjenester.behandling.dto.BehandlingAbacSuppliers;
 import no.nav.foreldrepenger.web.app.tjenester.behandling.dto.UuidDto;
@@ -39,8 +38,6 @@ import no.nav.vedtak.sikkerhet.abac.beskyttet.ResourceType;
 public class PersonRestTjeneste {
 
     static final String BASE_PATH = "/behandling";
-    private static final String VERGE_PART_PATH = "/person/verge";
-    public static final String VERGE_PATH = BASE_PATH + VERGE_PART_PATH;
     private static final String VERGE_BACKEND_PART_PATH = "/person/verge-backend";
     public static final String VERGE_BACKEND_PATH = BASE_PATH + VERGE_BACKEND_PART_PATH;
     private static final String MEDLEMSKAP_V3_PART_PATH = "/person/medlemskap-v3";
@@ -74,20 +71,6 @@ public class PersonRestTjeneste {
         this.personopplysningDtoTjeneste = personopplysningTjeneste;
         this.personopplysningFnrFinder = personopplysningFnrFinder;
         this.behandlingsprosessTjeneste = behandlingsprosessTjeneste;
-    }
-
-    @GET
-    @Path(VERGE_PART_PATH)
-    @Operation(description = "Returnerer informasjon om verge knyttet til søker for denne behandlingen", tags = "behandling - person", responses = {
-            @ApiResponse(responseCode = "200", description = "Returnerer Verge, null hvis ikke eksisterer (GUI støtter ikke NOT_FOUND p.t.)", content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = VergeDto.class)))
-    })
-    @BeskyttetRessurs(actionType = ActionType.READ, resourceType = ResourceType.FAGSAK, sporingslogg = false)
-    public VergeDto getVerge(@TilpassetAbacAttributt(supplierClass = BehandlingAbacSuppliers.UuidAbacDataSupplier.class)
-        @NotNull @QueryParam(UuidDto.NAME) @Parameter(description = UuidDto.DESC) @Valid UuidDto uuidDto) {
-        var behandlingId = getBehandlingsId(uuidDto.getBehandlingUuid());
-        var vergeDto = vergeRepository.hentAggregat(behandlingId).flatMap(vergeDtoTjenesteImpl::lagVergeDto);
-
-        return vergeDto.orElse(null);
     }
 
     @GET

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/personopplysning/PersonRestTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/personopplysning/PersonRestTjeneste.java
@@ -38,8 +38,6 @@ import no.nav.vedtak.sikkerhet.abac.beskyttet.ResourceType;
 public class PersonRestTjeneste {
 
     static final String BASE_PATH = "/behandling";
-    private static final String VERGE_BACKEND_PART_PATH = "/person/verge-backend";
-    public static final String VERGE_BACKEND_PATH = BASE_PATH + VERGE_BACKEND_PART_PATH;
     private static final String MEDLEMSKAP_V3_PART_PATH = "/person/medlemskap-v3";
     public static final String MEDLEMSKAP_V3_PATH = BASE_PATH + MEDLEMSKAP_V3_PART_PATH;
     private static final String PERSONOVERSIKT_PART_PATH = "/person/personoversikt";
@@ -47,8 +45,6 @@ public class PersonRestTjeneste {
     private static final String PERSONOPPLYSNINGER_TILBAKE_PART_PATH = "/person/personopplysninger-tilbake";
     public static final String PERSONOPPLYSNINGER_TILBAKE_PATH = BASE_PATH + PERSONOPPLYSNINGER_TILBAKE_PART_PATH;
 
-    private VergeRepository vergeRepository;
-    private VergeDtoTjeneste vergeDtoTjenesteImpl;
     private MedlemDtoTjeneste medlemDtoTjeneste;
     private PersonopplysningDtoPersonIdentTjeneste personopplysningFnrFinder;
     private PersonopplysningDtoTjeneste personopplysningDtoTjeneste;
@@ -59,30 +55,15 @@ public class PersonRestTjeneste {
     }
 
     @Inject
-    public PersonRestTjeneste(VergeRepository vergeRepository,
-            VergeDtoTjeneste vergeTjeneste,
+    public PersonRestTjeneste(
             MedlemDtoTjeneste medlemTjeneste,
             PersonopplysningDtoTjeneste personopplysningTjeneste,
             PersonopplysningDtoPersonIdentTjeneste personopplysningFnrFinder,
             BehandlingsprosessTjeneste behandlingsprosessTjeneste) {
-        this.vergeRepository = vergeRepository;
         this.medlemDtoTjeneste = medlemTjeneste;
-        this.vergeDtoTjenesteImpl = vergeTjeneste;
         this.personopplysningDtoTjeneste = personopplysningTjeneste;
         this.personopplysningFnrFinder = personopplysningFnrFinder;
         this.behandlingsprosessTjeneste = behandlingsprosessTjeneste;
-    }
-
-    @GET
-    @Path(VERGE_BACKEND_PART_PATH)
-    @Operation(description = "Returnerer informasjon om verge knyttet til søker for denne behandlingen for bruk backend", tags = "behandling - person", responses = {
-        @ApiResponse(responseCode = "200", description = "Returnerer Verge, null hvis ikke eksisterer (GUI støtter ikke NOT_FOUND p.t.)", content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = VergeBackendDto.class)))
-    })
-    @BeskyttetRessurs(actionType = ActionType.READ, resourceType = ResourceType.FAGSAK, sporingslogg = false)
-    public VergeBackendDto getVergeBackend(@TilpassetAbacAttributt(supplierClass = BehandlingAbacSuppliers.UuidAbacDataSupplier.class)
-        @NotNull @QueryParam(UuidDto.NAME) @Parameter(description = UuidDto.DESC) @Valid UuidDto uuidDto) {
-        var behandlingId = getBehandlingsId(uuidDto.getBehandlingUuid());
-        return vergeRepository.hentAggregat(behandlingId).flatMap(vergeDtoTjenesteImpl::lagVergeBackendDto).orElse(null);
     }
 
     @GET

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/verge/VergeRestTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/verge/VergeRestTjeneste.java
@@ -1,9 +1,13 @@
 package no.nav.foreldrepenger.web.app.tjenester.behandling.verge;
 
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.POST;
@@ -18,6 +22,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.headers.Header;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import no.nav.foreldrepenger.domene.person.verge.dto.VergeBackendDto;
 import no.nav.foreldrepenger.domene.person.verge.dto.VergeDto;
 import no.nav.foreldrepenger.web.app.tjenester.behandling.aksjonspunkt.BehandlingsprosessTjeneste;
 import no.nav.foreldrepenger.web.app.tjenester.behandling.dto.BehandlingAbacSuppliers;
@@ -35,6 +40,8 @@ import no.nav.vedtak.sikkerhet.abac.beskyttet.ResourceType;
 public class VergeRestTjeneste {
 
     public static final String BASE_PATH = "/verge";
+    private static final String VERGE_BACKEND_PART_PATH = "/backend";
+    public static final String VERGE_BACKEND_PATH = BASE_PATH + VERGE_BACKEND_PART_PATH;
 
     private static final String VERGE_FJERN_PART_PATH = "/fjern";
     public static final String VERGE_FJERN_PATH = BASE_PATH + VERGE_FJERN_PART_PATH;
@@ -62,6 +69,18 @@ public class VergeRestTjeneste {
     public VergeDto hentVerge(@TilpassetAbacAttributt(supplierClass = BehandlingAbacSuppliers.UuidAbacDataSupplier.class) @QueryParam(UuidDto.NAME) @Parameter(description = "Behandling uuid") @Valid UuidDto queryParam) {
         var behandling = behandlingsprosessTjeneste.hentBehandling(queryParam.getBehandlingUuid());
         return vergeTjeneste.hentVerge(behandling);
+    }
+
+    @GET
+    @Path(VERGE_BACKEND_PART_PATH)
+    @Operation(description = "Henter verge/fullmektig på behandlingen for bruk backend", tags = "verge", responses = {
+        @ApiResponse(responseCode = "200", description = "Verge hvis eksisterer ellers null", content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = VergeBackendDto.class)))
+    })
+    @BeskyttetRessurs(actionType = ActionType.READ, resourceType = ResourceType.FAGSAK, sporingslogg = false)
+    public VergeBackendDto getVergeBackend(@TilpassetAbacAttributt(supplierClass = BehandlingAbacSuppliers.UuidAbacDataSupplier.class)
+                                           @NotNull @QueryParam(UuidDto.NAME) @Parameter(description = UuidDto.DESC) @Valid UuidDto queryParam) {
+        var behandling = behandlingsprosessTjeneste.hentBehandling(queryParam.getBehandlingUuid());
+        return vergeTjeneste.hentVergeForBackend(behandling);
     }
 
     @POST

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/verge/VergeRestTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/verge/VergeRestTjeneste.java
@@ -1,10 +1,7 @@
 package no.nav.foreldrepenger.web.app.tjenester.behandling.verge;
 
-import java.net.URISyntaxException;
-
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
-import jakarta.servlet.http.HttpServletRequest;
 import jakarta.transaction.Transactional;
 import jakarta.validation.Valid;
 import jakarta.ws.rs.Consumes;
@@ -13,7 +10,6 @@ import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.QueryParam;
-import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
@@ -22,13 +18,9 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.headers.Header;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
 import no.nav.foreldrepenger.domene.person.verge.dto.VergeDto;
 import no.nav.foreldrepenger.web.app.tjenester.behandling.aksjonspunkt.BehandlingsprosessTjeneste;
-import no.nav.foreldrepenger.web.app.tjenester.behandling.aksjonspunkt.BehandlingsutredningTjeneste;
 import no.nav.foreldrepenger.web.app.tjenester.behandling.dto.BehandlingAbacSuppliers;
-import no.nav.foreldrepenger.web.app.tjenester.behandling.dto.BehandlingIdVersjonDto;
-import no.nav.foreldrepenger.web.app.tjenester.behandling.dto.Redirect;
 import no.nav.foreldrepenger.web.app.tjenester.behandling.dto.UuidDto;
 import no.nav.foreldrepenger.web.app.tjenester.behandling.verge.dto.NyVergeDto;
 import no.nav.vedtak.sikkerhet.abac.BeskyttetRessurs;
@@ -44,19 +36,13 @@ public class VergeRestTjeneste {
 
     public static final String BASE_PATH = "/verge";
 
-    private static final String VERGE_FJERN_PART_PATH = "/fjern-verge";
+    private static final String VERGE_FJERN_PART_PATH = "/fjern";
     public static final String VERGE_FJERN_PATH = BASE_PATH + VERGE_FJERN_PART_PATH;
 
-    private static final String VERGE_OPPRETT_PART_PATH = "/opprett-verge";
+    private static final String VERGE_OPPRETT_PART_PATH = "/opprett";
     public static final String VERGE_OPPRETT_PATH = BASE_PATH + VERGE_OPPRETT_PART_PATH;
 
-    private static final String VERGE_OPPRETT_PART_PATH_DEPRECATED = "/opprett";
-    public static final String VERGE_OPPRETT_PATH_DEPRECATED = BASE_PATH + VERGE_OPPRETT_PART_PATH_DEPRECATED;
-    private static final String VERGE_FJERN_PART_PATH_DEPRECATED = "/fjern";
-    public static final String VERGE_FJERN_PATH_DEPRECATED = BASE_PATH + VERGE_FJERN_PART_PATH_DEPRECATED;
-
     private BehandlingsprosessTjeneste behandlingsprosessTjeneste;
-    private BehandlingsutredningTjeneste behandlingsutredningTjeneste;
     private VergeTjeneste vergeTjeneste;
 
     public VergeRestTjeneste() {
@@ -65,10 +51,8 @@ public class VergeRestTjeneste {
 
     @Inject
     public VergeRestTjeneste(BehandlingsprosessTjeneste behandlingsprosessTjeneste,
-                             BehandlingsutredningTjeneste behandlingsutredningTjeneste,
                              VergeTjeneste vergeTjeneste) {
         this.behandlingsprosessTjeneste = behandlingsprosessTjeneste;
-        this.behandlingsutredningTjeneste = behandlingsutredningTjeneste;
         this.vergeTjeneste = vergeTjeneste;
     }
 
@@ -104,56 +88,5 @@ public class VergeRestTjeneste {
         vergeTjeneste.fjernVerge(behandling);
 
         return Response.ok().build();
-    }
-
-
-    @Deprecated(forRemoval = true)
-    @POST
-    @Path(VERGE_OPPRETT_PART_PATH_DEPRECATED)
-    @Consumes(MediaType.APPLICATION_JSON)
-    @Operation(description = "Oppretter aksjonspunkt for verge/fullmektig på behandlingen", tags = "verge", responses = {
-        @ApiResponse(responseCode = "200", description = "Aksjonspunkt for verge/fullmektig opprettes", headers = @Header(name = HttpHeaders.LOCATION))
-    })
-    @BeskyttetRessurs(actionType = ActionType.UPDATE, resourceType = ResourceType.FAGSAK, sporingslogg = true)
-    public Response opprettVerge(@Context HttpServletRequest request,
-                                 @TilpassetAbacAttributt(supplierClass = BehandlingAbacSuppliers.BehandlingIdAbacDataSupplier.class)
-         @Parameter(description = "Behandling som skal få verge/fullmektig") @Valid BehandlingIdVersjonDto dto) throws URISyntaxException {
-        var behandling = getBehandling(dto);
-        var behandlingVersjon = dto.getBehandlingVersjon();
-
-        // Precondition - sjekk behandling versjon/lås
-        behandlingsutredningTjeneste.kanEndreBehandling(behandling, behandlingVersjon);
-
-        vergeTjeneste.opprettVergeAksjonspunktOgHoppTilbakeTilFORVEDSTEGHvisSenereSteg(behandling);
-
-        behandling = behandlingsprosessTjeneste.hentBehandling(behandling.getUuid());
-        return Redirect.tilBehandlingPollStatus(request, behandling.getUuid());
-    }
-
-    @Deprecated(forRemoval = true)
-    @POST
-    @Path(VERGE_FJERN_PART_PATH_DEPRECATED)
-    @Consumes(MediaType.APPLICATION_JSON)
-    @Operation(description = "Fjerner aksjonspunkt og evt. registrert informasjon om verge/fullmektig fra behandlingen", tags = "verge", responses = {
-        @ApiResponse(responseCode = "200", description = "Fjerning av verge/fullmektig er gjennomført", headers = @Header(name = HttpHeaders.LOCATION))
-    })
-    @BeskyttetRessurs(actionType = ActionType.UPDATE, resourceType = ResourceType.FAGSAK, sporingslogg = true)
-    public Response fjernVerge(@Context HttpServletRequest request,
-                               @TilpassetAbacAttributt(supplierClass = BehandlingAbacSuppliers.BehandlingIdAbacDataSupplier.class)
-        @Parameter(description = "Behandling som skal få fjernet verge/fullmektig") @Valid BehandlingIdVersjonDto dto) throws URISyntaxException {
-        var behandling = getBehandling(dto);
-        var behandlingVersjon = dto.getBehandlingVersjon();
-
-        // Precondition - sjekk behandling versjon/lås
-        behandlingsutredningTjeneste.kanEndreBehandling(behandling, behandlingVersjon);
-
-        vergeTjeneste.fjernVergeGrunnlagOgAksjonspunkt(behandling);
-
-        behandling = behandlingsprosessTjeneste.hentBehandling(behandling.getUuid());
-        return Redirect.tilBehandlingPollStatus(request, behandling.getUuid());
-    }
-
-    private Behandling getBehandling(BehandlingIdVersjonDto behandlingIdDto) {
-        return behandlingsprosessTjeneste.hentBehandling(behandlingIdDto.getBehandlingUuid());
     }
 }

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/verge/VergeTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/verge/VergeTjeneste.java
@@ -33,7 +33,6 @@ import no.nav.vedtak.exception.TekniskException;
 public class VergeTjeneste {
 
     private BehandlingskontrollTjeneste behandlingskontrollTjeneste;
-    private BehandlingProsesseringTjeneste behandlingProsesseringTjeneste;
     private VergeRepository vergeRepository;
     private HistorikkinnslagRepository historikkinnslagRepository;
     private PersonopplysningTjeneste personopplysningTjeneste;
@@ -42,15 +41,12 @@ public class VergeTjeneste {
 
     @Inject
     public VergeTjeneste(BehandlingskontrollTjeneste behandlingskontrollTjeneste,
-                         BehandlingProsesseringTjeneste behandlingProsesseringTjeneste,
                          VergeRepository vergeRepository,
                          HistorikkinnslagRepository historikkinnslagRepository,
-                         BehandlingRepository behandlingRepository,
                          PersonopplysningTjeneste personopplysningTjeneste,
                          OpprettVergeTjeneste opprettVergeTjeneste,
                          VergeDtoTjeneste vergeDtoTjeneste) {
         this.behandlingskontrollTjeneste = behandlingskontrollTjeneste;
-        this.behandlingProsesseringTjeneste = behandlingProsesseringTjeneste;
         this.vergeRepository = vergeRepository;
         this.historikkinnslagRepository = historikkinnslagRepository;
         this.personopplysningTjeneste = personopplysningTjeneste;
@@ -93,30 +89,6 @@ public class VergeTjeneste {
             return VergeBehandlingsmenyEnum.OPPRETT;
         }
         return VergeBehandlingsmenyEnum.FJERN;
-    }
-
-
-    void opprettVergeAksjonspunktOgHoppTilbakeTilFORVEDSTEGHvisSenereSteg(Behandling behandling) {
-        if (behandling.harÅpentAksjonspunktMedType(AksjonspunktDefinisjon.AVKLAR_VERGE)) {
-            var msg = String.format("Behandling %s har allerede aksjonspunkt 5030 for verge/fullmektig", behandling.getId());
-            throw new TekniskException("FP-185321", msg);
-        }
-
-        var kontekst = behandlingskontrollTjeneste.initBehandlingskontroll(behandling);
-        behandlingskontrollTjeneste.lagreAksjonspunkterFunnet(kontekst, List.of(AksjonspunktDefinisjon.AVKLAR_VERGE));
-
-        if (behandlingskontrollTjeneste.erStegPassert(behandling.getId(), BehandlingStegType.FORESLÅ_VEDTAK)) {
-            behandlingProsesseringTjeneste.reposisjonerBehandlingTilbakeTil(behandling, BehandlingStegType.FORESLÅ_VEDTAK);
-        }
-
-        behandlingProsesseringTjeneste.opprettTasksForFortsettBehandling(behandling);
-    }
-
-    void fjernVergeGrunnlagOgAksjonspunkt(Behandling behandling) {
-        avbrytVergeAksjonspunktHvisFinnes(behandling);
-        vergeRepository.fjernVergeFraEksisterendeGrunnlagHvisFinnes(behandling.getId());
-        opprettHistorikkinnslagForFjernetVerge(behandling);
-        behandlingProsesseringTjeneste.opprettTasksForFortsettBehandling(behandling);
     }
 
     private void avbrytVergeAksjonspunktHvisFinnes(Behandling behandling) {

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/verge/VergeTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/verge/VergeTjeneste.java
@@ -22,6 +22,7 @@ import no.nav.foreldrepenger.behandlingsprosess.prosessering.BehandlingProsesser
 import no.nav.foreldrepenger.domene.person.verge.OpprettVergeTjeneste;
 import no.nav.foreldrepenger.domene.person.verge.VergeDtoTjeneste;
 import no.nav.foreldrepenger.domene.person.verge.dto.OpprettVergeDto;
+import no.nav.foreldrepenger.domene.person.verge.dto.VergeBackendDto;
 import no.nav.foreldrepenger.domene.person.verge.dto.VergeBehandlingsmenyEnum;
 import no.nav.foreldrepenger.domene.person.verge.dto.VergeDto;
 import no.nav.foreldrepenger.domene.personopplysning.PersonopplysningTjeneste;
@@ -60,6 +61,10 @@ public class VergeTjeneste {
 
     public VergeDto hentVerge(Behandling behandling) {
         return vergeRepository.hentAggregat(behandling.getId()).flatMap(vergeDtoTjeneste::lagVergeDto).orElse(null);
+    }
+
+    public VergeBackendDto hentVergeForBackend(Behandling behandling) {
+        return vergeRepository.hentAggregat(behandling.getId()).flatMap(vergeDtoTjeneste::lagVergeBackendDto).orElse(null);
     }
 
     public void opprettVerge(Behandling behandling, NyVergeDto param) {


### PR DESCRIPTION
Denne endringen: 
* sletter ubrukte endepunkt for oppretting og fjerning av verge via AP.
* flytter to vergeendepunkt fra `PersonRestTjeneste` til `VergeRestTjeneste` for å holde verge-logikk samlet(det innbærer at pathen endres fra  (`/behandling/person/verge` -> `/verge` og  `/behandling/person/verge-backend` -> `/verge/backend`). De to endepunktene det er snakk om er det som brukes til hente fakta-panel, og det andre brukes av backendtjenester.

Det ser ut som at denne endringen ikke medfører noen problemer, men jeg tenker det er greit å høre med dere som kjenner til de andre appene: 
Har vi noen backend applikasjoner som kaller verge-endepunktet uten å bruke ressurslenker, slik at denne endringen kan medføre problemer?
 