### PR TITLE
TFP-5430: Endrer rekkefølge for å fikse feilede tester i vtp

### DIFF
--- a/domenetjenester/produksjonsstyring/src/main/java/no/nav/foreldrepenger/produksjonsstyring/oppgavebehandling/OppgaveTjeneste.java
+++ b/domenetjenester/produksjonsstyring/src/main/java/no/nav/foreldrepenger/produksjonsstyring/oppgavebehandling/OppgaveTjeneste.java
@@ -83,7 +83,7 @@ public class OppgaveTjeneste {
      * Supplerende oppgaver: Vurder Dokument og Konsekvens for Ytelse
      */
     public List<Oppgave> hentÅpneVurderDokumentOgVurderKonsekvensOppgaver(AktørId aktørId) {
-        var oppgaveTyper = List.of(Oppgavetype.VURDER_DOKUMENT.getKode(), Oppgavetype.VURDER_KONSEKVENS_YTELSE.getKode());
+        var oppgaveTyper = List.of(Oppgavetype.VURDER_KONSEKVENS_YTELSE.getKode(), Oppgavetype.VURDER_DOKUMENT.getKode());
         try {
             var oppgaver = restKlient.finnÅpneOppgaver(oppgaveTyper, aktørId.getId(), null, null);
             LOG.debug("FPSAK GOSYS fant {} oppgaver av typer {}", oppgaver.size(), oppgaveTyper);

--- a/domenetjenester/produksjonsstyring/src/test/java/no/nav/foreldrepenger/produksjonsstyring/oppgavebehandling/OppgaveTjenesteTest.java
+++ b/domenetjenester/produksjonsstyring/src/test/java/no/nav/foreldrepenger/produksjonsstyring/oppgavebehandling/OppgaveTjenesteTest.java
@@ -85,7 +85,7 @@ class OppgaveTjenesteTest {
         var scenario = lagScenario();
         var behandling = lagBehandling(scenario);
         var tjeneste = lagTjeneste(scenario);
-        when(oppgaveRestKlient.finnÅpneOppgaver(eq(List.of(Oppgavetype.VURDER_DOKUMENT.getKode(), Oppgavetype.VURDER_KONSEKVENS_YTELSE.getKode())),
+        when(oppgaveRestKlient.finnÅpneOppgaver(eq(List.of(Oppgavetype.VURDER_KONSEKVENS_YTELSE.getKode(), Oppgavetype.VURDER_DOKUMENT.getKode())),
             any(), any(), any())).thenReturn(List.of(OPPGAVE));
 
         var oppgaver = tjeneste.hentÅpneVurderDokumentOgVurderKonsekvensOppgaver(behandling.getAktørId());


### PR DESCRIPTION
VTP leverer oppgaver kun for dem første oppgavetype i lista - man bør på sikt forbedre dette i VTP oppgave mocken.