### PR TITLE
Mer tolerant overlapphåndtering

### DIFF
--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/vedtak/overlapp/HåndterOverlappPleiepengerTask.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/vedtak/overlapp/HåndterOverlappPleiepengerTask.java
@@ -71,10 +71,13 @@ public class HåndterOverlappPleiepengerTask extends GenerellProsessTask {
             .stream()
             .filter(p -> p.getDagsats() > 0)
             .map(BeregningsresultatPeriode::getBeregningsresultatPeriodeFom)
-            .min(Comparator.naturalOrder())
-            .orElseThrow();
+            .min(Comparator.naturalOrder());
 
-        var ytelserPleiepenger = hentYtelser(fagsak.getAktørId(), tidligsteTilkjent);
+        if (tidligsteTilkjent.isEmpty()) {
+            return false;
+        }
+
+        var ytelserPleiepenger = hentYtelser(fagsak.getAktørId(), tidligsteTilkjent.get());
 
         return SjekkOverlapp.erOverlappOgMerEnn100Prosent(beregningsresultatEntitet, ytelserPleiepenger);
     }


### PR DESCRIPTION
tilfelle:
* Vedtak om PSB midt på dagen - denne fører til overlappstask som kjører neste morgen
* Søker utsatt start samme kveld
* overlappstask feiler pga tomt uttak (pga tømming)

Sørger for at task stopper i taushet.