### PR TITLE
TFP-6034 flytte manuell behandling årsak fra dok tabell uttakperiode,…

### DIFF
--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/uttak/fp/UttakResultatPeriodeEntitet.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/uttak/fp/UttakResultatPeriodeEntitet.java
@@ -111,6 +111,10 @@ public class UttakResultatPeriodeEntitet extends BaseEntitet {
     @Column(name = "manuelt_behandlet", nullable = false, updatable = false)
     private boolean manueltBehandlet;
 
+    @Column(name = "manuell_behandling_aarsak", updatable = false, nullable = false)
+    @Convert(converter = ManuellBehandlingÅrsak.KodeverdiConverter.class)
+    private ManuellBehandlingÅrsak manuellBehandlingÅrsak = ManuellBehandlingÅrsak.UKJENT;
+
     @Override
     public String toString() {
         return "UttakResultatPeriodeEntitet{" +
@@ -123,6 +127,7 @@ public class UttakResultatPeriodeEntitet extends BaseEntitet {
             ", periodeResultatÅrsak=" + periodeResultatÅrsak +
             ", samtidigUttak=" + samtidigUttak +
             ", samtidigUttaksprosent=" + samtidigUttaksprosent +
+            ", manuellBehandlingÅrsak=" + manuellBehandlingÅrsak.getKode() +
             ", manueltBehandlet=" + manueltBehandlet +
             '}';
     }
@@ -168,7 +173,7 @@ public class UttakResultatPeriodeEntitet extends BaseEntitet {
     }
 
     public UttakResultatDokRegelEntitet getDokRegel() {
-        return dokRegel.isEmpty() ? null : dokRegel.get(0);
+        return dokRegel.isEmpty() ? null : dokRegel.getFirst();
     }
 
     public boolean isSamtidigUttak() {
@@ -207,15 +212,14 @@ public class UttakResultatPeriodeEntitet extends BaseEntitet {
     }
 
     public ManuellBehandlingÅrsak getManuellBehandlingÅrsak() {
+        if (manuellBehandlingÅrsak != ManuellBehandlingÅrsak.UKJENT) {
+            return manuellBehandlingÅrsak;
+        }
         return getDokRegel() == null ? null : getDokRegel().getManuellBehandlingÅrsak();
     }
 
     public Optional<UttakResultatPeriodeSøknadEntitet> getPeriodeSøknad() {
         return Optional.ofNullable(periodeSøknad);
-    }
-
-    public boolean opprinneligSendtTilManuellBehandling() {
-        return getDokRegel() != null && getDokRegel().isTilManuellBehandling();
     }
 
     public boolean isManueltBehandlet() {
@@ -317,6 +321,11 @@ public class UttakResultatPeriodeEntitet extends BaseEntitet {
             return this;
         }
 
+        public Builder medManuellBehandlingÅrsak(ManuellBehandlingÅrsak manuellBehandlingÅrsak) {
+            kladd.manuellBehandlingÅrsak = manuellBehandlingÅrsak;
+            return this;
+        }
+
         public Builder medDokRegel(UttakResultatDokRegelEntitet dokRegel) {
             kladd.dokRegel = Collections.singletonList(dokRegel);
             return this;
@@ -336,7 +345,7 @@ public class UttakResultatPeriodeEntitet extends BaseEntitet {
             Objects.requireNonNull(kladd.tidsperiode, "tidsperiode");
             Objects.requireNonNull(kladd.periodeResultatType, "periodeResultatType");
             if (!kladd.dokRegel.isEmpty()) {
-                kladd.dokRegel.get(0).setPeriode(kladd);
+                kladd.dokRegel.getFirst().setPeriode(kladd);
             }
             if (kladd.utsettelseType == null) {
                 kladd.utsettelseType = UttakUtsettelseType.UDEFINERT;

--- a/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/ForeldrepengerUttakPeriode.java
+++ b/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/ForeldrepengerUttakPeriode.java
@@ -36,7 +36,6 @@ public class ForeldrepengerUttakPeriode {
     private OppholdÅrsak oppholdÅrsak = OppholdÅrsak.UDEFINERT;
     private OverføringÅrsak overføringÅrsak;
     private UttakPeriodeType søktKonto;
-    private boolean opprinneligSendtTilManuellBehandling;
     private String begrunnelse;
     private boolean manueltBehandlet;
     private LocalDate mottattDato;
@@ -158,10 +157,6 @@ public class ForeldrepengerUttakPeriode {
         return søktKonto;
     }
 
-    public boolean isOpprinneligSendtTilManuellBehandling() {
-        return opprinneligSendtTilManuellBehandling;
-    }
-
     public Boolean isManueltBehandlet() {
         return manueltBehandlet;
     }
@@ -253,7 +248,6 @@ public class ForeldrepengerUttakPeriode {
             ", oppholdÅrsak=" + oppholdÅrsak +
             ", overføringÅrsak=" + overføringÅrsak +
             ", søktKonto=" + søktKonto +
-            ", opprinneligSendtTilManuellBehandling=" + opprinneligSendtTilManuellBehandling +
             ", manueltBehandlet=" + manueltBehandlet +
             ", mottattDato=" + mottattDato +
             ", tidligstMottatttDato=" + tidligstMottatttDato +
@@ -347,11 +341,6 @@ public class ForeldrepengerUttakPeriode {
 
         public Builder medSøktKonto(UttakPeriodeType søktKonto) {
             kladd.søktKonto = søktKonto;
-            return this;
-        }
-
-        public Builder medOpprinneligSendtTilManuellBehandling(boolean opprinneligSendtTilManuellBehandling) {
-            kladd.opprinneligSendtTilManuellBehandling = opprinneligSendtTilManuellBehandling;
             return this;
         }
 

--- a/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/ForeldrepengerUttakTjeneste.java
+++ b/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/ForeldrepengerUttakTjeneste.java
@@ -78,7 +78,6 @@ public class ForeldrepengerUttakTjeneste {
             .medMottattDato(mottattDato)
             .medTidligstMottattDato(tidligsMottatt)
             .medMorsAktivitet(entitet.getPeriodeSøknad().map(UttakResultatPeriodeSøknadEntitet::getMorsAktivitet).orElse(MorsAktivitet.UDEFINERT))
-            .medOpprinneligSendtTilManuellBehandling(!ignoreDok && entitet.opprinneligSendtTilManuellBehandling())
             .medErFraSøknad(entitet.getPeriodeSøknad().isPresent())
             .medDokumentasjonVurdering(entitet.getPeriodeSøknad()
                 .map(UttakResultatPeriodeSøknadEntitet::getDokumentasjonVurdering)

--- a/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/fastsetteperioder/FastsettePerioderRegelResultatKonverterer.java
+++ b/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/fastsetteperioder/FastsettePerioderRegelResultatKonverterer.java
@@ -335,6 +335,7 @@ public class FastsettePerioderRegelResultatKonverterer {
             .medPeriodeSoknad(periodeSøknad)
             .medSamtidigUttak(uttakPeriode.erSamtidigUttak())
             .medSamtidigUttaksprosent(samtidigUttaksprosent(uttakPeriode))
+            .medManuellBehandlingÅrsak(UttakEnumMapper.map(uttakPeriode.getManuellbehandlingårsak()))
             .medFlerbarnsdager(uttakPeriode.isFlerbarnsdager())
             .build();
     }

--- a/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/fastsetteperioder/FastsettePerioderRevurderingUtil.java
+++ b/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/fastsetteperioder/FastsettePerioderRevurderingUtil.java
@@ -86,6 +86,7 @@ public final class FastsettePerioderRevurderingUtil {
             .medFlerbarnsdager(periode.isFlerbarnsdager())
             .medGraderingAvslagÅrsak(periode.getGraderingAvslagÅrsak())
             .medManueltBehandlet(periode.isManueltBehandlet())
+            .medManuellBehandlingÅrsak(periode.getManuellBehandlingÅrsak())
             .medBegrunnelse(periode.getBegrunnelse());
         if (periode.getDokRegel() != null) {
             builder.medDokRegel(kopierDokRegel(periode.getDokRegel()));

--- a/migreringer/src/main/resources/db/migration/defaultDS/4.1/V4.1_37__TFP-6034-uttak-manuell_aarsak.sql
+++ b/migreringer/src/main/resources/db/migration/defaultDS/4.1/V4.1_37__TFP-6034-uttak-manuell_aarsak.sql
@@ -1,0 +1,5 @@
+alter table UTTAK_RESULTAT_PERIODE add MANUELL_BEHANDLING_AARSAK VARCHAR2(100 char) default '-' not null;
+
+alter table UTTAK_RESULTAT_DOK_REGEL modify (MANUELL_BEHANDLING_AARSAK null);
+
+comment on column UTTAK_RESULTAT_PERIODE.MANUELL_BEHANDLING_AARSAK is 'Årsak til manuell behandling';

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/uttak/app/UttakPerioderDtoTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/uttak/app/UttakPerioderDtoTjeneste.java
@@ -150,7 +150,7 @@ public class UttakPerioderDtoTjeneste {
             .build();
 
         for (var aktivitet : periode.getAktiviteter()) {
-            dto.leggTilAktivitet(map(aktivitet, inntektArbeidYtelseGrunnlag, periode.isOpprinneligSendtTilManuellBehandling()));
+            dto.leggTilAktivitet(map(aktivitet, inntektArbeidYtelseGrunnlag));
         }
         return dto;
     }
@@ -178,18 +178,15 @@ public class UttakPerioderDtoTjeneste {
     }
 
     private UttakResultatPeriodeAktivitetDto map(ForeldrepengerUttakPeriodeAktivitet aktivitet,
-                                                 Optional<InntektArbeidYtelseGrunnlag> inntektArbeidYtelseGrunnlag,
-                                                 boolean opprinneligSendtTilManuellBehandling) {
+                                                 Optional<InntektArbeidYtelseGrunnlag> inntektArbeidYtelseGrunnlag) {
         var builder = new UttakResultatPeriodeAktivitetDto.Builder()
             .medProsentArbeid(aktivitet.getArbeidsprosent())
             .medGradering(aktivitet.isSøktGraderingForAktivitetIPeriode())
             .medTrekkdager(aktivitet.getTrekkdager())
             .medStønadskontoType(aktivitet.getTrekkonto())
-            .medUttakArbeidType(aktivitet.getUttakArbeidType());
+            .medUttakArbeidType(aktivitet.getUttakArbeidType())
+            .medUtbetalingsgrad(aktivitet.getUtbetalingsgrad());
         mapArbeidsforhold(aktivitet, builder, inntektArbeidYtelseGrunnlag);
-        if (!opprinneligSendtTilManuellBehandling) {
-            builder.medUtbetalingsgrad(aktivitet.getUtbetalingsgrad());
-        }
         return builder.build();
     }
 


### PR DESCRIPTION
… expand med ny kolonne

Neste er å bestille patch for flytting av data fra UTTAK_RESULTAT_DOK_REGEL til ny kolonne

`MERGE INTO fpsak.UTTAK_RESULTAT_PERIODE uper
USING fpsak.UTTAK_RESULTAT_DOK_REGEL udok
ON (udok.UTTAK_RESULTAT_PERIODE_ID = uper.id and udok.MANUELL_BEHANDLING_AARSAK <> '-')
WHEN MATCHED THEN
    UPDATE SET uper.manuell_behandling_aarsak = udok.MANUELL_BEHANDLING_AARSAK;`