### PR TITLE
TFP-6047: Forenkler mapping av besteberegning, viser seg at flere gam…

### DIFF
--- a/domenetjenester/beregningsgrunnlag/src/main/java/no/nav/foreldrepenger/domene/migrering/BeregningMigreringMapper.java
+++ b/domenetjenester/beregningsgrunnlag/src/main/java/no/nav/foreldrepenger/domene/migrering/BeregningMigreringMapper.java
@@ -486,21 +486,8 @@ public class BeregningMigreringMapper {
         if (!harVurderManuellBesteberegningTilfelle) {
             return Optional.empty();
         }
-        var harManuellBesteberegningtilfelle = tilfeller.stream().anyMatch(b -> b.equals(FaktaOmBeregningTilfelle.FASTSETT_BESTEBEREGNING_FØDENDE_KVINNE)
-            || b.equals(FaktaOmBeregningTilfelle.FASTSETT_BG_KUN_YTELSE));
-        // besteberegnetPrÅr fantes ikke før denne datoen, så for slike grunnlag vil besteberegning være lagret på beregnet
-        var bbLagretPåBeregnet = andelListe.getFirst().getOpprettetTidspunkt().toLocalDate().isBefore(LocalDate.of(2018, 12, 12));
-        var harSattManuellBesteberegning = bbLagretPåBeregnet ?
-            andelListe.stream().anyMatch(a -> a.getBeregnetPrÅr() != null && a.getBeregnetPrÅr().compareTo(BigDecimal.ZERO)>0)
-            : andelListe.stream().anyMatch(a -> a.getBesteberegningPrÅr() != null && a.getBesteberegningPrÅr().compareTo(BigDecimal.ZERO)>0);
-
-        if (!Objects.equals(harManuellBesteberegningtilfelle, harSattManuellBesteberegning)) {
-            var msg = String.format("Tvetydig data ved mapping av manuell besteberegning, må undersøkes manuelt. Har tilfeller: %s og andeler %s",
-                tilfeller, andelListe);
-            throw new IllegalStateException(msg);
-        }
-        var erManueltBesteberegnet = andelListe.stream().anyMatch(a -> a.getBesteberegningPrÅr() != null && a.getBesteberegningPrÅr().compareTo(BigDecimal.ZERO)>0);
-        return Optional.of(new FaktaVurderingMigreringDto(erManueltBesteberegnet, FaktaVurderingKilde.SAKSBEHANDLER));
+        var harSattManuellBesteberegning = andelListe.stream().anyMatch(a -> a.getBesteberegningPrÅr() != null && a.getBesteberegningPrÅr().compareTo(BigDecimal.ZERO)>0);
+        return Optional.of(new FaktaVurderingMigreringDto(harSattManuellBesteberegning, FaktaVurderingKilde.SAKSBEHANDLER));
     }
 
     private static Optional<FaktaVurderingMigreringDto> utledFaktaAvklaringEtterlønn(List<BeregningsgrunnlagPrStatusOgAndel> etterlønnSluttpakkeAndeler) {


### PR DESCRIPTION
…le grunnlag har lagret 'FASTSETT_BESTEBEREGNING_FØDENDE_KVINNE' tilfelle i tilfeller der vurderingen er satt til "false". Stoler nå på at det er rett om besteberegnetPrÅr er satt, da det er dette feltet som er brukt i regler og skjermbilder til saksbehandler