### PR TITLE
TFP-5972 autotest gjør det vanskelig med saksnummer

### DIFF
--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/pip/PipRepository.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/pip/PipRepository.java
@@ -29,7 +29,6 @@ public class PipRepository {
 
     private static final LRUCache<UUID, Saksnummer> BEH_SAK = new LRUCache<>(20000, TimeUnit.MILLISECONDS.convert(7, TimeUnit.DAYS));
     private static final LRUCache<String, AktørId> SAK_EIER = new LRUCache<>(5000, TimeUnit.MILLISECONDS.convert(2, TimeUnit.HOURS));
-    private static final LRUCache<String, Set<AktørId>> SAK_AKTØR = new LRUCache<>(1000, TimeUnit.MILLISECONDS.convert(2, TimeUnit.MINUTES));
 
     private static final String SAKSNUMMER = "saksnummer";
     private static final String BUUID = "behandlingUuid";
@@ -105,10 +104,6 @@ public class PipRepository {
     public Set<AktørId> hentAktørIdKnyttetTilSaksnummer(String saksnummer) {
         Objects.requireNonNull(saksnummer, SAKSNUMMER);
 
-        if (SAK_AKTØR.get(saksnummer) != null) {
-            return SAK_AKTØR.get(saksnummer);
-        }
-
         var sql = """
             SELECT por.AKTOER_ID From Fagsak fag
             JOIN BEHANDLING beh ON fag.ID = beh.FAGSAK_ID
@@ -133,9 +128,7 @@ public class PipRepository {
 
         @SuppressWarnings("unchecked")
         List<String> aktørIdList = query.getResultList();
-        var aktører = aktørIdList.stream().map(AktørId::new).collect(Collectors.toCollection(LinkedHashSet::new));
-        SAK_AKTØR.put(saksnummer, aktører);
-        return aktører;
+        return aktørIdList.stream().map(AktørId::new).collect(Collectors.toCollection(LinkedHashSet::new));
     }
 
     @SuppressWarnings({ "unchecked", "cast" })

--- a/web/src/main/java/no/nav/foreldrepenger/web/server/abac/AppPdpRequestBuilderImpl.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/server/abac/AppPdpRequestBuilderImpl.java
@@ -75,14 +75,18 @@ public class AppPdpRequestBuilderImpl implements PdpRequestBuilder {
             MDC_EXTENDED_LOG_CONTEXT.add("behandlingId", bd.behandlingId());
         });
 
-        Set<String> aktører = dataAttributter.getVerdier(AppAbacAttributtType.AKTØR_ID);
+        // TODO - finn ut måte å håndtere autotest med mye polling før sakskobling
+        Set<String> aktører = new HashSet<>(dataAttributter.getVerdier(AppAbacAttributtType.AKTØR_ID));
+        saksnummer.map(Saksnummer::getVerdi)
+            .ifPresent(s -> aktører.addAll(pipRepository.hentAktørIdKnyttetTilSaksnummer(s).stream().map(AktørId::getId).toList()));
         Set<String> fnrs = dataAttributter.getVerdier(AppAbacAttributtType.FNR);
 
         var builder = AppRessursData.builder()
             .leggTilAktørIdSet(aktører)
             .leggTilFødselsnumre(fnrs);
 
-        saksnummer.map(Saksnummer::getVerdi).ifPresent(builder::medSaksnummer);
+        // TODO - finn ut måte å håndtere autotest med mye polling før sakskobling
+        //saksnummer.map(Saksnummer::getVerdi).ifPresent(builder::medSaksnummer);
         behandlingData.flatMap(PipBehandlingsData::getAnsvarligSaksbehandler)
             .ifPresent(builder::medAnsvarligSaksbehandler);
         behandlingData.map(PipBehandlingsData::behandlingStatus).flatMap(AppPdpRequestBuilderImpl::oversettBehandlingStatus)


### PR DESCRIPTION
Autotest poller tett på ny sak før den rekker å koble seg - dermed er cache fylt av bruker, uten annenpart (beskyttet).
Går tilbake til å sende aktørId hentet fra lokal DB for saksnummer