### PR TITLE
TFP-5972 omlegging tilgangskontroll saksnummer

### DIFF
--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/events/SakensPersonerEndretEvent.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/events/SakensPersonerEndretEvent.java
@@ -1,0 +1,23 @@
+package no.nav.foreldrepenger.behandlingslager.behandling.events;
+
+import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingEvent;
+import no.nav.foreldrepenger.domene.typer.Saksnummer;
+
+public record SakensPersonerEndretEvent(Long fagsakId, Saksnummer saksnummer, Long behandlingId) implements BehandlingEvent {
+
+    @Override
+    public Long getFagsakId() {
+        return fagsakId();
+    }
+
+    @Override
+    public Saksnummer getSaksnummer() {
+        return saksnummer();
+    }
+
+    @Override
+    public Long getBehandlingId() {
+        return behandlingId();
+    }
+
+}

--- a/behandlingslager/domene/src/test/java/no/nav/foreldrepenger/behandlingslager/pip/PipRepositoryTest.java
+++ b/behandlingslager/domene/src/test/java/no/nav/foreldrepenger/behandlingslager/pip/PipRepositoryTest.java
@@ -17,7 +17,6 @@ import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakRepository;
 import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakYtelseType;
 import no.nav.foreldrepenger.behandlingslager.fagsak.Journalpost;
 import no.nav.foreldrepenger.dbstoette.EntityManagerAwareTest;
-import no.nav.foreldrepenger.domene.typer.AktørId;
 import no.nav.foreldrepenger.domene.typer.JournalpostId;
 
 class PipRepositoryTest extends EntityManagerAwareTest {
@@ -61,14 +60,6 @@ class PipRepositoryTest extends EntityManagerAwareTest {
     void skal_returne_tomt_resultat_når_det_søkes_etter_behandling_id_som_ikke_finnes() {
         var pipBehandlingsData = pipRepository.hentDataForBehandlingUuid(UUID.randomUUID());
         assertThat(pipBehandlingsData).isNotPresent();
-    }
-
-    @Test
-    void skal_finne_aktoerId_for_saksnummer() {
-        var fagsak = behandlingBuilder.opprettFagsak(FagsakYtelseType.FORELDREPENGER, AktørId.dummy());
-
-        var aktørIder = pipRepository.hentAktørIdKnyttetTilSaksnummer(fagsak.getSaksnummer().getVerdi());
-        assertThat(aktørIder).containsOnly(fagsak.getAktørId());
     }
 
     @Test

--- a/domenetjenester/registerinnhenting/src/main/java/no/nav/foreldrepenger/domene/registerinnhenting/task/InnhentPersonopplysningerTask.java
+++ b/domenetjenester/registerinnhenting/src/main/java/no/nav/foreldrepenger/domene/registerinnhenting/task/InnhentPersonopplysningerTask.java
@@ -1,16 +1,23 @@
 package no.nav.foreldrepenger.domene.registerinnhenting.task;
 
+import java.util.Set;
+
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import no.nav.foreldrepenger.behandling.BehandlingEventPubliserer;
+import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
+import no.nav.foreldrepenger.behandlingslager.behandling.events.SakensPersonerEndretEvent;
+import no.nav.foreldrepenger.behandlingslager.behandling.personopplysning.PersonopplysningRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepositoryProvider;
 import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakProsesstaskRekkefølge;
 import no.nav.foreldrepenger.behandlingslager.task.BehandlingProsessTask;
 import no.nav.foreldrepenger.domene.registerinnhenting.RegisterdataInnhenter;
+import no.nav.foreldrepenger.domene.typer.AktørId;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTask;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTaskData;
 
@@ -21,7 +28,9 @@ public class InnhentPersonopplysningerTask extends BehandlingProsessTask {
 
     private static final Logger LOG = LoggerFactory.getLogger(InnhentPersonopplysningerTask.class);
     private BehandlingRepository behandlingRepository;
+    private PersonopplysningRepository personopplysningRepository;
     private RegisterdataInnhenter registerdataInnhenter;
+    private BehandlingEventPubliserer behandlingEventPubliserer;
 
     InnhentPersonopplysningerTask() {
         // for CDI proxy
@@ -29,16 +38,29 @@ public class InnhentPersonopplysningerTask extends BehandlingProsessTask {
 
     @Inject
     public InnhentPersonopplysningerTask(BehandlingRepositoryProvider behandlingRepositoryProvider,
-                                         RegisterdataInnhenter registerdataInnhenter) {
+                                         RegisterdataInnhenter registerdataInnhenter,
+                                         BehandlingEventPubliserer behandlingEventPubliserer) {
         super(behandlingRepositoryProvider.getBehandlingLåsRepository());
         this.behandlingRepository = behandlingRepositoryProvider.getBehandlingRepository();
+        this.personopplysningRepository = behandlingRepositoryProvider.getPersonopplysningRepository();
         this.registerdataInnhenter = registerdataInnhenter;
+        this.behandlingEventPubliserer = behandlingEventPubliserer;
     }
 
     @Override
     protected void prosesser(ProsessTaskData prosessTaskData, Long behandlingId) {
         var behandling = behandlingRepository.hentBehandling(behandlingId);
+        var personerFør = personopplysningRepository.hentAktørIdKnyttetTilSaksnummer(behandling.getSaksnummer().getVerdi());
         LOG.info("Innhenter personopplysninger for behandling: {}", behandling.getId());
         registerdataInnhenter.innhentPersonopplysninger(behandling);
+        notifiserEndringPersoner(behandling, personerFør);
+    }
+
+    private void notifiserEndringPersoner(Behandling behandling, Set<AktørId> personerFør) {
+        var personerEtter = personopplysningRepository.hentAktørIdKnyttetTilSaksnummer(behandling.getSaksnummer().getVerdi());
+        if (personerFør.size() != personerEtter.size() || !personerFør.containsAll(personerEtter)) {
+            LOG.info("Persongalleri er endret for sak: {}", behandling.getSaksnummer().getVerdi());
+            behandlingEventPubliserer.publiserBehandlingEvent(new SakensPersonerEndretEvent(behandling.getFagsakId(), behandling.getSaksnummer(), behandling.getId()));
+        }
     }
 }

--- a/web/src/main/java/no/nav/foreldrepenger/web/server/abac/AppPdpRequestBuilderImpl.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/server/abac/AppPdpRequestBuilderImpl.java
@@ -76,16 +76,12 @@ public class AppPdpRequestBuilderImpl implements PdpRequestBuilder {
 
         var builder = AppRessursData.builder();
 
-        // TODO - finn ut måte å håndtere autotest med mye polling før sakskobling - eller slå seg til ro med dagens opplegg
-        Set<String> aktører = new HashSet<>(dataAttributter.getVerdier(AppAbacAttributtType.AKTØR_ID));
-        saksnummer.map(Saksnummer::getVerdi)
-            .ifPresent(s -> aktører.addAll(pipRepository.hentAktørIdKnyttetTilSaksnummer(s).stream().map(AktørId::getId).toList()));
+        Set<String> aktører = dataAttributter.getVerdier(AppAbacAttributtType.AKTØR_ID);
         Set<String> fnrs = dataAttributter.getVerdier(AppAbacAttributtType.FNR);
 
         builder.leggTilAktørIdSet(aktører)
             .leggTilFødselsnumre(fnrs);
-        // TODO - finn ut måte å håndtere autotest med mye polling før sakskobling - eller slå seg til ro med dagens opplegg
-        //saksnummer.map(Saksnummer::getVerdi).ifPresent(builder::medSaksnummer);
+        saksnummer.map(Saksnummer::getVerdi).ifPresent(builder::medSaksnummer);
         behandlingData.map(PipBehandlingsData::behandlingStatus).flatMap(AppPdpRequestBuilderImpl::oversettBehandlingStatus)
             .ifPresent(builder::medBehandlingStatus);
         behandlingData.map(PipBehandlingsData::fagsakStatus).flatMap(AppPdpRequestBuilderImpl::oversettFagstatus)

--- a/web/src/main/java/no/nav/foreldrepenger/web/server/abac/InvaliderSakObserverKlient.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/server/abac/InvaliderSakObserverKlient.java
@@ -1,0 +1,52 @@
+package no.nav.foreldrepenger.web.server.abac;
+
+import java.net.URI;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import jakarta.ws.rs.core.UriBuilder;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import no.nav.foreldrepenger.behandlingslager.behandling.events.SakensPersonerEndretEvent;
+import no.nav.foreldrepenger.domene.typer.Saksnummer;
+import no.nav.vedtak.felles.integrasjon.rest.FpApplication;
+import no.nav.vedtak.felles.integrasjon.rest.RestClient;
+import no.nav.vedtak.felles.integrasjon.rest.RestClientConfig;
+import no.nav.vedtak.felles.integrasjon.rest.RestConfig;
+import no.nav.vedtak.felles.integrasjon.rest.RestRequest;
+import no.nav.vedtak.felles.integrasjon.rest.TokenFlow;
+
+@ApplicationScoped
+@RestClientConfig(tokenConfig = TokenFlow.AZUREAD_CC, application = FpApplication.FPTILGANG)
+public class InvaliderSakObserverKlient {
+
+    private static final Logger LOG = LoggerFactory.getLogger(InvaliderSakObserverKlient.class);
+
+    private final RestClient restClient;
+    private final RestConfig restConfig;
+    private final URI invaliderUri;
+
+    public InvaliderSakObserverKlient() {
+        this.restClient = RestClient.client();
+        this.restConfig = RestConfig.forClient(this.getClass());
+        this.invaliderUri = UriBuilder.fromUri(restConfig.fpContextPath()).path("/api/populasjon/invalidersak").build();
+    }
+
+    public void observerStoppetEvent(@Observes SakensPersonerEndretEvent event) {
+        invaliderSak(event.getSaksnummer());
+    }
+
+    public void invaliderSak(Saksnummer saksnummer) {
+        LOG.info("Invaliderer sak {}", saksnummer.getVerdi());
+        var payload = new SakRequest(saksnummer.getVerdi());
+        var request = RestRequest.newPOSTJson(payload, invaliderUri, restConfig);
+        restClient.sendReturnOptional(request, String.class);
+    }
+
+    public record SakRequest(@NotNull @Valid String saksnummer) { }
+
+}

--- a/web/src/test/java/no/nav/foreldrepenger/web/server/abac/PdpRequestBuilderTest.java
+++ b/web/src/test/java/no/nav/foreldrepenger/web/server/abac/PdpRequestBuilderTest.java
@@ -58,7 +58,6 @@ class PdpRequestBuilderTest {
         var attributter = AbacDataAttributter.opprett()
                 .leggTil(AppAbacAttributtType.BEHANDLING_UUID, BEHANDLING_UUID);
 
-        lenient().when(pipRepository.hentAktørIdKnyttetTilSaksnummer(SAKSNUMMER.getVerdi())).thenReturn(Collections.singleton(AKTØR_1));
         var behandligStatus = BehandlingStatus.OPPRETTET;
         var ansvarligSaksbehandler = "Z123456";
         var fagsakStatus = FagsakStatus.UNDER_BEHANDLING;
@@ -66,8 +65,7 @@ class PdpRequestBuilderTest {
                 Optional.of(new PipBehandlingsData(behandligStatus, ansvarligSaksbehandler, BEHANDLING_ID, BEHANDLING_UUID, fagsakStatus, SAKSNUMMER)));
 
         var request = requestBuilder.lagAppRessursData(attributter);
-        //assertThat(request.getSaksnummer()).isEqualTo(SAKSNUMMER.getVerdi());
-        assertThat(request.getAktørIdSet()).containsOnly(AKTØR_1.getId());
+        assertThat(request.getSaksnummer()).isEqualTo(SAKSNUMMER.getVerdi());
         assertThat(request.getResource(ForeldrepengerDataKeys.SAKSBEHANDLER).verdi()).isEqualTo(ansvarligSaksbehandler);
         assertThat(request.getResource(ForeldrepengerDataKeys.BEHANDLING_STATUS).verdi())
                 .isEqualTo(PipBehandlingStatus.OPPRETTET.getVerdi());
@@ -81,11 +79,9 @@ class PdpRequestBuilderTest {
                 .leggTil(AppAbacAttributtType.JOURNALPOST_ID, JOURNALPOST_ID);
 
         lenient().when(pipRepository.saksnummerForJournalpostId(Collections.singleton(JOURNALPOST_ID))).thenReturn(Collections.singleton(SAKSNUMMER));
-        lenient().when(pipRepository.hentAktørIdKnyttetTilSaksnummer(SAKSNUMMER.getVerdi())).thenReturn(Collections.singleton(AKTØR_1));
 
         var request = requestBuilder.lagAppRessursData(attributter);
-        //assertThat(request.getSaksnummer()).isEqualTo(SAKSNUMMER.getVerdi());
-        assertThat(request.getAktørIdSet()).containsOnly(AKTØR_1.getId());
+        assertThat(request.getSaksnummer()).isEqualTo(SAKSNUMMER.getVerdi());
     }
 
     @Test


### PR DESCRIPTION
Byggesteinene er allerede på plass, forrige forsøk strandet på aggressiv polling i autotest.
* Fptilgang bruker nå delt cache så det nytter å sende invalider til en av nodene
* Persongalleriet i en sak endres 3 steder - oppretting (bare bruker), lagre søknad (annen part), registeroppdatering (barn)
* Trigger PersonerEndret for førstegang etter lagring av søknad og saksbehandling. Deretter ved endringer i registerdata.
* Testet og validert lokalt 
* Neste steg: gjøre ferdig tilbake + los. En runde med ny felles + alle apps bruker saksnummer