### PR TITLE
TFP-5972 start expand for fase 3 - mer info for tilgang

### DIFF
--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/personopplysning/PersonopplysningRepository.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/personopplysning/PersonopplysningRepository.java
@@ -16,6 +16,7 @@ import no.nav.foreldrepenger.behandlingslager.TraverseEntityGraphFactory;
 import no.nav.foreldrepenger.behandlingslager.diff.DiffEntity;
 import no.nav.foreldrepenger.behandlingslager.fagsak.Fagsak;
 import no.nav.foreldrepenger.domene.typer.AktørId;
+import no.nav.foreldrepenger.domene.typer.Saksnummer;
 import no.nav.vedtak.felles.jpa.HibernateVerktøy;
 
 /**
@@ -275,7 +276,7 @@ public class PersonopplysningRepository {
         return resultat.orElse(null);
     }
 
-    public Set<AktørId> hentAktørIdKnyttetTilSaksnummer(String saksnummer) {
+    public Set<AktørId> hentAktørIdKnyttetTilSaksnummer(Saksnummer saksnummer) {
         Objects.requireNonNull(saksnummer, "saksnummer");
 
         var sql = """
@@ -297,7 +298,7 @@ public class PersonopplysningRepository {
             """;
 
         var query = entityManager.createNativeQuery(sql)
-            .setParameter("saksnummer", saksnummer);
+            .setParameter("saksnummer", saksnummer.getVerdi());
 
         @SuppressWarnings("unchecked")
         List<String> aktørIdList = query.getResultList();

--- a/behandlingslager/domene/src/test/java/no/nav/foreldrepenger/behandlingslager/behandling/personopplysning/PersonopplysningRepositoryTest.java
+++ b/behandlingslager/domene/src/test/java/no/nav/foreldrepenger/behandlingslager/behandling/personopplysning/PersonopplysningRepositoryTest.java
@@ -81,7 +81,7 @@ class PersonopplysningRepositoryTest extends EntityManagerAwareTest {
     void skal_finne_aktoerId_for_saksnummer_kun_sak() {
         var fagsak = new BasicBehandlingBuilder(getEntityManager()).opprettFagsak(FagsakYtelseType.FORELDREPENGER, AktørId.dummy());
 
-        var aktørIder = repository.hentAktørIdKnyttetTilSaksnummer(fagsak.getSaksnummer().getVerdi());
+        var aktørIder = repository.hentAktørIdKnyttetTilSaksnummer(fagsak.getSaksnummer());
         assertThat(aktørIder).containsOnly(fagsak.getAktørId());
     }
 
@@ -94,7 +94,7 @@ class PersonopplysningRepositoryTest extends EntityManagerAwareTest {
         var annenPart = AktørId.dummy();
         repository.lagre(behandling.getId(), new OppgittAnnenPartBuilder().medType(SøknadAnnenPartType.FAR).medAktørId(annenPart).build());
 
-        var aktørIder = repository.hentAktørIdKnyttetTilSaksnummer(fagsak.getSaksnummer().getVerdi());
+        var aktørIder = repository.hentAktørIdKnyttetTilSaksnummer(fagsak.getSaksnummer());
         assertThat(aktørIder).containsOnly(fagsak.getAktørId(), annenPart);
     }
 
@@ -116,7 +116,7 @@ class PersonopplysningRepositoryTest extends EntityManagerAwareTest {
         informasjonBuilder.leggTil(personopplysningBuilder);
         repository.lagre(behandling.getId(), informasjonBuilder);
 
-        var aktørIder = repository.hentAktørIdKnyttetTilSaksnummer(fagsak.getSaksnummer().getVerdi());
+        var aktørIder = repository.hentAktørIdKnyttetTilSaksnummer(fagsak.getSaksnummer());
         assertThat(aktørIder).containsOnly(fagsak.getAktørId(), annenPart);
     }
 
@@ -148,7 +148,7 @@ class PersonopplysningRepositoryTest extends EntityManagerAwareTest {
 
         repository.lagre(behandling.getId(), informasjonBuilder);
 
-        var aktørIder = repository.hentAktørIdKnyttetTilSaksnummer(fagsak.getSaksnummer().getVerdi());
+        var aktørIder = repository.hentAktørIdKnyttetTilSaksnummer(fagsak.getSaksnummer());
         assertThat(aktørIder).containsOnly(fagsak.getAktørId(), annenPart, barn);
     }
 
@@ -170,7 +170,7 @@ class PersonopplysningRepositoryTest extends EntityManagerAwareTest {
 
         repository.lagre(behandling.getId(), informasjonBuilder);
 
-        var aktørIder = repository.hentAktørIdKnyttetTilSaksnummer(fagsak.getSaksnummer().getVerdi());
+        var aktørIder = repository.hentAktørIdKnyttetTilSaksnummer(fagsak.getSaksnummer());
         assertThat(aktørIder).containsOnly(fagsak.getAktørId(), barn);
     }
 

--- a/behandlingslager/domene/src/test/java/no/nav/foreldrepenger/behandlingslager/pip/PipRepositoryTest.java
+++ b/behandlingslager/domene/src/test/java/no/nav/foreldrepenger/behandlingslager/pip/PipRepositoryTest.java
@@ -54,6 +54,9 @@ class PipRepositoryTest extends EntityManagerAwareTest {
         assertThat(pipBehandlingsData.get().behandlingStatus()).isEqualTo(behandling.getStatus());
         assertThat(pipBehandlingsData.get().fagsakStatus()).isEqualTo(behandling.getFagsak().getStatus());
         assertThat(pipBehandlingsData.get().saksnummer()).isEqualTo(behandling.getFagsak().getSaksnummer());
+
+        var saksident = pipRepository.hentAktørIdSomEierFagsak(behandling.getSaksnummer());
+        assertThat(saksident).hasValueSatisfying(a -> assertThat(a).isEqualTo(behandling.getAktørId()));
     }
 
     @Test
@@ -69,6 +72,9 @@ class PipRepositoryTest extends EntityManagerAwareTest {
 
         var fagsakId = pipRepository.hentSaksnummerForBehandlingUuid(behandling.getUuid());
         assertThat(fagsakId).hasValueSatisfying(s -> assertThat(fagsak.getSaksnummer()).isEqualTo(s));
+
+        var saksident = pipRepository.hentAktørIdSomEierFagsak(behandling.getSaksnummer());
+        assertThat(saksident).hasValueSatisfying(a -> assertThat(a).isEqualTo(behandling.getAktørId()));
     }
 
     @Test

--- a/domenetjenester/registerinnhenting/src/main/java/no/nav/foreldrepenger/domene/registerinnhenting/task/InnhentPersonopplysningerTask.java
+++ b/domenetjenester/registerinnhenting/src/main/java/no/nav/foreldrepenger/domene/registerinnhenting/task/InnhentPersonopplysningerTask.java
@@ -50,14 +50,14 @@ public class InnhentPersonopplysningerTask extends BehandlingProsessTask {
     @Override
     protected void prosesser(ProsessTaskData prosessTaskData, Long behandlingId) {
         var behandling = behandlingRepository.hentBehandling(behandlingId);
-        var personerFør = personopplysningRepository.hentAktørIdKnyttetTilSaksnummer(behandling.getSaksnummer().getVerdi());
+        var personerFør = personopplysningRepository.hentAktørIdKnyttetTilSaksnummer(behandling.getSaksnummer());
         LOG.info("Innhenter personopplysninger for behandling: {}", behandling.getId());
         registerdataInnhenter.innhentPersonopplysninger(behandling);
         notifiserEndringPersoner(behandling, personerFør);
     }
 
     private void notifiserEndringPersoner(Behandling behandling, Set<AktørId> personerFør) {
-        var personerEtter = personopplysningRepository.hentAktørIdKnyttetTilSaksnummer(behandling.getSaksnummer().getVerdi());
+        var personerEtter = personopplysningRepository.hentAktørIdKnyttetTilSaksnummer(behandling.getSaksnummer());
         if (personerFør.size() != personerEtter.size() || !personerFør.containsAll(personerEtter)) {
             LOG.info("Persongalleri er endret for sak: {}", behandling.getSaksnummer().getVerdi());
             behandlingEventPubliserer.publiserBehandlingEvent(new SakensPersonerEndretEvent(behandling.getFagsakId(), behandling.getSaksnummer(), behandling.getId()));

--- a/web/src/main/java/no/nav/foreldrepenger/web/server/abac/SakOgPersonerDto.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/server/abac/SakOgPersonerDto.java
@@ -1,0 +1,6 @@
+package no.nav.foreldrepenger.web.server.abac;
+
+import java.util.Set;
+
+public record SakOgPersonerDto(String saksnummer, String saksident, Set<String> identer) {
+}


### PR DESCRIPTION
Planen er at fptilgang utvides med
* map fra behandling(uuid) til sak
* map fra sak til ident som saken gjelder - "saksident"

Da kan fptilgang returnere både audit-info (FNR) til auditlogg +
Kan også returnere vanlig logg-kontekst (sak + behandling) - men det bør helst komme fra dato eller lokale oppslag