### PR TITLE
TFP-6103 redaksjonell - typer i beh.kontrollkontekst

### DIFF
--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/Behandling.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/Behandling.java
@@ -399,7 +399,7 @@ public class Behandling extends BaseEntitet {
                 .min(compareOpprettetTid().reversed().thenComparing(Comparator.nullsLast(compareEndretTid()).reversed())));
     }
 
-    public Optional<BehandlingStegTilstand> getBehandlingStegTilstand(BehandlingStegType stegType) {
+    public Optional<BehandlingStegTilstand> getBehandlingStegTilstandHvisSteg(BehandlingStegType stegType) {
         return getBehandlingStegTilstand()
             .filter(t -> Objects.equals(stegType, t.getBehandlingSteg()));
     }

--- a/behandlingslager/testutil/src/main/java/no/nav/foreldrepenger/behandlingslager/testutilities/behandling/AbstractTestScenario.java
+++ b/behandlingslager/testutil/src/main/java/no/nav/foreldrepenger/behandlingslager/testutilities/behandling/AbstractTestScenario.java
@@ -566,8 +566,7 @@ public abstract class AbstractTestScenario<S extends AbstractTestScenario<S>> {
 
         lenient().when(behandlingRepository.taSkriveLås(behandlingCaptor.capture())).thenAnswer((Answer<BehandlingLås>) invocation -> {
             Behandling beh = invocation.getArgument(0);
-            return new BehandlingLås(beh.getId()) {
-            };
+            return new BehandlingLås(beh.getId());
         });
 
         lenient().when(behandlingRepository.hentSistOppdatertTidspunkt(any()))

--- a/behandlingsprosess/src/main/java/no/nav/foreldrepenger/behandling/steg/iverksettevedtak/HenleggBehandlingTjeneste.java
+++ b/behandlingsprosess/src/main/java/no/nav/foreldrepenger/behandling/steg/iverksettevedtak/HenleggBehandlingTjeneste.java
@@ -54,8 +54,8 @@ public class HenleggBehandlingTjeneste {
     }
 
     private void doHenleggBehandling(Long behandlingId, BehandlingResultatType årsakKode, String begrunnelse, boolean avbrytVentendeAutopunkt) {
-        var kontekst = behandlingskontrollTjeneste.initBehandlingskontroll(behandlingId);
         var behandling = behandlingRepository.hentBehandling(behandlingId);
+        var kontekst = behandlingskontrollTjeneste.initBehandlingskontroll(behandling);
         if (avbrytVentendeAutopunkt && behandling.isBehandlingPåVent()) {
             behandlingskontrollTjeneste.taBehandlingAvVentSetAlleAutopunktUtførtForHenleggelse(behandling, kontekst);
         } else {

--- a/behandlingsprosess/src/main/java/no/nav/foreldrepenger/behandling/steg/startuttak/fp/InngangUttakStegRevurdering.java
+++ b/behandlingsprosess/src/main/java/no/nav/foreldrepenger/behandling/steg/startuttak/fp/InngangUttakStegRevurdering.java
@@ -67,7 +67,7 @@ public class InngangUttakStegRevurdering implements InngangUttakSteg {
             .anyMatch(Vilkår::erIkkeOppfylt);
         if (avslag) {
             if (flytkontroll.finnesÅpenBerørtForFagsak(kontekst.getFagsakId(), kontekst.getBehandlingId())) {
-                LOG.warn("Si fra i driftskanal når du ser denne meldingen. Avslag og det finnes åpen berørt behandling. Fagsak {}", kontekst.getFagsakId());
+                LOG.warn("Si fra i driftskanal når du ser denne meldingen. Avslag og det finnes åpen berørt behandling. Fagsak {}", kontekst.getSaksnummer().getVerdi());
             }
             return BehandleStegResultat.utførtUtenAksjonspunkter();
         }

--- a/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/anke/AnkeStegTest.java
+++ b/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/anke/AnkeStegTest.java
@@ -30,7 +30,7 @@ class AnkeStegTest {
         var mockAnkeresultat = mock(AnkeResultatEntitet.class);
         when(mockAnkeresultat.erBehandletAvKabal()).thenReturn(Boolean.TRUE);
         when(ankeRepository.hentAnkeResultatHvisEksisterer(any())).thenReturn(Optional.of(mockAnkeresultat));
-        var kontekst = new BehandlingskontrollKontekst(ankeBehandling.getSaksnummer(), ankeBehandling.getFagsakId(),
+        var kontekst = new BehandlingskontrollKontekst(ankeBehandling,
                 new BehandlingLås(ankeBehandling.getId()));
 
         var steg = new AnkeSteg(ankeRepository, rProvider);

--- a/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/avklarfakta/fp/KontrollerFaktaRevurderingStegImplTest.java
+++ b/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/avklarfakta/fp/KontrollerFaktaRevurderingStegImplTest.java
@@ -53,10 +53,9 @@ class KontrollerFaktaRevurderingStegImplTest {
     @Test
     void skal_ikke_fjerne_aksjonspunkter_som_er_utledet_etter_startpunktet() {
         var behandling = opprettRevurdering();
-        var fagsak = behandling.getFagsak();
         // Arrange
         var lås = behandlingRepository.taSkriveLås(behandling);
-        var kontekst = new BehandlingskontrollKontekst(fagsak.getSaksnummer(), fagsak.getId(), lås);
+        var kontekst = new BehandlingskontrollKontekst(behandling, lås);
 
         // Act
         var aksjonspunkter = steg.utførSteg(kontekst).getAksjonspunktListe();
@@ -71,10 +70,9 @@ class KontrollerFaktaRevurderingStegImplTest {
     @Test
     void må_nullstille_fordelingsperiode_hvis_ikke_er_endringssøknad() {
         var behandling = opprettRevurdering();
-        var fagsak = behandling.getFagsak();
         // Arrange
         var lås = behandlingRepository.taSkriveLås(behandling);
-        var kontekst = new BehandlingskontrollKontekst(fagsak.getSaksnummer(), fagsak.getId(), lås);
+        var kontekst = new BehandlingskontrollKontekst(behandling, lås);
 
         // Act
         steg.utførSteg(kontekst).getAksjonspunktListe();
@@ -106,8 +104,7 @@ class KontrollerFaktaRevurderingStegImplTest {
                 .medDefaultOppgittTilknytning()
                 .lagre(repositoryProvider);
 
-        var kontekst = new BehandlingskontrollKontekst(revurdering.getSaksnummer(), revurdering.getFagsakId(),
-            behandlingRepository.taSkriveLås(revurdering.getId()));
+        var kontekst = new BehandlingskontrollKontekst(revurdering, behandlingRepository.taSkriveLås(revurdering.getId()));
         steg.utførSteg(kontekst);
 
         var ytelseFordelingAggregat = repositoryProvider.getYtelsesFordelingRepository()
@@ -139,8 +136,7 @@ class KontrollerFaktaRevurderingStegImplTest {
                 .medDefaultOppgittTilknytning()
                 .lagre(repositoryProvider);
 
-        var kontekst = new BehandlingskontrollKontekst(revurdering.getSaksnummer(), revurdering.getFagsakId(),
-                behandlingRepository.taSkriveLås(revurdering.getId()));
+        var kontekst = new BehandlingskontrollKontekst(revurdering, behandlingRepository.taSkriveLås(revurdering.getId()));
         steg.utførSteg(kontekst);
 
         var ytelseFordelingAggregat = repositoryProvider.getYtelsesFordelingRepository()
@@ -156,10 +152,9 @@ class KontrollerFaktaRevurderingStegImplTest {
 
         var revurdering = opprettRevurderingPgaEndringsSøknad(behandling, fom, tom);
 
-        var fagsak = revurdering.getFagsak();
         // Arrange
         var lås = behandlingRepository.taSkriveLås(revurdering);
-        var kontekst = new BehandlingskontrollKontekst(fagsak.getSaksnummer(), fagsak.getId(), lås);
+        var kontekst = new BehandlingskontrollKontekst(revurdering, lås);
 
         // Act
         steg.utførSteg(kontekst).getAksjonspunktListe();
@@ -178,10 +173,9 @@ class KontrollerFaktaRevurderingStegImplTest {
     @Test
     void skal_gå_til_nærmeste_startpunkt_før_åpen_overstyring() {
         var behandling = opprettAutomatiskRevurderingMedÅpenOverstyring();
-        var fagsak = behandling.getFagsak();
         // Arrange
         var lås = behandlingRepository.taSkriveLås(behandling);
-        var kontekst = new BehandlingskontrollKontekst(fagsak.getSaksnummer(), fagsak.getId(), lås);
+        var kontekst = new BehandlingskontrollKontekst(behandling, lås);
 
         // Act
         var aksjonspunkter = steg.utførSteg(kontekst).getAksjonspunktListe();
@@ -197,10 +191,9 @@ class KontrollerFaktaRevurderingStegImplTest {
     @Test
     void feriepenge_berørt_hopper_til_tilkjent() {
         var behandling = opprettRevurdering(BehandlingÅrsakType.REBEREGN_FERIEPENGER);
-        var fagsak = behandling.getFagsak();
         // Arrange
         var lås = behandlingRepository.taSkriveLås(behandling);
-        var kontekst = new BehandlingskontrollKontekst(fagsak.getSaksnummer(), fagsak.getId(), lås);
+        var kontekst = new BehandlingskontrollKontekst(behandling, lås);
         var expectedTransisjon =  new Transisjon(StegTransisjon.FLYOVER, StartpunktType.TILKJENT_YTELSE.getBehandlingSteg());
 
         // Act
@@ -241,9 +234,8 @@ class KontrollerFaktaRevurderingStegImplTest {
     void skal_utlede_startpunkt_dersom_uttaksplan_på_original_behandling_mangler() {
         // Arrange
         var revurdering = opprettRevurderingPgaBerørtBehandling();
-        var fagsak = revurdering.getFagsak();
         var lås = behandlingRepository.taSkriveLås(revurdering);
-        var kontekst = new BehandlingskontrollKontekst(fagsak.getSaksnummer(), fagsak.getId(), lås);
+        var kontekst = new BehandlingskontrollKontekst(revurdering, lås);
 
         // Act
         steg.utførSteg(kontekst).getAksjonspunktListe();
@@ -259,9 +251,8 @@ class KontrollerFaktaRevurderingStegImplTest {
         var revurdering = opprettRevurderingPgaBerørtBehandling();
         repositoryProvider.getFagsakRelasjonRepository().oppdaterDekningsgrad(revurdering.getFagsak(), Dekningsgrad._100);
         endreDekningsgrad(revurdering.getId(), Dekningsgrad._80);
-        var fagsak = revurdering.getFagsak();
         var lås = behandlingRepository.taSkriveLås(revurdering);
-        var kontekst = new BehandlingskontrollKontekst(fagsak.getSaksnummer(), fagsak.getId(), lås);
+        var kontekst = new BehandlingskontrollKontekst(revurdering, lås);
 
         // Act
         steg.utførSteg(kontekst).getAksjonspunktListe();
@@ -286,9 +277,8 @@ class KontrollerFaktaRevurderingStegImplTest {
         var revurdering = opprettRevurdering(BehandlingÅrsakType.ENDRE_DEKNINGSGRAD);
         repositoryProvider.getFagsakRelasjonRepository().oppdaterDekningsgrad(revurdering.getFagsak(), Dekningsgrad._80);
         endreDekningsgrad(revurdering.getId(), Dekningsgrad._100);
-        var fagsak = revurdering.getFagsak();
         var lås = behandlingRepository.taSkriveLås(revurdering);
-        var kontekst = new BehandlingskontrollKontekst(fagsak.getSaksnummer(), fagsak.getId(), lås);
+        var kontekst = new BehandlingskontrollKontekst(revurdering, lås);
 
         // Act
         steg.utførSteg(kontekst).getAksjonspunktListe();
@@ -310,9 +300,8 @@ class KontrollerFaktaRevurderingStegImplTest {
         var behandlingLås = behandlingRepository.taSkriveLås(behandling);
         behandlingRepository.lagre(behandling, behandlingLås);
 
-        var fagsak = behandling.getFagsak();
         var lås = behandlingRepository.taSkriveLås(behandling);
-        var kontekst = new BehandlingskontrollKontekst(fagsak.getSaksnummer(), fagsak.getId(), lås);
+        var kontekst = new BehandlingskontrollKontekst(behandling, lås);
 
         // Act
         steg.utførSteg(kontekst).getAksjonspunktListe();

--- a/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/avklarfakta/svp/KontrollerFaktaStegImplTest.java
+++ b/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/avklarfakta/svp/KontrollerFaktaStegImplTest.java
@@ -91,9 +91,8 @@ class KontrollerFaktaStegImplTest {
 
     @Test
     void skal_utlede_inngangsvilkår_for_svp() {
-        var fagsak = behandling.getFagsak();
         var lås = behandlingRepository.taSkriveLås(behandling.getId());
-        var kontekst = new BehandlingskontrollKontekst(fagsak.getSaksnummer(), fagsak.getId(), lås);
+        var kontekst = new BehandlingskontrollKontekst(behandling, lås);
 
         // Act
         steg.utførSteg(kontekst);

--- a/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/beregningsgrunnlag/fp/KontrollerFaktaBeregningStegTest.java
+++ b/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/beregningsgrunnlag/fp/KontrollerFaktaBeregningStegTest.java
@@ -77,6 +77,6 @@ class KontrollerFaktaBeregningStegTest {
 
     private BehandlingskontrollKontekst lagBehandlingskontrollkontekst(Behandling behandling) {
         var behandlingLås = behandlingRepository.taSkriveLås(behandling.getId());
-        return new BehandlingskontrollKontekst(behandling.getSaksnummer(), behandling.getFagsakId(), behandlingLås);
+        return new BehandlingskontrollKontekst(behandling, behandlingLås);
     }
 }

--- a/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/foreslåvedtak/ForeslåVedtakStegImplTest.java
+++ b/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/foreslåvedtak/ForeslåVedtakStegImplTest.java
@@ -21,9 +21,8 @@ class ForeslåVedtakStegImplTest {
         var steg = new ForeslåVedtakStegImpl(behandlingRepository, foreslåVedtakTjeneste);
 
         // Act
-        var fagsak = behandling.getFagsak();
         var behandlingLås = behandlingRepository.taSkriveLås(behandling);
-        var kontekst = new BehandlingskontrollKontekst(fagsak.getSaksnummer(), fagsak.getId(), behandlingLås);
+        var kontekst = new BehandlingskontrollKontekst(behandling, behandlingLås);
         steg.utførSteg(kontekst);
 
         // Assert

--- a/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/inngangsvilkår/InngangsvilkårStegImplTest.java
+++ b/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/inngangsvilkår/InngangsvilkårStegImplTest.java
@@ -64,8 +64,7 @@ class InngangsvilkårStegImplTest {
         var repositoryProvider = scenario.mockBehandlingRepositoryProvider();
         Behandlingsresultat.builderEndreEksisterende(behandling.getBehandlingsresultat())
                 .medBehandlingResultatType(BehandlingResultatType.INNVILGET);
-        var kontekst = new BehandlingskontrollKontekst(behandling.getSaksnummer(), behandling.getFagsakId(),
-                repositoryProvider.getBehandlingRepository().taSkriveLås(behandling));
+        var kontekst = new BehandlingskontrollKontekst(behandling, repositoryProvider.getBehandlingRepository().taSkriveLås(behandling));
 
         var val = new RegelResultat(behandling.getBehandlingsresultat().getVilkårResultat(), emptyList(), emptyMap());
         when(regelOrkestrerer.vurderInngangsvilkår(eq(Set.of(medlVilkårType)), any(), any())).thenReturn(val);
@@ -93,8 +92,7 @@ class InngangsvilkårStegImplTest {
         var repositoryProvider = scenario.mockBehandlingRepositoryProvider();
         Behandlingsresultat.builderEndreEksisterende(behandling.getBehandlingsresultat())
                 .medBehandlingResultatType(BehandlingResultatType.INNVILGET);
-        var kontekst = new BehandlingskontrollKontekst(behandling.getSaksnummer(), behandling.getFagsakId(),
-                repositoryProvider.getBehandlingRepository().taSkriveLås(behandling));
+        var kontekst = new BehandlingskontrollKontekst(behandling, repositoryProvider.getBehandlingRepository().taSkriveLås(behandling));
 
         var val = lagRegelResultatOpptjening(behandling);
         when(regelOrkestrerer.vurderInngangsvilkår(eq(Set.of(oppVilkårType)), any(), any())).thenReturn(val);
@@ -130,8 +128,7 @@ class InngangsvilkårStegImplTest {
         var repositoryProvider = revurderingsscenario.mockBehandlingRepositoryProvider();
         Behandlingsresultat.builderEndreEksisterende(revurdering.getBehandlingsresultat())
                 .medBehandlingResultatType(BehandlingResultatType.AVSLÅTT);
-        var kontekst = new BehandlingskontrollKontekst(revurdering.getSaksnummer(), revurdering.getFagsakId(),
-                repositoryProvider.getBehandlingRepository().taSkriveLås(revurdering));
+        var kontekst = new BehandlingskontrollKontekst(revurdering, repositoryProvider.getBehandlingRepository().taSkriveLås(revurdering));
 
         var val = lagRegelResultatOpptjening(revurdering);
         when(regelOrkestrerer.vurderInngangsvilkår(eq(Set.of(oppVilkårType)), any(), any())).thenReturn(val);
@@ -174,7 +171,7 @@ class InngangsvilkårStegImplTest {
         var repositoryProvider = revurderingsscenario.mockBehandlingRepositoryProvider();
         Behandlingsresultat.builderEndreEksisterende(revurdering.getBehandlingsresultat())
                 .medBehandlingResultatType(BehandlingResultatType.INNVILGET);
-        var kontekst = new BehandlingskontrollKontekst(revurdering.getSaksnummer(), revurdering.getFagsakId(),
+        var kontekst = new BehandlingskontrollKontekst(revurdering,
                 repositoryProvider.getBehandlingRepository().taSkriveLås(revurdering));
 
         var val = new RegelResultat(revurdering.getBehandlingsresultat().getVilkårResultat(), emptyList(), emptyMap());
@@ -208,7 +205,7 @@ class InngangsvilkårStegImplTest {
         var repositoryProvider = revurderingsscenario.mockBehandlingRepositoryProvider();
         Behandlingsresultat.builderEndreEksisterende(revurdering.getBehandlingsresultat())
                 .medBehandlingResultatType(BehandlingResultatType.INNVILGET);
-        var kontekst = new BehandlingskontrollKontekst(revurdering.getSaksnummer(), revurdering.getFagsakId(),
+        var kontekst = new BehandlingskontrollKontekst(revurdering,
                 repositoryProvider.getBehandlingRepository().taSkriveLås(revurdering));
 
         var val = new RegelResultat(revurdering.getBehandlingsresultat().getVilkårResultat(), emptyList(), emptyMap());
@@ -251,7 +248,7 @@ class InngangsvilkårStegImplTest {
         var repositoryProvider = andreRevurderingsscenario.mockBehandlingRepositoryProvider();
         Behandlingsresultat.builderEndreEksisterende(revurdering2.getBehandlingsresultat())
                 .medBehandlingResultatType(BehandlingResultatType.INNVILGET);
-        var kontekst = new BehandlingskontrollKontekst(revurdering2.getSaksnummer(), revurdering2.getFagsakId(),
+        var kontekst = new BehandlingskontrollKontekst(revurdering2,
                 repositoryProvider.getBehandlingRepository().taSkriveLås(revurdering2));
 
         var val = new RegelResultat(revurdering2.getBehandlingsresultat().getVilkårResultat(), emptyList(), emptyMap());
@@ -278,7 +275,7 @@ class InngangsvilkårStegImplTest {
         var repositoryProvider = scenario.mockBehandlingRepositoryProvider();
         Behandlingsresultat.builderEndreEksisterende(behandling.getBehandlingsresultat())
                 .medBehandlingResultatType(BehandlingResultatType.INNVILGET);
-        var kontekst = new BehandlingskontrollKontekst(behandling.getSaksnummer(), behandling.getFagsakId(),
+        var kontekst = new BehandlingskontrollKontekst(behandling,
                 repositoryProvider.getBehandlingRepository().taSkriveLås(behandling));
         var inngangsvilkårFellesTjeneste = new InngangsvilkårFellesTjeneste(regelOrkestrerer);
         // Act

--- a/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/inngangsvilkår/SamletInngangsvilkårStegImplTest.java
+++ b/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/inngangsvilkår/SamletInngangsvilkårStegImplTest.java
@@ -61,7 +61,7 @@ class SamletInngangsvilkårStegImplTest {
         var repositoryProvider = scenario.mockBehandlingRepositoryProvider();
         Behandlingsresultat.builderEndreEksisterende(behandling.getBehandlingsresultat())
                 .medBehandlingResultatType(BehandlingResultatType.INNVILGET);
-        kontekst = new BehandlingskontrollKontekst(behandling.getSaksnummer(), behandling.getFagsakId(),
+        kontekst = new BehandlingskontrollKontekst(behandling,
                 repositoryProvider.getBehandlingRepository().taSkriveLås(behandling));
 
         var val = new RegelResultat(behandling.getBehandlingsresultat().getVilkårResultat(), emptyList(), emptyMap());
@@ -93,7 +93,7 @@ class SamletInngangsvilkårStegImplTest {
         var repositoryProvider = scenario.mockBehandlingRepositoryProvider();
         Behandlingsresultat.builderEndreEksisterende(behandling.getBehandlingsresultat())
                 .medBehandlingResultatType(BehandlingResultatType.INNVILGET);
-        kontekst = new BehandlingskontrollKontekst(behandling.getSaksnummer(), behandling.getFagsakId(),
+        kontekst = new BehandlingskontrollKontekst(behandling,
                 repositoryProvider.getBehandlingRepository().taSkriveLås(behandling));
 
         var val = new RegelResultat(behandling.getBehandlingsresultat().getVilkårResultat(), emptyList(), emptyMap());

--- a/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/inngangsvilkår/medlem/es/VurderMedlemskapvilkårStegTest.java
+++ b/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/inngangsvilkår/medlem/es/VurderMedlemskapvilkårStegTest.java
@@ -86,8 +86,7 @@ class VurderMedlemskapvilkårStegTest {
         scenario.leggTilVilkår(VilkårType.MEDLEMSKAPSVILKÅRET_FORUTGÅENDE, VilkårUtfallType.IKKE_VURDERT);
 
         var behandling = lagre(scenario);
-        var fagsak = behandling.getFagsak();
-        var kontekst = new BehandlingskontrollKontekst(fagsak.getSaksnummer(), fagsak.getId(),
+        var kontekst = new BehandlingskontrollKontekst(behandling,
             repositoryProvider.getBehandlingLåsRepository().taLås(behandling.getId()));
 
         // Act - vurder vilkåret
@@ -114,8 +113,7 @@ class VurderMedlemskapvilkårStegTest {
         scenario.leggTilVilkår(VilkårType.MEDLEMSKAPSVILKÅRET_FORUTGÅENDE, VilkårUtfallType.IKKE_VURDERT);
 
         var behandling = lagre(scenario);
-        var fagsak = behandling.getFagsak();
-        var kontekst = new BehandlingskontrollKontekst(fagsak.getSaksnummer(), fagsak.getId(),
+        var kontekst = new BehandlingskontrollKontekst(behandling,
             repositoryProvider.getBehandlingLåsRepository().taLås(behandling.getId()));
 
         // Act - vurder vilkåret
@@ -142,8 +140,7 @@ class VurderMedlemskapvilkårStegTest {
         scenario.leggTilVilkår(VilkårType.MEDLEMSKAPSVILKÅRET, VilkårUtfallType.IKKE_VURDERT);
 
         var behandling = lagre(scenario);
-        var fagsak = behandling.getFagsak();
-        var kontekst = new BehandlingskontrollKontekst(fagsak.getSaksnummer(), fagsak.getId(),
+        var kontekst = new BehandlingskontrollKontekst(behandling,
                 repositoryProvider.getBehandlingLåsRepository().taLås(behandling.getId()));
 
         // Act - vurder vilkåret
@@ -181,8 +178,7 @@ class VurderMedlemskapvilkårStegTest {
         scenario.leggTilVilkår(VilkårType.MEDLEMSKAPSVILKÅRET, VilkårUtfallType.IKKE_VURDERT);
 
         var behandling = lagre(scenario);
-        var fagsak = behandling.getFagsak();
-        var kontekst = new BehandlingskontrollKontekst(fagsak.getSaksnummer(), fagsak.getId(),
+        var kontekst = new BehandlingskontrollKontekst(behandling,
             repositoryProvider.getBehandlingLåsRepository().taLås(behandling.getId()));
 
         // Act - vurder vilkåret

--- a/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/inngangsvilkår/opptjening/fp/VurderOpptjeningsvilkårStegTest.java
+++ b/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/inngangsvilkår/opptjening/fp/VurderOpptjeningsvilkårStegTest.java
@@ -48,8 +48,7 @@ class VurderOpptjeningsvilkårStegTest {
         scenario.medAvklarteUttakDatoer(avklarteUttakDatoer);
 
         var behandling = lagre(scenario);
-        var fagsak = behandling.getFagsak();
-        var kontekst = new BehandlingskontrollKontekst(fagsak.getSaksnummer(), fagsak.getId(),
+        var kontekst = new BehandlingskontrollKontekst(behandling,
                 repositoryProvider.getBehandlingLåsRepository().taLås(behandling.getId()));
 
         // Act

--- a/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/inngangsvilkår/opptjening/svp/FastsettOpptjeningsperiodeStegTest.java
+++ b/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/inngangsvilkår/opptjening/svp/FastsettOpptjeningsperiodeStegTest.java
@@ -86,11 +86,10 @@ class FastsettOpptjeningsperiodeStegTest {
         var behandling = lagre(scenario);
         lagreSvp(behandling, jordmorsdato);
 
-        var fagsak = behandling.getFagsak();
         var lås = behandlingRepository.taSkriveLås(behandling.getId());
         // Simulerer at disse vilkårene har blitt opprettet
         opprettVilkår(List.of(OPPTJENINGSPERIODEVILKÅR, OPPTJENINGSVILKÅRET), behandling, lås);
-        var kontekst = new BehandlingskontrollKontekst(fagsak.getSaksnummer(), fagsak.getId(), lås);
+        var kontekst = new BehandlingskontrollKontekst(behandling, lås);
 
         // Act
         opptjeningsperiodeSvpSteg.utførSteg(kontekst);
@@ -119,15 +118,14 @@ class FastsettOpptjeningsperiodeStegTest {
 
         lagreSvp(behandling, jordmorsdato);
 
-        var fagsak = behandling.getFagsak();
         var lås = behandlingRepository.taSkriveLås(behandling.getId());
         // Simulerer at disse vilkårene har blitt opprettet
         opprettVilkår(List.of(OPPTJENINGSPERIODEVILKÅR, OPPTJENINGSVILKÅRET), behandling, lås);
-        var kontekst = new BehandlingskontrollKontekst(fagsak.getSaksnummer(), fagsak.getId(), lås);
+        var kontekst = new BehandlingskontrollKontekst(behandling, lås);
         opptjeningsperiodeSvpSteg.utførSteg(kontekst);
 
         var lås2 = behandlingRepository.taSkriveLås(behandling.getId());
-        var kontekst2 = new BehandlingskontrollKontekst(fagsak.getSaksnummer(), fagsak.getId(), lås2);
+        var kontekst2 = new BehandlingskontrollKontekst(behandling, lås2);
 
         // Act
         vurderOpptjeningsvilkårSteg.utførSteg(kontekst2);
@@ -151,15 +149,14 @@ class FastsettOpptjeningsperiodeStegTest {
         var behandling = lagre(scenario);
         lagreSvp(behandling, jordmorsdato);
 
-        var fagsak = behandling.getFagsak();
         var lås = behandlingRepository.taSkriveLås(behandling.getId());
         // Simulerer at disse vilkårene har blitt opprettet
         opprettVilkår(List.of(OPPTJENINGSPERIODEVILKÅR, OPPTJENINGSVILKÅRET), behandling, lås);
-        var kontekst = new BehandlingskontrollKontekst(fagsak.getSaksnummer(), fagsak.getId(), lås);
+        var kontekst = new BehandlingskontrollKontekst(behandling, lås);
         opptjeningsperiodeSvpSteg.utførSteg(kontekst);
 
         var lås2 = behandlingRepository.taSkriveLås(behandling.getId());
-        var kontekst2 = new BehandlingskontrollKontekst(fagsak.getSaksnummer(), fagsak.getId(), lås2);
+        var kontekst2 = new BehandlingskontrollKontekst(behandling, lås2);
 
         // Act
         vurderOpptjeningsvilkårSteg.utførSteg(kontekst2);
@@ -181,15 +178,14 @@ class FastsettOpptjeningsperiodeStegTest {
         var behandling = lagre(scenario);
         lagreSvp(behandling, jordmorsdato);
 
-        var fagsak = behandling.getFagsak();
         var lås = behandlingRepository.taSkriveLås(behandling.getId());
         // Simulerer at disse vilkårene har blitt opprettet
         opprettVilkår(List.of(OPPTJENINGSPERIODEVILKÅR, OPPTJENINGSVILKÅRET), behandling, lås);
-        var kontekst = new BehandlingskontrollKontekst(fagsak.getSaksnummer(), fagsak.getId(), lås);
+        var kontekst = new BehandlingskontrollKontekst(behandling, lås);
         opptjeningsperiodeSvpSteg.utførSteg(kontekst);
 
         var lås2 = behandlingRepository.taSkriveLås(behandling.getId());
-        var kontekst2 = new BehandlingskontrollKontekst(fagsak.getSaksnummer(), fagsak.getId(), lås2);
+        var kontekst2 = new BehandlingskontrollKontekst(behandling, lås2);
 
         // simuler at aktiviteten har blitt godkjent
         var aktivitetsPeriode = DatoIntervallEntitet.fraOgMedTilOgMed(LocalDate.now().minusMonths(6), LocalDate.now().plusMonths(6));

--- a/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/innhentsaksopplysninger/InnhentRegisteropplysningerResterendeOppgaverStegImplTest.java
+++ b/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/innhentsaksopplysninger/InnhentRegisteropplysningerResterendeOppgaverStegImplTest.java
@@ -96,7 +96,7 @@ class InnhentRegisteropplysningerResterendeOppgaverStegImplTest {
         mockSkjæringstidspunkt(LocalDate.now().plusWeeks(2));
 
         // Act
-        var resultat = steg.utførSteg(new BehandlingskontrollKontekst(behandling.getSaksnummer(), behandling.getFagsakId(), new BehandlingLås(behandling.getId())));
+        var resultat = steg.utførSteg(new BehandlingskontrollKontekst(behandling, new BehandlingLås(behandling.getId())));
 
         // Assert
         assertThat(resultat.getTransisjon().stegTransisjon()).isEqualTo(StegTransisjon.UTFØRT);
@@ -115,7 +115,7 @@ class InnhentRegisteropplysningerResterendeOppgaverStegImplTest {
         mockSkjæringstidspunkt(LocalDate.now().plusWeeks(2));
 
         // Act
-        var resultat = steg.utførSteg(new BehandlingskontrollKontekst(revudering.getSaksnummer(), revudering.getFagsakId(), new BehandlingLås(revudering.getId())));
+        var resultat = steg.utførSteg(new BehandlingskontrollKontekst(revudering, new BehandlingLås(revudering.getId())));
 
         // Assert
         assertThat(resultat.getTransisjon().stegTransisjon()).isEqualTo(StegTransisjon.UTFØRT);
@@ -132,7 +132,7 @@ class InnhentRegisteropplysningerResterendeOppgaverStegImplTest {
         mockSkjæringstidspunkt(LocalDate.now().minusWeeks(6).minusDays(1));
 
         // Act
-        var resultat = steg.utførSteg(new BehandlingskontrollKontekst(behandling.getSaksnummer(), behandling.getFagsakId(), new BehandlingLås(behandling.getId())));
+        var resultat = steg.utførSteg(new BehandlingskontrollKontekst(behandling, new BehandlingLås(behandling.getId())));
 
         // Assert
         assertThat(resultat.getTransisjon().stegTransisjon()).isEqualTo(StegTransisjon.UTFØRT);
@@ -153,7 +153,7 @@ class InnhentRegisteropplysningerResterendeOppgaverStegImplTest {
         mockSkjæringstidspunkt(LocalDate.now().plusWeeks(2));
 
         // Act
-        var resultat = steg.utførSteg(new BehandlingskontrollKontekst(behandling.getSaksnummer(), behandling.getFagsakId(), new BehandlingLås(behandling.getId())));
+        var resultat = steg.utførSteg(new BehandlingskontrollKontekst(behandling, new BehandlingLås(behandling.getId())));
 
 
         // Assert
@@ -173,7 +173,7 @@ class InnhentRegisteropplysningerResterendeOppgaverStegImplTest {
         mockSkjæringstidspunkt(LocalDate.now().plusWeeks(2));
 
         // Act
-        var resultat = steg.utførSteg(new BehandlingskontrollKontekst(behandling.getSaksnummer(), behandling.getFagsakId(), new BehandlingLås(behandling.getId())));
+        var resultat = steg.utførSteg(new BehandlingskontrollKontekst(behandling, new BehandlingLås(behandling.getId())));
 
         // Assert
         assertThat(resultat.getAksjonspunktResultater()).containsExactly(opprettForAksjonspunktMedFrist(AUTO_VENT_ETTERLYST_INNTEKTSMELDING, Venteårsak.VENT_OPDT_INNTEKTSMELDING, ventefrist));
@@ -191,7 +191,7 @@ class InnhentRegisteropplysningerResterendeOppgaverStegImplTest {
         mockSkjæringstidspunkt(LocalDate.now().plusWeeks(2));
 
         // Act
-        var resultat = steg.utførSteg(new BehandlingskontrollKontekst(behandling.getSaksnummer(), behandling.getFagsakId(), new BehandlingLås(behandling.getId())));
+        var resultat = steg.utførSteg(new BehandlingskontrollKontekst(behandling, new BehandlingLås(behandling.getId())));
 
 
         // Assert

--- a/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/innsyn/VurderInnsynStegTest.java
+++ b/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/innsyn/VurderInnsynStegTest.java
@@ -40,8 +40,7 @@ class VurderInnsynStegTest extends EntityManagerAwareTest {
 
         // Act
         var lås = behandlingRepository.taSkriveLås(behandling);
-        var fagsak = behandling.getFagsak();
-        var kontekst = new BehandlingskontrollKontekst(fagsak.getSaksnummer(), fagsak.getId(), lås);
+        var kontekst = new BehandlingskontrollKontekst(behandling, lås);
         var resultat = steg.utførSteg(kontekst);
         assertThat(resultat.getAksjonspunktListe()).containsOnly(AksjonspunktDefinisjon.VURDER_INNSYN);
     }

--- a/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/iverksettevedtak/IverksetteInnsynVedtakStegFellesTest.java
+++ b/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/iverksettevedtak/IverksetteInnsynVedtakStegFellesTest.java
@@ -27,8 +27,7 @@ class IverksetteInnsynVedtakStegFellesTest {
         var repositoryProvider = scenario.mockBehandlingRepositoryProvider();
         var steg = new IverksetteInnsynVedtakStegFelles(dokumentBestillerTjeneste, repositoryProvider, mock(BehandlingEventPubliserer.class));
         var behandling = scenario.getBehandling();
-        var fagsak = behandling.getFagsak();
-        var kontekst = new BehandlingskontrollKontekst(fagsak.getSaksnummer(), fagsak.getId(),
+        var kontekst = new BehandlingskontrollKontekst(behandling,
             repositoryProvider.getBehandlingRepository().taSkriveLås(behandling));
         steg.utførSteg(kontekst);
 
@@ -43,8 +42,7 @@ class IverksetteInnsynVedtakStegFellesTest {
         var repositoryProvider = scenario.mockBehandlingRepositoryProvider();
         var steg = new IverksetteInnsynVedtakStegFelles(dokumentBestillerTjeneste, repositoryProvider, mock(BehandlingEventPubliserer.class));
         var behandling = scenario.getBehandling();
-        var fagsak = behandling.getFagsak();
-        var kontekst = new BehandlingskontrollKontekst(fagsak.getSaksnummer(), fagsak.getId(),
+        var kontekst = new BehandlingskontrollKontekst(behandling,
             repositoryProvider.getBehandlingRepository().taSkriveLås(behandling));
         steg.utførSteg(kontekst);
 
@@ -62,8 +60,7 @@ class IverksetteInnsynVedtakStegFellesTest {
         var repositoryProvider = scenario.mockBehandlingRepositoryProvider();
         var steg = new IverksetteInnsynVedtakStegFelles(dokumentBestillerTjeneste, repositoryProvider, mock(BehandlingEventPubliserer.class));
         var behandling = scenario.getBehandling();
-        var fagsak = behandling.getFagsak();
-        var kontekst = new BehandlingskontrollKontekst(fagsak.getSaksnummer(), fagsak.getId(),
+        var kontekst = new BehandlingskontrollKontekst(behandling,
             repositoryProvider.getBehandlingRepository().taSkriveLås(behandling));
         steg.utførSteg(kontekst);
 

--- a/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/iverksettevedtak/es/IverksetteVedtakStegFellesTest.java
+++ b/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/iverksettevedtak/es/IverksetteVedtakStegFellesTest.java
@@ -151,7 +151,7 @@ class IverksetteVedtakStegFellesTest extends EntityManagerAwareTest {
 
     private BehandleStegResultat utførSteg(Behandling behandling) {
         var lås = behandlingRepository.taSkriveLås(behandling);
-        return iverksetteVedtakSteg.utførSteg(new BehandlingskontrollKontekst(behandling.getSaksnummer(), behandling.getFagsakId(), lås));
+        return iverksetteVedtakSteg.utførSteg(new BehandlingskontrollKontekst(behandling, lås));
     }
 
     private Behandling opprettBehandling() {

--- a/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/iverksettevedtak/fp/IverksetteVedtakStegYtelseTest.java
+++ b/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/iverksettevedtak/fp/IverksetteVedtakStegYtelseTest.java
@@ -85,7 +85,7 @@ class IverksetteVedtakStegYtelseTest {
 
     private BehandleStegResultat utførSteg(Behandling behandling) {
         var lås = repositoryProvider.getBehandlingRepository().taSkriveLås(behandling);
-        return iverksetteVedtakSteg.utførSteg(new BehandlingskontrollKontekst(behandling.getSaksnummer(), behandling.getFagsakId(), lås));
+        return iverksetteVedtakSteg.utførSteg(new BehandlingskontrollKontekst(behandling, lås));
     }
 
     private Behandling opprettBehandling() {

--- a/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/klage/KlageNfpStegTest.java
+++ b/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/klage/KlageNfpStegTest.java
@@ -41,8 +41,7 @@ class KlageNfpStegTest {
     void skalOppretteAksjonspunktManuellVurderingAvKlageNfpNårStegKjøres() {
         var scenario = ScenarioKlageEngangsstønad.forMedholdNK(ScenarioMorSøkerEngangsstønad.forFødsel());
         var klageBehandling = scenario.lagMocked();
-        var kontekst = new BehandlingskontrollKontekst(klageBehandling.getSaksnummer(), klageBehandling.getFagsakId(),
-                new BehandlingLås(klageBehandling.getId()));
+        var kontekst = new BehandlingskontrollKontekst(klageBehandling, new BehandlingLås(klageBehandling.getId()));
 
         // Act
         var behandlingStegResultat = steg.utførSteg(kontekst);
@@ -62,8 +61,7 @@ class KlageNfpStegTest {
 
         var scenario = ScenarioKlageEngangsstønad.forMedholdNK(ScenarioMorSøkerEngangsstønad.forFødsel());
         var klageBehandling = scenario.lagMocked();
-        var kontekst = new BehandlingskontrollKontekst(klageBehandling.getSaksnummer(), klageBehandling.getFagsakId(),
-                new BehandlingLås(klageBehandling.getId()));
+        var kontekst = new BehandlingskontrollKontekst(klageBehandling, new BehandlingLås(klageBehandling.getId()));
         var repositoryProviderMock = scenario.mockBehandlingRepositoryProvider();
         steg = new KlageNfpSteg(repositoryProviderMock.getBehandlingRepository(), behandlendeEnhetTjeneste);
 

--- a/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/klage/KlageNkStegTest.java
+++ b/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/klage/KlageNkStegTest.java
@@ -17,8 +17,7 @@ class KlageNkStegTest {
         // Arrange
         var scenario = ScenarioKlageEngangsstønad.forAvvistNFP(ScenarioMorSøkerEngangsstønad.forAdopsjon());
         var klageBehandling = scenario.lagMocked();
-        var kontekst = new BehandlingskontrollKontekst(klageBehandling.getSaksnummer(), klageBehandling.getFagsakId(),
-                new BehandlingLås(klageBehandling.getId()));
+        var kontekst = new BehandlingskontrollKontekst(klageBehandling, new BehandlingLås(klageBehandling.getId()));
         var klageRepository = scenario.getKlageRepository();
 
         var steg = new KlageNkSteg(scenario.mockBehandlingRepository(), klageRepository);

--- a/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/mottatteopplysninger/fp/TilknyttFagsakUtlandsAksjonspunktTest.java
+++ b/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/mottatteopplysninger/fp/TilknyttFagsakUtlandsAksjonspunktTest.java
@@ -45,8 +45,7 @@ class TilknyttFagsakUtlandsAksjonspunktTest {
 
         when(kobleSakerTjeneste.finnFagsakRelasjonDersomOpprettet(behandling)).thenReturn(Optional.of(new FagsakRelasjon(behandling.getFagsak(), null,
                 null, Dekningsgrad._100, fødselsdato.plusYears(3))));
-        var kontekst = new BehandlingskontrollKontekst(behandling.getSaksnummer(), behandling.getFagsakId(),
-            provider.getBehandlingRepository().taSkriveLås(behandling));
+        var kontekst = new BehandlingskontrollKontekst(behandling, provider.getBehandlingRepository().taSkriveLås(behandling));
 
         var tilknyttFagsakSteg = new TilknyttFagsakStegImpl(provider, kobleSakerTjeneste, mock(BehandlendeEnhetTjeneste.class),
             mock(InntektArbeidYtelseTjeneste.class), mock(RegistrerFagsakEgenskaper.class));

--- a/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/registrersøknad/RegistrerSøknadStegTest.java
+++ b/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/registrersøknad/RegistrerSøknadStegTest.java
@@ -82,7 +82,7 @@ class RegistrerSøknadStegTest extends EntityManagerAwareTest {
                 .build();
         mottatteDokumentRepository.lagre(mottattDokument);
 
-        var kontekst = new BehandlingskontrollKontekst(saksnummer, fagsakId, lås);
+        var kontekst = new BehandlingskontrollKontekst(revurdering, lås);
         var resultat = steg.utførSteg(kontekst);
 
         assertThat(resultat.getAksjonspunktListe()).containsExactly(AksjonspunktDefinisjon.REGISTRER_PAPIR_ENDRINGSØKNAD_FORELDREPENGER);
@@ -114,7 +114,7 @@ class RegistrerSøknadStegTest extends EntityManagerAwareTest {
                 .build();
         mottatteDokumentRepository.lagre(mottattDokument);
 
-        var kontekst = new BehandlingskontrollKontekst(saksnummer, fagsakId, lås);
+        var kontekst = new BehandlingskontrollKontekst(revurdering, lås);
         var resultat = steg.utførSteg(kontekst);
 
         assertThat(resultat.getAksjonspunktListe()).containsExactly(AksjonspunktDefinisjon.REGISTRER_PAPIRSØKNAD_SVANGERSKAPSPENGER);

--- a/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/simulering/SimulerOppdragStegTest.java
+++ b/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/simulering/SimulerOppdragStegTest.java
@@ -73,8 +73,7 @@ class SimulerOppdragStegTest {
         beregningsresultatRepository = repositoryProvider.getBeregningsresultatRepository();
         this.entityManager = entityManager;
         behandling = scenario.lagre(repositoryProvider);
-        kontekst = new BehandlingskontrollKontekst(behandling.getSaksnummer(), behandling.getFagsakId(),
-                behandlingRepository.taSkriveLås(behandling));
+        kontekst = new BehandlingskontrollKontekst(behandling, behandlingRepository.taSkriveLås(behandling));
     }
 
     @Test

--- a/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/søknadsfrist/fp/VurderSøknadsfristStegTest.java
+++ b/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/søknadsfrist/fp/VurderSøknadsfristStegTest.java
@@ -99,9 +99,8 @@ class VurderSøknadsfristStegTest extends EntityManagerAwareTest {
 
         var søknad = opprettSøknad(førsteUttaksdato, mottattDato, behandling.getId());
         behandlingRepositoryProvider.getSøknadRepository().lagreOgFlush(behandling, søknad);
-        var fagsak = behandling.getFagsak();
         // Act
-        var kontekst = new BehandlingskontrollKontekst(fagsak.getSaksnummer(), fagsak.getId(),
+        var kontekst = new BehandlingskontrollKontekst(behandling,
                 behandlingRepository.taSkriveLås(behandling));
         var behandleStegResultat = fastsettUttaksgrunnlagOgVurderSøknadsfristSteg.utførSteg(kontekst);
 
@@ -143,9 +142,8 @@ class VurderSøknadsfristStegTest extends EntityManagerAwareTest {
         var søknad = opprettSøknad(førsteUttaksdato, mottattDato, behandling.getId());
         behandlingRepositoryProvider.getSøknadRepository().lagreOgFlush(behandling, søknad);
 
-        var fagsak = behandling.getFagsak();
         // Act
-        var kontekst = new BehandlingskontrollKontekst(fagsak.getSaksnummer(), fagsak.getId(),
+        var kontekst = new BehandlingskontrollKontekst(behandling,
                 behandlingRepository.taSkriveLås(behandling));
         var behandleStegResultat = fastsettUttaksgrunnlagOgVurderSøknadsfristSteg.utførSteg(kontekst);
 

--- a/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/søknadsfrist/svp/VurderSøknadsfristStegTest.java
+++ b/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/søknadsfrist/svp/VurderSøknadsfristStegTest.java
@@ -69,10 +69,9 @@ class VurderSøknadsfristStegTest {
         repositoryProvider.getSøknadRepository().lagreOgFlush(behandling, søknad);
         em.flush();
         em.clear();
-        var fagsak = behandling.getFagsak();
 
         // Act
-        var kontekst = new BehandlingskontrollKontekst(fagsak.getSaksnummer(), fagsak.getId(),
+        var kontekst = new BehandlingskontrollKontekst(behandling,
                 behandlingRepository.taSkriveLås(behandling));
         var behandleStegResultat = fastsettUttaksgrunnlagOgVurderSøknadsfristSteg.utførSteg(kontekst);
         em.flush();
@@ -102,10 +101,9 @@ class VurderSøknadsfristStegTest {
         repositoryProvider.getSøknadRepository().lagreOgFlush(behandling, søknad);
         em.flush();
         em.clear();
-        var fagsak = behandling.getFagsak();
 
         // Act
-        var kontekst = new BehandlingskontrollKontekst(fagsak.getSaksnummer(), fagsak.getId(), behandlingRepository.taSkriveLås(behandling));
+        var kontekst = new BehandlingskontrollKontekst(behandling, behandlingRepository.taSkriveLås(behandling));
         var behandleStegResultat = fastsettUttaksgrunnlagOgVurderSøknadsfristSteg.utførSteg(kontekst);
         em.flush();
         em.clear();
@@ -134,10 +132,9 @@ class VurderSøknadsfristStegTest {
         repositoryProvider.getSøknadRepository().lagreOgFlush(behandling, søknad);
         em.flush();
         em.clear();
-        var fagsak = behandling.getFagsak();
 
         // Act
-        var kontekst = new BehandlingskontrollKontekst(fagsak.getSaksnummer(), fagsak.getId(),
+        var kontekst = new BehandlingskontrollKontekst(behandling,
             behandlingRepository.taSkriveLås(behandling));
         var behandleStegResultat = fastsettUttaksgrunnlagOgVurderSøknadsfristSteg.utførSteg(kontekst);
         em.flush();
@@ -163,7 +160,7 @@ class VurderSøknadsfristStegTest {
         em.flush();
         em.clear();
         // Act
-        var rkontekst = new BehandlingskontrollKontekst(fagsak.getSaksnummer(), fagsak.getId(),
+        var rkontekst = new BehandlingskontrollKontekst(revurdering,
             behandlingRepository.taSkriveLås(revurdering));
         var rbehandleStegResultat = fastsettUttaksgrunnlagOgVurderSøknadsfristSteg.utførSteg(rkontekst);
         em.flush();

--- a/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/uttak/fp/FaktaLøpendeOmsorgStegTest.java
+++ b/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/uttak/fp/FaktaLøpendeOmsorgStegTest.java
@@ -42,9 +42,8 @@ class FaktaLøpendeOmsorgStegTest {
     void utførerMedAksjonspunktFaktaForOmsorg() {
         var scenario = opprettBehandlingForFarSomSøker();
         var behandling = scenario.lagre(repositoryProvider);
-        var fagsak = behandling.getFagsak();
         var lås = repositoryProvider.getBehandlingRepository().taSkriveLås(behandling);
-        var kontekst = new BehandlingskontrollKontekst(fagsak.getSaksnummer(), fagsak.getId(), lås);
+        var kontekst = new BehandlingskontrollKontekst(behandling, lås);
 
         var behandleStegResultat = steg.utførSteg(kontekst);
         assertThat(behandleStegResultat.getTransisjon().stegTransisjon()).isEqualTo(StegTransisjon.UTFØRT);

--- a/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/uttak/fp/FaktaUttakDokumentasjonStegTest.java
+++ b/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/uttak/fp/FaktaUttakDokumentasjonStegTest.java
@@ -48,7 +48,7 @@ class FaktaUttakDokumentasjonStegTest {
         var behandling = scenario.lagre(repositoryProvider);
 
         var stegResultat = steg.utførSteg(
-            new BehandlingskontrollKontekst(behandling.getSaksnummer(), behandling.getFagsakId(), new BehandlingLås(behandling.getId())));
+            new BehandlingskontrollKontekst(behandling, new BehandlingLås(behandling.getId())));
 
         assertThat(stegResultat.getAksjonspunktListe()).containsExactly(AksjonspunktDefinisjon.VURDER_UTTAK_DOKUMENTASJON);
 

--- a/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/uttak/fp/FaktaUttakStegTest.java
+++ b/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/uttak/fp/FaktaUttakStegTest.java
@@ -50,7 +50,7 @@ class FaktaUttakStegTest {
         var behandling = scenario.lagre(repositoryProvider);
 
         var stegResultat = steg.utførSteg(
-            new BehandlingskontrollKontekst(behandling.getSaksnummer(), behandling.getFagsakId(), new BehandlingLås(behandling.getId())));
+            new BehandlingskontrollKontekst(behandling, new BehandlingLås(behandling.getId())));
 
         assertThat(stegResultat.getAksjonspunktListe()).containsExactly(AksjonspunktDefinisjon.FAKTA_UTTAK_MANUELT_SATT_STARTDATO_ULIK_SØKNAD_STARTDATO);
     }

--- a/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/uttak/fp/UttakStegImplTest.java
+++ b/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/uttak/fp/UttakStegImplTest.java
@@ -156,7 +156,7 @@ class UttakStegImplTest {
     }
 
     private BehandlingskontrollKontekst kontekst(Behandling behandling) {
-        return new BehandlingskontrollKontekst(behandling.getSaksnummer(), behandling.getFagsakId(), behandlingRepository.taSkriveLås(behandling));
+        return new BehandlingskontrollKontekst(behandling, behandlingRepository.taSkriveLås(behandling));
     }
 
     @Test
@@ -241,7 +241,7 @@ class UttakStegImplTest {
         oppdatereFagsakRelasjonVedVedtak.oppdaterRelasjonVedVedtattBehandling(behandling);
 
         // Act -- behandler fars behandling, skal ikke opprette stønadskontoer på nytt
-        var kontekstForFarsBehandling = new BehandlingskontrollKontekst(fagsak.getSaksnummer(), fagsak.getId(),
+        var kontekstForFarsBehandling = new BehandlingskontrollKontekst(farsBehandling,
                 behandlingRepository.taSkriveLås(farsBehandling));
         steg.utførSteg(kontekstForFarsBehandling);
 
@@ -264,7 +264,7 @@ class UttakStegImplTest {
         opprettUttaksperiodegrense(fødselsdato, morsFørstegang);
         opprettPersonopplysninger(morsFørstegang);
         fagsakRelasjonTjeneste.oppdaterDekningsgrad(morsFørstegang.getFagsakId(), Dekningsgrad._80);
-        var førstegangsKontekst = new BehandlingskontrollKontekst(fagsak.getSaksnummer(), fagsak.getId(),
+        var førstegangsKontekst = new BehandlingskontrollKontekst(morsFørstegang,
                 behandlingRepository.taSkriveLås(morsFørstegang));
 
         // Første versjon av kontoer opprettes
@@ -281,7 +281,7 @@ class UttakStegImplTest {
         var morsRevurdering = opprettRevurdering(morsFørstegang, fødselsdato.minusWeeks(3));
         oppdaterDekningsgrad(morsRevurdering.getId(), Dekningsgrad._100);
 
-        var revurderingKontekst = new BehandlingskontrollKontekst(fagsak.getSaksnummer(), fagsak.getId(),
+        var revurderingKontekst = new BehandlingskontrollKontekst(morsRevurdering,
                 behandlingRepository.taSkriveLås(morsRevurdering));
         steg.utførSteg(revurderingKontekst);
 
@@ -309,7 +309,7 @@ class UttakStegImplTest {
         opprettUttaksperiodegrense(fødselsdato, morsFørstegang);
         opprettPersonopplysninger(morsFørstegang);
         fagsakRelasjonTjeneste.oppdaterDekningsgrad(fagsak.getId(), dekningsgrad);
-        var førstegangsKontekst = new BehandlingskontrollKontekst(fagsak.getSaksnummer(), fagsak.getId(),
+        var førstegangsKontekst = new BehandlingskontrollKontekst(morsFørstegang,
             behandlingRepository.taSkriveLås(morsFørstegang));
 
         // Første versjon av kontoer opprettes
@@ -326,7 +326,7 @@ class UttakStegImplTest {
         oppdaterDekningsgrad(morsRevurdering.getId(), dekningsgrad);
 
         nesteSakRepository.lagreNesteSak(morsRevurdering.getId(), new Saksnummer("987"), fødselsdato.plusWeeks(40), fødselsdato.plusWeeks(40));
-        var revurderingKontekst = new BehandlingskontrollKontekst(fagsak.getSaksnummer(), fagsak.getId(),
+        var revurderingKontekst = new BehandlingskontrollKontekst(morsRevurdering,
             behandlingRepository.taSkriveLås(morsRevurdering));
         steg.utførSteg(revurderingKontekst);
 
@@ -402,7 +402,7 @@ class UttakStegImplTest {
     }
 
     private void kjørSteg(Behandling førstegangsBehandling) {
-        var kontekst = new BehandlingskontrollKontekst(førstegangsBehandling.getSaksnummer(), førstegangsBehandling.getFagsakId(),
+        var kontekst = new BehandlingskontrollKontekst(førstegangsBehandling,
                 behandlingLåsRepository.taLås(førstegangsBehandling.getId()));
         steg.utførSteg(kontekst);
     }

--- a/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/vedtak/BehandlingVedtakTjenesteTest.java
+++ b/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/vedtak/BehandlingVedtakTjenesteTest.java
@@ -66,8 +66,7 @@ class BehandlingVedtakTjenesteTest extends EntityManagerAwareTest {
         forceOppdaterBehandlingSteg(revurdering, BehandlingStegType.FATTE_VEDTAK);
         var behandlingLås = lagreBehandling(revurdering);
         opprettFamilieHendelseGrunnlag(originalBehandling, revurdering);
-        var fagsak = revurdering.getFagsak();
-        var revurderingKontekst = new BehandlingskontrollKontekst(fagsak.getSaksnummer(), fagsak.getId(), behandlingLås);
+        var revurderingKontekst = new BehandlingskontrollKontekst(revurdering, behandlingLås);
         oppdaterMedBehandlingsresultat(revurderingKontekst, BehandlingResultatType.OPPHØR);
         lagUttaksresultatOpphørEtterSkjæringstidspunkt(revurdering);
 
@@ -146,7 +145,6 @@ class BehandlingVedtakTjenesteTest extends EntityManagerAwareTest {
                 .medBehandlendeEnhet("Stord")
                 .lagre(repositoryProvider);
         Behandlingsresultat.builder().medBehandlingResultatType(BehandlingResultatType.INNVILGET).buildFor(behandling);
-        var fagsak = behandling.getFagsak();
-        return new BehandlingskontrollKontekst(fagsak.getSaksnummer(), fagsak.getId(), behandlingRepository.taSkriveLås(behandling));
+        return new BehandlingskontrollKontekst(behandling, behandlingRepository.taSkriveLås(behandling));
     }
 }

--- a/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/vedtak/FatteVedtakStegTest.java
+++ b/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/vedtak/FatteVedtakStegTest.java
@@ -208,8 +208,7 @@ class FatteVedtakStegTest {
         forceOppdaterBehandlingSteg(revurdering, BehandlingStegType.FATTE_VEDTAK);
         var behandlingLås = lagreBehandling(revurdering);
         opprettFamilieHendelseGrunnlag(originalBehandling, revurdering);
-        var fagsak = revurdering.getFagsak();
-        var revurderingKontekst = new BehandlingskontrollKontekst(fagsak.getSaksnummer(), fagsak.getId(), behandlingLås);
+        var revurderingKontekst = new BehandlingskontrollKontekst(revurdering, behandlingLås);
         oppdaterMedBehandlingsresultat(revurderingKontekst, false, antallBarn);
 
         fatteVedtakSteg.utførSteg(revurderingKontekst);
@@ -240,8 +239,7 @@ class FatteVedtakStegTest {
         forceOppdaterBehandlingSteg(revurdering, BehandlingStegType.FATTE_VEDTAK);
         var behandlingLås = lagreBehandling(revurdering);
         opprettFamilieHendelseGrunnlag(originalBehandling, revurdering);
-        var fagsak = revurdering.getFagsak();
-        var revurderingKontekst = new BehandlingskontrollKontekst(fagsak.getSaksnummer(), fagsak.getId(), behandlingLås);
+        var revurderingKontekst = new BehandlingskontrollKontekst(revurdering, behandlingLås);
         oppdaterMedBehandlingsresultat(revurderingKontekst, true, faktiskAntallBarn);
 
         fatteVedtakSteg.utførSteg(revurderingKontekst);
@@ -272,8 +270,7 @@ class FatteVedtakStegTest {
         var behandlingLås = lagreBehandling(revurdering);
 
         opprettFamilieHendelseGrunnlag(originalBehandling, revurdering);
-        var fagsak = revurdering.getFagsak();
-        var revurderingKontekst = new BehandlingskontrollKontekst(fagsak.getSaksnummer(), fagsak.getId(), behandlingLås);
+        var revurderingKontekst = new BehandlingskontrollKontekst(revurdering, behandlingLås);
         oppdaterMedBehandlingsresultat(revurderingKontekst, true, antallBarn);
 
         fatteVedtakSteg.utførSteg(revurderingKontekst);
@@ -312,8 +309,7 @@ class FatteVedtakStegTest {
         forceOppdaterBehandlingSteg(revurdering, BehandlingStegType.FATTE_VEDTAK);
         var behandlingLås = lagreBehandling(revurdering);
         opprettFamilieHendelseGrunnlag(originalBehandling, revurdering);
-        var fagsak = revurdering.getFagsak();
-        var revurderingKontekst = new BehandlingskontrollKontekst(fagsak.getSaksnummer(), fagsak.getId(), behandlingLås);
+        var revurderingKontekst = new BehandlingskontrollKontekst(revurdering, behandlingLås);
         oppdaterMedBehandlingsresultat(revurderingKontekst, false, antallBarn);
 
         fatteVedtakSteg.utførSteg(revurderingKontekst);
@@ -496,8 +492,7 @@ class FatteVedtakStegTest {
         var beregningResultat = LegacyESBeregningsresultat.builder().medBeregning(beregning).buildFor(behandling, bres);
         beregningRepository.lagre(beregningResultat, repositoryProvider.getBehandlingRepository().taSkriveLås(behandling));
 
-        var fagsak = behandling.getFagsak();
-        return new BehandlingskontrollKontekst(fagsak.getSaksnummer(), fagsak.getId(), repositoryProvider.getBehandlingRepository().taSkriveLås(behandling));
+        return new BehandlingskontrollKontekst(behandling, repositoryProvider.getBehandlingRepository().taSkriveLås(behandling));
     }
 
     private void oppdaterMedVedtak(BehandlingskontrollKontekst kontekst) {

--- a/domenetjenester/arbeidsforhold/src/test/java/no/nav/foreldrepenger/domene/arbeidsforhold/testutilities/behandling/AbstractIAYTestScenario.java
+++ b/domenetjenester/arbeidsforhold/src/test/java/no/nav/foreldrepenger/domene/arbeidsforhold/testutilities/behandling/AbstractIAYTestScenario.java
@@ -271,8 +271,7 @@ abstract class AbstractIAYTestScenario<S extends AbstractIAYTestScenario<S>> {
         var behandlingCaptor = ArgumentCaptor.forClass(Behandling.class);
         when(behandlingRepository.taSkriveLås(behandlingCaptor.capture())).thenAnswer((Answer<BehandlingLås>) invocation -> {
             Behandling beh = invocation.getArgument(0);
-            return new BehandlingLås(beh.getId()) {
-            };
+            return new BehandlingLås(beh.getId());
         });
 
         when(behandlingRepository.lagre(behandlingCaptor.capture(), ArgumentMatchers.any()))

--- a/domenetjenester/arbeidsforhold/src/test/java/no/nav/foreldrepenger/domene/fpinntektsmelding/LukkForespørselObserverTest.java
+++ b/domenetjenester/arbeidsforhold/src/test/java/no/nav/foreldrepenger/domene/fpinntektsmelding/LukkForespørselObserverTest.java
@@ -65,7 +65,7 @@ class LukkForespørselObserverTest {
         var behandling = Behandling.forFørstegangssøknad(fagsak).build();
 
         var behandlingsres = new Behandlingsresultat.Builder().medBehandlingResultatType(BehandlingResultatType.MERGET_OG_HENLAGT).build();
-        BehandlingStatusEvent.BehandlingAvsluttetEvent event = BehandlingStatusEvent.nyEvent(byggKontekst(behandling, fagsak), BehandlingStatus.AVSLUTTET);
+        BehandlingStatusEvent.BehandlingAvsluttetEvent event = BehandlingStatusEvent.nyEvent(byggKontekst(behandling), BehandlingStatus.AVSLUTTET);
 
         behandling.setBehandlingType(BehandlingType.FØRSTEGANGSSØKNAD);
         when(behandlingRepository.hentBehandling(behandling.getId())).thenReturn(behandling);
@@ -82,7 +82,7 @@ class LukkForespørselObserverTest {
         var behandling = Behandling.forFørstegangssøknad(fagsak).build();
 
         var behandlingsres = new Behandlingsresultat.Builder().medBehandlingResultatType(BehandlingResultatType.MERGET_OG_HENLAGT).build();
-        BehandlingStatusEvent.BehandlingAvsluttetEvent event = BehandlingStatusEvent.nyEvent(byggKontekst(behandling, fagsak), BehandlingStatus.AVSLUTTET);
+        BehandlingStatusEvent.BehandlingAvsluttetEvent event = BehandlingStatusEvent.nyEvent(byggKontekst(behandling), BehandlingStatus.AVSLUTTET);
 
         behandling.setBehandlingType(BehandlingType.REVURDERING);
         when(behandlingRepository.hentBehandling(behandling.getId())).thenReturn(behandling);
@@ -93,9 +93,8 @@ class LukkForespørselObserverTest {
         verify(fpInntektsmeldingTjeneste, times(0)).lagLukkForespørselTask(behandling, null, ForespørselStatus.UTGÅTT);
     }
 
-    private BehandlingskontrollKontekst byggKontekst(Behandling behandling, Fagsak fagsak) {
-        var behandlingLås = new BehandlingLås(behandling.getId()) {
-        };
-        return new BehandlingskontrollKontekst(fagsak.getSaksnummer(), fagsak.getId(), behandlingLås);
+    private BehandlingskontrollKontekst byggKontekst(Behandling behandling) {
+        var behandlingLås = new BehandlingLås(behandling.getId());
+        return new BehandlingskontrollKontekst(behandling, behandlingLås);
     }
 }

--- a/domenetjenester/behandling-klage/src/main/java/no/nav/foreldrepenger/behandling/kabal/MottaFraKabalTask.java
+++ b/domenetjenester/behandling-klage/src/main/java/no/nav/foreldrepenger/behandling/kabal/MottaFraKabalTask.java
@@ -92,8 +92,8 @@ public class MottaFraKabalTask extends BehandlingProsessTask {
     private void klageAvsluttet(ProsessTaskData prosessTaskData, Long behandlingId, String ref) {
         var utfall = Optional.ofNullable(prosessTaskData.getPropertyValue(UTFALL_KEY))
             .map(KabalUtfall::valueOf).orElseThrow(() -> new IllegalStateException("Utviklerfeil: Kabal-klage avsluttet men mangler utfall"));
-        var kontekst = behandlingskontrollTjeneste.initBehandlingskontroll(behandlingId);
         var klageBehandling = behandlingRepository.hentBehandling(behandlingId);
+        var kontekst = behandlingskontrollTjeneste.initBehandlingskontroll(klageBehandling);
         kabalTjeneste.settKabalReferanse(klageBehandling, ref);
         if (!UTEN_VURDERING.contains(utfall)) {
             kabalTjeneste.lagreKlageUtfallFraKabal(klageBehandling, utfall);
@@ -167,7 +167,7 @@ public class MottaFraKabalTask extends BehandlingProsessTask {
             .orElseThrow(() -> new IllegalStateException("Utviklerfeil: Kabal-anke avsluttet men mangler utfall"));
         var ankeBehandling = kabalTjeneste.finnAnkeBehandling(behandlingId, ref)
             .orElseThrow(() -> new IllegalStateException("Mangler ankebehandling for behandling " + behandlingId));
-        var kontekst = behandlingskontrollTjeneste.initBehandlingskontroll(ankeBehandling.getId());
+        var kontekst = behandlingskontrollTjeneste.initBehandlingskontroll(ankeBehandling);
         kabalTjeneste.settKabalReferanse(ankeBehandling, ref);
         if (KabalUtfall.TRUKKET.equals(utfall) || KabalUtfall.HEVET.equals(utfall)) {
             if (ankeBehandling.isBehandlingPåVent()) {
@@ -199,7 +199,7 @@ public class MottaFraKabalTask extends BehandlingProsessTask {
             kabalTjeneste.finnAnkeBehandling(behandlingId, ref)
                 .orElseThrow(() -> new IllegalStateException("Finner ike ankebehandling for behandling " + behandlingId));
         kabalTjeneste.settKabalReferanse(behandling, ref);
-        var kontekst = behandlingskontrollTjeneste.initBehandlingskontroll(behandling.getId());
+        var kontekst = behandlingskontrollTjeneste.initBehandlingskontroll(behandling);
         kabalTjeneste.settKabalReferanse(behandling, ref);
         if (behandling.isBehandlingPåVent()) {
             behandlingskontrollTjeneste.taBehandlingAvVentSetAlleAutopunktUtførtForHenleggelse(behandling, kontekst);

--- a/domenetjenester/behandling-klage/src/main/java/no/nav/foreldrepenger/behandling/klage/KlageVurderingTjeneste.java
+++ b/domenetjenester/behandling-klage/src/main/java/no/nav/foreldrepenger/behandling/klage/KlageVurderingTjeneste.java
@@ -157,7 +157,7 @@ public class KlageVurderingTjeneste {
     }
 
     private void tilbakeførBehandling(Behandling behandling, BehandlingStegType vurderingSteg) {
-        var kontekst = behandlingskontrollTjeneste.initBehandlingskontroll(behandling.getId());
+        var kontekst = behandlingskontrollTjeneste.initBehandlingskontroll(behandling);
         behandlingskontrollTjeneste.behandlingTilbakeføringTilTidligereBehandlingSteg(kontekst, vurderingSteg);
         prosesseringAsynkTjeneste.asynkProsesserBehandling(behandling);
     }

--- a/domenetjenester/behandling-prosessering/src/main/java/no/nav/foreldrepenger/behandlingsprosess/prosessering/task/FortsettBehandlingTask.java
+++ b/domenetjenester/behandling-prosessering/src/main/java/no/nav/foreldrepenger/behandlingsprosess/prosessering/task/FortsettBehandlingTask.java
@@ -51,8 +51,8 @@ public class FortsettBehandlingTask implements ProsessTaskHandler {
 
         try {
             var behandlingId = getBehandlingId(data);
-            var kontekst = behandlingskontrollTjeneste.initBehandlingskontroll(behandlingId);
             var behandling = behandlingRepository.hentBehandling(behandlingId);
+            var kontekst = behandlingskontrollTjeneste.initBehandlingskontroll(behandling);
             var manuellFortsettelse = Optional.ofNullable(data.getPropertyValue(MANUELL_FORTSETTELSE))
                     .map(Boolean::valueOf)
                     .orElse(Boolean.FALSE);

--- a/domenetjenester/behandling-prosessering/src/main/java/no/nav/foreldrepenger/behandlingsprosess/prosessering/task/GjenopptaBehandlingTask.java
+++ b/domenetjenester/behandling-prosessering/src/main/java/no/nav/foreldrepenger/behandlingsprosess/prosessering/task/GjenopptaBehandlingTask.java
@@ -39,8 +39,9 @@ public class GjenopptaBehandlingTask extends BehandlingProsessTask {
     @Override
     protected void prosesser(ProsessTaskData prosessTaskData, Long behandlingId) {
 
-        var kontekst = behandlingskontrollTjeneste.initBehandlingskontroll(behandlingId);
         var behandling = behandlingRepository.hentBehandling(behandlingId);
+        var kontekst = behandlingskontrollTjeneste.initBehandlingskontroll(behandling);
+
 
         if (behandling.isBehandlingPåVent()) {
             behandlingskontrollTjeneste.taBehandlingAvVentSetAlleAutopunktUtført(behandling, kontekst);

--- a/domenetjenester/behandling-prosessering/src/main/java/no/nav/foreldrepenger/behandlingsprosess/prosessering/task/StartBehandlingTask.java
+++ b/domenetjenester/behandling-prosessering/src/main/java/no/nav/foreldrepenger/behandlingsprosess/prosessering/task/StartBehandlingTask.java
@@ -2,8 +2,11 @@ package no.nav.foreldrepenger.behandlingsprosess.prosessering.task;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.spi.CDI;
+import jakarta.inject.Inject;
 
 import no.nav.foreldrepenger.behandlingskontroll.BehandlingskontrollTjeneste;
+import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepository;
+import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepositoryProvider;
 import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakProsesstaskRekkefølge;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTask;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTaskData;
@@ -16,6 +19,18 @@ import no.nav.vedtak.felles.prosesstask.api.ProsessTaskHandler;
 @ProsessTask("behandlingskontroll.startBehandling")
 @FagsakProsesstaskRekkefølge(gruppeSekvens = true)
 public class StartBehandlingTask implements ProsessTaskHandler {
+
+    private BehandlingRepository behandlingRepository;
+
+    StartBehandlingTask() {
+        // For CDI proxy
+    }
+
+    @Inject
+    public StartBehandlingTask(BehandlingRepositoryProvider repositoryProvider) {
+        behandlingRepository = repositoryProvider.getBehandlingRepository();
+    }
+
     @Override
     public void doTask(ProsessTaskData data) {
 
@@ -24,7 +39,8 @@ public class StartBehandlingTask implements ProsessTaskHandler {
         var behandlingskontrollTjeneste = cdi.select(BehandlingskontrollTjeneste.class).get();
 
         try {
-            var kontekst = behandlingskontrollTjeneste.initBehandlingskontroll(getBehandlingId(data));
+            var behandling = behandlingRepository.hentBehandling(getBehandlingId(data));
+            var kontekst = behandlingskontrollTjeneste.initBehandlingskontroll(behandling);
             // TODO (FC): assert at behandlingen starter fra første steg?
             behandlingskontrollTjeneste.prosesserBehandling(kontekst);
         } finally {

--- a/domenetjenester/behandling-prosessering/src/test/java/no/nav/foreldrepenger/behandlingsprosess/prosessering/GjenopptaBehandlingTaskTest.java
+++ b/domenetjenester/behandling-prosessering/src/test/java/no/nav/foreldrepenger/behandlingsprosess/prosessering/GjenopptaBehandlingTaskTest.java
@@ -1,7 +1,6 @@
 package no.nav.foreldrepenger.behandlingsprosess.prosessering;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -13,6 +12,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import no.nav.foreldrepenger.behandlingskontroll.BehandlingskontrollTjeneste;
+import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingLåsRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepository;
 import no.nav.foreldrepenger.behandlingslager.testutilities.behandling.ScenarioMorSøkerEngangsstønad;
@@ -48,7 +48,7 @@ class GjenopptaBehandlingTaskTest {
 
         task.doTask(prosessTaskData);
 
-        verify(mockBehandlingskontrollTjeneste).initBehandlingskontroll(anyLong());
+        verify(mockBehandlingskontrollTjeneste).initBehandlingskontroll(any(Behandling.class));
     }
 
 }

--- a/domenetjenester/behandling-revurdering/src/main/java/no/nav/foreldrepenger/behandling/revurdering/flytkontroll/TilbakeførTilDekningsgradStegTask.java
+++ b/domenetjenester/behandling-revurdering/src/main/java/no/nav/foreldrepenger/behandling/revurdering/flytkontroll/TilbakeførTilDekningsgradStegTask.java
@@ -87,6 +87,6 @@ public class TilbakeførTilDekningsgradStegTask extends FagsakProsessTask {
     }
 
     private boolean erIStegTidligereEnnDekningsgrad(Behandling behandling) {
-        return !behandlingskontrollTjeneste.erIStegEllerSenereSteg(behandling.getId(), BehandlingStegType.DEKNINGSGRAD);
+        return !behandlingskontrollTjeneste.erIStegEllerSenereSteg(behandling, BehandlingStegType.DEKNINGSGRAD);
     }
 }

--- a/domenetjenester/behandlingskontroll/src/main/java/no/nav/foreldrepenger/behandlingskontroll/BehandlingStegTilstandSnapshot.java
+++ b/domenetjenester/behandlingskontroll/src/main/java/no/nav/foreldrepenger/behandlingskontroll/BehandlingStegTilstandSnapshot.java
@@ -15,8 +15,8 @@ public record BehandlingStegTilstandSnapshot(BehandlingStegType steg, Behandling
         return stegType.map(s -> new BehandlingStegTilstandSnapshot(s, status)).orElse(null);
     }
 
-    public static BehandlingStegTilstandSnapshot tilBehandlingsStegSnapshot(Behandling behandling, BehandlingStegType steg) {
-        var tilstand = behandling.getBehandlingStegTilstand(steg);
+    public static BehandlingStegTilstandSnapshot tilBehandlingsStegSnapshotHvisSteg(Behandling behandling, BehandlingStegType steg) {
+        var tilstand = behandling.getBehandlingStegTilstandHvisSteg(steg);
         var stegType = tilstand.map(BehandlingStegTilstand::getBehandlingSteg);
         var status = tilstand.map(BehandlingStegTilstand::getBehandlingStegStatus).orElse(null);
         return stegType.map(s -> new BehandlingStegTilstandSnapshot(s, status)).orElse(null);

--- a/domenetjenester/behandlingskontroll/src/main/java/no/nav/foreldrepenger/behandlingskontroll/BehandlingskontrollKontekst.java
+++ b/domenetjenester/behandlingskontroll/src/main/java/no/nav/foreldrepenger/behandlingskontroll/BehandlingskontrollKontekst.java
@@ -2,7 +2,10 @@ package no.nav.foreldrepenger.behandlingskontroll;
 
 import java.util.Objects;
 
+import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
+import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingType;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingLås;
+import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakYtelseType;
 import no.nav.foreldrepenger.domene.typer.Saksnummer;
 
 /**
@@ -10,19 +13,33 @@ import no.nav.foreldrepenger.domene.typer.Saksnummer;
  */
 public class BehandlingskontrollKontekst {
 
-    private BehandlingLås behandlingLås;
-    private Long fagsakId;
-    private Saksnummer saksnummer;
+    private final BehandlingLås behandlingLås;
+    private final Long fagsakId;
+    private final Saksnummer saksnummer;
+    private final FagsakYtelseType ytelseType;
+    private final BehandlingType behandlingType;
 
     /**
      * NB: Foretrekk {@link BehandlingskontrollTjeneste#initBehandlingskontroll} i
      * stedet for å opprette her direkte.
      */
-    public BehandlingskontrollKontekst(Saksnummer saksnummer, Long fagsakId, BehandlingLås behandlingLås) {
+    public BehandlingskontrollKontekst(Saksnummer saksnummer, Long fagsakId, BehandlingLås behandlingLås,
+                                       FagsakYtelseType ytelseType, BehandlingType behandlingType) {
         Objects.requireNonNull(behandlingLås, "behandlingLås");
         this.saksnummer = saksnummer;
         this.fagsakId = fagsakId;
         this.behandlingLås = behandlingLås;
+        this.ytelseType = ytelseType;
+        this.behandlingType = behandlingType;
+    }
+
+    public BehandlingskontrollKontekst(Behandling behandling, BehandlingLås behandlingLås) {
+        Objects.requireNonNull(behandlingLås, "behandlingLås");
+        this.saksnummer = behandling.getSaksnummer();
+        this.fagsakId = behandling.getFagsakId();
+        this.behandlingLås = behandlingLås;
+        this.ytelseType = behandling.getFagsakYtelseType();
+        this.behandlingType = behandling.getType();
     }
 
     public BehandlingLås getSkriveLås() {
@@ -39,6 +56,14 @@ public class BehandlingskontrollKontekst {
 
     public Saksnummer getSaksnummer() {
         return saksnummer;
+    }
+
+    public FagsakYtelseType getYtelseType() {
+        return ytelseType;
+    }
+
+    public BehandlingType getBehandlingType() {
+        return behandlingType;
     }
 
     @Override

--- a/domenetjenester/behandlingskontroll/src/main/java/no/nav/foreldrepenger/behandlingskontroll/BehandlingskontrollTjeneste.java
+++ b/domenetjenester/behandlingskontroll/src/main/java/no/nav/foreldrepenger/behandlingskontroll/BehandlingskontrollTjeneste.java
@@ -4,10 +4,8 @@ import java.time.LocalDateTime;
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
-import java.util.UUID;
 import java.util.function.Consumer;
 
-import no.nav.foreldrepenger.behandlingskontroll.transisjoner.Transisjon;
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingResultatType;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingStegType;
@@ -15,20 +13,10 @@ import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingType;
 import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.Aksjonspunkt;
 import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.AksjonspunktDefinisjon;
 import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.Venteårsak;
-import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingLås;
 import no.nav.foreldrepenger.behandlingslager.fagsak.Fagsak;
 import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakYtelseType;
 
 public interface BehandlingskontrollTjeneste {
-
-    /**
-     * Initier ny Behandlingskontroll, oppretter kontekst som brukes til sikre at
-     * parallle behandlinger og kjøringer går i tur og orden. Dette skjer gjennom å
-     * opprette en {@link BehandlingLås} som legges ved ved lagring.
-     *
-     * @param behandlingId - må være med
-     */
-    BehandlingskontrollKontekst initBehandlingskontroll(Long behandlingId);
 
     /**
      * Initierer ny behandlingskontroll for en ny behandling, som ikke er lagret i
@@ -39,20 +27,11 @@ public interface BehandlingskontrollTjeneste {
     BehandlingskontrollKontekst initBehandlingskontroll(Behandling behandling);
 
     /**
-     * Initier ny Behandlingskontroll, oppretter kontekst som brukes til sikre at
-     * parallle behandlinger og kjøringer går i tur og orden. Dette skjer gjennom å
-     * opprette en {@link BehandlingLås} som legges ved ved lagring.
-     *
-     * @param behandlingUuid - må være med
-     */
-    BehandlingskontrollKontekst initBehandlingskontroll(UUID behandlingUuid);
-
-    /**
      * Prosesser behandling fra dit den sist har kommet. Avhengig av vurderingspunkt
      * (inngang- og utgang-kriterier) vil steget kjøres på nytt.
      *
      * @param kontekst - kontekst for prosessering. Opprettes gjennom
-     *                 {@link #initBehandlingskontroll(Long)}
+     *                 {@link #initBehandlingskontroll(Behandling)}
      */
     void prosesserBehandling(BehandlingskontrollKontekst kontekst);
 
@@ -61,7 +40,7 @@ public interface BehandlingskontrollTjeneste {
      * Vil kalle gjenopptaSteg for angitt steg, senere vanlig framdrift
      *
      * @param kontekst           - kontekst for prosessering. Opprettes gjennom
-     *                           {@link #initBehandlingskontroll(Long)}
+     *                           {@link #initBehandlingskontroll(Behandling)}
      * @param behandlingStegType - precondition steg
      */
     void prosesserBehandlingGjenopptaHvisStegVenter(BehandlingskontrollKontekst kontekst, BehandlingStegType behandlingStegType);
@@ -186,7 +165,7 @@ public interface BehandlingskontrollTjeneste {
      *
      * @param behandling
      * @param aksjonspunktDefinisjon hvilket Aksjonspunkt skal holde i 'ventingen'
-     * @param BehandlingStegType     stegType aksjonspunktet står i.
+     * @param stegType               stegType aksjonspunktet står i.
      * @param fristTid               Frist før Behandlingen å adresseres
      * @param venteårsak             Årsak til ventingen.
      *
@@ -219,7 +198,7 @@ public interface BehandlingskontrollTjeneste {
     /** Henlegg en behandling. */
     void henleggBehandling(BehandlingskontrollKontekst kontekst, BehandlingResultatType årsakKode);
 
-    Set<AksjonspunktDefinisjon> finnAksjonspunktDefinisjonerFraOgMed(Behandling behandling, BehandlingStegType steg, boolean medInngangOgså);
+    Set<AksjonspunktDefinisjon> finnAksjonspunktDefinisjonerFraOgMed(BehandlingskontrollKontekst kontekst, BehandlingStegType steg, boolean medInngangOgså);
 
     void henleggBehandlingFraSteg(BehandlingskontrollKontekst kontekst, BehandlingResultatType årsak);
 
@@ -227,7 +206,8 @@ public interface BehandlingskontrollTjeneste {
      * Sjekker i behandlingsmodellen om aksjonspunktet skal løses i eller etter det
      * angitte steget.
      *
-     * @param behandling
+     * @param ytelseType             ytelsen som skal sjekkes
+     * @param behandlingType         behandlingstypen som skal sjekkes
      * @param behandlingSteg         steget som aksjonspunktet skal sjekkes mot
      * @param aksjonspunktDefinisjon aksjonspunktet som skal sjekkes
      * @return true dersom aksjonspunktet skal løses i eller etter det angitte
@@ -242,9 +222,7 @@ public interface BehandlingskontrollTjeneste {
 
     int sammenlignRekkefølge(FagsakYtelseType ytelseType, BehandlingType behandlingType, BehandlingStegType stegA, BehandlingStegType stegB);
 
-    boolean erStegPassert(Long behandlingId, BehandlingStegType stegType);
-
     boolean erStegPassert(Behandling behandling, BehandlingStegType stegType);
 
-    boolean erIStegEllerSenereSteg(Long behandlingId, BehandlingStegType stegType);
+    boolean erIStegEllerSenereSteg(Behandling behandling, BehandlingStegType stegType);
 }

--- a/domenetjenester/behandlingskontroll/src/main/java/no/nav/foreldrepenger/behandlingskontroll/events/AksjonspunktStatusEvent.java
+++ b/domenetjenester/behandlingskontroll/src/main/java/no/nav/foreldrepenger/behandlingskontroll/events/AksjonspunktStatusEvent.java
@@ -10,31 +10,35 @@ import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.Aksjonspun
 import no.nav.foreldrepenger.domene.typer.Saksnummer;
 
 public class AksjonspunktStatusEvent implements BehandlingEvent {
-    private final BehandlingskontrollKontekst kontekst;
+
+    private final Long behandlingId;
+    private final Saksnummer saksnummer;
+    private final Long fagsakId;
     private final BehandlingStegType behandlingStegType;
     private final List<Aksjonspunkt> aksjonspunkter;
 
     public AksjonspunktStatusEvent(BehandlingskontrollKontekst kontekst, List<Aksjonspunkt> aksjonspunkter,
             BehandlingStegType behandlingStegType) {
-        super();
-        this.kontekst = kontekst;
+        this.behandlingId = kontekst.getBehandlingId();
+        this.saksnummer = kontekst.getSaksnummer();
+        this.fagsakId = kontekst.getFagsakId();
         this.behandlingStegType = behandlingStegType;
         this.aksjonspunkter = Collections.unmodifiableList(aksjonspunkter);
     }
 
     @Override
     public Long getFagsakId() {
-        return kontekst.getFagsakId();
+        return fagsakId;
     }
 
     @Override
     public Saksnummer getSaksnummer() {
-        return kontekst.getSaksnummer();
+        return saksnummer;
     }
 
     @Override
     public Long getBehandlingId() {
-        return kontekst.getBehandlingId();
+        return behandlingId;
     }
 
     public BehandlingStegType getBehandlingStegType() {

--- a/domenetjenester/behandlingskontroll/src/main/java/no/nav/foreldrepenger/behandlingskontroll/events/BehandlingStatusEvent.java
+++ b/domenetjenester/behandlingskontroll/src/main/java/no/nav/foreldrepenger/behandlingskontroll/events/BehandlingStatusEvent.java
@@ -16,27 +16,31 @@ import no.nav.foreldrepenger.domene.typer.Saksnummer;
  */
 public class BehandlingStatusEvent implements BehandlingEvent {
 
-    private final BehandlingskontrollKontekst kontekst;
+    private final Long behandlingId;
+    private final Saksnummer saksnummer;
+    private final Long fagsakId;
     private final BehandlingStatus nyStatus;
 
     BehandlingStatusEvent(BehandlingskontrollKontekst kontekst, BehandlingStatus nyStatus) {
-        this.kontekst = kontekst;
+        this.behandlingId = kontekst.getBehandlingId();
+        this.saksnummer = kontekst.getSaksnummer();
+        this.fagsakId = kontekst.getFagsakId();
         this.nyStatus = nyStatus;
     }
 
     @Override
     public Saksnummer getSaksnummer() {
-        return kontekst.getSaksnummer();
+        return saksnummer;
     }
 
     @Override
     public Long getBehandlingId() {
-        return kontekst.getBehandlingId();
+        return behandlingId;
     }
 
     @Override
     public Long getFagsakId() {
-        return kontekst.getFagsakId();
+        return fagsakId;
     }
 
     public BehandlingStatus getNyStatus() {
@@ -51,7 +55,7 @@ public class BehandlingStatusEvent implements BehandlingEvent {
 
     @Override
     public String toString() {
-        return getClass().getSimpleName() + "<" + kontekst +
+        return getClass().getSimpleName() + "<behandlingId=" + getBehandlingId() +
                 ", nyStatus=" + nyStatus +
                 ">";
     }

--- a/domenetjenester/behandlingskontroll/src/main/java/no/nav/foreldrepenger/behandlingskontroll/impl/BehandlingStegVisitor.java
+++ b/domenetjenester/behandlingskontroll/src/main/java/no/nav/foreldrepenger/behandlingskontroll/impl/BehandlingStegVisitor.java
@@ -173,7 +173,7 @@ class BehandlingStegVisitor {
             BehandlingStegType stegType,
             BehandlingStegStatus førsteStegStatus,
             BehandlingStegStatus nyStegStatus) {
-        var behandlingStegTilstand = behandling.getBehandlingStegTilstand(stegType);
+        var behandlingStegTilstand = behandling.getBehandlingStegTilstandHvisSteg(stegType);
         if (behandlingStegTilstand.isPresent() && erForskjellig(førsteStegStatus, nyStegStatus)) {
                 InternalManipulerBehandling.forceOppdaterBehandlingSteg(behandling, stegType, nyStegStatus, BehandlingStegStatus.UTFØRT);
                 behandlingRepository.lagre(behandling, kontekst.getSkriveLås());

--- a/domenetjenester/behandlingskontroll/src/main/java/no/nav/foreldrepenger/behandlingskontroll/impl/TekniskBehandlingStegVisitor.java
+++ b/domenetjenester/behandlingskontroll/src/main/java/no/nav/foreldrepenger/behandlingskontroll/impl/TekniskBehandlingStegVisitor.java
@@ -1,14 +1,11 @@
 package no.nav.foreldrepenger.behandlingskontroll.impl;
 
-import java.util.Optional;
-
 import no.nav.foreldrepenger.behandlingskontroll.BehandlingModellVisitor;
 import no.nav.foreldrepenger.behandlingskontroll.BehandlingStegModell;
 import no.nav.foreldrepenger.behandlingskontroll.BehandlingStegTilstandSnapshot;
 import no.nav.foreldrepenger.behandlingskontroll.BehandlingskontrollKontekst;
 import no.nav.foreldrepenger.behandlingskontroll.spi.BehandlingskontrollServiceProvider;
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
-import no.nav.foreldrepenger.domene.typer.Saksnummer;
 import no.nav.vedtak.felles.jpa.savepoint.Work;
 import no.nav.vedtak.log.mdc.MdcExtendedLogContext;
 
@@ -26,7 +23,7 @@ public class TekniskBehandlingStegVisitor implements BehandlingModellVisitor {
 
     private final BehandlingskontrollKontekst kontekst;
 
-    private BehandlingskontrollServiceProvider serviceProvider;
+    private final BehandlingskontrollServiceProvider serviceProvider;
 
     public TekniskBehandlingStegVisitor(BehandlingskontrollServiceProvider serviceProvider,
             BehandlingskontrollKontekst kontekst) {
@@ -36,9 +33,7 @@ public class TekniskBehandlingStegVisitor implements BehandlingModellVisitor {
 
     @Override
     public StegProsesseringResultat prosesser(BehandlingStegModell steg) {
-        var saksreferanse = Optional.ofNullable(kontekst.getSaksnummer()).map(Saksnummer::getVerdi)
-            .orElseGet(() -> kontekst.getFagsakId().toString());
-        LOG_CONTEXT.add("fagsak", saksreferanse);
+        LOG_CONTEXT.add("fagsak", kontekst.getSaksnummer().getVerdi());
         LOG_CONTEXT.add("behandling", kontekst.getBehandlingId());
         LOG_CONTEXT.add("steg", steg.getBehandlingStegType().getKode());
 

--- a/domenetjenester/behandlingskontroll/src/main/java/no/nav/foreldrepenger/behandlingskontroll/impl/observer/BehandlingStatusEventLogger.java
+++ b/domenetjenester/behandlingskontroll/src/main/java/no/nav/foreldrepenger/behandlingskontroll/impl/observer/BehandlingStatusEventLogger.java
@@ -18,10 +18,10 @@ public class BehandlingStatusEventLogger {
 
     public void loggBehandlingStatusEndring(@Observes BehandlingStatusEvent event) {
         var behandlingId = event.getBehandlingId();
-        var fagsakId = event.getFagsakId();
+        var saksnummer = event.getSaksnummer();
 
         var nyStatus = event.getNyStatus();
         var kode = nyStatus == null ? null : nyStatus.getKode();
-        LOG.info("Behandling status oppdatert; behandlingId [{}]; fagsakId [{}]; status [{}]]", behandlingId, fagsakId, kode);
+        LOG.info("Behandling status oppdatert; behandlingId [{}]; saksnummer [{}]; status [{}]]", behandlingId, saksnummer.getVerdi(), kode);
     }
 }

--- a/domenetjenester/behandlingskontroll/src/main/java/no/nav/foreldrepenger/behandlingskontroll/impl/observer/BehandlingskontrollFremoverhoppTransisjonEventObserver.java
+++ b/domenetjenester/behandlingskontroll/src/main/java/no/nav/foreldrepenger/behandlingskontroll/impl/observer/BehandlingskontrollFremoverhoppTransisjonEventObserver.java
@@ -12,6 +12,7 @@ import jakarta.inject.Inject;
 import no.nav.foreldrepenger.behandlingskontroll.BehandlingModell;
 import no.nav.foreldrepenger.behandlingskontroll.BehandlingSteg.TransisjonType;
 import no.nav.foreldrepenger.behandlingskontroll.BehandlingStegModell;
+import no.nav.foreldrepenger.behandlingskontroll.BehandlingskontrollKontekst;
 import no.nav.foreldrepenger.behandlingskontroll.events.AksjonspunktStatusEvent;
 import no.nav.foreldrepenger.behandlingskontroll.events.BehandlingTransisjonEvent;
 import no.nav.foreldrepenger.behandlingskontroll.spi.BehandlingskontrollServiceProvider;
@@ -47,7 +48,7 @@ public class BehandlingskontrollFremoverhoppTransisjonEventObserver {
         //            return;
         //        }
         var behandling = serviceProvider.hentBehandling(transisjonEvent.getBehandlingId());
-        var modell = getModell(behandling);
+        var modell = getModell(transisjonEvent.getKontekst());
 
         var førsteSteg = transisjonEvent.getFørsteSteg();
         var sisteSteg = transisjonEvent.getSisteSteg();
@@ -103,8 +104,8 @@ public class BehandlingskontrollFremoverhoppTransisjonEventObserver {
         stegModell.getSteg().vedTransisjon(transisjonEvent.getKontekst(), stegModell, TransisjonType.HOPP_OVER_FRAMOVER, finalFørsteSteg, sisteSteg);
     }
 
-    protected BehandlingModell getModell(Behandling behandling) {
-        return serviceProvider.getBehandlingModellRepository().getModell(behandling.getType(), behandling.getFagsakYtelseType());
+    protected BehandlingModell getModell(BehandlingskontrollKontekst kontekst) {
+        return serviceProvider.getBehandlingModellRepository().getModell(kontekst.getBehandlingType(), kontekst.getYtelseType());
     }
 
     private boolean skalBesøkeStegene(StegTransisjon transisjon) {

--- a/domenetjenester/behandlingskontroll/src/main/java/no/nav/foreldrepenger/behandlingskontroll/impl/observer/BehandlingskontrollTransisjonTilbakeføringEventObserver.java
+++ b/domenetjenester/behandlingskontroll/src/main/java/no/nav/foreldrepenger/behandlingskontroll/impl/observer/BehandlingskontrollTransisjonTilbakeføringEventObserver.java
@@ -51,7 +51,7 @@ public class BehandlingskontrollTransisjonTilbakeføringEventObserver {
     public void observerBehandlingSteg(@Observes BehandlingStegTilbakeføringEvent event) {
         var behandlingId = event.getBehandlingId();
         var behandling = serviceProvider.hentBehandling(behandlingId);
-        var modell = getModell(behandling);
+        var modell = getModell(event.getKontekst());
         guardIngenÅpneAutopunkter(behandling);
 
         var førsteSteg = event.getFørsteSteg();
@@ -79,8 +79,8 @@ public class BehandlingskontrollTransisjonTilbakeføringEventObserver {
         s.getSteg().vedTransisjon(event.getKontekst(), s, BehandlingSteg.TransisjonType.HOPP_OVER_BAKOVER, førsteSteg, sisteSteg);
     }
 
-    private BehandlingModell getModell(Behandling behandling) {
-        return serviceProvider.getBehandlingModellRepository().getModell(behandling.getType(), behandling.getFagsakYtelseType());
+    private BehandlingModell getModell(BehandlingskontrollKontekst kontekst) {
+        return serviceProvider.getBehandlingModellRepository().getModell(kontekst.getBehandlingType(), kontekst.getYtelseType());
     }
 
     private List<Aksjonspunkt> håndterAksjonspunkter(Behandling behandling, Set<AksjonspunktDefinisjon> mellomliggendeAksjonspunkt,

--- a/domenetjenester/behandlingskontroll/src/test/java/no/nav/foreldrepenger/behandlingskontroll/impl/BehandlingskontrollEventPublisererTest.java
+++ b/domenetjenester/behandlingskontroll/src/test/java/no/nav/foreldrepenger/behandlingskontroll/impl/BehandlingskontrollEventPublisererTest.java
@@ -66,7 +66,7 @@ class BehandlingskontrollEventPublisererTest {
         var scenario = TestScenario.forEngangsstønad();
         var behandling = scenario.lagre(serviceProvider);
 
-        var kontekst = kontrollTjeneste.initBehandlingskontroll(behandling.getId());
+        var kontekst = kontrollTjeneste.initBehandlingskontroll(behandling);
 
         var stegType = BehandlingStegType.SØKERS_RELASJON_TIL_BARN;
 
@@ -86,7 +86,7 @@ class BehandlingskontrollEventPublisererTest {
 
         var behandling = scenario.lagre(serviceProvider);
 
-        var kontekst = kontrollTjeneste.initBehandlingskontroll(behandling.getId());
+        var kontekst = kontrollTjeneste.initBehandlingskontroll(behandling);
 
         // Act
         kontrollTjeneste.prosesserBehandling(kontekst);
@@ -108,7 +108,7 @@ class BehandlingskontrollEventPublisererTest {
 
         var behandling = scenario.lagre(serviceProvider);
 
-        var kontekst = kontrollTjeneste.initBehandlingskontroll(behandling.getId());
+        var kontekst = kontrollTjeneste.initBehandlingskontroll(behandling);
 
         // Act
         kontrollTjeneste.prosesserBehandling(kontekst);
@@ -145,7 +145,7 @@ class BehandlingskontrollEventPublisererTest {
 
         var behandling = scenario.lagre(serviceProvider);
 
-        var kontekst = kontrollTjeneste.initBehandlingskontroll(behandling.getId());
+        var kontekst = kontrollTjeneste.initBehandlingskontroll(behandling);
 
         // Act
         kontrollTjeneste.prosesserBehandling(kontekst);
@@ -164,7 +164,7 @@ class BehandlingskontrollEventPublisererTest {
 
         var behandling = scenario.lagre(serviceProvider);
 
-        var kontekst = kontrollTjeneste.initBehandlingskontroll(behandling.getId());
+        var kontekst = kontrollTjeneste.initBehandlingskontroll(behandling);
 
         // Act
         kontrollTjeneste.prosesserBehandling(kontekst);
@@ -185,7 +185,7 @@ class BehandlingskontrollEventPublisererTest {
 
         var behandling = scenario.lagre(serviceProvider);
 
-        var kontekst = kontrollTjeneste.initBehandlingskontroll(behandling.getId());
+        var kontekst = kontrollTjeneste.initBehandlingskontroll(behandling);
 
         // Act
         kontrollTjeneste.prosesserBehandling(kontekst);

--- a/domenetjenester/behandlingskontroll/src/test/java/no/nav/foreldrepenger/behandlingskontroll/impl/BehandlingskontrollTjenesteImplTest.java
+++ b/domenetjenester/behandlingskontroll/src/test/java/no/nav/foreldrepenger/behandlingskontroll/impl/BehandlingskontrollTjenesteImplTest.java
@@ -28,6 +28,7 @@ import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingStegStatus;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingStegType;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingType;
 import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.AksjonspunktDefinisjon;
+import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingLås;
 import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakYtelseType;
 import no.nav.foreldrepenger.dbstoette.JpaExtension;
 
@@ -68,9 +69,9 @@ class BehandlingskontrollTjenesteImplTest {
         var behandling = TestScenario.forEngangsstønad()
                 .lagre(serviceProvider);
         forceOppdaterBehandlingSteg(behandling, steg3);
-        var kontekst = mock(BehandlingskontrollKontekst.class);
-        when(kontekst.getBehandlingId()).thenReturn(behandling.getId());
-        when(kontekst.getFagsakId()).thenReturn(behandling.getFagsakId());
+        var lås = mock(BehandlingLås.class);
+        when(lås.getBehandlingId()).thenReturn(behandling.getId());
+        var kontekst = new BehandlingskontrollKontekst(behandling, lås);
 
         var steg = steg2;
         var inngangAksjonspunkt = steg2InngangAksjonspunkt;
@@ -93,9 +94,9 @@ class BehandlingskontrollTjenesteImplTest {
         var behandling = TestScenario.forEngangsstønad()
                 .lagre(serviceProvider);
         forceOppdaterBehandlingSteg(behandling, steg3);
-        var kontekst = mock(BehandlingskontrollKontekst.class);
-        when(kontekst.getBehandlingId()).thenReturn(behandling.getId());
-        when(kontekst.getFagsakId()).thenReturn(behandling.getFagsakId());
+        var lås = mock(BehandlingLås.class);
+        when(lås.getBehandlingId()).thenReturn(behandling.getId());
+        var kontekst = new BehandlingskontrollKontekst(behandling, lås);
 
         kontrollTjeneste.behandlingTilbakeføringTilTidligsteAksjonspunkt(kontekst, List.of(steg2UtgangAksjonspunkt));
 
@@ -104,7 +105,7 @@ class BehandlingskontrollTjenesteImplTest {
         assertThat(behandling.getBehandlingStegStatus()).isEqualTo(BehandlingStegStatus.UTGANG);
         assertThat(behandling.getBehandlingStegTilstand()).isNotNull();
 
-        assertThat(behandling.getBehandlingStegTilstand(steg2)).isPresent();
+        assertThat(behandling.getBehandlingStegTilstandHvisSteg(steg2)).isPresent();
         assertThat(behandling.harBehandlingStegTilstandHistorikk(2)).isTrue();
 
         sjekkBehandlingStegTilstandHistorikk(behandling, steg3, BehandlingStegStatus.TILBAKEFØRT);
@@ -117,9 +118,9 @@ class BehandlingskontrollTjenesteImplTest {
         var behandling = TestScenario.forEngangsstønad()
                 .lagre(serviceProvider);
         forceOppdaterBehandlingSteg(behandling, steg3);
-        var kontekst = mock(BehandlingskontrollKontekst.class);
-        when(kontekst.getBehandlingId()).thenReturn(behandling.getId());
-        when(kontekst.getFagsakId()).thenReturn(behandling.getFagsakId());
+        var lås = mock(BehandlingLås.class);
+        when(lås.getBehandlingId()).thenReturn(behandling.getId());
+        var kontekst = new BehandlingskontrollKontekst(behandling, lås);
 
         kontrollTjeneste.behandlingTilbakeføringTilTidligereBehandlingSteg(kontekst, steg2);
 
@@ -128,7 +129,7 @@ class BehandlingskontrollTjenesteImplTest {
         assertThat(behandling.getBehandlingStegStatus()).isEqualTo(BehandlingStegStatus.INNGANG);
         assertThat(behandling.getBehandlingStegTilstand()).isNotNull();
 
-        assertThat(behandling.getBehandlingStegTilstand(steg2)).isPresent();
+        assertThat(behandling.getBehandlingStegTilstandHvisSteg(steg2)).isPresent();
         assertThat(behandling.harBehandlingStegTilstandHistorikk(2)).isTrue();
 
         sjekkBehandlingStegTilstandHistorikk(behandling, steg3, BehandlingStegStatus.TILBAKEFØRT);
@@ -141,9 +142,9 @@ class BehandlingskontrollTjenesteImplTest {
         var behandling = TestScenario.forEngangsstønad()
                 .lagre(serviceProvider);
         forceOppdaterBehandlingSteg(behandling, steg3);
-        var kontekst = mock(BehandlingskontrollKontekst.class);
-        when(kontekst.getBehandlingId()).thenReturn(behandling.getId());
-        when(kontekst.getFagsakId()).thenReturn(behandling.getFagsakId());
+        var lås = mock(BehandlingLås.class);
+        when(lås.getBehandlingId()).thenReturn(behandling.getId());
+        var kontekst = new BehandlingskontrollKontekst(behandling, lås);
 
         kontrollTjeneste.behandlingTilbakeføringHvisTidligereBehandlingSteg(kontekst, steg4);
 
@@ -152,8 +153,8 @@ class BehandlingskontrollTjenesteImplTest {
         assertThat(behandling.getBehandlingStegStatus()).isNull();
         assertThat(behandling.getBehandlingStegTilstand()).isNotNull();
 
-        assertThat(behandling.getBehandlingStegTilstand(steg3)).isPresent();
-        assertThat(behandling.getBehandlingStegTilstand(steg4)).isNotPresent();
+        assertThat(behandling.getBehandlingStegTilstandHvisSteg(steg3)).isPresent();
+        assertThat(behandling.getBehandlingStegTilstandHvisSteg(steg4)).isNotPresent();
         assertThat(behandling.harBehandlingStegTilstandHistorikk(1)).isTrue();
     }
 
@@ -162,9 +163,9 @@ class BehandlingskontrollTjenesteImplTest {
         var behandling = TestScenario.forEngangsstønad()
                 .lagre(serviceProvider);
         forceOppdaterBehandlingSteg(behandling, steg3);
-        var kontekst = mock(BehandlingskontrollKontekst.class);
-        when(kontekst.getBehandlingId()).thenReturn(behandling.getId());
-        when(kontekst.getFagsakId()).thenReturn(behandling.getFagsakId());
+        var lås = mock(BehandlingLås.class);
+        when(lås.getBehandlingId()).thenReturn(behandling.getId());
+        var kontekst = new BehandlingskontrollKontekst(behandling, lås);
 
         kontrollTjeneste.behandlingFramføringTilSenereBehandlingSteg(kontekst, steg5);
 
@@ -173,7 +174,7 @@ class BehandlingskontrollTjenesteImplTest {
         assertThat(behandling.getBehandlingStegStatus()).isEqualTo(BehandlingStegStatus.INNGANG);
         assertThat(behandling.getBehandlingStegTilstand()).isNotNull();
 
-        assertThat(behandling.getBehandlingStegTilstand(steg5)).isPresent();
+        assertThat(behandling.getBehandlingStegTilstandHvisSteg(steg5)).isPresent();
         assertThat(behandling.harBehandlingStegTilstandHistorikk(2)).isTrue();
 
         sjekkBehandlingStegTilstandHistorikk(behandling, steg3, BehandlingStegStatus.AVBRUTT);
@@ -190,9 +191,9 @@ class BehandlingskontrollTjenesteImplTest {
         var behandling = TestScenario.forEngangsstønad()
                 .lagre(serviceProvider);
         forceOppdaterBehandlingSteg(behandling, steg3);
-        var kontekst = mock(BehandlingskontrollKontekst.class);
-        when(kontekst.getBehandlingId()).thenReturn(behandling.getId());
-        when(kontekst.getFagsakId()).thenReturn(behandling.getFagsakId());
+        var lås = mock(BehandlingLås.class);
+        when(lås.getBehandlingId()).thenReturn(behandling.getId());
+        var kontekst = new BehandlingskontrollKontekst(behandling, lås);
 
         assertThatThrownBy(() -> kontrollTjeneste.behandlingTilbakeføringTilTidligereBehandlingSteg(kontekst, steg4))
                 .isInstanceOf(IllegalStateException.class)
@@ -205,9 +206,9 @@ class BehandlingskontrollTjenesteImplTest {
         var behandling = TestScenario.forEngangsstønad()
                 .lagre(serviceProvider);
         forceOppdaterBehandlingSteg(behandling, steg3);
-        var kontekst = mock(BehandlingskontrollKontekst.class);
-        when(kontekst.getBehandlingId()).thenReturn(behandling.getId());
-        when(kontekst.getFagsakId()).thenReturn(behandling.getFagsakId());
+        var lås = mock(BehandlingLås.class);
+        when(lås.getBehandlingId()).thenReturn(behandling.getId());
+        var kontekst = new BehandlingskontrollKontekst(behandling, lås);
         var modell = serviceProvider.getBehandlingModellRepository().getModell(behandling.getType(), behandling.getFagsakYtelseType());
         // Arrange
         var iverksettSteg = BehandlingStegType.IVERKSETT_VEDTAK;
@@ -225,9 +226,9 @@ class BehandlingskontrollTjenesteImplTest {
         var behandling = TestScenario.forEngangsstønad()
                 .lagre(serviceProvider);
         forceOppdaterBehandlingSteg(behandling, steg3);
-        var kontekst = mock(BehandlingskontrollKontekst.class);
-        when(kontekst.getBehandlingId()).thenReturn(behandling.getId());
-        when(kontekst.getFagsakId()).thenReturn(behandling.getFagsakId());
+        var lås = mock(BehandlingLås.class);
+        when(lås.getBehandlingId()).thenReturn(behandling.getId());
+        var kontekst = new BehandlingskontrollKontekst(behandling, lås);
         // Arrange
         var steg = steg2;
         forceOppdaterBehandlingSteg(behandling, steg, BehandlingStegStatus.UTGANG, BehandlingStegStatus.AVBRUTT);
@@ -249,7 +250,7 @@ class BehandlingskontrollTjenesteImplTest {
 
         sjekkBehandlingStegTilstandHistorikk(behandling, steg, BehandlingStegStatus.INNGANG);
 
-        assertThat(behandling.getBehandlingStegTilstand(steg))
+        assertThat(behandling.getBehandlingStegTilstandHvisSteg(steg))
             .hasValueSatisfying(v -> assertThat(v.getBehandlingStegStatus()).isEqualTo(BehandlingStegStatus.INNGANG));
 
     }
@@ -269,9 +270,9 @@ class BehandlingskontrollTjenesteImplTest {
         var behandling = TestScenario.forEngangsstønad()
                 .lagre(serviceProvider);
         forceOppdaterBehandlingSteg(behandling, steg3);
-        var kontekst = mock(BehandlingskontrollKontekst.class);
-        when(kontekst.getBehandlingId()).thenReturn(behandling.getId());
-        when(kontekst.getFagsakId()).thenReturn(behandling.getFagsakId());
+        var lås = mock(BehandlingLås.class);
+        when(lås.getBehandlingId()).thenReturn(behandling.getId());
+        var kontekst = new BehandlingskontrollKontekst(behandling, lås);
 
         assertThatThrownBy(() -> this.kontrollTjeneste.prosesserBehandling(kontekst))
                 .isInstanceOf(IllegalStateException.class)
@@ -283,9 +284,6 @@ class BehandlingskontrollTjenesteImplTest {
         var behandling = TestScenario.forEngangsstønad()
                 .lagre(serviceProvider);
         forceOppdaterBehandlingSteg(behandling, steg3);
-        var kontekst = mock(BehandlingskontrollKontekst.class);
-        when(kontekst.getBehandlingId()).thenReturn(behandling.getId());
-        when(kontekst.getFagsakId()).thenReturn(behandling.getFagsakId());
         assertThat(kontrollTjeneste.skalAksjonspunktLøsesIEllerEtterSteg(behandling.getFagsakYtelseType(),
                 behandling.getType(), steg3, AksjonspunktDefinisjon.VURDER_MEDLEMSKAPSVILKÅRET)).isTrue();
     }
@@ -295,9 +293,6 @@ class BehandlingskontrollTjenesteImplTest {
         var behandling = TestScenario.forEngangsstønad()
                 .lagre(serviceProvider);
         forceOppdaterBehandlingSteg(behandling, steg3);
-        var kontekst = mock(BehandlingskontrollKontekst.class);
-        when(kontekst.getBehandlingId()).thenReturn(behandling.getId());
-        when(kontekst.getFagsakId()).thenReturn(behandling.getFagsakId());
         assertThat(kontrollTjeneste.skalAksjonspunktLøsesIEllerEtterSteg(behandling.getFagsakYtelseType(),
                 behandling.getType(), steg2, AksjonspunktDefinisjon.AVKLAR_VERGE))
                         .isTrue();
@@ -308,9 +303,6 @@ class BehandlingskontrollTjenesteImplTest {
         var behandling = TestScenario.forEngangsstønad()
                 .lagre(serviceProvider);
         forceOppdaterBehandlingSteg(behandling, steg3);
-        var kontekst = mock(BehandlingskontrollKontekst.class);
-        when(kontekst.getBehandlingId()).thenReturn(behandling.getId());
-        when(kontekst.getFagsakId()).thenReturn(behandling.getFagsakId());
         assertThat(kontrollTjeneste.skalAksjonspunktLøsesIEllerEtterSteg(behandling.getFagsakYtelseType(),
                 behandling.getType(), steg4, AksjonspunktDefinisjon.REGISTRER_PAPIRSØKNAD_ENGANGSSTØNAD))
                         .isFalse();

--- a/domenetjenester/behandlingskontroll/src/test/java/no/nav/foreldrepenger/behandlingskontroll/impl/observer/TilbakehoppTest.java
+++ b/domenetjenester/behandlingskontroll/src/test/java/no/nav/foreldrepenger/behandlingskontroll/impl/observer/TilbakehoppTest.java
@@ -201,8 +201,7 @@ class TilbakehoppTest {
 
         var fraTilstand = new BehandlingStegTilstandSnapshot(fra.steg(), getBehandlingStegStatus(fra));
         var tilTilstand = new BehandlingStegTilstandSnapshot(til.steg(), getBehandlingStegStatus(til));
-        var fagsak = behandling.getFagsak();
-        var kontekst = new BehandlingskontrollKontekst(fagsak.getSaksnummer(), fagsak.getId(), behandlingLås);
+        var kontekst = new BehandlingskontrollKontekst(behandling, behandlingLås);
         var event = new BehandlingStegOvergangEvent.BehandlingStegTilbakeføringEvent(
                 kontekst,
                 fraTilstand, tilTilstand);
@@ -217,8 +216,7 @@ class TilbakehoppTest {
         var fraTilstand = new BehandlingStegTilstandSnapshot(fra.steg(), getBehandlingStegStatus(fra));
         var tilTilstand = new BehandlingStegTilstandSnapshot(til.steg(), getBehandlingStegStatus(til));
 
-        var fagsak = behandling.getFagsak();
-        var kontekst = new BehandlingskontrollKontekst(fagsak.getSaksnummer(), fagsak.getId(), behandlingLås);
+        var kontekst = new BehandlingskontrollKontekst(behandling, behandlingLås);
         var event = new BehandlingStegOvergangEvent.BehandlingStegTilbakeføringEvent(
                 kontekst,
                 fraTilstand, tilTilstand);

--- a/domenetjenester/behandlingskontroll/src/test/java/no/nav/foreldrepenger/behandlingskontroll/impl/transisjoner/FremoverhoppTest.java
+++ b/domenetjenester/behandlingskontroll/src/test/java/no/nav/foreldrepenger/behandlingskontroll/impl/transisjoner/FremoverhoppTest.java
@@ -158,8 +158,7 @@ class FremoverhoppTest {
         }
 
         var fraTilstand = new BehandlingStegTilstandSnapshot(fra.steg(), fraStatus);
-        var fagsak = behandling.getFagsak();
-        var kontekst = new BehandlingskontrollKontekst(fagsak.getSaksnummer(), fagsak.getId(), behandlingLås);
+        var kontekst = new BehandlingskontrollKontekst(behandling, behandlingLås);
         /*
          * BehandlingStegOvergangEvent.BehandlingStegOverhoppEvent behandlingEvent = new
          * BehandlingStegOvergangEvent.BehandlingStegOverhoppEvent(kontekst,

--- a/domenetjenester/beregningsgrunnlag/src/test/java/no/nav/foreldrepenger/domene/prosess/RyddBeregningsgrunnlagTest.java
+++ b/domenetjenester/beregningsgrunnlag/src/test/java/no/nav/foreldrepenger/domene/prosess/RyddBeregningsgrunnlagTest.java
@@ -34,7 +34,7 @@ class RyddBeregningsgrunnlagTest {
 
         var behandling = ScenarioMorSøkerForeldrepenger.forFødsel().lagre(new BehandlingRepositoryProvider(entityManager));
         referanse = BehandlingReferanse.fra(behandling);
-        var kontekst = new BehandlingskontrollKontekst(referanse.saksnummer(), referanse.fagsakId(), new BehandlingLås(referanse.behandlingId()));
+        var kontekst = new BehandlingskontrollKontekst(behandling, new BehandlingLås(referanse.behandlingId()));
         ryddBeregningsgrunnlag = new RyddBeregningsgrunnlag(beregningsgrunnlagRepository, kontekst);
     }
 

--- a/domenetjenester/datavarehus/src/test/java/no/nav/foreldrepenger/datavarehus/observer/DatavarehusEventObserverTest.java
+++ b/domenetjenester/datavarehus/src/test/java/no/nav/foreldrepenger/datavarehus/observer/DatavarehusEventObserverTest.java
@@ -75,10 +75,8 @@ class DatavarehusEventObserverTest {
     }
 
     private BehandlingskontrollKontekst byggKontekst(Behandling behandling) {
-        var behandlingLås = new BehandlingLås(behandling.getId()) {
-        };
-        var fagsak = behandling.getFagsak();
-        return new BehandlingskontrollKontekst(fagsak.getSaksnummer(), fagsak.getId(), behandlingLås);
+        var behandlingLås = new BehandlingLås(behandling.getId());
+        return new BehandlingskontrollKontekst(behandling, behandlingLås);
     }
 
     private Behandling byggBehandling() {

--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/Behandlingsoppretter.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/Behandlingsoppretter.java
@@ -152,7 +152,7 @@ public class Behandlingsoppretter {
     }
 
     public void henleggBehandling(Behandling behandling) {
-        var kontekst = behandlingskontrollTjeneste.initBehandlingskontroll(behandling.getId());
+        var kontekst = behandlingskontrollTjeneste.initBehandlingskontroll(behandling);
         behandlingskontrollTjeneste.taBehandlingAvVentSetAlleAutopunktUtførtForHenleggelse(behandling, kontekst);
         behandlingskontrollTjeneste.henleggBehandling(kontekst, BehandlingResultatType.MERGET_OG_HENLAGT);
     }

--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/sakskompleks/KøKontroller.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/sakskompleks/KøKontroller.java
@@ -158,8 +158,8 @@ public class KøKontroller {
     }
 
     public void oppdaterVedHenleggelseOmNødvendigOgFortsettBehandling(Long behandlingId) {
-        behandlingskontrollTjeneste.initBehandlingskontroll(behandlingId);
         var behandling = behandlingRepository.hentBehandling(behandlingId);
+        behandlingskontrollTjeneste.initBehandlingskontroll(behandling);
         oppdaterVedHenleggelseOmNødvendigOgFortsettBehandling(behandling);
     }
 

--- a/domenetjenester/mottak/src/test/java/no/nav/foreldrepenger/mottak/dokumentmottak/impl/DokumentmottakerKlageTest.java
+++ b/domenetjenester/mottak/src/test/java/no/nav/foreldrepenger/mottak/dokumentmottak/impl/DokumentmottakerKlageTest.java
@@ -189,9 +189,7 @@ class DokumentmottakerKlageTest {
         var behandling = scenario
                 .medBehandlingStegStart(BehandlingStegType.FATTE_VEDTAK)
                 .lagre(repositoryProvider);
-        var fagsak = behandling.getFagsak();
-        var kontekst = new BehandlingskontrollKontekst(fagsak.getSaksnummer(), fagsak.getId(),
-                behandlingRepository.taSkriveLås(behandling));
+        var kontekst = new BehandlingskontrollKontekst(behandling, behandlingRepository.taSkriveLås(behandling));
 
         Behandlingsresultat.builderForInngangsvilkår()
                 .medBehandlingResultatType(BehandlingResultatType.INNVILGET)

--- a/domenetjenester/mottak/src/test/java/no/nav/foreldrepenger/mottak/dokumentmottak/impl/KompletthetskontrollerTest.java
+++ b/domenetjenester/mottak/src/test/java/no/nav/foreldrepenger/mottak/dokumentmottak/impl/KompletthetskontrollerTest.java
@@ -95,7 +95,7 @@ class KompletthetskontrollerTest {
 
         when(kompletthetsjekker.vurderEtterlysningInntektsmelding(any(), any())).thenReturn(
             KompletthetResultat.ikkeOppfylt(ventefrist, Venteårsak.AVV_FODSEL));
-        lenient().when(behandlingskontrollTjeneste.erStegPassert(behandling.getId(), BehandlingStegType.REGISTRER_SØKNAD)).thenReturn(true);
+        lenient().when(behandlingskontrollTjeneste.erStegPassert(behandling, BehandlingStegType.REGISTRER_SØKNAD)).thenReturn(true);
 
         // Act
         kompletthetskontroller.persisterDokumentOgVurderKompletthet(behandling, mottattDokument);
@@ -116,8 +116,8 @@ class KompletthetskontrollerTest {
     @Test
     void skal_gjenoppta_behandling_dersom_behandling_er_komplett_og_kompletthet_ikke_passert() {
         // Arrange
-        when(behandlingskontrollTjeneste.erStegPassert(behandling.getId(), BehandlingStegType.INNHENT_REGISTEROPP)).thenReturn(false);
-        when(behandlingskontrollTjeneste.erIStegEllerSenereSteg(behandling.getId(), BehandlingStegType.VURDER_KOMPLETT_TIDLIG)).thenReturn(true);
+        when(behandlingskontrollTjeneste.erStegPassert(behandling, BehandlingStegType.INNHENT_REGISTEROPP)).thenReturn(false);
+        when(behandlingskontrollTjeneste.erIStegEllerSenereSteg(behandling, BehandlingStegType.VURDER_KOMPLETT_TIDLIG)).thenReturn(true);
 
         kompletthetskontroller.persisterDokumentOgVurderKompletthet(behandling, mottattDokument);
 
@@ -127,7 +127,7 @@ class KompletthetskontrollerTest {
     @Test
     void skal_ikke_gjenoppta_behandling_dersom_behandling_er_komplett_og_regsok_ikke_passert() {
         // Arrange
-        when(behandlingskontrollTjeneste.erIStegEllerSenereSteg(behandling.getId(), BehandlingStegType.VURDER_KOMPLETT_TIDLIG)).thenReturn(false);
+        when(behandlingskontrollTjeneste.erIStegEllerSenereSteg(behandling, BehandlingStegType.VURDER_KOMPLETT_TIDLIG)).thenReturn(false);
 
         kompletthetskontroller.persisterDokumentOgVurderKompletthet(behandling, mottattDokument);
 
@@ -138,7 +138,7 @@ class KompletthetskontrollerTest {
     @Test
     void skal_gjenoppta_behandling_ved_mottak_av_ny_forretningshendelse() {
         // Arrange
-        when(behandlingskontrollTjeneste.erStegPassert(behandling.getId(), BehandlingStegType.INNHENT_REGISTEROPP)).thenReturn(true);
+        when(behandlingskontrollTjeneste.erStegPassert(behandling, BehandlingStegType.INNHENT_REGISTEROPP)).thenReturn(true);
 
         kompletthetskontroller.vurderNyForretningshendelse(behandling, BehandlingÅrsakType.RE_HENDELSE_FØDSEL);
 
@@ -151,7 +151,7 @@ class KompletthetskontrollerTest {
         var scenario2 = ScenarioMorSøkerForeldrepenger.forFødsel()
             .leggTilAksjonspunkt(AksjonspunktDefinisjon.VENT_PGA_FOR_TIDLIG_SØKNAD, BehandlingStegType.VURDER_KOMPLETT_TIDLIG);
         var behandling2 = scenario2.lagMocked();
-        when(behandlingskontrollTjeneste.erStegPassert(behandling2.getId(), BehandlingStegType.INNHENT_REGISTEROPP)).thenReturn(false);
+        when(behandlingskontrollTjeneste.erStegPassert(behandling2, BehandlingStegType.INNHENT_REGISTEROPP)).thenReturn(false);
 
         kompletthetskontroller.vurderNyForretningshendelse(behandling2, BehandlingÅrsakType.RE_HENDELSE_DØD_FORELDER);
 
@@ -161,8 +161,8 @@ class KompletthetskontrollerTest {
     @Test
     void skal_spole_til_startpunkt_dersom_komplett_og_vurder_kompletthet_er_passert() {
         // Arrange
-        when(behandlingskontrollTjeneste.erStegPassert(behandling.getId(), BehandlingStegType.INNHENT_REGISTEROPP)).thenReturn(true);
-        when(behandlingskontrollTjeneste.erIStegEllerSenereSteg(behandling.getId(), BehandlingStegType.VURDER_KOMPLETT_TIDLIG)).thenReturn(true);
+        when(behandlingskontrollTjeneste.erStegPassert(behandling, BehandlingStegType.INNHENT_REGISTEROPP)).thenReturn(true);
+        when(behandlingskontrollTjeneste.erIStegEllerSenereSteg(behandling, BehandlingStegType.VURDER_KOMPLETT_TIDLIG)).thenReturn(true);
 
         var endringsresultatSnapshot = EndringsresultatSnapshot.opprett();
         when(behandlingProsesseringTjeneste.taSnapshotAvBehandlingsgrunnlag(behandling)).thenReturn(endringsresultatSnapshot);

--- a/domenetjenester/produksjonsstyring/src/main/java/no/nav/foreldrepenger/produksjonsstyring/fagsakstatus/FagsakStatusEventObserver.java
+++ b/domenetjenester/produksjonsstyring/src/main/java/no/nav/foreldrepenger/produksjonsstyring/fagsakstatus/FagsakStatusEventObserver.java
@@ -35,14 +35,14 @@ public class FagsakStatusEventObserver {
 
     public void observerBehandlingOpprettetEvent(@Observes BehandlingStatusEvent.BehandlingOpprettetEvent event) {
         LOG.debug("Oppdaterer status på Fagsak etter endring i behandling {}", event.getBehandlingId());
-        var fagsak = fagsakRepository.finnEksaktFagsak(event.getFagsakId());
+        var fagsak = fagsakRepository.finnEksaktFagsak(event.getSaksnummer());
         oppdaterFagsakStatusTjeneste.oppdaterFagsakNårBehandlingOpprettet(fagsak, event.getBehandlingId(), event.getNyStatus());
     }
 
     public void observerBehandlingAvsluttetEvent(@Observes BehandlingStatusEvent.BehandlingAvsluttetEvent event) {
         if (BehandlingStatus.AVSLUTTET.equals(event.getNyStatus())) {
             LOG.debug("Oppdaterer status på Fagsak etter endring i behandling {}", event.getBehandlingId());
-            var fagsak = fagsakRepository.finnEksaktFagsak(event.getFagsakId());
+            var fagsak = fagsakRepository.finnEksaktFagsak(event.getSaksnummer());
             oppdaterFagsakStatusTjeneste.lagBehandlingAvsluttetTask(fagsak, event.getBehandlingId());
         } else {
             throw new IllegalStateException(String.format("Utviklerfeil: AvsluttetEvent for behandlingId %s med status %s. Det skal ikke skje og må følges opp",

--- a/domenetjenester/produksjonsstyring/src/test/java/no/nav/foreldrepenger/produksjonsstyring/sakogbehandling/OppdaterSakOgBehandlingEventObserverTest.java
+++ b/domenetjenester/produksjonsstyring/src/test/java/no/nav/foreldrepenger/produksjonsstyring/sakogbehandling/OppdaterSakOgBehandlingEventObserverTest.java
@@ -42,12 +42,11 @@ class OppdaterSakOgBehandlingEventObserverTest {
         scenario.medFødselAdopsjonsdato(Collections.singletonList(LocalDate.now().plusDays(1)));
 
         var behandling = scenario.lagMocked();
-        var fagsak = behandling.getFagsak();
 
         repositoryProvider = scenario.mockBehandlingRepositoryProvider();
         observer = new OppdaterSakOgBehandlingEventObserver(repositoryProvider, taskTjenesteMock);
 
-        var kontekst = new BehandlingskontrollKontekst(fagsak.getSaksnummer(), fagsak.getId(), scenario.taSkriveLåsForBehandling());
+        var kontekst = new BehandlingskontrollKontekst(behandling, scenario.taSkriveLåsForBehandling());
         BehandlingOpprettetEvent event = BehandlingStatusEvent.nyEvent(kontekst, BehandlingStatus.OPPRETTET);
 
         var captor = ArgumentCaptor.forClass(ProsessTaskData.class);
@@ -65,12 +64,11 @@ class OppdaterSakOgBehandlingEventObserverTest {
         scenario.medFødselAdopsjonsdato(Collections.singletonList(LocalDate.now().plusDays(1)));
 
         var behandling = scenario.lagMocked();
-        var fagsak = behandling.getFagsak();
 
         repositoryProvider = scenario.mockBehandlingRepositoryProvider();
         observer = new OppdaterSakOgBehandlingEventObserver(repositoryProvider, taskTjenesteMock);
 
-        var kontekst = new BehandlingskontrollKontekst(fagsak.getSaksnummer(), fagsak.getId(), scenario.taSkriveLåsForBehandling());
+        var kontekst = new BehandlingskontrollKontekst(behandling, scenario.taSkriveLåsForBehandling());
         BehandlingAvsluttetEvent event = BehandlingStatusEvent.nyEvent(kontekst, BehandlingStatus.AVSLUTTET);
 
         var captor = ArgumentCaptor.forClass(ProsessTaskData.class);

--- a/domenetjenester/registerinnhenting/src/main/java/no/nav/foreldrepenger/domene/registerinnhenting/impl/RegisterdataOppdatererTask.java
+++ b/domenetjenester/registerinnhenting/src/main/java/no/nav/foreldrepenger/domene/registerinnhenting/impl/RegisterdataOppdatererTask.java
@@ -54,8 +54,8 @@ public class RegisterdataOppdatererTask extends BehandlingProsessTask {
     @Override
     protected void prosesser(ProsessTaskData prosessTaskData, Long behandlingsId) {
         // NB lås før hent behandling
-        var kontekst = behandlingskontrollTjeneste.initBehandlingskontroll(behandlingsId);
         var behandling = behandlingRepository.hentBehandling(behandlingsId);
+        var kontekst = behandlingskontrollTjeneste.initBehandlingskontroll(behandling);
         if (behandling.erSaksbehandlingAvsluttet()) return;
 
         if (behandling.isBehandlingPåVent()) {

--- a/domenetjenester/registerinnhenting/src/main/java/no/nav/foreldrepenger/domene/registerinnhenting/impl/ÅpneBehandlingForEndringerTask.java
+++ b/domenetjenester/registerinnhenting/src/main/java/no/nav/foreldrepenger/domene/registerinnhenting/impl/ÅpneBehandlingForEndringerTask.java
@@ -58,7 +58,7 @@ public class ÅpneBehandlingForEndringerTask extends BehandlingProsessTask {
 
     private void reaktiverAksjonspunkter(BehandlingskontrollKontekst kontekst, Behandling behandling, StartpunktType startpunkt) {
         var aksjonspunkterFraOgMedStartpunkt = behandlingskontrollTjeneste
-            .finnAksjonspunktDefinisjonerFraOgMed(behandling, startpunkt.getBehandlingSteg(), true);
+            .finnAksjonspunktDefinisjonerFraOgMed(kontekst, startpunkt.getBehandlingSteg(), true);
 
         behandling.getAksjonspunkter().stream()
             .filter(ap -> !ap.getAksjonspunktDefinisjon().erUtgått())

--- a/domenetjenester/registerinnhenting/src/test/java/no/nav/foreldrepenger/domene/registerinnhenting/impl/RegisterdataOppdatererTaskTest.java
+++ b/domenetjenester/registerinnhenting/src/test/java/no/nav/foreldrepenger/domene/registerinnhenting/impl/RegisterdataOppdatererTaskTest.java
@@ -2,7 +2,6 @@ package no.nav.foreldrepenger.domene.registerinnhenting.impl;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
-import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
@@ -68,7 +67,7 @@ class RegisterdataOppdatererTaskTest {
         behandling.setBehandlendeEnhet(organisasjonsEnhet);
         when(mockBehandlingRepository.hentBehandling(any(Long.class))).thenReturn(behandling);
         lenient().when(mockBehandlingRepository.lagre(any(Behandling.class), any())).thenReturn(0L);
-        when(mockBehandlingskontrollTjeneste.initBehandlingskontroll(anyLong())).thenReturn(kontekst);
+        when(mockBehandlingskontrollTjeneste.initBehandlingskontroll(any(Behandling.class))).thenReturn(kontekst);
         lenient().when(kontekst.getSkriveLås()).thenReturn(lås);
         when(mockEnhetsTjeneste.sjekkEnhetEtterEndring(any())).thenReturn(Optional.of(enhet));
 
@@ -77,7 +76,7 @@ class RegisterdataOppdatererTaskTest {
 
         task.doTask(prosessTaskData);
 
-        verify(mockBehandlingskontrollTjeneste).initBehandlingskontroll(anyLong());
+        verify(mockBehandlingskontrollTjeneste).initBehandlingskontroll(any(Behandling.class));
         verify(mockRegisterdataEndringshåndterer).utledDiffOgReposisjonerBehandlingVedEndringer(any(), eq(null), anyBoolean());
         verify(mockEnhetsTjeneste).oppdaterBehandlendeEnhet(any(), eq(enhet), any(), any());
     }
@@ -96,7 +95,7 @@ class RegisterdataOppdatererTaskTest {
         behandling.setBehandlendeEnhet(organisasjonsEnhet);
         when(mockBehandlingRepository.hentBehandling(any(Long.class))).thenReturn(behandling);
         lenient().when(mockBehandlingRepository.lagre(any(Behandling.class), any())).thenReturn(0L);
-        when(mockBehandlingskontrollTjeneste.initBehandlingskontroll(anyLong())).thenReturn(kontekst);
+        when(mockBehandlingskontrollTjeneste.initBehandlingskontroll(any(Behandling.class))).thenReturn(kontekst);
         lenient().when(kontekst.getSkriveLås()).thenReturn(lås);
         when(mockEnhetsTjeneste.sjekkEnhetEtterEndring(any())).thenReturn(Optional.of(enhet));
 
@@ -108,7 +107,7 @@ class RegisterdataOppdatererTaskTest {
 
         task.doTask(prosessTaskData);
 
-        verify(mockBehandlingskontrollTjeneste).initBehandlingskontroll(anyLong());
+        verify(mockBehandlingskontrollTjeneste).initBehandlingskontroll(any(Behandling.class));
         verify(mockRegisterdataEndringshåndterer).utledDiffOgReposisjonerBehandlingVedEndringer(any(), eq(snapshot), anyBoolean());
         verify(mockEnhetsTjeneste).oppdaterBehandlendeEnhet(any(), eq(enhet), any(), any());
     }

--- a/domenetjenester/vedtak/src/main/java/no/nav/foreldrepenger/domene/vedtak/intern/AvsluttBehandling.java
+++ b/domenetjenester/vedtak/src/main/java/no/nav/foreldrepenger/domene/vedtak/intern/AvsluttBehandling.java
@@ -3,9 +3,6 @@ package no.nav.foreldrepenger.domene.vedtak.intern;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 
-import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakYtelseType;
-import no.nav.foreldrepenger.konfig.Environment;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -18,6 +15,7 @@ import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRe
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepositoryProvider;
 import no.nav.foreldrepenger.behandlingslager.behandling.vedtak.BehandlingVedtakRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.vedtak.IverksettingStatus;
+import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakYtelseType;
 import no.nav.foreldrepenger.behandlingsprosess.prosessering.BehandlingProsesseringTjeneste;
 import no.nav.foreldrepenger.domene.arbeidsforhold.InntektArbeidYtelseTjeneste;
 import no.nav.foreldrepenger.domene.prosess.BeregningTjeneste;
@@ -64,8 +62,8 @@ public class AvsluttBehandling {
 
     void avsluttBehandling(Long behandlingId) {
         LOG.info("Avslutter behandling inngang {}", behandlingId);
-        var kontekst = behandlingskontrollTjeneste.initBehandlingskontroll(behandlingId);
         var behandling = behandlingRepository.hentBehandling(behandlingId);
+        var kontekst = behandlingskontrollTjeneste.initBehandlingskontroll(behandling);
 
         oppdatereFagsakRelasjonVedVedtak.oppdaterRelasjonVedVedtattBehandling(behandling);
 

--- a/domenetjenester/vedtak/src/test/java/no/nav/foreldrepenger/domene/vedtak/intern/AvsluttBehandlingTest.java
+++ b/domenetjenester/vedtak/src/test/java/no/nav/foreldrepenger/domene/vedtak/intern/AvsluttBehandlingTest.java
@@ -84,18 +84,11 @@ class AvsluttBehandlingTest {
         avsluttBehandling = new AvsluttBehandling(repositoryProvider, behandlingskontrollTjeneste, behandlingVedtakEventPubliserer,
             vurderBehandlingerUnderIverksettelse, behandlingProsesseringTjeneste, oppdatereFagsakRelasjonVedVedtak, beregningTjeneste, iayTjeneste);
 
-        when(behandlingskontrollTjeneste.initBehandlingskontroll(Mockito.anyLong())).thenAnswer(invocation -> {
-            Long behId = invocation.getArgument(0);
-            var lås = new BehandlingLås(behId) {
-            };
-            return new BehandlingskontrollKontekst(fagsak.getSaksnummer(), fagsak.getId(), lås);
-        });
         when(behandlingskontrollTjeneste.initBehandlingskontroll(Mockito.any(Behandling.class))).thenAnswer(
                 invocation -> {
                     Behandling beh = invocation.getArgument(0);
-                    var lås = new BehandlingLås(beh.getId()) {
-                    };
-                    return new BehandlingskontrollKontekst(fagsak.getSaksnummer(), fagsak.getId(), lås);
+                    var lås = new BehandlingLås(beh.getId());
+                    return new BehandlingskontrollKontekst(beh, lås);
                 });
     }
 

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/aksjonspunkt/AksjonspunktRestTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/aksjonspunkt/AksjonspunktRestTjeneste.java
@@ -151,7 +151,7 @@ public class AksjonspunktRestTjeneste {
             LOG.info("Bekrefter flere aksjonspunkt {}", bekreftedeAksjonspunktDtoer.stream().map(a -> a.getAksjonspunktDefinisjon().getKode()).toList());
         }
 
-        applikasjonstjeneste.bekreftAksjonspunkter(bekreftedeAksjonspunktDtoer, behandling.getId());
+        applikasjonstjeneste.bekreftAksjonspunkter(bekreftedeAksjonspunktDtoer, behandling);
 
         return Redirect.tilBehandlingPollStatus(request, behandling.getUuid());
     }
@@ -183,7 +183,7 @@ public class AksjonspunktRestTjeneste {
             LOG.info("Overstyrer flere aksjonspunkt {}", overstyrteAksjonspunktDtoer.stream().map(a -> a.getAksjonspunktDefinisjon().getKode()).toList());
         }
 
-        applikasjonstjeneste.overstyrAksjonspunkter(overstyrteAksjonspunktDtoer, behandling.getId());
+        applikasjonstjeneste.overstyrAksjonspunkter(overstyrteAksjonspunktDtoer, behandling);
 
         return Redirect.tilBehandlingPollStatus(request, behandling.getUuid());
     }

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/aksjonspunkt/AksjonspunktTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/aksjonspunkt/AksjonspunktTjeneste.java
@@ -86,10 +86,8 @@ public class AksjonspunktTjeneste {
         this.behandlingEventPubliserer = behandlingEventPubliserer;
     }
 
-    public void bekreftAksjonspunkter(Collection<BekreftetAksjonspunktDto> bekreftedeAksjonspunktDtoer, Long behandlingId) {
-        var behandling = behandlingRepository.hentBehandling(behandlingId);
-
-        var kontekst = behandlingskontrollTjeneste.initBehandlingskontroll(behandlingId);
+    void bekreftAksjonspunkter(Collection<BekreftetAksjonspunktDto> bekreftedeAksjonspunktDtoer, Behandling behandling) {
+        var kontekst = behandlingskontrollTjeneste.initBehandlingskontroll(behandling);
         setAnsvarligSaksbehandler(bekreftedeAksjonspunktDtoer, behandling);
 
         spoolTilbakeTilTidligsteAksjonspunkt(bekreftedeAksjonspunktDtoer, kontekst);
@@ -154,13 +152,12 @@ public class AksjonspunktTjeneste {
         }
     }
 
-    public void overstyrAksjonspunkter(Collection<OverstyringAksjonspunktDto> overstyrteAksjonspunkter, Long behandlingId) {
-        var behandling = behandlingRepository.hentBehandling(behandlingId);
+    public void overstyrAksjonspunkter(Collection<OverstyringAksjonspunktDto> overstyrteAksjonspunkter, Behandling behandling) {
         if (SpesialBehandling.kanIkkeOverstyres(behandling)) {
             throw new FunksjonellException("FP-760744", "Behandlingen kan ikke overstyres og må gjennomføres",
                 "Vurder behov for ordinær revurdering etter at denne behnadlingen er avsluttet");
         }
-        var kontekst = behandlingskontrollTjeneste.initBehandlingskontroll(behandlingId);
+        var kontekst = behandlingskontrollTjeneste.initBehandlingskontroll(behandling);
         setAnsvarligSaksbehandler(List.of(), behandling);
 
         // Tilbakestill gjeldende steg før fremføring

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/arbeidsforhold/InntektArbeidYtelseRestTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/arbeidsforhold/InntektArbeidYtelseRestTjeneste.java
@@ -236,7 +236,7 @@ public class InntektArbeidYtelseRestTjeneste {
             alleReferanser.addAll(referanserFraOppgittOpptjening(iayg.getGjeldendeOppgittOpptjening()));
         });
 
-        if (behandling.erAvsluttet() || behandlingskontrollTjeneste.erIStegEllerSenereSteg(behandling.getId(), BehandlingStegType.SIMULER_OPPDRAG)) {
+        if (behandling.erAvsluttet() || behandlingskontrollTjeneste.erIStegEllerSenereSteg(behandling, BehandlingStegType.SIMULER_OPPDRAG)) {
             try {
                 var simuleringResultatDto = fpOppdragRestKlient.hentSimuleringResultatMedOgUtenInntrekk(behandling.getId(), behandling.getUuid(), behandling.getSaksnummer().getVerdi());
                 arbeidsgivere.addAll(simuleringResultatDto.map(this::finnArbeidsgivereFraSimulering).orElse(Collections.emptySet()));

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/medlem/MedlemDtoTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/medlem/MedlemDtoTjeneste.java
@@ -208,7 +208,7 @@ public class MedlemDtoTjeneste {
     }
 
     private boolean behandlingLiggerEtterMedlemskapsvilkårssteg(Behandling behandling) {
-        return behandlingskontrollTjeneste.erIStegEllerSenereSteg(behandling.getId(), BehandlingStegType.VURDER_MEDLEMSKAPVILKÅR);
+        return behandlingskontrollTjeneste.erIStegEllerSenereSteg(behandling, BehandlingStegType.VURDER_MEDLEMSKAPVILKÅR);
     }
 
     private static Optional<MedlemskapDto.Annenpart> annenpart(PersonopplysningerAggregat personopplysningerAggregat,

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/verge/VergeTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/verge/VergeTjeneste.java
@@ -16,9 +16,7 @@ import no.nav.foreldrepenger.behandlingslager.behandling.historikk.Historikkinns
 import no.nav.foreldrepenger.behandlingslager.behandling.historikk.HistorikkinnslagRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.personopplysning.PersonopplysningEntitet;
 import no.nav.foreldrepenger.behandlingslager.behandling.personopplysning.PersonopplysningerAggregat;
-import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.verge.VergeRepository;
-import no.nav.foreldrepenger.behandlingsprosess.prosessering.BehandlingProsesseringTjeneste;
 import no.nav.foreldrepenger.domene.person.verge.OpprettVergeTjeneste;
 import no.nav.foreldrepenger.domene.person.verge.VergeDtoTjeneste;
 import no.nav.foreldrepenger.domene.person.verge.dto.OpprettVergeDto;
@@ -28,7 +26,6 @@ import no.nav.foreldrepenger.domene.person.verge.dto.VergeDto;
 import no.nav.foreldrepenger.domene.personopplysning.PersonopplysningTjeneste;
 import no.nav.foreldrepenger.domene.typer.AktørId;
 import no.nav.foreldrepenger.web.app.tjenester.behandling.verge.dto.NyVergeDto;
-import no.nav.vedtak.exception.TekniskException;
 
 @ApplicationScoped
 public class VergeTjeneste {
@@ -82,8 +79,8 @@ public class VergeTjeneste {
         var vergeAggregat = vergeRepository.hentAggregat(behandlingId);
         var harRegistrertVerge = vergeAggregat.isPresent() && vergeAggregat.get().getVerge().isPresent();
         var harÅpentVergeAP = behandling.harÅpentAksjonspunktMedType(AksjonspunktDefinisjon.AVKLAR_VERGE);
-        var iForeslåVedtakllerSenereSteg = behandlingskontrollTjeneste.erIStegEllerSenereSteg(behandlingId, BehandlingStegType.FORESLÅ_VEDTAK);
-        var iFatteVedtakEllerSenereSteg = behandlingskontrollTjeneste.erIStegEllerSenereSteg(behandlingId, BehandlingStegType.FATTE_VEDTAK);
+        var iForeslåVedtakllerSenereSteg = behandlingskontrollTjeneste.erIStegEllerSenereSteg(behandling, BehandlingStegType.FORESLÅ_VEDTAK);
+        var iFatteVedtakEllerSenereSteg = behandlingskontrollTjeneste.erIStegEllerSenereSteg(behandling, BehandlingStegType.FATTE_VEDTAK);
         var under18År = erSøkerUnder18ar(behandlingId, behandling.getAktørId());
 
         if (harRegistrertVerge && under18År && iForeslåVedtakllerSenereSteg || SpesialBehandling.erSpesialBehandling(behandling)

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/forvaltning/ForvaltningStegRestTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/forvaltning/ForvaltningStegRestTjeneste.java
@@ -96,7 +96,8 @@ public class ForvaltningStegRestTjeneste {
     @Path("/fjernFHValgHoppTilbake")
     @BeskyttetRessurs(actionType = ActionType.READ, resourceType = ResourceType.DRIFT, sporingslogg = true)
     public Response fjernOverstyrtFH(@BeanParam @Valid ForvaltningBehandlingIdDto dto) {
-        var kontekst = behandlingskontrollTjeneste.initBehandlingskontroll(dto.getBehandlingUuid());
+        var behandling = behandlingRepository.hentBehandling(dto.getBehandlingUuid());
+        var kontekst = behandlingskontrollTjeneste.initBehandlingskontroll(behandling);
         var grunnlag = familieHendelseRepository.hentAggregat(kontekst.getBehandlingId());
         if (grunnlag.getOverstyrtVersjon().isPresent()) {
             familieHendelseRepository.slettAvklarteData(kontekst.getBehandlingId(), kontekst.getSkriveLås());
@@ -124,8 +125,8 @@ public class ForvaltningStegRestTjeneste {
     }
 
     private void hoppTilbake(UUID behandlingUuid, BehandlingStegType tilSteg) {
-        var kontekst = behandlingskontrollTjeneste.initBehandlingskontroll(behandlingUuid);
-        var behandling = behandlingsprosessTjeneste.hentBehandling(behandlingUuid);
+        var behandling = behandlingRepository.hentBehandling(behandlingUuid);
+        var kontekst = behandlingskontrollTjeneste.initBehandlingskontroll(behandling);
         hoppTilbake(kontekst, behandling, tilSteg);
     }
 

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/forvaltning/TilbakeføringTilStegTask.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/forvaltning/TilbakeføringTilStegTask.java
@@ -42,8 +42,8 @@ public class TilbakeføringTilStegTask extends BehandlingProsessTask {
 
     @Override
     protected void prosesser(ProsessTaskData prosessTaskData, Long behandlingId) {
-        var kontekst = behandlingskontrollTjeneste.initBehandlingskontroll(behandlingId);
         var behandling = behandlingRepository.hentBehandling(behandlingId);
+        var kontekst = behandlingskontrollTjeneste.initBehandlingskontroll(behandling);
         if (behandling.isBehandlingPåVent()) {
             behandlingskontrollTjeneste.taBehandlingAvVentSetAlleAutopunktUtført(behandling, kontekst);
         }

--- a/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/aksjonspunkt/AksjonspunktRestTjenesteTest.java
+++ b/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/aksjonspunkt/AksjonspunktRestTjenesteTest.java
@@ -74,7 +74,7 @@ class AksjonspunktRestTjenesteTest {
         aksjonspunktRestTjeneste.bekreft(mock(HttpServletRequest.class),
             BekreftedeAksjonspunkterDto.lagDto(behandlingUuid, BEHANDLING_VERSJON, aksjonspunkt));
 
-        verify(aksjonspunktTjenesteMock).bekreftAksjonspunkter(ArgumentMatchers.anyCollection(), anyLong());
+        verify(aksjonspunktTjenesteMock).bekreftAksjonspunkter(ArgumentMatchers.anyCollection(), any());
     }
 
     @Test
@@ -86,7 +86,7 @@ class AksjonspunktRestTjenesteTest {
         aksjonspunktRestTjeneste.bekreft(mock(HttpServletRequest.class),
             BekreftedeAksjonspunkterDto.lagDto(behandlingUuid, BEHANDLING_VERSJON, aksjonspunkt));
 
-        verify(aksjonspunktTjenesteMock).bekreftAksjonspunkter(ArgumentMatchers.anyCollection(), anyLong());
+        verify(aksjonspunktTjenesteMock).bekreftAksjonspunkter(ArgumentMatchers.anyCollection(), any());
     }
 
     @Test
@@ -97,7 +97,7 @@ class AksjonspunktRestTjenesteTest {
         aksjonspunktRestTjeneste.bekreft(mock(HttpServletRequest.class),
             BekreftedeAksjonspunkterDto.lagDto(behandlingUuid, BEHANDLING_VERSJON, aksjonspunkt));
 
-        verify(aksjonspunktTjenesteMock).bekreftAksjonspunkter(ArgumentMatchers.anyCollection(), anyLong());
+        verify(aksjonspunktTjenesteMock).bekreftAksjonspunkter(ArgumentMatchers.anyCollection(), any());
 
     }
 
@@ -113,7 +113,7 @@ class AksjonspunktRestTjenesteTest {
         aksjonspunktRestTjeneste.beslutt(mock(HttpServletRequest.class),
             BekreftedeAksjonspunkterDto.lagDto(behandlingUuid, BEHANDLING_VERSJON, aksjonspunkt));
 
-        verify(aksjonspunktTjenesteMock).bekreftAksjonspunkter(ArgumentMatchers.anyCollection(), anyLong());
+        verify(aksjonspunktTjenesteMock).bekreftAksjonspunkter(ArgumentMatchers.anyCollection(), any());
     }
 
     @Test
@@ -131,7 +131,7 @@ class AksjonspunktRestTjenesteTest {
         aksjonspunktRestTjeneste.beslutt(mock(HttpServletRequest.class), BekreftedeAksjonspunkterDto.lagDto(behandlingUuid, BEHANDLING_VERSJON,
             List.of(new FatterVedtakAksjonspunktDto(BEGRUNNELSE, List.of(new AksjonspunktGodkjenningDto())))));
 
-        verify(aksjonspunktTjenesteMock).bekreftAksjonspunkter(ArgumentMatchers.anyCollection(), anyLong());
+        verify(aksjonspunktTjenesteMock).bekreftAksjonspunkter(ArgumentMatchers.anyCollection(), any());
     }
 
     @Test

--- a/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/aksjonspunkt/AksjonspunktTjenesteTest.java
+++ b/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/aksjonspunkt/AksjonspunktTjenesteTest.java
@@ -77,7 +77,7 @@ class AksjonspunktTjenesteTest {
         var dto = new BekreftTerminbekreftelseAksjonspunktDto(BEGRUNNELSE, TERMINDATO, UTSTEDTDATO, 1);
 
         // Act
-        aksjonspunktTjeneste.bekreftAksjonspunkter(singletonList(dto), behandling.getId());
+        aksjonspunktTjeneste.bekreftAksjonspunkter(singletonList(dto), behandling);
 
         // Assert
         var oppdatertBehandling = behandlingRepository.hentBehandling(behandling.getId());
@@ -93,7 +93,7 @@ class AksjonspunktTjenesteTest {
                 Avslagsårsak.SØKER_ER_IKKE_BARNETS_FAR_O.getKode());
 
         // Act
-        aksjonspunktTjeneste.bekreftAksjonspunkter(singletonList(dto), behandling.getId());
+        aksjonspunktTjeneste.bekreftAksjonspunkter(singletonList(dto), behandling);
 
         // Assert
         assertThat(behandling.getBehandlingsresultat().getVilkårResultat()).isNotNull();
@@ -153,7 +153,7 @@ class AksjonspunktTjenesteTest {
         var dto = new BekreftTerminbekreftelseAksjonspunktDto(BEGRUNNELSE, LocalDate.now(), LocalDate.now(), 2);
 
         // Act
-        aksjonspunktTjeneste.bekreftAksjonspunkter(singletonList(dto), revurdering.getId());
+        aksjonspunktTjeneste.bekreftAksjonspunkter(singletonList(dto), revurdering);
 
         // Assert
         var oppdatertBehandling = behandlingRepository.hentBehandling(revurdering.getId());
@@ -172,7 +172,7 @@ class AksjonspunktTjenesteTest {
                 Avslagsårsak.SØKER_ER_IKKE_BARNETS_FAR_O.getKode());
 
         // Act
-        aksjonspunktTjeneste.bekreftAksjonspunkter(singletonList(dto), revurdering.getId());
+        aksjonspunktTjeneste.bekreftAksjonspunkter(singletonList(dto), revurdering);
 
         // Assert
         var oppdatertBehandling = behandlingRepository.hentBehandling(revurdering.getId());

--- a/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/verge/VergeTjenesteTest.java
+++ b/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/verge/VergeTjenesteTest.java
@@ -11,16 +11,6 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 
-import no.nav.foreldrepenger.behandlingslager.behandling.verge.VergeAggregat;
-import no.nav.foreldrepenger.domene.bruker.NavBrukerTjeneste;
-import no.nav.foreldrepenger.domene.person.PersoninfoAdapter;
-import no.nav.foreldrepenger.domene.person.verge.OpprettVergeTjeneste;
-import no.nav.foreldrepenger.domene.person.verge.VergeDtoTjeneste;
-
-import no.nav.foreldrepenger.web.app.tjenester.behandling.verge.dto.NyVergeDto;
-
-import no.nav.vedtak.exception.TekniskException;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -42,6 +32,7 @@ import no.nav.foreldrepenger.behandlingslager.behandling.personopplysning.Person
 import no.nav.foreldrepenger.behandlingslager.behandling.personopplysning.PersonopplysningerAggregat;
 import no.nav.foreldrepenger.behandlingslager.behandling.personopplysning.RelasjonsRolleType;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepository;
+import no.nav.foreldrepenger.behandlingslager.behandling.verge.VergeAggregat;
 import no.nav.foreldrepenger.behandlingslager.behandling.verge.VergeEntitet;
 import no.nav.foreldrepenger.behandlingslager.behandling.verge.VergeRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.verge.VergeType;
@@ -50,10 +41,16 @@ import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakRepository;
 import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakYtelseType;
 import no.nav.foreldrepenger.behandlingslager.hendelser.StartpunktType;
 import no.nav.foreldrepenger.dbstoette.EntityManagerAwareTest;
+import no.nav.foreldrepenger.domene.bruker.NavBrukerTjeneste;
+import no.nav.foreldrepenger.domene.person.PersoninfoAdapter;
+import no.nav.foreldrepenger.domene.person.verge.OpprettVergeTjeneste;
+import no.nav.foreldrepenger.domene.person.verge.VergeDtoTjeneste;
 import no.nav.foreldrepenger.domene.person.verge.dto.VergeBehandlingsmenyEnum;
 import no.nav.foreldrepenger.domene.personopplysning.PersonopplysningTjeneste;
 import no.nav.foreldrepenger.domene.typer.AktørId;
 import no.nav.foreldrepenger.domene.typer.Saksnummer;
+import no.nav.foreldrepenger.web.app.tjenester.behandling.verge.dto.NyVergeDto;
+import no.nav.vedtak.exception.TekniskException;
 
 @ExtendWith(MockitoExtension.class)
 class VergeTjenesteTest extends EntityManagerAwareTest {
@@ -109,7 +106,7 @@ class VergeTjenesteTest extends EntityManagerAwareTest {
 
             var pa = opprettPersonopplysningAggregatForPersonUnder18(behandling.getAktørId());
             when(personopplysningTjeneste.hentPersonopplysningerHvisEksisterer(any(), any())).thenReturn(Optional.of(pa));
-            when(behandlingskontrollTjeneste.erIStegEllerSenereSteg(behandling.getId(), BehandlingStegType.FORESLÅ_VEDTAK)).thenReturn(true);
+            when(behandlingskontrollTjeneste.erIStegEllerSenereSteg(behandling, BehandlingStegType.FORESLÅ_VEDTAK)).thenReturn(true);
 
             // Act
             var behandlingOperasjon = vergeTjeneste.utledBehandlingOperasjon(behandling);

--- a/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/vilkår/aksjonspunkt/AbstractOverstyringshåndtererTest.java
+++ b/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/vilkår/aksjonspunkt/AbstractOverstyringshåndtererTest.java
@@ -39,7 +39,7 @@ class AbstractOverstyringshåndtererTest {
 
         OverstyringAksjonspunktDto dto = new OverstyringFødselsvilkåretDto(false, IKKE_OK, Avslagsårsak.MANGLENDE_DOKUMENTASJON.getKode());
 
-        aksjonspunktTjeneste.overstyrAksjonspunkter(Set.of(dto), behandling.getId());
+        aksjonspunktTjeneste.overstyrAksjonspunkter(Set.of(dto), behandling);
 
         assertThat(behandling.getAksjonspunktFor(AksjonspunktDefinisjon.OVERSTYRING_AV_FØDSELSVILKÅRET).getBegrunnelse()).isEqualTo(IKKE_OK);
     }

--- a/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/vilkår/aksjonspunkt/AdopsjonsvilkårEngangsstønadOverstyringhåndtererTest.java
+++ b/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/vilkår/aksjonspunkt/AdopsjonsvilkårEngangsstønadOverstyringhåndtererTest.java
@@ -50,7 +50,7 @@ class AdopsjonsvilkårEngangsstønadOverstyringhåndtererTest {
         assertThat(behandling.getAksjonspunkter()).hasSize(1);
 
         // Act
-        aksjonspunktTjeneste.overstyrAksjonspunkter(Set.of(overstyringspunktDto), behandling.getId());
+        aksjonspunktTjeneste.overstyrAksjonspunkter(Set.of(overstyringspunktDto), behandling);
 
         // Assert
         var aksjonspunktSet = behandling.getAksjonspunkter();

--- a/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/vilkår/aksjonspunkt/AdopsjonsvilkårForeldrepengerOverstyringhåndtererTest.java
+++ b/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/vilkår/aksjonspunkt/AdopsjonsvilkårForeldrepengerOverstyringhåndtererTest.java
@@ -59,7 +59,7 @@ class AdopsjonsvilkårForeldrepengerOverstyringhåndtererTest {
         assertThat(behandling.getAksjonspunkter()).hasSize(1);
 
         // Act
-        aksjonspunktTjeneste.overstyrAksjonspunkter(Set.of(overstyringspunktDto), behandling.getId());
+        aksjonspunktTjeneste.overstyrAksjonspunkter(Set.of(overstyringspunktDto), behandling);
 
         // Assert
         var aksjonspunktSet = behandling.getAksjonspunkter();

--- a/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/vilkår/aksjonspunkt/FødselsvilkåretFarMedmorOverstyringshåndtererTest.java
+++ b/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/vilkår/aksjonspunkt/FødselsvilkåretFarMedmorOverstyringshåndtererTest.java
@@ -57,7 +57,7 @@ class FødselsvilkåretFarMedmorOverstyringshåndtererTest {
         assertThat(behandling.getAksjonspunkter()).hasSize(1);
 
         // Act
-        aksjonspunktTjeneste.overstyrAksjonspunkter(Set.of(overstyringDto), behandling.getId());
+        aksjonspunktTjeneste.overstyrAksjonspunkter(Set.of(overstyringDto), behandling);
 
         // Assert
         var historikkinnslagene = repositoryProvider.getHistorikkinnslagRepository().hent(behandling.getSaksnummer());

--- a/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/vilkår/aksjonspunkt/OpptjeningsvilkåretOverstyringshåndtererTest.java
+++ b/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/vilkår/aksjonspunkt/OpptjeningsvilkåretOverstyringshåndtererTest.java
@@ -57,7 +57,7 @@ class OpptjeningsvilkåretOverstyringshåndtererTest {
         assertThat(behandling.getAksjonspunkter()).hasSize(1);
 
         // Act
-        aksjonspunktTjeneste.overstyrAksjonspunkter(Set.of(overstyringspunktDto), behandling.getId());
+        aksjonspunktTjeneste.overstyrAksjonspunkter(Set.of(overstyringspunktDto), behandling);
 
         // Assert
         var aksjonspunktSet = behandling.getAksjonspunkter();
@@ -92,7 +92,7 @@ class OpptjeningsvilkåretOverstyringshåndtererTest {
                 "test av overstyring opptjeningsvilkåret", "1035");
 
         // Act
-        aksjonspunktTjeneste.overstyrAksjonspunkter(Set.of(overstyringspunktDto), behandling.getId());
+        aksjonspunktTjeneste.overstyrAksjonspunkter(Set.of(overstyringspunktDto), behandling);
 
         // Assert
         var historikkinnslagene = repositoryProvider.getHistorikkinnslagRepository().hent(behandling.getSaksnummer());
@@ -114,14 +114,13 @@ class OpptjeningsvilkåretOverstyringshåndtererTest {
         scenario.lagre(repositoryProvider);
 
         var behandling = scenario.getBehandling();
-        var behandlingId = behandling.getId();
         // Dto
         var overstyringspunktDto = new OverstyringOpptjeningsvilkåretDto(true,
                 "test av overstyring opptjeningsvilkåret", "1035");
         Collection<OverstyringAksjonspunktDto> dto = Set.of(overstyringspunktDto);
 
         //Act
-        assertThatThrownBy(() -> aksjonspunktTjeneste.overstyrAksjonspunkter(dto, behandlingId))
+        assertThatThrownBy(() -> aksjonspunktTjeneste.overstyrAksjonspunkter(dto, behandling))
             .isInstanceOf(FunksjonellException.class)
             .hasMessage("FP-093923:Kan ikke overstyre vilkår. Det må være minst en aktivitet for at opptjeningsvilkåret skal kunne overstyres.");
     }

--- a/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/vilkår/aksjonspunkt/SøkersopplysningspliktOverstyringhåndtererTest.java
+++ b/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/vilkår/aksjonspunkt/SøkersopplysningspliktOverstyringhåndtererTest.java
@@ -45,7 +45,7 @@ class SøkersopplysningspliktOverstyringhåndtererTest {
         assertThat(behandling.getAksjonspunkter()).hasSize(1);
 
         // Act
-        aksjonspunktTjeneste.overstyrAksjonspunkter(Set.of(overstyringspunktDto), behandling.getId());
+        aksjonspunktTjeneste.overstyrAksjonspunkter(Set.of(overstyringspunktDto), behandling);
 
         // Assert
         var historikkinnslagene = repositoryProvider.getHistorikkinnslagRepository().hent(behandling.getSaksnummer());


### PR DESCRIPTION
Redaksjonell: Utvider behandlingskontrollkontekst med YtelseType og BehandlingType, samt enklere oppretting.
Disse to typene trengs for oppslag av riktig  BehandlingModell for å sjekke stegrekkefølge mm. Dermed bortfaller noen tilfelle av oppslag i behandlingRepository for å hente nettopp disse to typene til oppslag av modell.
Dessuten vil initBehandlingskontroll bare ta Behandling (vet ikke lenger om behId) - slik at man på sikt kan sende interface.

Neste steg
* Skille ut oppslag av stegrekkefølger i en BehandlingModellTjeneste
* Skille ut aksjonspunkt-relaterte ting i en AksjonspunktkontrollTjeneste - bruke Behandling over Beh.kontrollKontekst 
* Utvide kontekst med behandlingTilstandSnaphot - vil redusere behov for Behandling.getStegTilstand()
* Gjøre BehandlingModell (+repository) til en static affære?
* Rydde henleggelser