### PR TITLE
TFP-6103 skille ut behandlingmodelltjeneste

### DIFF
--- a/behandlingsprosess/src/main/java/no/nav/foreldrepenger/behandling/steg/avklarfakta/KontrollerFaktaTjenesteInngangsVilkår.java
+++ b/behandlingsprosess/src/main/java/no/nav/foreldrepenger/behandling/steg/avklarfakta/KontrollerFaktaTjenesteInngangsVilkår.java
@@ -12,7 +12,7 @@ import no.nav.foreldrepenger.behandling.Skjæringstidspunkt;
 import no.nav.foreldrepenger.behandling.aksjonspunkt.AksjonspunktUtlederInput;
 import no.nav.foreldrepenger.behandling.aksjonspunkt.AksjonspunktUtlederResultat;
 import no.nav.foreldrepenger.behandlingskontroll.AksjonspunktResultat;
-import no.nav.foreldrepenger.behandlingskontroll.BehandlingskontrollTjeneste;
+import no.nav.foreldrepenger.behandlingskontroll.BehandlingModellTjeneste;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingStegType;
 import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.AksjonspunktDefinisjon;
 import no.nav.foreldrepenger.behandlingslager.hendelser.StartpunktType;
@@ -23,16 +23,16 @@ public abstract class KontrollerFaktaTjenesteInngangsVilkår implements Kontroll
     private static final Logger LOG = LoggerFactory.getLogger(KontrollerFaktaTjenesteInngangsVilkår.class);
 
     private KontrollerFaktaUtledere utlederTjeneste;
-    private BehandlingskontrollTjeneste behandlingskontrollTjeneste;
+    private BehandlingModellTjeneste behandlingModellTjeneste;
 
     protected KontrollerFaktaTjenesteInngangsVilkår() {
         // for CDI proxy
     }
 
     protected KontrollerFaktaTjenesteInngangsVilkår(KontrollerFaktaUtledere utlederTjeneste,
-            BehandlingskontrollTjeneste behandlingskontrollTjeneste) {
+                                                    BehandlingModellTjeneste behandlingModellTjeneste) {
         this.utlederTjeneste = utlederTjeneste;
-        this.behandlingskontrollTjeneste = behandlingskontrollTjeneste;
+        this.behandlingModellTjeneste = behandlingModellTjeneste;
     }
 
     @Override
@@ -55,7 +55,7 @@ public abstract class KontrollerFaktaTjenesteInngangsVilkår implements Kontroll
 
     @Override
     public boolean skalOverstyringLøsesTilHøyreForStartpunkt(BehandlingReferanse ref, StartpunktType startpunktType, AksjonspunktDefinisjon apDef) {
-        return behandlingskontrollTjeneste.skalAksjonspunktLøsesIEllerEtterSteg(
+        return behandlingModellTjeneste.skalAksjonspunktLøsesIEllerEtterSteg(
                 ref.fagsakYtelseType(), ref.behandlingType(), startpunktType.getBehandlingSteg(), apDef);
     }
 
@@ -70,7 +70,7 @@ public abstract class KontrollerFaktaTjenesteInngangsVilkår implements Kontroll
     }
 
     private boolean skalBeholdeAksjonspunkt(BehandlingReferanse ref, BehandlingStegType steg, AksjonspunktDefinisjon apDef) {
-        var skalBeholde = behandlingskontrollTjeneste.skalAksjonspunktLøsesIEllerEtterSteg(
+        var skalBeholde = behandlingModellTjeneste.skalAksjonspunktLøsesIEllerEtterSteg(
                 ref.fagsakYtelseType(), ref.behandlingType(), steg, apDef);
         if (!skalBeholde) {
             LOG.debug("Fjerner aksjonspunkt {} da det skal løses før startsteg {}.",

--- a/behandlingsprosess/src/main/java/no/nav/foreldrepenger/behandling/steg/avklarfakta/es/KontrollerFaktaTjeneste.java
+++ b/behandlingsprosess/src/main/java/no/nav/foreldrepenger/behandling/steg/avklarfakta/es/KontrollerFaktaTjeneste.java
@@ -4,7 +4,7 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 
 import no.nav.foreldrepenger.behandling.steg.avklarfakta.KontrollerFaktaTjenesteInngangsVilkår;
-import no.nav.foreldrepenger.behandlingskontroll.BehandlingskontrollTjeneste;
+import no.nav.foreldrepenger.behandlingskontroll.BehandlingModellTjeneste;
 import no.nav.foreldrepenger.behandlingskontroll.FagsakYtelseTypeRef;
 import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakYtelseType;
 
@@ -18,8 +18,8 @@ class KontrollerFaktaTjeneste extends KontrollerFaktaTjenesteInngangsVilkår {
 
     @Inject
     protected KontrollerFaktaTjeneste(KontrollerFaktaUtledereTjenesteImpl utlederTjeneste,
-            BehandlingskontrollTjeneste behandlingskontrollTjeneste) {
-        super(utlederTjeneste, behandlingskontrollTjeneste);
+            BehandlingModellTjeneste behandlingModellTjeneste) {
+        super(utlederTjeneste, behandlingModellTjeneste);
     }
 
 }

--- a/behandlingsprosess/src/main/java/no/nav/foreldrepenger/behandling/steg/avklarfakta/fp/KontrollerFaktaTjeneste.java
+++ b/behandlingsprosess/src/main/java/no/nav/foreldrepenger/behandling/steg/avklarfakta/fp/KontrollerFaktaTjeneste.java
@@ -4,7 +4,7 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 
 import no.nav.foreldrepenger.behandling.steg.avklarfakta.KontrollerFaktaTjenesteInngangsVilkår;
-import no.nav.foreldrepenger.behandlingskontroll.BehandlingskontrollTjeneste;
+import no.nav.foreldrepenger.behandlingskontroll.BehandlingModellTjeneste;
 import no.nav.foreldrepenger.behandlingskontroll.FagsakYtelseTypeRef;
 import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakYtelseType;
 
@@ -18,7 +18,7 @@ class KontrollerFaktaTjeneste extends KontrollerFaktaTjenesteInngangsVilkår {
 
     @Inject
     KontrollerFaktaTjeneste(KontrollerFaktaUtledereTjenesteImpl utlederTjeneste,
-            BehandlingskontrollTjeneste behandlingskontrollTjeneste) {
-        super(utlederTjeneste, behandlingskontrollTjeneste);
+            BehandlingModellTjeneste behandlingModellTjeneste) {
+        super(utlederTjeneste, behandlingModellTjeneste);
     }
 }

--- a/behandlingsprosess/src/main/java/no/nav/foreldrepenger/behandling/steg/avklarfakta/svp/KontrollerFaktaRevurderingStegImpl.java
+++ b/behandlingsprosess/src/main/java/no/nav/foreldrepenger/behandling/steg/avklarfakta/svp/KontrollerFaktaRevurderingStegImpl.java
@@ -21,11 +21,11 @@ import no.nav.foreldrepenger.behandling.steg.avklarfakta.KontrollerFaktaSteg;
 import no.nav.foreldrepenger.behandling.steg.avklarfakta.RyddRegisterData;
 import no.nav.foreldrepenger.behandlingskontroll.AksjonspunktResultat;
 import no.nav.foreldrepenger.behandlingskontroll.BehandleStegResultat;
+import no.nav.foreldrepenger.behandlingskontroll.BehandlingModellTjeneste;
 import no.nav.foreldrepenger.behandlingskontroll.BehandlingStegModell;
 import no.nav.foreldrepenger.behandlingskontroll.BehandlingStegRef;
 import no.nav.foreldrepenger.behandlingskontroll.BehandlingTypeRef;
 import no.nav.foreldrepenger.behandlingskontroll.BehandlingskontrollKontekst;
-import no.nav.foreldrepenger.behandlingskontroll.BehandlingskontrollTjeneste;
 import no.nav.foreldrepenger.behandlingskontroll.FagsakYtelseTypeRef;
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingStegType;
@@ -78,7 +78,7 @@ class KontrollerFaktaRevurderingStegImpl implements KontrollerFaktaSteg {
 
     private static final StartpunktType DEFAULT_STARTPUNKT = StartpunktType.INNGANGSVILKÅR_OPPLYSNINGSPLIKT;
 
-    private BehandlingskontrollTjeneste behandlingskontrollTjeneste;
+    private BehandlingModellTjeneste behandlingModellTjeneste;
     private BehandlingRepository behandlingRepository;
     private KontrollerFaktaTjeneste tjeneste;
     private BehandlingRepositoryProvider repositoryProvider;
@@ -100,7 +100,7 @@ class KontrollerFaktaRevurderingStegImpl implements KontrollerFaktaSteg {
 
     @Inject
     KontrollerFaktaRevurderingStegImpl(BehandlingRepositoryProvider repositoryProvider,
-                                       BehandlingskontrollTjeneste behandlingskontrollTjeneste,
+                                       BehandlingModellTjeneste behandlingModellTjeneste,
                                        SkjæringstidspunktTjeneste skjæringstidspunktTjeneste,
                                        @FagsakYtelseTypeRef(FagsakYtelseType.SVANGERSKAPSPENGER) KontrollerFaktaTjeneste tjeneste,
                                        @FagsakYtelseTypeRef(FagsakYtelseType.SVANGERSKAPSPENGER) StartpunktTjeneste startpunktTjeneste,
@@ -108,7 +108,7 @@ class KontrollerFaktaRevurderingStegImpl implements KontrollerFaktaSteg {
                                        SvangerskapspengerRepository svangerskapspengerRepository, BeregningTjeneste beregningTjeneste,
                                        MottatteDokumentTjeneste mottatteDokumentTjeneste, SatsRepository satsRepository) {
         this.repositoryProvider = repositoryProvider;
-        this.behandlingskontrollTjeneste = behandlingskontrollTjeneste;
+        this.behandlingModellTjeneste = behandlingModellTjeneste;
         this.skjæringstidspunktTjeneste = skjæringstidspunktTjeneste;
         this.behandlingRepository = repositoryProvider.getBehandlingRepository();
         this.tjeneste = tjeneste;
@@ -200,24 +200,27 @@ class KontrollerFaktaRevurderingStegImpl implements KontrollerFaktaSteg {
     }
 
     private StartpunktType sjekkÅpneAksjonspunkt(BehandlingReferanse ref, Behandling revurdering, StartpunktType gjeldendeStartpunkt) {
+        // Finn evt åpne aksjonspunkt ( overstyringer ) som må løses før startpunkt - ta vare på vurderingspunkt-steg.
         var stegForÅpneAksjonspunktFørStartpunkt = revurdering.getÅpneAksjonspunkter().stream()
             .map(Aksjonspunkt::getAksjonspunktDefinisjon)
             .map(AksjonspunktDefinisjon::getBehandlingSteg)
-            .filter(behandlingSteg -> sammenlignRekkefølge(ref, gjeldendeStartpunkt, behandlingSteg) > 0)
+            .filter(behandlingSteg -> erStartpunktEtterSteg(ref, gjeldendeStartpunkt, behandlingSteg))
             .toList();
         if (stegForÅpneAksjonspunktFørStartpunkt.isEmpty()) {
             return gjeldendeStartpunkt;
         }
+        // Det finnes åpne aksjonspunkt ( overstyringer ) som må løses før startpunkt - har vurderingspunkt-steg for disse.
+        // Finn seneste startpunkt som ligger før vurderingspunkt-stegene (ingen VP-steg er før startpunkt)
         return Arrays.stream(StartpunktType.values())
             .filter(stp -> !StartpunktType.UDEFINERT.equals(stp))
             .filter(stp -> stp.getRangering() >= DEFAULT_STARTPUNKT.getRangering()) // Se bort fra helt tidlige startpunkt her i KOFAK
-            .filter(stp -> stegForÅpneAksjonspunktFørStartpunkt.stream().allMatch(steg -> sammenlignRekkefølge(ref, stp, steg) <= 0))
+            .filter(stp -> stegForÅpneAksjonspunktFørStartpunkt.stream().noneMatch(steg -> erStartpunktEtterSteg(ref, stp, steg)))
             .max(Comparator.comparing(StartpunktType::getRangering))
             .orElse(gjeldendeStartpunkt);
     }
 
-    private int sammenlignRekkefølge(BehandlingReferanse ref, StartpunktType startpunkt, BehandlingStegType behandlingSteg) {
-        return behandlingskontrollTjeneste.sammenlignRekkefølge(ref.fagsakYtelseType(), ref.behandlingType(),
+    private boolean erStartpunktEtterSteg(BehandlingReferanse ref, StartpunktType startpunkt, BehandlingStegType behandlingSteg) {
+        return behandlingModellTjeneste.erStegAEtterStegB(ref.fagsakYtelseType(), ref.behandlingType(),
             startpunkt.getBehandlingSteg(), behandlingSteg);
     }
 

--- a/behandlingsprosess/src/main/java/no/nav/foreldrepenger/behandling/steg/avklarfakta/svp/KontrollerFaktaTjeneste.java
+++ b/behandlingsprosess/src/main/java/no/nav/foreldrepenger/behandling/steg/avklarfakta/svp/KontrollerFaktaTjeneste.java
@@ -4,7 +4,7 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 
 import no.nav.foreldrepenger.behandling.steg.avklarfakta.KontrollerFaktaTjenesteInngangsVilkår;
-import no.nav.foreldrepenger.behandlingskontroll.BehandlingskontrollTjeneste;
+import no.nav.foreldrepenger.behandlingskontroll.BehandlingModellTjeneste;
 import no.nav.foreldrepenger.behandlingskontroll.FagsakYtelseTypeRef;
 import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakYtelseType;
 
@@ -18,8 +18,8 @@ class KontrollerFaktaTjeneste extends KontrollerFaktaTjenesteInngangsVilkår {
 
     @Inject
     protected KontrollerFaktaTjeneste(KontrollerFaktaUtledereTjenesteImpl utlederTjeneste,
-            BehandlingskontrollTjeneste behandlingskontrollTjeneste) {
-        super(utlederTjeneste, behandlingskontrollTjeneste);
+            BehandlingModellTjeneste behandlingModellTjeneste) {
+        super(utlederTjeneste, behandlingModellTjeneste);
     }
 
 }

--- a/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/BehandlingModellTest.java
+++ b/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/BehandlingModellTest.java
@@ -32,8 +32,7 @@ class BehandlingModellTest {
         BehandlingTypeYtelseType tuple) {
         var behandlingType = tuple.behandlingType();
         var ytelseType = tuple.ytelseType();
-        var behandlingModellRepository = new BehandlingModellRepository();
-        var modell = behandlingModellRepository.getModell(behandlingType, ytelseType);
+        var modell = BehandlingModellRepository.getModell(behandlingType, ytelseType);
         for (var stegType : modell.hvertSteg().map(BehandlingStegModell::getBehandlingStegType).toList()) {
             var steg = modell.finnSteg(stegType);
             var description = String.format("Feilet for %s, %s, %s", ytelseType.getKode(), behandlingType.getKode(),

--- a/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/iverksettevedtak/HenleggBehandlingTjenesteTest.java
+++ b/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/iverksettevedtak/HenleggBehandlingTjenesteTest.java
@@ -85,7 +85,6 @@ class HenleggBehandlingTjenesteTest {
                 repositoryProvider.getBehandlingRepository(),
                 repositoryProvider.getFagsakLåsRepository(),
                 repositoryProvider.getBehandlingLåsRepository(),
-                behandlingModellRepository,
                 aksjonspunktKontrollRepository);
 
         var behandlingskontrollTjenesteImpl = new BehandlingskontrollTjenesteImpl(serviceProvider);

--- a/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/iverksettevedtak/HenleggBehandlingUtenSøknadTest.java
+++ b/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/iverksettevedtak/HenleggBehandlingUtenSøknadTest.java
@@ -7,7 +7,6 @@ import static org.mockito.Mockito.mock;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import no.nav.foreldrepenger.behandlingskontroll.impl.BehandlingModellRepository;
 import no.nav.foreldrepenger.behandlingskontroll.impl.BehandlingskontrollTjenesteImpl;
 import no.nav.foreldrepenger.behandlingskontroll.spi.BehandlingskontrollServiceProvider;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingResultatType;
@@ -32,7 +31,7 @@ class HenleggBehandlingUtenSøknadTest extends EntityManagerAwareTest {
     @BeforeEach
     void setUp() {
         repositoryProvider = new BehandlingRepositoryProvider(getEntityManager());
-        var serviceProvider = new BehandlingskontrollServiceProvider(getEntityManager(), new BehandlingModellRepository(), null);
+        var serviceProvider = new BehandlingskontrollServiceProvider(getEntityManager(), null);
         var behandlingskontrollTjenesteImpl = new BehandlingskontrollTjenesteImpl(serviceProvider);
         henleggBehandlingTjeneste = new HenleggBehandlingTjeneste(repositoryProvider, behandlingskontrollTjenesteImpl,
                 mock(DokumentBestillerTjeneste.class), mock(ProsessTaskTjeneste.class));

--- a/domenetjenester/behandling-prosessering/src/main/java/no/nav/foreldrepenger/behandlingsprosess/prosessering/BehandlingProsesseringTjeneste.java
+++ b/domenetjenester/behandling-prosessering/src/main/java/no/nav/foreldrepenger/behandlingsprosess/prosessering/BehandlingProsesseringTjeneste.java
@@ -31,7 +31,11 @@ public interface BehandlingProsesseringTjeneste {
     void tvingInnhentingRegisteropplysninger(Behandling behandling);
 
     // Har behandlingen oppgitt steg i modellen?
-    boolean erStegAktueltForBehandling(Behandling behandling, BehandlingStegType behandlingStegType);
+    boolean erStegAktueltForBehandling(Behandling behandling, BehandlingStegType stegType);
+
+    boolean erBehandlingFørSteg(Behandling behandling, BehandlingStegType stegType);
+
+    boolean erBehandlingEtterSteg(Behandling behandling, BehandlingStegType stegType);
 
     // AV/PÅ Vent
     void taBehandlingAvVent(Behandling behandling);
@@ -64,7 +68,7 @@ public interface BehandlingProsesseringTjeneste {
     String opprettTasksForFortsettBehandlingSettUtført(Behandling behandling, Optional<AksjonspunktDefinisjon> autoPunktUtført);
 
     // Brukes kun der et steg har suspendet seg selv. Lagrer tasks. Returnerer gruppe-handle
-    String opprettTasksForFortsettBehandlingResumeStegNesteKjøring(Behandling behandling, BehandlingStegType behandlingStegType,
+    String opprettTasksForFortsettBehandlingResumeStegNesteKjøring(Behandling behandling, BehandlingStegType stegType,
                                                                    LocalDateTime nesteKjøringEtter);
 
     // Robust task til bruk ved gjenopptak fra vent (eller annen tilstand)

--- a/domenetjenester/behandling-prosessering/src/main/java/no/nav/foreldrepenger/behandlingsprosess/prosessering/ProsesseringAsynkTjeneste.java
+++ b/domenetjenester/behandling-prosessering/src/main/java/no/nav/foreldrepenger/behandlingsprosess/prosessering/ProsesseringAsynkTjeneste.java
@@ -18,7 +18,6 @@ import no.nav.vedtak.felles.prosesstask.api.ProsessTaskStatus;
 @ApplicationScoped
 public class ProsesseringAsynkTjeneste {
 
-    private BehandlingProsesseringTjeneste prosesseringTjeneste;
     private FagsakProsessTaskRepository fagsakProsessTaskRepository;
 
     ProsesseringAsynkTjeneste() {
@@ -26,8 +25,7 @@ public class ProsesseringAsynkTjeneste {
     }
 
     @Inject
-    public ProsesseringAsynkTjeneste(BehandlingProsesseringTjeneste prosesseringTjeneste, FagsakProsessTaskRepository fagsakProsessTaskRepository) {
-        this.prosesseringTjeneste = prosesseringTjeneste;
+    public ProsesseringAsynkTjeneste(FagsakProsessTaskRepository fagsakProsessTaskRepository) {
         this.fagsakProsessTaskRepository = fagsakProsessTaskRepository;
     }
 
@@ -88,24 +86,6 @@ public class ProsesseringAsynkTjeneste {
     private Map<String, List<ProsessTaskData>> sjekkStatusProsessTasksGrouped(Long fagsakId, Long behandlingId, String gruppe) {
         var tasks = fagsakProsessTaskRepository.sjekkStatusProsessTasks(fagsakId, behandlingId, gruppe);
         return tasks.stream().collect(Collectors.groupingBy(ProsessTaskData::getGruppe));
-    }
-
-    /**
-     * Kjør prosess asynkront (i egen prosess task) videre.
-     *
-     * @return gruppe assignet til prosess task
-     */
-    public String asynkStartBehandlingProsess(Behandling behandling) {
-        return prosesseringTjeneste.opprettTasksForStartBehandling(behandling);
-    }
-
-    /**
-     * Kjør prosess asynkront (i egen prosess task) videre.
-     *
-     * @return gruppe assignet til prosess task
-     */
-    public String asynkProsesserBehandling(Behandling behandling) {
-        return prosesseringTjeneste.opprettTasksForFortsettBehandling(behandling);
     }
 
 }

--- a/domenetjenester/behandling-revurdering/src/main/java/no/nav/foreldrepenger/behandling/revurdering/flytkontroll/BehandlingFlytkontroll.java
+++ b/domenetjenester/behandling-revurdering/src/main/java/no/nav/foreldrepenger/behandling/revurdering/flytkontroll/BehandlingFlytkontroll.java
@@ -8,6 +8,7 @@ import jakarta.inject.Inject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import no.nav.foreldrepenger.behandling.BehandlingRevurderingTjeneste;
 import no.nav.foreldrepenger.behandlingskontroll.BehandlingskontrollTjeneste;
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingStegType;
@@ -15,7 +16,6 @@ import no.nav.foreldrepenger.behandlingslager.behandling.SpesialBehandling;
 import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.AksjonspunktDefinisjon;
 import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.Venteårsak;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepository;
-import no.nav.foreldrepenger.behandling.BehandlingRevurderingTjeneste;
 import no.nav.foreldrepenger.behandlingslager.fagsak.Fagsak;
 import no.nav.foreldrepenger.behandlingslager.hendelser.StartpunktType;
 import no.nav.foreldrepenger.behandlingsprosess.prosessering.BehandlingProsesseringTjeneste;
@@ -66,7 +66,7 @@ public class BehandlingFlytkontroll {
         var annenPartHarBerørt = annenpartÅpneBehandlinger.stream()
                 .anyMatch(SpesialBehandling::skalIkkeKøes);
         var annenPartAktivUttak = annenpartÅpneBehandlinger.stream()
-                .anyMatch(b -> behandlingskontrollTjeneste.erStegPassert(b, SYNK_STEG));
+                .anyMatch(b -> behandlingProsesseringTjeneste.erBehandlingEtterSteg(b, SYNK_STEG));
         // Berørt skal bare køes dersom annenpart har en berørt som står i uttak.
         if (SpesialBehandling.skalIkkeKøes(behandling)) {
             // TODO fjern sjekk på ventVedSynk og fortsettAnnenPart dersom ikke inntreffer ila nov 2022
@@ -91,7 +91,7 @@ public class BehandlingFlytkontroll {
         var finnesBerørt = behandlingRepository.hentÅpneYtelseBehandlingerForFagsakId(fagsak.getId()).stream()
                 .anyMatch(SpesialBehandling::skalIkkeKøes);
         var annenPartRevurderingEllerAktivUttak = behandlingRepository.hentÅpneYtelseBehandlingerForFagsakId(annenpartFagsak.getId()).stream()
-                .anyMatch(b -> b.erRevurdering() || behandlingskontrollTjeneste.erStegPassert(b, SYNK_STEG));
+                .anyMatch(b -> b.erRevurdering() || behandlingProsesseringTjeneste.erBehandlingEtterSteg(b, SYNK_STEG));
         // TODO avklare om aktivUttak skal ekskludere behandling.isBehandlingPåVent();
         return finnesBerørt || annenPartRevurderingEllerAktivUttak;
     }
@@ -107,7 +107,7 @@ public class BehandlingFlytkontroll {
     }
 
     private boolean passertUttakSynk(Behandling behandling) {
-        return behandlingskontrollTjeneste.erStegPassert(behandling, SYNK_STEG) || venterVedUttakSynk(behandling);
+        return behandlingProsesseringTjeneste.erBehandlingEtterSteg(behandling, SYNK_STEG) || venterVedUttakSynk(behandling);
     }
 
     private boolean venterVedUttakSynk(Behandling behandling) {

--- a/domenetjenester/behandling-revurdering/src/test/java/no/nav/foreldrepenger/behandling/revurdering/flytkontroll/BehandlingFlytkontrollTest.java
+++ b/domenetjenester/behandling-revurdering/src/test/java/no/nav/foreldrepenger/behandling/revurdering/flytkontroll/BehandlingFlytkontrollTest.java
@@ -16,37 +16,37 @@ import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import no.nav.foreldrepenger.behandling.BehandlingRevurderingTjeneste;
 import no.nav.foreldrepenger.behandlingskontroll.BehandlingskontrollTjeneste;
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingÅrsakType;
 import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.AksjonspunktDefinisjon;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepository;
-import no.nav.foreldrepenger.behandling.BehandlingRevurderingTjeneste;
 import no.nav.foreldrepenger.behandlingslager.fagsak.Fagsak;
 import no.nav.foreldrepenger.behandlingslager.hendelser.StartpunktType;
 import no.nav.foreldrepenger.behandlingsprosess.prosessering.BehandlingProsesseringTjeneste;
 
 class BehandlingFlytkontrollTest {
 
-    private static Long FAGSAK_ID = 1L;
-    private static Long FAGSAK_AP_ID = 2L;
-    private static Long BEHANDLING_ID = 99L;
-    private static Long BERØRT_ID = 98L;
-    private static Long EGEN_BERØRT_ID = 97L;
+    private static final Long FAGSAK_ID = 1L;
+    private static final Long FAGSAK_AP_ID = 2L;
+    private static final Long BEHANDLING_ID = 99L;
+    private static final Long BERØRT_ID = 98L;
+    private static final Long EGEN_BERØRT_ID = 97L;
 
-    private BehandlingRepository behandlingRepository = mock(BehandlingRepository.class);
-    private BehandlingRevurderingTjeneste behandlingRevurderingTjeneste = mock(
+    private final BehandlingRepository behandlingRepository = mock(BehandlingRepository.class);
+    private final BehandlingRevurderingTjeneste behandlingRevurderingTjeneste = mock(
         BehandlingRevurderingTjeneste.class);
-    private BehandlingskontrollTjeneste behandlingskontrollTjeneste = mock(BehandlingskontrollTjeneste.class);
-    private BehandlingProsesseringTjeneste behandlingProsesseringTjeneste = mock(BehandlingProsesseringTjeneste.class);
+    private final BehandlingskontrollTjeneste behandlingskontrollTjeneste = mock(BehandlingskontrollTjeneste.class);
+    private final BehandlingProsesseringTjeneste behandlingProsesseringTjeneste = mock(BehandlingProsesseringTjeneste.class);
     private BehandlingFlytkontroll flytkontroll;
-    private Behandling behandling = mock(Behandling.class);
-    private Behandling behandlingAnnenPart = mock(Behandling.class);
-    private Behandling behandlingBerørt = mock(Behandling.class);
-    private Behandling behandlingSammeSak = mock(Behandling.class);
-    private Behandling behandlingSammeSakBerørt = mock(Behandling.class);
-    private Fagsak fagsak = mock(Fagsak.class);
-    private Fagsak fagsakAnnenPart = mock(Fagsak.class);
+    private final Behandling behandling = mock(Behandling.class);
+    private final Behandling behandlingAnnenPart = mock(Behandling.class);
+    private final Behandling behandlingBerørt = mock(Behandling.class);
+    private final Behandling behandlingSammeSak = mock(Behandling.class);
+    private final Behandling behandlingSammeSakBerørt = mock(Behandling.class);
+    private final Fagsak fagsak = mock(Fagsak.class);
+    private final Fagsak fagsakAnnenPart = mock(Fagsak.class);
 
     @BeforeEach
     public void setup() {
@@ -88,7 +88,7 @@ class BehandlingFlytkontrollTest {
         when(behandlingRevurderingTjeneste.finnFagsakPåMedforelder(fagsak)).thenReturn(Optional.of(fagsakAnnenPart));
         when(behandlingRepository.hentÅpneYtelseBehandlingerForFagsakId(FAGSAK_AP_ID)).thenReturn(
                 List.of(behandlingAnnenPart));
-        when(behandlingskontrollTjeneste.erStegPassert(behandlingAnnenPart,
+        when(behandlingProsesseringTjeneste.erBehandlingEtterSteg(behandlingAnnenPart,
                 StartpunktType.UTTAKSVILKÅR.getBehandlingSteg())).thenReturn(false);
         assertThat(flytkontroll.uttaksProsessenSkalVente(BEHANDLING_ID)).isFalse();
     }
@@ -98,7 +98,7 @@ class BehandlingFlytkontrollTest {
         when(behandlingRevurderingTjeneste.finnFagsakPåMedforelder(fagsak)).thenReturn(Optional.of(fagsakAnnenPart));
         when(behandlingRepository.hentÅpneYtelseBehandlingerForFagsakId(FAGSAK_AP_ID)).thenReturn(
                 List.of(behandlingAnnenPart));
-        when(behandlingskontrollTjeneste.erStegPassert(behandlingAnnenPart,
+        when(behandlingProsesseringTjeneste.erBehandlingEtterSteg(behandlingAnnenPart,
                 StartpunktType.UTTAKSVILKÅR.getBehandlingSteg())).thenReturn(true);
         assertThat(flytkontroll.uttaksProsessenSkalVente(BEHANDLING_ID)).isTrue();
     }
@@ -108,7 +108,7 @@ class BehandlingFlytkontrollTest {
         when(behandlingRevurderingTjeneste.finnFagsakPåMedforelder(fagsak)).thenReturn(Optional.of(fagsakAnnenPart));
         when(behandlingRepository.hentÅpneYtelseBehandlingerForFagsakId(FAGSAK_AP_ID)).thenReturn(
                 List.of(behandlingBerørt));
-        when(behandlingskontrollTjeneste.erStegPassert(behandlingBerørt,
+        when(behandlingProsesseringTjeneste.erBehandlingEtterSteg(behandlingBerørt,
                 StartpunktType.UTTAKSVILKÅR.getBehandlingSteg())).thenReturn(false);
         assertThat(flytkontroll.uttaksProsessenSkalVente(BEHANDLING_ID)).isTrue();
     }
@@ -118,7 +118,7 @@ class BehandlingFlytkontrollTest {
         when(behandlingRevurderingTjeneste.finnFagsakPåMedforelder(fagsak)).thenReturn(Optional.of(fagsakAnnenPart));
         when(behandlingRepository.hentÅpneYtelseBehandlingerForFagsakId(FAGSAK_AP_ID)).thenReturn(
             List.of(behandlingBerørt));
-        when(behandlingskontrollTjeneste.erStegPassert(behandlingBerørt,
+        when(behandlingProsesseringTjeneste.erBehandlingEtterSteg(behandlingBerørt,
             StartpunktType.UTTAKSVILKÅR.getBehandlingSteg())).thenReturn(false);
         assertThat(flytkontroll.uttaksProsessenSkalVente(EGEN_BERØRT_ID)).isFalse();
     }
@@ -128,7 +128,7 @@ class BehandlingFlytkontrollTest {
         when(behandlingRevurderingTjeneste.finnFagsakPåMedforelder(fagsak)).thenReturn(Optional.of(fagsakAnnenPart));
         when(behandlingRepository.hentÅpneYtelseBehandlingerForFagsakId(FAGSAK_AP_ID)).thenReturn(
             List.of(behandlingBerørt));
-        when(behandlingskontrollTjeneste.erStegPassert(behandlingBerørt,
+        when(behandlingProsesseringTjeneste.erBehandlingEtterSteg(behandlingBerørt,
             StartpunktType.UTTAKSVILKÅR.getBehandlingSteg())).thenReturn(true);
         assertThat(flytkontroll.uttaksProsessenSkalVente(EGEN_BERØRT_ID)).isTrue();
     }
@@ -138,7 +138,7 @@ class BehandlingFlytkontrollTest {
         when(behandlingRevurderingTjeneste.finnFagsakPåMedforelder(fagsak)).thenReturn(Optional.of(fagsakAnnenPart));
         when(behandlingRepository.hentÅpneYtelseBehandlingerForFagsakId(FAGSAK_AP_ID)).thenReturn(
             List.of(behandlingBerørt));
-        when(behandlingskontrollTjeneste.erStegPassert(behandlingBerørt,
+        when(behandlingProsesseringTjeneste.erBehandlingEtterSteg(behandlingBerørt,
             StartpunktType.UTTAKSVILKÅR.getBehandlingSteg())).thenReturn(false);
         when(behandlingBerørt.harÅpentAksjonspunktMedType(AksjonspunktDefinisjon.AUTO_KØET_BEHANDLING)).thenReturn(true);
         when(behandlingBerørt.getAktivtBehandlingSteg()).thenReturn(StartpunktType.UTTAKSVILKÅR.getBehandlingSteg());
@@ -154,7 +154,7 @@ class BehandlingFlytkontrollTest {
                 List.of(behandlingBerørt));
         when(behandlingRepository.hentÅpneYtelseBehandlingerForFagsakId(FAGSAK_AP_ID)).thenReturn(
                 Collections.emptyList());
-        when(behandlingskontrollTjeneste.erStegPassert(behandlingBerørt,
+        when(behandlingProsesseringTjeneste.erBehandlingEtterSteg(behandlingBerørt,
                 StartpunktType.UTTAKSVILKÅR.getBehandlingSteg())).thenReturn(false);
         assertThat(flytkontroll.uttaksProsessenSkalVente(BEHANDLING_ID)).isTrue();
     }
@@ -179,7 +179,7 @@ class BehandlingFlytkontrollTest {
         when(behandlingRepository.hentÅpneYtelseBehandlingerForFagsakId(FAGSAK_AP_ID)).thenReturn(
                 List.of(behandlingAnnenPart));
         when(behandlingAnnenPart.erRevurdering()).thenReturn(false);
-        when(behandlingskontrollTjeneste.erStegPassert(behandlingAnnenPart,
+        when(behandlingProsesseringTjeneste.erBehandlingEtterSteg(behandlingAnnenPart,
                 StartpunktType.UTTAKSVILKÅR.getBehandlingSteg())).thenReturn(false);
         assertThat(flytkontroll.nyRevurderingSkalVente(fagsak)).isFalse();
     }
@@ -190,7 +190,7 @@ class BehandlingFlytkontrollTest {
         when(behandlingRepository.hentÅpneYtelseBehandlingerForFagsakId(FAGSAK_AP_ID)).thenReturn(
                 List.of(behandlingAnnenPart));
         when(behandlingAnnenPart.erRevurdering()).thenReturn(true);
-        when(behandlingskontrollTjeneste.erStegPassert(behandlingAnnenPart,
+        when(behandlingProsesseringTjeneste.erBehandlingEtterSteg(behandlingAnnenPart,
                 StartpunktType.UTTAKSVILKÅR.getBehandlingSteg())).thenReturn(false);
         assertThat(flytkontroll.nyRevurderingSkalVente(fagsak)).isTrue();
     }
@@ -201,7 +201,7 @@ class BehandlingFlytkontrollTest {
         when(behandlingRepository.hentÅpneYtelseBehandlingerForFagsakId(FAGSAK_AP_ID)).thenReturn(
                 List.of(behandlingAnnenPart));
         when(behandlingAnnenPart.erRevurdering()).thenReturn(false);
-        when(behandlingskontrollTjeneste.erStegPassert(behandlingAnnenPart,
+        when(behandlingProsesseringTjeneste.erBehandlingEtterSteg(behandlingAnnenPart,
                 StartpunktType.UTTAKSVILKÅR.getBehandlingSteg())).thenReturn(true);
         assertThat(flytkontroll.nyRevurderingSkalVente(fagsak)).isTrue();
     }
@@ -211,7 +211,7 @@ class BehandlingFlytkontrollTest {
         when(behandlingRevurderingTjeneste.finnFagsakPåMedforelder(fagsak)).thenReturn(Optional.of(fagsakAnnenPart));
         when(behandlingRepository.hentÅpneYtelseBehandlingerForFagsakId(FAGSAK_AP_ID)).thenReturn(
                 List.of(behandlingBerørt));
-        when(behandlingskontrollTjeneste.erStegPassert(behandlingBerørt,
+        when(behandlingProsesseringTjeneste.erBehandlingEtterSteg(behandlingBerørt,
                 StartpunktType.UTTAKSVILKÅR.getBehandlingSteg())).thenReturn(false);
         assertThat(flytkontroll.nyRevurderingSkalVente(fagsak)).isTrue();
     }
@@ -232,7 +232,7 @@ class BehandlingFlytkontrollTest {
                 List.of(behandlingBerørt));
         when(behandlingRepository.hentÅpneYtelseBehandlingerForFagsakId(FAGSAK_AP_ID)).thenReturn(
                 Collections.emptyList());
-        when(behandlingskontrollTjeneste.erStegPassert(behandlingBerørt,
+        when(behandlingProsesseringTjeneste.erBehandlingEtterSteg(behandlingBerørt,
                 StartpunktType.UTTAKSVILKÅR.getBehandlingSteg())).thenReturn(false);
         assertThat(flytkontroll.nyRevurderingSkalVente(fagsak)).isTrue();
     }

--- a/domenetjenester/behandling-revurdering/src/test/java/no/nav/foreldrepenger/behandling/revurdering/ytelse/es/RevurderingTjenesteImplTest.java
+++ b/domenetjenester/behandling-revurdering/src/test/java/no/nav/foreldrepenger/behandling/revurdering/ytelse/es/RevurderingTjenesteImplTest.java
@@ -14,7 +14,6 @@ import no.nav.foreldrepenger.behandling.BehandlingRevurderingTjeneste;
 import no.nav.foreldrepenger.behandling.FagsakRelasjonTjeneste;
 import no.nav.foreldrepenger.behandling.revurdering.RevurderingTjeneste;
 import no.nav.foreldrepenger.behandling.revurdering.RevurderingTjenesteFelles;
-import no.nav.foreldrepenger.behandlingskontroll.impl.BehandlingModellRepository;
 import no.nav.foreldrepenger.behandlingskontroll.impl.BehandlingskontrollTjenesteImpl;
 import no.nav.foreldrepenger.behandlingskontroll.spi.BehandlingskontrollServiceProvider;
 import no.nav.foreldrepenger.behandlingslager.aktør.OrganisasjonsEnhet;
@@ -42,7 +41,7 @@ class RevurderingTjenesteImplTest {
         var grunnlagProvider = new BehandlingGrunnlagRepositoryProvider(entityManager);
         behandlingRepository = new BehandlingRepository(entityManager);
         var serviceProvider = new BehandlingskontrollServiceProvider(entityManager,
-                new BehandlingModellRepository(), null);
+                null);
         var revurderingEndringES = new RevurderingEndringImpl(behandlingRepository,
                 new LegacyESBeregningRepository(entityManager), repositoryProvider.getBehandlingsresultatRepository());
         var vergeRepository = new VergeRepository(entityManager);

--- a/domenetjenester/behandlingskontroll/src/main/java/no/nav/foreldrepenger/behandlingskontroll/BehandlingModell.java
+++ b/domenetjenester/behandlingskontroll/src/main/java/no/nav/foreldrepenger/behandlingskontroll/BehandlingModell.java
@@ -43,6 +43,8 @@ public interface BehandlingModell {
 
     Set<AksjonspunktDefinisjon> finnAksjonspunktDefinisjonerUtgang(BehandlingStegType steg);
 
+    boolean inneholderSteg(BehandlingStegType stegType);
+
     BehandlingStegModell finnForrigeSteg(BehandlingStegType stegType);
 
     BehandlingStegModell finnFørsteSteg(BehandlingStegType... behandlingStegTyper);
@@ -65,7 +67,10 @@ public interface BehandlingModell {
 
     Stream<BehandlingStegModell> hvertStegFraOgMedTil(BehandlingStegType fraOgMedSteg, BehandlingStegType tilSteg, boolean tilOgMed);
 
+    // To metoder for bedre lesbarhet og redusert kognitiv belastning
     boolean erStegAFørStegB(BehandlingStegType stegA, BehandlingStegType stegB);
+
+    boolean erStegAEtterStegB(BehandlingStegType stegA, BehandlingStegType stegB);
 
     /**
      * Beregn relativ forflytning mellom to steg.

--- a/domenetjenester/behandlingskontroll/src/main/java/no/nav/foreldrepenger/behandlingskontroll/BehandlingModellTjeneste.java
+++ b/domenetjenester/behandlingskontroll/src/main/java/no/nav/foreldrepenger/behandlingskontroll/BehandlingModellTjeneste.java
@@ -1,0 +1,57 @@
+package no.nav.foreldrepenger.behandlingskontroll;
+
+import static java.util.Collections.singletonList;
+
+import java.util.Optional;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import no.nav.foreldrepenger.behandlingskontroll.impl.BehandlingModellRepository;
+import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingStegType;
+import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingType;
+import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.AksjonspunktDefinisjon;
+import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakYtelseType;
+
+/**
+ * Grensesnitt for oppslag av stegrekkefølger for en behandling, egentlig ytelseType og behandlingType.
+ */
+@ApplicationScoped // I praksis for å kunne mocke injects.
+public class BehandlingModellTjeneste {
+
+    public BehandlingModellTjeneste() {
+        // Empty supplier
+    }
+
+    public boolean inneholderSteg(FagsakYtelseType ytelseType, BehandlingType behandlingType, BehandlingStegType behandlingStegType) {
+        var modell = getModell(behandlingType, ytelseType);
+        return modell.inneholderSteg(behandlingStegType);
+    }
+
+    public boolean erStegAFørStegB(FagsakYtelseType ytelseType, BehandlingType behandlingType, BehandlingStegType stegA, BehandlingStegType stegB) {
+        var modell = getModell(behandlingType, ytelseType);
+        return modell.erStegAFørStegB(stegA, stegB);
+    }
+
+    public boolean erStegAEtterStegB(FagsakYtelseType ytelseType, BehandlingType behandlingType, BehandlingStegType stegA, BehandlingStegType stegB) {
+        var modell = getModell(behandlingType, ytelseType);
+        return modell.erStegAEtterStegB(stegA, stegB);
+    }
+
+    public boolean skalAksjonspunktLøsesIEllerEtterSteg(FagsakYtelseType ytelseType, BehandlingType behandlingType,
+                                                        BehandlingStegType behandlingSteg, AksjonspunktDefinisjon apDef) {
+
+        var modell = getModell(behandlingType, ytelseType);
+        var apLøsesteg = Optional.ofNullable(modell.finnTidligsteStegForAksjonspunktDefinisjon(singletonList(apDef)))
+            .map(BehandlingStegModell::getBehandlingStegType)
+            .orElse(null);
+
+        return apLøsesteg != null && !modell.erStegAFørStegB(apLøsesteg, behandlingSteg);
+    }
+
+    private static BehandlingModell getModell(BehandlingType behandlingType, FagsakYtelseType ytelseType) {
+        return BehandlingModellRepository.getModell(behandlingType, ytelseType);
+    }
+
+
+
+}

--- a/domenetjenester/behandlingskontroll/src/main/java/no/nav/foreldrepenger/behandlingskontroll/BehandlingskontrollTjeneste.java
+++ b/domenetjenester/behandlingskontroll/src/main/java/no/nav/foreldrepenger/behandlingskontroll/BehandlingskontrollTjeneste.java
@@ -3,7 +3,6 @@ package no.nav.foreldrepenger.behandlingskontroll;
 import java.time.LocalDateTime;
 import java.util.Collection;
 import java.util.List;
-import java.util.Set;
 import java.util.function.Consumer;
 
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
@@ -15,7 +14,6 @@ import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.Aksjonspun
 import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.Venteårsak;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingLås;
 import no.nav.foreldrepenger.behandlingslager.fagsak.Fagsak;
-import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakYtelseType;
 
 public interface BehandlingskontrollTjeneste {
 
@@ -63,9 +61,6 @@ public interface BehandlingskontrollTjeneste {
      * @see #prosesserBehandling(BehandlingskontrollKontekst)
      */
     void behandlingTilbakeføringTilTidligsteAksjonspunkt(BehandlingskontrollKontekst kontekst, Collection<AksjonspunktDefinisjon> endredeAksjonspunkt);
-
-    boolean behandlingTilbakeføringHvisTidligereBehandlingSteg(BehandlingskontrollKontekst kontekst,
-            BehandlingStegType tidligereStegType);
 
     /**
      * FLytt prosesen til et tidlligere steg.
@@ -209,31 +204,7 @@ public interface BehandlingskontrollTjeneste {
     /** Henlegg en behandling. */
     void henleggBehandling(BehandlingskontrollKontekst kontekst, BehandlingResultatType årsakKode);
 
-    Set<AksjonspunktDefinisjon> finnAksjonspunktDefinisjonerFraOgMed(BehandlingskontrollKontekst kontekst, BehandlingStegType steg, boolean medInngangOgså);
-
     void henleggBehandlingFraSteg(BehandlingskontrollKontekst kontekst, BehandlingResultatType årsak);
 
-    /**
-     * Sjekker i behandlingsmodellen om aksjonspunktet skal løses i eller etter det
-     * angitte steget.
-     *
-     * @param ytelseType             ytelsen som skal sjekkes
-     * @param behandlingType         behandlingstypen som skal sjekkes
-     * @param behandlingSteg         steget som aksjonspunktet skal sjekkes mot
-     * @param aksjonspunktDefinisjon aksjonspunktet som skal sjekkes
-     * @return true dersom aksjonspunktet skal løses i eller etter det angitte
-     *         steget.
-     */
-    boolean skalAksjonspunktLøsesIEllerEtterSteg(FagsakYtelseType ytelseType, BehandlingType behandlingType, BehandlingStegType behandlingSteg,
-            AksjonspunktDefinisjon aksjonspunktDefinisjon);
-
     void fremoverTransisjon(BehandlingStegType målSteg, BehandlingskontrollKontekst kontekst);
-
-    boolean inneholderSteg(Behandling behandling, BehandlingStegType registrerSøknad);
-
-    int sammenlignRekkefølge(FagsakYtelseType ytelseType, BehandlingType behandlingType, BehandlingStegType stegA, BehandlingStegType stegB);
-
-    boolean erStegPassert(Behandling behandling, BehandlingStegType stegType);
-
-    boolean erIStegEllerSenereSteg(Behandling behandling, BehandlingStegType stegType);
 }

--- a/domenetjenester/behandlingskontroll/src/main/java/no/nav/foreldrepenger/behandlingskontroll/impl/BehandlingModellImpl.java
+++ b/domenetjenester/behandlingskontroll/src/main/java/no/nav/foreldrepenger/behandlingskontroll/impl/BehandlingModellImpl.java
@@ -94,6 +94,15 @@ public class BehandlingModellImpl implements AutoCloseable, BehandlingModell {
     }
 
     @Override
+    public boolean inneholderSteg(BehandlingStegType stegType) {
+        try {
+            return indexOf(stegType) >= 0;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    @Override
     public BehandlingStegModell finnSteg(BehandlingStegType stegType) {
         return internFinnSteg(stegType);
     }
@@ -395,6 +404,11 @@ public class BehandlingModellImpl implements AutoCloseable, BehandlingModell {
     @Override
     public boolean erStegAFørStegB(BehandlingStegType stegA, BehandlingStegType stegB) {
         return indexOfNullable(stegA) < indexOfNullable(stegB);
+    }
+
+    @Override
+    public boolean erStegAEtterStegB(BehandlingStegType stegA, BehandlingStegType stegB) {
+        return indexOfNullable(stegA) > indexOfNullable(stegB);
     }
 
     /** Legger til default. */

--- a/domenetjenester/behandlingskontroll/src/main/java/no/nav/foreldrepenger/behandlingskontroll/impl/BehandlingModellRepository.java
+++ b/domenetjenester/behandlingskontroll/src/main/java/no/nav/foreldrepenger/behandlingskontroll/impl/BehandlingModellRepository.java
@@ -1,11 +1,10 @@
 package no.nav.foreldrepenger.behandlingskontroll.impl;
 
-import java.util.Arrays;
+import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
 import jakarta.enterprise.context.ApplicationScoped;
-import jakarta.inject.Inject;
 
 import no.nav.foreldrepenger.behandlingskontroll.BehandlingModell;
 import no.nav.foreldrepenger.behandlingskontroll.BehandlingTypeRef;
@@ -13,41 +12,26 @@ import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingType;
 import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakYtelseType;
 
 @ApplicationScoped
-public class BehandlingModellRepository implements AutoCloseable {
+public class BehandlingModellRepository {
 
-    private final ConcurrentMap<Object, BehandlingModell> cachedModell = new ConcurrentHashMap<>();
+    private static final ConcurrentMap<Object, BehandlingModell> MODELL_CACHE = new ConcurrentHashMap<>();
 
-    @Inject
-    public BehandlingModellRepository() {
-        // Plattform trenger tom Ctor (Hibernate, CDI, etc)
+    private BehandlingModellRepository() {
     }
+
 
     /**
      * Finn modell for angitt behandling type.
-     * <p>
-     * Når modellen ikke lenger er i bruk må {@link BehandlingModellImpl#close()}
-     * kalles slik at den ikke fortsetter å holde på referanser til objekter. (DETTE
-     * KAN DROPPES OM VI FÅR CACHET MODELLENE!)
      */
-    public BehandlingModell getModell(BehandlingType behandlingType, FagsakYtelseType fagsakYtelseType) {
-        var key = cacheKey(behandlingType, fagsakYtelseType);
-        cachedModell.computeIfAbsent(key, kode -> byggModell(behandlingType, fagsakYtelseType));
-        return cachedModell.get(key);
+    public static synchronized BehandlingModell getModell(BehandlingType behandlingType, FagsakYtelseType fagsakYtelseType) {
+        var key = List.of(behandlingType, fagsakYtelseType);
+        MODELL_CACHE.computeIfAbsent(key, kode -> byggModell(behandlingType, fagsakYtelseType));
+        return MODELL_CACHE.get(key);
     }
 
-    protected Object cacheKey(BehandlingType behandlingType, FagsakYtelseType fagsakYtelseType) {
-        // lager en key av flere sammensatte elementer.
-        return Arrays.asList(behandlingType, fagsakYtelseType);
-    }
-
-    protected BehandlingModell byggModell(BehandlingType behandlingType, FagsakYtelseType ytelseType) {
+    private static BehandlingModell byggModell(BehandlingType behandlingType, FagsakYtelseType ytelseType) {
         return BehandlingTypeRef.Lookup.find(BehandlingModell.class, ytelseType, behandlingType)
                 .orElseThrow(() -> new IllegalStateException(
                         "Har ikke BehandlingModell for BehandlingType:" + behandlingType + ", ytelseType:" + ytelseType));
-    }
-
-    @Override
-    public void close() {
-        cachedModell.clear();
     }
 }

--- a/domenetjenester/behandlingskontroll/src/main/java/no/nav/foreldrepenger/behandlingskontroll/impl/observer/BehandlingskontrollFremoverhoppTransisjonEventObserver.java
+++ b/domenetjenester/behandlingskontroll/src/main/java/no/nav/foreldrepenger/behandlingskontroll/impl/observer/BehandlingskontrollFremoverhoppTransisjonEventObserver.java
@@ -15,6 +15,7 @@ import no.nav.foreldrepenger.behandlingskontroll.BehandlingStegModell;
 import no.nav.foreldrepenger.behandlingskontroll.BehandlingskontrollKontekst;
 import no.nav.foreldrepenger.behandlingskontroll.events.AksjonspunktStatusEvent;
 import no.nav.foreldrepenger.behandlingskontroll.events.BehandlingTransisjonEvent;
+import no.nav.foreldrepenger.behandlingskontroll.impl.BehandlingModellRepository;
 import no.nav.foreldrepenger.behandlingskontroll.spi.BehandlingskontrollServiceProvider;
 import no.nav.foreldrepenger.behandlingskontroll.transisjoner.StegTransisjon;
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
@@ -105,7 +106,7 @@ public class BehandlingskontrollFremoverhoppTransisjonEventObserver {
     }
 
     protected BehandlingModell getModell(BehandlingskontrollKontekst kontekst) {
-        return serviceProvider.getBehandlingModellRepository().getModell(kontekst.getBehandlingType(), kontekst.getYtelseType());
+        return BehandlingModellRepository.getModell(kontekst.getBehandlingType(), kontekst.getYtelseType());
     }
 
     private boolean skalBesøkeStegene(StegTransisjon transisjon) {

--- a/domenetjenester/behandlingskontroll/src/main/java/no/nav/foreldrepenger/behandlingskontroll/impl/observer/BehandlingskontrollTransisjonTilbakeføringEventObserver.java
+++ b/domenetjenester/behandlingskontroll/src/main/java/no/nav/foreldrepenger/behandlingskontroll/impl/observer/BehandlingskontrollTransisjonTilbakeføringEventObserver.java
@@ -17,6 +17,7 @@ import no.nav.foreldrepenger.behandlingskontroll.BehandlingStegModell;
 import no.nav.foreldrepenger.behandlingskontroll.BehandlingskontrollKontekst;
 import no.nav.foreldrepenger.behandlingskontroll.events.AksjonspunktStatusEvent;
 import no.nav.foreldrepenger.behandlingskontroll.events.BehandlingStegOvergangEvent.BehandlingStegTilbakeføringEvent;
+import no.nav.foreldrepenger.behandlingskontroll.impl.BehandlingModellRepository;
 import no.nav.foreldrepenger.behandlingskontroll.impl.BehandlingskontrollEventPubliserer;
 import no.nav.foreldrepenger.behandlingskontroll.spi.BehandlingskontrollServiceProvider;
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
@@ -80,7 +81,7 @@ public class BehandlingskontrollTransisjonTilbakeføringEventObserver {
     }
 
     private BehandlingModell getModell(BehandlingskontrollKontekst kontekst) {
-        return serviceProvider.getBehandlingModellRepository().getModell(kontekst.getBehandlingType(), kontekst.getYtelseType());
+        return BehandlingModellRepository.getModell(kontekst.getBehandlingType(), kontekst.getYtelseType());
     }
 
     private List<Aksjonspunkt> håndterAksjonspunkter(Behandling behandling, Set<AksjonspunktDefinisjon> mellomliggendeAksjonspunkt,

--- a/domenetjenester/behandlingskontroll/src/main/java/no/nav/foreldrepenger/behandlingskontroll/spi/BehandlingskontrollServiceProvider.java
+++ b/domenetjenester/behandlingskontroll/src/main/java/no/nav/foreldrepenger/behandlingskontroll/spi/BehandlingskontrollServiceProvider.java
@@ -7,7 +7,6 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.persistence.EntityManager;
 
-import no.nav.foreldrepenger.behandlingskontroll.impl.BehandlingModellRepository;
 import no.nav.foreldrepenger.behandlingskontroll.impl.BehandlingskontrollEventPubliserer;
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
 import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.AksjonspunktKontrollRepository;
@@ -31,17 +30,13 @@ public class BehandlingskontrollServiceProvider {
     private AksjonspunktKontrollRepository aksjonspunktKontrollRepository;
     private BehandlingRepository behandlingRepository;
     private FagsakLåsRepository fagsakLåsRepository;
-    private BehandlingModellRepository behandlingModellRepository;
     private TekniskRepository tekniskRepository;
     private BehandlingskontrollEventPubliserer eventPubliserer;
 
     @Inject
-    public BehandlingskontrollServiceProvider(EntityManager entityManager, BehandlingModellRepository behandlingModellRepository,
-            BehandlingskontrollEventPubliserer eventPubliserer) {
+    public BehandlingskontrollServiceProvider(EntityManager entityManager, BehandlingskontrollEventPubliserer eventPubliserer) {
         Objects.requireNonNull(entityManager, "entityManager");
         this.entityManager = entityManager;
-
-        this.behandlingModellRepository = behandlingModellRepository;
 
         // behandling repositories
         this.behandlingRepository = new BehandlingRepository(entityManager);
@@ -56,14 +51,11 @@ public class BehandlingskontrollServiceProvider {
     public BehandlingskontrollServiceProvider(FagsakRepository fagsakRepository,
             BehandlingRepository behandlingRepository,
             FagsakLåsRepository fagsakLåsRepository,
-            BehandlingLåsRepository behandlingLåsRepository,
-            BehandlingModellRepository behandlingModellRepository,
-            AksjonspunktKontrollRepository aksjonspunktKontrollRepository) {
+            BehandlingLåsRepository behandlingLåsRepository, AksjonspunktKontrollRepository aksjonspunktKontrollRepository) {
         this.fagsakRepository = fagsakRepository;
         this.behandlingRepository = behandlingRepository;
         this.fagsakLåsRepository = fagsakLåsRepository;
         this.behandlingLåsRepository = behandlingLåsRepository;
-        this.behandlingModellRepository = behandlingModellRepository;
         this.aksjonspunktKontrollRepository = aksjonspunktKontrollRepository;
         this.eventPubliserer = BehandlingskontrollEventPubliserer.NULL_EVENT_PUB;
     }
@@ -78,10 +70,6 @@ public class BehandlingskontrollServiceProvider {
 
     public BehandlingskontrollEventPubliserer getEventPubliserer() {
         return eventPubliserer;
-    }
-
-    public BehandlingModellRepository getBehandlingModellRepository() {
-        return behandlingModellRepository;
     }
 
     public BehandlingRepository getBehandlingRepository() {

--- a/domenetjenester/behandlingskontroll/src/test/java/no/nav/foreldrepenger/behandlingskontroll/impl/BehandlingModellTest.java
+++ b/domenetjenester/behandlingskontroll/src/test/java/no/nav/foreldrepenger/behandlingskontroll/impl/BehandlingModellTest.java
@@ -55,7 +55,7 @@ class BehandlingModellTest {
 
     @BeforeEach
     void setUp(EntityManager entityManager) {
-        serviceProvider = new BehandlingskontrollServiceProvider(entityManager, new BehandlingModellRepository(), null);
+        serviceProvider = new BehandlingskontrollServiceProvider(entityManager, null);
         kontrollTjeneste = new BehandlingskontrollTjenesteImpl(serviceProvider);
     }
 
@@ -318,15 +318,13 @@ class BehandlingModellTest {
 
     private BehandlingStegVisitorUtenLagring lagVisitor(Behandling behandling) {
         var kontekst = kontrollTjeneste.initBehandlingskontroll(behandling);
-        var lokalServiceProvider = new BehandlingskontrollServiceProvider(serviceProvider.getEntityManager(),
-                serviceProvider.getBehandlingModellRepository(), null);
+        var lokalServiceProvider = new BehandlingskontrollServiceProvider(serviceProvider.getEntityManager(), null);
         return new BehandlingStegVisitorUtenLagring(lokalServiceProvider, kontekst);
     }
 
     private BehandlingStegVisitorVenterUtenLagring lagVisitorVenter(Behandling behandling) {
         var kontekst = kontrollTjeneste.initBehandlingskontroll(behandling);
-        var lokalServiceProvider = new BehandlingskontrollServiceProvider(serviceProvider.getEntityManager(),
-                serviceProvider.getBehandlingModellRepository(), null);
+        var lokalServiceProvider = new BehandlingskontrollServiceProvider(serviceProvider.getEntityManager(), null);
         return new BehandlingStegVisitorVenterUtenLagring(lokalServiceProvider, kontekst);
     }
 

--- a/domenetjenester/behandlingskontroll/src/test/java/no/nav/foreldrepenger/behandlingskontroll/impl/BehandlingModellTjenesteTest.java
+++ b/domenetjenester/behandlingskontroll/src/test/java/no/nav/foreldrepenger/behandlingskontroll/impl/BehandlingModellTjenesteTest.java
@@ -1,0 +1,85 @@
+package no.nav.foreldrepenger.behandlingskontroll.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import no.nav.vedtak.felles.testutilities.cdi.CdiAwareExtension;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import no.nav.foreldrepenger.behandlingskontroll.BehandlingModellTjeneste;
+import no.nav.foreldrepenger.behandlingskontroll.BehandlingStegModell;
+import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingStegType;
+import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingType;
+import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.AksjonspunktDefinisjon;
+import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakYtelseType;
+import no.nav.foreldrepenger.dbstoette.CdiDbAwareTest;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(CdiAwareExtension.class)
+class BehandlingModellTjenesteTest {
+
+    private BehandlingStegType steg2;
+    private BehandlingStegType steg3;
+    private BehandlingStegType steg4;
+
+
+    @BeforeEach
+    void setUp() {
+        var modell = BehandlingModellRepository.getModell(BehandlingType.FØRSTEGANGSSØKNAD, FagsakYtelseType.ENGANGSTØNAD);
+        steg2 = modell.hvertSteg().map(BehandlingStegModell::getBehandlingStegType).toList().get(8);
+        steg3 = modell.finnNesteSteg(steg2).getBehandlingStegType();
+        steg4 = modell.finnNesteSteg(steg3).getBehandlingStegType();
+    }
+
+    @Test
+    void steg_rekkefølger() {
+        var behandlingModell = new BehandlingModellTjeneste();
+        assertThat(behandlingModell.inneholderSteg(FagsakYtelseType.ENGANGSTØNAD, BehandlingType.FØRSTEGANGSSØKNAD,
+            BehandlingStegType.VURDER_MEDLEMSKAPVILKÅR)).isTrue();
+        assertThat(behandlingModell.erStegAFørStegB(FagsakYtelseType.ENGANGSTØNAD, BehandlingType.FØRSTEGANGSSØKNAD,
+            steg2, steg3)).isTrue();
+        assertThat(behandlingModell.erStegAFørStegB(FagsakYtelseType.ENGANGSTØNAD, BehandlingType.FØRSTEGANGSSØKNAD,
+            steg4, steg3)).isFalse();
+        assertThat(behandlingModell.erStegAFørStegB(FagsakYtelseType.ENGANGSTØNAD, BehandlingType.FØRSTEGANGSSØKNAD,
+            steg3, steg3)).isFalse();
+
+        assertThat(behandlingModell.erStegAEtterStegB(FagsakYtelseType.ENGANGSTØNAD, BehandlingType.FØRSTEGANGSSØKNAD,
+            steg2, steg3)).isFalse();
+        assertThat(behandlingModell.erStegAEtterStegB(FagsakYtelseType.ENGANGSTØNAD, BehandlingType.FØRSTEGANGSSØKNAD,
+            steg4, steg3)).isTrue();
+        assertThat(behandlingModell.erStegAEtterStegB(FagsakYtelseType.ENGANGSTØNAD, BehandlingType.FØRSTEGANGSSØKNAD,
+            steg3, steg3)).isFalse();
+    }
+
+
+    @Test
+    void skal_returnere_true_når_aksjonspunktet_skal_løses_etter_angitt_steg() {
+        assertThat(new BehandlingModellTjeneste().skalAksjonspunktLøsesIEllerEtterSteg(FagsakYtelseType.ENGANGSTØNAD,
+                BehandlingType.FØRSTEGANGSSØKNAD, steg3, AksjonspunktDefinisjon.VURDER_MEDLEMSKAPSVILKÅRET)).isTrue();
+    }
+
+    @Test
+    void skal_returnere_true_når_aksjonspunktet_skal_løses_i_angitt_steg() {
+        assertThat(new BehandlingModellTjeneste().skalAksjonspunktLøsesIEllerEtterSteg(FagsakYtelseType.ENGANGSTØNAD,
+                BehandlingType.FØRSTEGANGSSØKNAD, steg2, AksjonspunktDefinisjon.AVKLAR_VERGE))
+                        .isTrue();
+    }
+
+    @Test
+    void skal_returnere_false_når_aksjonspunktet_skal_løses_før_angitt_steg() {
+        assertThat(new BehandlingModellTjeneste().skalAksjonspunktLøsesIEllerEtterSteg(FagsakYtelseType.ENGANGSTØNAD,
+                BehandlingType.FØRSTEGANGSSØKNAD, steg4, AksjonspunktDefinisjon.REGISTRER_PAPIRSØKNAD_ENGANGSSTØNAD))
+                        .isFalse();
+    }
+
+    @Test
+    void skal_returnere_true_ved_senere_steg() {
+        assertThat(new BehandlingModellTjeneste().skalAksjonspunktLøsesIEllerEtterSteg(FagsakYtelseType.ENGANGSTØNAD,
+            BehandlingType.FØRSTEGANGSSØKNAD, steg4, AksjonspunktDefinisjon.REGISTRER_PAPIRSØKNAD_ENGANGSSTØNAD))
+            .isFalse();
+    }
+
+
+}

--- a/domenetjenester/behandlingskontroll/src/test/java/no/nav/foreldrepenger/behandlingskontroll/impl/observer/TilbakehoppTest.java
+++ b/domenetjenester/behandlingskontroll/src/test/java/no/nav/foreldrepenger/behandlingskontroll/impl/observer/TilbakehoppTest.java
@@ -49,7 +49,6 @@ class TilbakehoppTest {
 
     private final List<StegTransisjon> transisjoner = new ArrayList<>();
 
-    private final BehandlingModellRepository behandlingModellRepository = new BehandlingModellRepository();
     private BehandlingskontrollServiceProvider serviceProvider;
     private BehandlingRepository behandlingRepository;
 
@@ -60,9 +59,9 @@ class TilbakehoppTest {
 
     @BeforeEach
     void setUp(EntityManager entityManager) {
-        serviceProvider = new BehandlingskontrollServiceProvider(entityManager, behandlingModellRepository, null);
+        serviceProvider = new BehandlingskontrollServiceProvider(entityManager, null);
         behandlingRepository = serviceProvider.getBehandlingRepository();
-        var modell = behandlingModellRepository.getModell(BehandlingType.FØRSTEGANGSSØKNAD, FagsakYtelseType.FORELDREPENGER);
+        var modell = BehandlingModellRepository.getModell(BehandlingType.FØRSTEGANGSSØKNAD, FagsakYtelseType.FORELDREPENGER);
         observer = new BehandlingskontrollTransisjonTilbakeføringEventObserver(serviceProvider) {
             @Override
             protected void hoppBakover(BehandlingStegModell s,

--- a/domenetjenester/behandlingskontroll/src/test/java/no/nav/foreldrepenger/behandlingskontroll/impl/transisjoner/FremoverhoppTest.java
+++ b/domenetjenester/behandlingskontroll/src/test/java/no/nav/foreldrepenger/behandlingskontroll/impl/transisjoner/FremoverhoppTest.java
@@ -49,7 +49,6 @@ class FremoverhoppTest {
     private final List<StegTransisjon> transisjoner = new ArrayList<>();
 
     private BehandlingRepository behandlingRepository;
-    private final BehandlingModellRepository behandlingModellRepository = new BehandlingModellRepository();
 
     private BehandlingskontrollServiceProvider serviceProvider;
 
@@ -63,7 +62,7 @@ class FremoverhoppTest {
 
     @BeforeEach
     void setUp(EntityManager entityManager) {
-        serviceProvider = new BehandlingskontrollServiceProvider(entityManager, behandlingModellRepository, null);
+        serviceProvider = new BehandlingskontrollServiceProvider(entityManager, null);
         behandlingRepository = serviceProvider.getBehandlingRepository();
         observer = new BehandlingskontrollFremoverhoppTransisjonEventObserver(serviceProvider) {
             @Override
@@ -74,7 +73,7 @@ class FremoverhoppTest {
             }
         };
 
-        var modell = behandlingModellRepository.getModell(BehandlingType.FØRSTEGANGSSØKNAD, FagsakYtelseType.FORELDREPENGER);
+        var modell = BehandlingModellRepository.getModell(BehandlingType.FØRSTEGANGSSØKNAD, FagsakYtelseType.FORELDREPENGER);
         steg1 = BehandlingStegType.FASTSETT_SKJÆRINGSTIDSPUNKT_BEREGNING;
         steg2 = modell.finnNesteSteg(steg1).getBehandlingStegType();
         steg3 = modell.finnNesteSteg(steg2).getBehandlingStegType();

--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/Behandlingsoppretter.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/Behandlingsoppretter.java
@@ -13,7 +13,6 @@ import no.nav.foreldrepenger.behandlingskontroll.BehandlingskontrollTjeneste;
 import no.nav.foreldrepenger.behandlingskontroll.FagsakYtelseTypeRef;
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingResultatType;
-import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingStegType;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingType;
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandlingsresultat;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingsresultatRepository;
@@ -74,10 +73,6 @@ public class Behandlingsoppretter {
         this.behandlingsresultatRepository = behandlingRepositoryProvider.getBehandlingsresultatRepository();
         this.behandlingVedtakRepository = behandlingRepositoryProvider.getBehandlingVedtakRepository();
         this.søknadRepository = behandlingRepositoryProvider.getSøknadRepository();
-    }
-
-    public boolean erKompletthetssjekkPassert(Behandling behandling) {
-        return behandlingskontrollTjeneste.erStegPassert(behandling, BehandlingStegType.VURDER_KOMPLETT_BEH);
     }
 
     /**
@@ -145,8 +140,8 @@ public class Behandlingsoppretter {
             årsakBuilder.medManueltOpprettet(sisteYtelseBehandling.erManueltOpprettet()).buildFor(revurdering);
         }
 
-        var nyKontekst = behandlingskontrollTjeneste.initBehandlingskontroll(revurdering);
-        behandlingRepository.lagre(revurdering, nyKontekst.getSkriveLås());
+        var nyLås = behandlingRepository.taSkriveLås(revurdering);
+        behandlingRepository.lagre(revurdering, nyLås);
 
         return revurdering;
     }

--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/dokumentmottak/impl/DokumentmottakerEndringssøknad.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/dokumentmottak/impl/DokumentmottakerEndringssøknad.java
@@ -127,6 +127,6 @@ class DokumentmottakerEndringssøknad extends DokumentmottakerYtelsesesrelatertD
     }
 
     private boolean kompletthetErPassert(Behandling behandling) {
-        return behandlingsoppretter.erKompletthetssjekkPassert(behandling);
+        return kompletthetskontroller.erKompletthetssjekkPassert(behandling);
     }
 }

--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/dokumentmottak/impl/Kompletthetskontroller.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/dokumentmottak/impl/Kompletthetskontroller.java
@@ -15,7 +15,6 @@ import jakarta.inject.Inject;
 
 import no.nav.foreldrepenger.behandling.BehandlingReferanse;
 import no.nav.foreldrepenger.behandling.Skjæringstidspunkt;
-import no.nav.foreldrepenger.behandlingskontroll.BehandlingskontrollTjeneste;
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingStegType;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingÅrsakType;
@@ -39,7 +38,6 @@ public class Kompletthetskontroller {
 
     private DokumentmottakerFelles dokumentmottakerFelles;
     private MottatteDokumentTjeneste mottatteDokumentTjeneste;
-    private BehandlingskontrollTjeneste behandlingskontrollTjeneste;
     private BehandlingProsesseringTjeneste behandlingProsesseringTjeneste;
     private SkjæringstidspunktTjeneste skjæringstidspunktTjeneste;
     private Kompletthetsjekker kompletthetsjekker;
@@ -51,13 +49,11 @@ public class Kompletthetskontroller {
     @Inject
     public Kompletthetskontroller(DokumentmottakerFelles dokumentmottakerFelles,
                                   MottatteDokumentTjeneste mottatteDokumentTjeneste,
-                                  BehandlingskontrollTjeneste behandlingskontrollTjeneste,
                                   BehandlingProsesseringTjeneste behandlingProsesseringTjeneste,
                                   SkjæringstidspunktTjeneste skjæringstidspunktTjeneste,
                                   Kompletthetsjekker kompletthetsjekker) {
         this.dokumentmottakerFelles = dokumentmottakerFelles;
         this.mottatteDokumentTjeneste = mottatteDokumentTjeneste;
-        this.behandlingskontrollTjeneste = behandlingskontrollTjeneste;
         this.behandlingProsesseringTjeneste = behandlingProsesseringTjeneste;
         this.skjæringstidspunktTjeneste = skjæringstidspunktTjeneste;
         this.kompletthetsjekker = kompletthetsjekker;
@@ -82,7 +78,7 @@ public class Kompletthetskontroller {
                 behandlingProsesseringTjeneste.settBehandlingPåVent(behandling, AksjonspunktDefinisjon.AUTO_VENTER_PÅ_KOMPLETT_SØKNAD, kompletthetResultat.ventefrist(), kompletthetResultat.venteårsak());
             }
         }
-        if (kompletthetResultat.erOppfylt() && (erKompletthetssjekkEllerPassert(behandling)
+        if (kompletthetResultat.erOppfylt() && (erTidligKompletthetssjekkEllerPassert(behandling)
             || behandling.isBehandlingPåVent() || mottattDokument.getDokumentType().erSøknadType() || mottattDokument.getDokumentType().erEndringsSøknadType())) {
             if (behandling.isBehandlingPåVent()) {
                 behandlingProsesseringTjeneste.taBehandlingAvVent(behandling);
@@ -167,10 +163,14 @@ public class Kompletthetskontroller {
     }
 
     private boolean erRegisterinnhentingPassert(Behandling behandling) {
-        return behandlingskontrollTjeneste.erStegPassert(behandling, BehandlingStegType.INNHENT_REGISTEROPP);
+        return behandlingProsesseringTjeneste.erBehandlingEtterSteg(behandling, BehandlingStegType.INNHENT_REGISTEROPP);
     }
 
-    private boolean erKompletthetssjekkEllerPassert(Behandling behandling) {
-        return behandlingskontrollTjeneste.erIStegEllerSenereSteg(behandling, BehandlingStegType.VURDER_KOMPLETT_TIDLIG);
+    private boolean erTidligKompletthetssjekkEllerPassert(Behandling behandling) {
+        return !behandlingProsesseringTjeneste.erBehandlingFørSteg(behandling, BehandlingStegType.VURDER_KOMPLETT_TIDLIG);
+    }
+
+    public boolean erKompletthetssjekkPassert(Behandling behandling) {
+        return behandlingProsesseringTjeneste.erBehandlingEtterSteg(behandling, BehandlingStegType.VURDER_KOMPLETT_BEH);
     }
 }

--- a/domenetjenester/registerinnhenting/src/main/java/no/nav/foreldrepenger/domene/registerinnhenting/RegisterdataEndringshåndterer.java
+++ b/domenetjenester/registerinnhenting/src/main/java/no/nav/foreldrepenger/domene/registerinnhenting/RegisterdataEndringshåndterer.java
@@ -4,18 +4,16 @@ import java.time.Duration;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.temporal.TemporalAmount;
-import java.util.Collections;
 import java.util.Optional;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 
-import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingResultatType;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
+import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingResultatType;
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandlingsresultat;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingsresultatRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.EndringsresultatDiff;
@@ -23,9 +21,6 @@ import no.nav.foreldrepenger.behandlingslager.behandling.EndringsresultatSnapsho
 import no.nav.foreldrepenger.behandlingslager.behandling.SpesialBehandling;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepositoryProvider;
-import no.nav.foreldrepenger.behandlingslager.behandling.vilkår.Vilkår;
-import no.nav.foreldrepenger.behandlingslager.behandling.vilkår.VilkårResultat;
-import no.nav.foreldrepenger.behandlingslager.behandling.vilkår.VilkårUtfallType;
 import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakYtelseType;
 import no.nav.foreldrepenger.behandlingslager.hendelser.StartpunktType;
 import no.nav.foreldrepenger.domene.registerinnhenting.impl.Endringskontroller;

--- a/domenetjenester/registerinnhenting/src/main/java/no/nav/foreldrepenger/domene/registerinnhenting/impl/Endringskontroller.java
+++ b/domenetjenester/registerinnhenting/src/main/java/no/nav/foreldrepenger/domene/registerinnhenting/impl/Endringskontroller.java
@@ -1,5 +1,6 @@
 package no.nav.foreldrepenger.domene.registerinnhenting.impl;
 
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -14,6 +15,7 @@ import org.slf4j.LoggerFactory;
 import no.nav.foreldrepenger.behandling.BehandlingReferanse;
 import no.nav.foreldrepenger.behandling.Skjæringstidspunkt;
 import no.nav.foreldrepenger.behandlingskontroll.AksjonspunktResultat;
+import no.nav.foreldrepenger.behandlingskontroll.BehandlingModellTjeneste;
 import no.nav.foreldrepenger.behandlingskontroll.BehandlingskontrollKontekst;
 import no.nav.foreldrepenger.behandlingskontroll.BehandlingskontrollTjeneste;
 import no.nav.foreldrepenger.behandlingskontroll.FagsakYtelseTypeRef;
@@ -43,7 +45,9 @@ public class Endringskontroller {
     private static final Set<BehandlingStegType> STARTPUNKT_STEG_INNGANG_VILKÅR = Set.of(StartpunktType.INNGANGSVILKÅR_OPPLYSNINGSPLIKT.getBehandlingSteg(),
         StartpunktType.SØKERS_RELASJON_TIL_BARNET.getBehandlingSteg());
     private static final AksjonspunktDefinisjon SPESIALHÅNDTERT_AKSJONSPUNKT = AksjonspunktDefinisjon.SØKERS_OPPLYSNINGSPLIKT_MANU;
+    private static final StartpunktType SPESIALHÅNDTERT_AKSJONSPUNKT_STARTPUNKT = StartpunktType.INNGANGSVILKÅR_OPPLYSNINGSPLIKT;
     private BehandlingskontrollTjeneste behandlingskontrollTjeneste;
+    private BehandlingModellTjeneste behandlingModellTjeneste;
     private RegisterinnhentingHistorikkinnslagTjeneste historikkinnslagTjeneste;
     private Instance<KontrollerFaktaInngangsVilkårUtleder> kontrollerFaktaTjenester;
     private SkjæringstidspunktTjeneste skjæringstidspunktTjeneste;
@@ -56,12 +60,14 @@ public class Endringskontroller {
 
     @Inject
     public Endringskontroller(BehandlingskontrollTjeneste behandlingskontrollTjeneste,
+                              BehandlingModellTjeneste behandlingModellTjeneste,
                               @Any Instance<StartpunktTjeneste> startpunktTjenester,
                               RegisterinnhentingHistorikkinnslagTjeneste historikkinnslagTjeneste,
                               @Any Instance<KontrollerFaktaInngangsVilkårUtleder> kontrollerFaktaTjenester,
                               SkjæringstidspunktTjeneste skjæringstidspunktTjeneste,
                               TotrinnRepository totrinnRepository) {
         this.behandlingskontrollTjeneste = behandlingskontrollTjeneste;
+        this.behandlingModellTjeneste = behandlingModellTjeneste;
         this.skjæringstidspunktTjeneste = skjæringstidspunktTjeneste;
         this.startpunktTjenester = startpunktTjenester;
         this.historikkinnslagTjeneste = historikkinnslagTjeneste;
@@ -70,7 +76,8 @@ public class Endringskontroller {
     }
 
     public boolean erRegisterinnhentingPassert(Behandling behandling) {
-        return behandling.getType().erYtelseBehandlingType() && behandlingskontrollTjeneste.erStegPassert(behandling, BehandlingStegType.INNHENT_REGISTEROPP);
+        return behandling.getType().erYtelseBehandlingType()
+            && behandlingModellTjeneste.erStegAEtterStegB(behandling.getFagsakYtelseType(), behandling.getType(), behandling.getAktivtBehandlingSteg(), BehandlingStegType.INNHENT_REGISTEROPP);
     }
 
     // Kalles når behandlingen har ligget over natten (en dag) - selv om EndringsresultatDiff er tom. For å få med endringer i andre ytelser
@@ -114,8 +121,7 @@ public class Endringskontroller {
     private void doSpolTilStartpunkt(BehandlingReferanse ref, Skjæringstidspunkt stp, Behandling behandling, StartpunktType startpunktType) {
         var startPunktSteg = startpunktType.getBehandlingSteg();
         var skalSpesialHåndteres = behandling.getÅpentAksjonspunktMedDefinisjonOptional(SPESIALHÅNDTERT_AKSJONSPUNKT).isPresent() &&
-            behandlingskontrollTjeneste.sammenlignRekkefølge(behandling.getFagsakYtelseType(), behandling.getType(),
-                SPESIALHÅNDTERT_AKSJONSPUNKT.getBehandlingSteg(), startPunktSteg) < 0;
+            SPESIALHÅNDTERT_AKSJONSPUNKT_STARTPUNKT.getRangering() < startpunktType.getRangering();
         var tilSteg = skalSpesialHåndteres ? SPESIALHÅNDTERT_AKSJONSPUNKT.getBehandlingSteg() : startPunktSteg;
 
         var kontekst = behandlingskontrollTjeneste.initBehandlingskontroll(behandling);
@@ -134,18 +140,21 @@ public class Endringskontroller {
         }
 
         if (tilbakeføres) {
-            // Eventuelt ta behandling av vent
+            // Eventuelt ta behandling av vent. Kan flytte på behandling dersom autopunkt med tilbakehopp
             behandlingskontrollTjeneste.taBehandlingAvVentSetAlleAutopunktUtført(behandling, kontekst);
-            // Spol tilbake
-            behandlingskontrollTjeneste.behandlingTilbakeføringHvisTidligereBehandlingSteg(kontekst, tilSteg);
+            var tilbakeføresNySjekk = skalTilbakeføres(behandling, behandling.getAktivtBehandlingSteg(), tilSteg);
+            if (tilbakeføresNySjekk) {
+                // Spol tilbake
+                behandlingskontrollTjeneste.behandlingTilbakeføringTilTidligereBehandlingSteg(kontekst, tilSteg);
+            }
         }
         loggSpoleutfall(behandling, fraSteg, tilSteg, tilbakeføres);
     }
 
     private boolean skalTilbakeføres(Behandling behandling, BehandlingStegType fraSteg, BehandlingStegType tilSteg) {
         // Dersom vi står i UTGANG, og skal til samme steg som vi står i, vil det også være en tilbakeføring siden vi går UTGANG -> INNGANG
-        var sammenlign = behandlingskontrollTjeneste.sammenlignRekkefølge(behandling.getFagsakYtelseType(), behandling.getType(), fraSteg, tilSteg);
-        return sammenlign == 0 && BehandlingStegStatus.UTGANG.equals(behandling.getBehandlingStegStatus()) || sammenlign > 0;
+        return Objects.equals(fraSteg, tilSteg) && BehandlingStegStatus.UTGANG.equals(behandling.getBehandlingStegStatus())
+            || behandlingModellTjeneste.erStegAEtterStegB(behandling.getFagsakYtelseType(), behandling.getType(), fraSteg, tilSteg);
     }
 
     private boolean harUtførtKontrollerFakta(Behandling behandling) {
@@ -184,7 +193,7 @@ public class Endringskontroller {
             .filter(ap -> !ap.erManueltOpprettet() && !ap.erAutopunkt() && !SPESIALHÅNDTERT_AKSJONSPUNKT.equals(ap.getAksjonspunktDefinisjon()))
             .filter(ap -> !erReturBeslutter(ref, ap.getAksjonspunktDefinisjon()))
             .filter(ap -> !resultatDef.contains(ap.getAksjonspunktDefinisjon()))
-            .filter(ap -> behandlingskontrollTjeneste.skalAksjonspunktLøsesIEllerEtterSteg(ref.fagsakYtelseType(), ref.behandlingType(), fomSteg, ap.getAksjonspunktDefinisjon()))
+            .filter(ap -> behandlingModellTjeneste.skalAksjonspunktLøsesIEllerEtterSteg(ref.fagsakYtelseType(), ref.behandlingType(), fomSteg, ap.getAksjonspunktDefinisjon()))
             .toList();
         var opprettes = resultater.stream()
             .filter(ar -> !AksjonspunktStatus.UTFØRT.equals(behandling.getAksjonspunktMedDefinisjonOptional(ar.getAksjonspunktDefinisjon())

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/aksjonspunkt/BehandlingsprosessTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/aksjonspunkt/BehandlingsprosessTjeneste.java
@@ -84,7 +84,7 @@ public class BehandlingsprosessTjeneste {
      * @return ProsessTask gruppe
      */
     public String asynkStartBehandlingsprosess(Behandling behandling) {
-        return prosesseringAsynkTjeneste.asynkStartBehandlingProsess(behandling);
+        return behandlingProsesseringTjeneste.opprettTasksForStartBehandling(behandling);
     }
 
     /**

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/arbeidInntektsmelding/ArbeidOgInntektsmeldingProsessTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/arbeidInntektsmelding/ArbeidOgInntektsmeldingProsessTjeneste.java
@@ -68,13 +68,10 @@ public class ArbeidOgInntektsmeldingProsessTjeneste {
         } else if (behandling.isBehandlingPåVent()) {
             throw new IllegalStateException("FEIL: Prøver å tilbakestille en behandling som er på vent. Ugyldig aksjon.");
         }
-        if (!behandlingskontrollTjeneste.erStegPassert(behandling, BehandlingStegType.KONTROLLER_FAKTA_ARBEIDSFORHOLD_INNTEKTSMELDING)) {
+        if (!behandlingProsesseringTjeneste.erBehandlingEtterSteg(behandling, BehandlingStegType.KONTROLLER_FAKTA_ARBEIDSFORHOLD_INNTEKTSMELDING)) {
             throw new IllegalStateException("FEIL: Prøver å tilbakestille en behandling før den har kommet langt nok i behandlingsprosessen. Ugyldig aksjon.");
         }
-        if (!behandlingskontrollTjeneste.erStegPassert(behandling, BehandlingStegType.KONTROLLER_FAKTA_ARBEIDSFORHOLD_INNTEKTSMELDING)) {
-            throw new IllegalStateException("FEIL: Prøver å tilbakestille en behandling før den har kommet langt nok i behandlingsprosessen. Ugyldig aksjon.");
-        }
-        if (behandlingskontrollTjeneste.erStegPassert(behandling, BehandlingStegType.FORESLÅ_VEDTAK)) {
+        if (behandlingProsesseringTjeneste.erBehandlingEtterSteg(behandling, BehandlingStegType.FORESLÅ_VEDTAK)) {
             throw new IllegalStateException("FEIL: Prøver å tilbakestille en behandling som har passert steg for å foreslå vedtak. Ugyldig aksjon.");
         }
         if (behandling.getStatus().equals(BehandlingStatus.FATTER_VEDTAK) || behandling.getStatus().equals(BehandlingStatus.IVERKSETTER_VEDTAK)) {

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/arbeidsforhold/InntektArbeidYtelseRestTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/arbeidsforhold/InntektArbeidYtelseRestTjeneste.java
@@ -27,7 +27,6 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import no.nav.foreldrepenger.behandling.BehandlingReferanse;
-import no.nav.foreldrepenger.behandlingskontroll.BehandlingskontrollTjeneste;
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingStegType;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepository;
@@ -41,6 +40,7 @@ import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.periode
 import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakYtelseType;
 import no.nav.foreldrepenger.behandlingslager.virksomhet.Arbeidsgiver;
 import no.nav.foreldrepenger.behandlingslager.virksomhet.OrgNummer;
+import no.nav.foreldrepenger.behandlingsprosess.prosessering.BehandlingProsesseringTjeneste;
 import no.nav.foreldrepenger.domene.arbeidsforhold.InntektArbeidYtelseTjeneste;
 import no.nav.foreldrepenger.domene.arbeidsforhold.dto.AlleInntektsmeldingerDtoMapper;
 import no.nav.foreldrepenger.domene.arbeidsforhold.dto.IAYYtelseDto;
@@ -103,7 +103,7 @@ public class InntektArbeidYtelseRestTjeneste {
 
     private InntektArbeidYtelseTjeneste iayTjeneste;
     private FpOppdragRestKlient fpOppdragRestKlient;
-    private BehandlingskontrollTjeneste behandlingskontrollTjeneste;
+    private BehandlingProsesseringTjeneste behandlingProsesseringTjeneste;
 
     public InntektArbeidYtelseRestTjeneste() {
         // for CDI proxy
@@ -120,7 +120,7 @@ public class InntektArbeidYtelseRestTjeneste {
                                            SkjæringstidspunktTjeneste skjæringstidspunktTjeneste,
                                            AlleInntektsmeldingerDtoMapper alleInntektsmeldingerMapper,
                                            FpOppdragRestKlient fpOppdragRestKlient,
-                                           BehandlingskontrollTjeneste behandlingskontrollTjeneste) {
+                                           BehandlingProsesseringTjeneste behandlingProsesseringTjeneste) {
         this.personopplysningTjeneste = personopplysningTjeneste;
         this.iayTjeneste = iayTjeneste;
         this.skjæringstidspunktTjeneste = skjæringstidspunktTjeneste;
@@ -131,7 +131,7 @@ public class InntektArbeidYtelseRestTjeneste {
         this.svangerskapspengerRepository = svangerskapspengerRepository;
         this.alleInntektsmeldingerMapper = alleInntektsmeldingerMapper;
         this.fpOppdragRestKlient = fpOppdragRestKlient;
-        this.behandlingskontrollTjeneste = behandlingskontrollTjeneste;
+        this.behandlingProsesseringTjeneste = behandlingProsesseringTjeneste;
     }
 
     @GET
@@ -236,7 +236,7 @@ public class InntektArbeidYtelseRestTjeneste {
             alleReferanser.addAll(referanserFraOppgittOpptjening(iayg.getGjeldendeOppgittOpptjening()));
         });
 
-        if (behandling.erAvsluttet() || behandlingskontrollTjeneste.erIStegEllerSenereSteg(behandling, BehandlingStegType.SIMULER_OPPDRAG)) {
+        if (behandling.erAvsluttet() || !behandlingProsesseringTjeneste.erBehandlingFørSteg(behandling, BehandlingStegType.SIMULER_OPPDRAG)) {
             try {
                 var simuleringResultatDto = fpOppdragRestKlient.hentSimuleringResultatMedOgUtenInntrekk(behandling.getId(), behandling.getUuid(), behandling.getSaksnummer().getVerdi());
                 arbeidsgivere.addAll(simuleringResultatDto.map(this::finnArbeidsgivereFraSimulering).orElse(Collections.emptySet()));

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/medlem/MedlemDtoTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/medlem/MedlemDtoTjeneste.java
@@ -16,7 +16,6 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 
 import no.nav.foreldrepenger.behandling.BehandlingReferanse;
-import no.nav.foreldrepenger.behandlingskontroll.BehandlingskontrollTjeneste;
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingStegType;
 import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.AksjonspunktDefinisjon;
@@ -32,6 +31,7 @@ import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRe
 import no.nav.foreldrepenger.behandlingslager.behandling.vilkår.Avslagsårsak;
 import no.nav.foreldrepenger.behandlingslager.behandling.vilkår.VilkårResultatRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.vilkår.VilkårUtfallType;
+import no.nav.foreldrepenger.behandlingsprosess.prosessering.BehandlingProsesseringTjeneste;
 import no.nav.foreldrepenger.domene.medlem.MedlemTjeneste;
 import no.nav.foreldrepenger.domene.personopplysning.PersonopplysningTjeneste;
 import no.nav.foreldrepenger.domene.tid.AbstractLocalDateInterval;
@@ -54,7 +54,7 @@ public class MedlemDtoTjeneste {
     private PersonopplysningTjeneste personopplysningTjeneste;
     private AvklarMedlemskapUtleder medlemskapUtleder;
     private VilkårResultatRepository vilkårResultatRepository;
-    private BehandlingskontrollTjeneste behandlingskontrollTjeneste;
+    private BehandlingProsesseringTjeneste behandlingProsesseringTjeneste;
 
     @Inject
     public MedlemDtoTjeneste(BehandlingRepositoryProvider behandlingRepositoryProvider,
@@ -63,7 +63,7 @@ public class MedlemDtoTjeneste {
                              PersonopplysningTjeneste personopplysningTjeneste,
                              AvklarMedlemskapUtleder medlemskapUtleder,
                              VilkårResultatRepository vilkårResultatRepository,
-                             BehandlingskontrollTjeneste behandlingskontrollTjeneste) {
+                             BehandlingProsesseringTjeneste behandlingProsesseringTjeneste) {
 
         this.medlemskapRepository = behandlingRepositoryProvider.getMedlemskapRepository();
         this.skjæringstidspunktTjeneste = skjæringstidspunktTjeneste;
@@ -72,7 +72,7 @@ public class MedlemDtoTjeneste {
         this.personopplysningTjeneste = personopplysningTjeneste;
         this.medlemskapUtleder = medlemskapUtleder;
         this.vilkårResultatRepository = vilkårResultatRepository;
-        this.behandlingskontrollTjeneste = behandlingskontrollTjeneste;
+        this.behandlingProsesseringTjeneste = behandlingProsesseringTjeneste;
     }
 
     MedlemDtoTjeneste() {
@@ -208,7 +208,7 @@ public class MedlemDtoTjeneste {
     }
 
     private boolean behandlingLiggerEtterMedlemskapsvilkårssteg(Behandling behandling) {
-        return behandlingskontrollTjeneste.erIStegEllerSenereSteg(behandling, BehandlingStegType.VURDER_MEDLEMSKAPVILKÅR);
+        return !behandlingProsesseringTjeneste.erBehandlingFørSteg(behandling, BehandlingStegType.VURDER_MEDLEMSKAPVILKÅR);
     }
 
     private static Optional<MedlemskapDto.Annenpart> annenpart(PersonopplysningerAggregat personopplysningerAggregat,

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/verge/VergeTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/verge/VergeTjeneste.java
@@ -20,6 +20,7 @@ import no.nav.foreldrepenger.behandlingslager.behandling.personopplysning.Person
 import no.nav.foreldrepenger.behandlingslager.behandling.personopplysning.PersonopplysningerAggregat;
 import no.nav.foreldrepenger.behandlingslager.behandling.verge.VergeAggregat;
 import no.nav.foreldrepenger.behandlingslager.behandling.verge.VergeRepository;
+import no.nav.foreldrepenger.behandlingsprosess.prosessering.BehandlingProsesseringTjeneste;
 import no.nav.foreldrepenger.domene.person.verge.OpprettVergeTjeneste;
 import no.nav.foreldrepenger.domene.person.verge.VergeDtoTjeneste;
 import no.nav.foreldrepenger.domene.person.verge.dto.VergeBackendDto;
@@ -32,6 +33,7 @@ import no.nav.foreldrepenger.domene.typer.AktørId;
 public class VergeTjeneste {
 
     private BehandlingskontrollTjeneste behandlingskontrollTjeneste;
+    private BehandlingProsesseringTjeneste behandlingProsesseringTjeneste;
     private VergeRepository vergeRepository;
     private HistorikkinnslagRepository historikkinnslagRepository;
     private PersonopplysningTjeneste personopplysningTjeneste;
@@ -41,6 +43,7 @@ public class VergeTjeneste {
 
     @Inject
     public VergeTjeneste(BehandlingskontrollTjeneste behandlingskontrollTjeneste,
+                         BehandlingProsesseringTjeneste behandlingProsesseringTjeneste,
                          VergeRepository vergeRepository,
                          HistorikkinnslagRepository historikkinnslagRepository,
                          PersonopplysningTjeneste personopplysningTjeneste,
@@ -48,6 +51,7 @@ public class VergeTjeneste {
                          VergeDtoTjeneste vergeDtoTjeneste,
                          BehandlingEventPubliserer behandlingEventPubliserer) {
         this.behandlingskontrollTjeneste = behandlingskontrollTjeneste;
+        this.behandlingProsesseringTjeneste = behandlingProsesseringTjeneste;
         this.vergeRepository = vergeRepository;
         this.historikkinnslagRepository = historikkinnslagRepository;
         this.personopplysningTjeneste = personopplysningTjeneste;
@@ -90,8 +94,8 @@ public class VergeTjeneste {
         var vergeAggregat = vergeRepository.hentAggregat(behandlingId);
         var harRegistrertVerge = vergeAggregat.isPresent() && vergeAggregat.get().getVerge().isPresent();
         var harÅpentVergeAP = behandling.harÅpentAksjonspunktMedType(AksjonspunktDefinisjon.AVKLAR_VERGE);
-        var iForeslåVedtakllerSenereSteg = behandlingskontrollTjeneste.erIStegEllerSenereSteg(behandling, BehandlingStegType.FORESLÅ_VEDTAK);
-        var iFatteVedtakEllerSenereSteg = behandlingskontrollTjeneste.erIStegEllerSenereSteg(behandling, BehandlingStegType.FATTE_VEDTAK);
+        var iForeslåVedtakllerSenereSteg = !behandlingProsesseringTjeneste.erBehandlingFørSteg(behandling, BehandlingStegType.FORESLÅ_VEDTAK);
+        var iFatteVedtakEllerSenereSteg = !behandlingProsesseringTjeneste.erBehandlingFørSteg(behandling, BehandlingStegType.FATTE_VEDTAK);
         var under18År = erSøkerUnder18ar(behandlingId, behandling.getAktørId());
 
         if (harRegistrertVerge && under18År && iForeslåVedtakllerSenereSteg || SpesialBehandling.erSpesialBehandling(behandling)

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/forvaltning/ForvaltningFagsakRestTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/forvaltning/ForvaltningFagsakRestTjeneste.java
@@ -374,7 +374,7 @@ public class ForvaltningFagsakRestTjeneste {
         @ApiResponse(responseCode = "400", description = "Ukjent fagsak oppgitt."),
         @ApiResponse(responseCode = "500", description = "Feilet pga ukjent feil.")
     })
-    @BeskyttetRessurs(actionType = ActionType.CREATE, resourceType = ResourceType.FAGSAK, sporingslogg = true)
+    @BeskyttetRessurs(actionType = ActionType.CREATE, resourceType = ResourceType.DRIFT, sporingslogg = true)
     public Response oppdaterPersongalleriForTilgang(@TilpassetAbacAttributt(supplierClass = SaksnummerAbacSupplier.Supplier.class)
                                                         @NotNull @QueryParam("saksnummer") @Valid SaksnummerDto saksnummerDto) {
         var saksnummer = new Saksnummer(saksnummerDto.getVerdi());

--- a/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/klage/KlageFormkravOppdatererTest.java
+++ b/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/klage/KlageFormkravOppdatererTest.java
@@ -64,7 +64,7 @@ class KlageFormkravOppdatererTest extends EntityManagerAwareTest {
         repositoryProvider = new BehandlingRepositoryProvider(getEntityManager());
         BehandlingRepository behandlingRepository = repositoryProvider.getBehandlingRepository();
         klageRepository = new KlageRepository(getEntityManager());
-        KlageVurderingTjeneste klageVurderingTjeneste = new KlageVurderingTjeneste(null, null, null, behandlingRepository, klageRepository, null,
+        KlageVurderingTjeneste klageVurderingTjeneste = new KlageVurderingTjeneste(null, null, behandlingRepository, klageRepository, null,
             repositoryProvider.getBehandlingsresultatRepository(), mock(BehandlingEventPubliserer.class));
         var formHistorikk = new KlageHistorikkinnslag(repositoryProvider.getHistorikkinnslagRepository(), behandlingRepository,
             repositoryProvider.getBehandlingVedtakRepository(), mockFptilbakeRestKlient);

--- a/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/klage/KlagevurderingOppdatererTest.java
+++ b/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/klage/KlagevurderingOppdatererTest.java
@@ -30,7 +30,7 @@ import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRe
 import no.nav.foreldrepenger.behandlingslager.behandling.skjermlenke.SkjermlenkeType;
 import no.nav.foreldrepenger.behandlingslager.testutilities.behandling.ScenarioFarSøkerEngangsstønad;
 import no.nav.foreldrepenger.behandlingslager.testutilities.behandling.ScenarioKlageEngangsstønad;
-import no.nav.foreldrepenger.behandlingsprosess.prosessering.ProsesseringAsynkTjeneste;
+import no.nav.foreldrepenger.behandlingsprosess.prosessering.BehandlingProsesseringTjeneste;
 import no.nav.foreldrepenger.dbstoette.CdiDbAwareTest;
 import no.nav.foreldrepenger.dokumentbestiller.DokumentBehandlingTjeneste;
 import no.nav.foreldrepenger.dokumentbestiller.DokumentBestillerTjeneste;
@@ -55,9 +55,7 @@ class KlagevurderingOppdatererTest {
     @Mock
     private BehandlingsutredningTjeneste behandlingsutredningTjeneste;
     @Mock
-    private BehandlingskontrollTjeneste behandlingskontrollTjeneste;
-    @Mock
-    private ProsesseringAsynkTjeneste prosesseringAsynkTjeneste;
+    private BehandlingProsesseringTjeneste behandlingProsesseringTjeneste;
 
 
     @Test
@@ -114,7 +112,7 @@ class KlagevurderingOppdatererTest {
     private KlagevurderingOppdaterer getKlageVurderer(BehandlingRepositoryProvider repositoryProvider, KlageRepository klageRepository) {
         var behandlingRepository = repositoryProvider.getBehandlingRepository();
         var klageVurderingTjeneste = new KlageVurderingTjeneste(dokumentBestillerTjeneste, Mockito.mock(DokumentBehandlingTjeneste.class),
-            prosesseringAsynkTjeneste, behandlingRepository, klageRepository, behandlingskontrollTjeneste,
+            behandlingRepository, klageRepository, behandlingProsesseringTjeneste,
             repositoryProvider.getBehandlingsresultatRepository(), mock(BehandlingEventPubliserer.class));
         var klageHistorikk = new KlageHistorikkinnslag(repositoryProvider.getHistorikkinnslagRepository(),
             behandlingRepository, repositoryProvider.getBehandlingVedtakRepository(), mock(FptilbakeRestKlient.class));

--- a/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/medlem/MedlemDtoTjenesteTest.java
+++ b/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/medlem/MedlemDtoTjenesteTest.java
@@ -12,7 +12,6 @@ import jakarta.inject.Inject;
 
 import org.junit.jupiter.api.Test;
 
-import no.nav.foreldrepenger.behandlingskontroll.BehandlingskontrollTjeneste;
 import no.nav.foreldrepenger.behandlingslager.aktør.AdresseType;
 import no.nav.foreldrepenger.behandlingslager.aktør.Adresseinfo;
 import no.nav.foreldrepenger.behandlingslager.aktør.NavBrukerKjønn;
@@ -33,6 +32,7 @@ import no.nav.foreldrepenger.behandlingslager.geografisk.Landkoder;
 import no.nav.foreldrepenger.behandlingslager.geografisk.Region;
 import no.nav.foreldrepenger.behandlingslager.testutilities.aktør.FiktiveFnr;
 import no.nav.foreldrepenger.behandlingslager.testutilities.behandling.ScenarioMorSøkerForeldrepenger;
+import no.nav.foreldrepenger.behandlingsprosess.prosessering.BehandlingProsesseringTjeneste;
 import no.nav.foreldrepenger.dbstoette.CdiDbAwareTest;
 import no.nav.foreldrepenger.domene.arbeidsforhold.InntektArbeidYtelseTjeneste;
 import no.nav.foreldrepenger.domene.medlem.MedlemTjeneste;
@@ -59,7 +59,7 @@ class MedlemDtoTjenesteTest {
     @Inject
     private PersonopplysningTjeneste poTjeneste;
     @Inject
-    private BehandlingskontrollTjeneste behandlingskontrollTjeneste;
+    private BehandlingProsesseringTjeneste behandlingProsesseringTjeneste;
     @Inject
     private MedlemskapVurderingPeriodeTjeneste medlemVurderingPeriodeTjeneste;
     @Inject
@@ -188,6 +188,6 @@ class MedlemDtoTjenesteTest {
         var utleder = new AvklarMedlemskapUtleder(new MedlemRegelGrunnlagBygger(medlemTjeneste, poTjeneste, medlemVurderingPeriodeTjeneste,
             iayTjeneste, satsRepository, stpTjeneste, personinfoAdapter));
         return new MedlemDtoTjeneste(repositoryProvider, stpTjeneste, medlemTjeneste, poTjeneste, utleder,
-            new VilkårResultatRepository(repositoryProvider.getEntityManager()), behandlingskontrollTjeneste);
+            new VilkårResultatRepository(repositoryProvider.getEntityManager()), behandlingProsesseringTjeneste);
     }
 }

--- a/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/vedtak/aksjonspunkt/ForeslåOgFatteVedtakAksjonspunktTest.java
+++ b/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/vedtak/aksjonspunkt/ForeslåOgFatteVedtakAksjonspunktTest.java
@@ -13,7 +13,6 @@ import org.junit.jupiter.api.Test;
 
 import no.nav.foreldrepenger.behandling.BehandlingReferanse;
 import no.nav.foreldrepenger.behandling.aksjonspunkt.AksjonspunktOppdaterParameter;
-import no.nav.foreldrepenger.behandlingskontroll.impl.BehandlingModellRepository;
 import no.nav.foreldrepenger.behandlingskontroll.impl.BehandlingskontrollEventPubliserer;
 import no.nav.foreldrepenger.behandlingskontroll.impl.BehandlingskontrollTjenesteImpl;
 import no.nav.foreldrepenger.behandlingskontroll.spi.BehandlingskontrollServiceProvider;
@@ -61,7 +60,7 @@ class ForeslåOgFatteVedtakAksjonspunktTest extends EntityManagerAwareTest {
     void setup() {
         var em = getEntityManager();
         var behandlingskontrollTjeneste = new BehandlingskontrollTjenesteImpl(
-            new BehandlingskontrollServiceProvider(em, new BehandlingModellRepository(), mock(BehandlingskontrollEventPubliserer.class)));
+            new BehandlingskontrollServiceProvider(em, mock(BehandlingskontrollEventPubliserer.class)));
         var lagretVedtakRepository = new LagretVedtakRepository(em);
         repositoryProvider = new BehandlingRepositoryProvider(em);
         behandlingDokumentRepository = new BehandlingDokumentRepository(em);


### PR DESCRIPTION
Skiller ut metoder som går på å sammenligne steg og aksjonspunkt/steg fra BehandlingskontrollTjeneste, gjør BehandlingModellRepository til en static-affære.

Neste steg: Skille ut aksjonspunkt-metoden fra BehandllingskontrollTjeneste, så det bare gjenstår behandlingsprosess.