### PR TITLE
TFP-6246 undersøk fødte barn for rolle vs alle barn

### DIFF
--- a/domenetjenester/person/src/main/java/no/nav/foreldrepenger/domene/person/PersoninfoAdapter.java
+++ b/domenetjenester/person/src/main/java/no/nav/foreldrepenger/domene/person/PersoninfoAdapter.java
@@ -19,6 +19,7 @@ import no.nav.foreldrepenger.behandlingslager.aktør.PersoninfoKjønn;
 import no.nav.foreldrepenger.behandlingslager.aktør.PersoninfoSpråk;
 import no.nav.foreldrepenger.behandlingslager.aktør.PersoninfoVisning;
 import no.nav.foreldrepenger.behandlingslager.aktør.historikk.Personhistorikkinfo;
+import no.nav.foreldrepenger.behandlingslager.behandling.personopplysning.RelasjonsRolleType;
 import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakYtelseType;
 import no.nav.foreldrepenger.behandlingslager.geografisk.Språkkode;
 import no.nav.foreldrepenger.domene.person.krr.KrrSpråkKlient;
@@ -98,7 +99,12 @@ public class PersoninfoAdapter {
     }
 
     public List<FødtBarnInfo> innhentAlleFødteForBehandlingIntervaller(FagsakYtelseType ytelseType, AktørId aktørId, List<LocalDateInterval> intervaller) {
-        return fødselTjeneste.hentFødteBarnInfoFor(ytelseType, aktørId, intervaller);
+        return fødselTjeneste.hentFødteBarnInfoFor(ytelseType, null, aktørId, intervaller);
+    }
+
+    public List<FødtBarnInfo> innhentAlleFødteForBehandlingIntervaller(FagsakYtelseType ytelseType, RelasjonsRolleType rolleType,
+                                                                       AktørId aktørId, List<LocalDateInterval> intervaller) {
+        return fødselTjeneste.hentFødteBarnInfoFor(ytelseType, rolleType, aktørId, intervaller);
     }
 
     public Optional<AktørId> hentAktørForFnr(PersonIdent fnr) {

--- a/domenetjenester/person/src/main/java/no/nav/foreldrepenger/domene/personopplysning/PersonopplysningInnhenter.java
+++ b/domenetjenester/person/src/main/java/no/nav/foreldrepenger/domene/personopplysning/PersonopplysningInnhenter.java
@@ -51,6 +51,12 @@ public class PersonopplysningInnhenter {
         return personinfoAdapter.innhentAlleFødteForBehandlingIntervaller(ytelseType, aktørId, intervaller);
     }
 
+    public List<FødtBarnInfo> innhentAlleFødteForIntervaller(FagsakYtelseType ytelseType, RelasjonsRolleType rolleType,
+                                                             AktørId aktørId, List<LocalDateInterval> intervaller) {
+        return personinfoAdapter.innhentAlleFødteForBehandlingIntervaller(ytelseType, rolleType, aktørId, intervaller);
+    }
+
+
     public Optional<PersonIdent> hentPersonIdentForAktør(AktørId aktørId) {
         return personinfoAdapter.hentFnr(aktørId);
     }

--- a/domenetjenester/person/src/test/java/no/nav/foreldrepenger/domene/person/PersoninfoAdapterTest.java
+++ b/domenetjenester/person/src/test/java/no/nav/foreldrepenger/domene/person/PersoninfoAdapterTest.java
@@ -117,7 +117,7 @@ class PersoninfoAdapterTest {
 
         var aktørId = AktørId.dummy();
         var personinfo = opprettPersonInfo(aktørId, antallBarn);
-        when(fødselTjeneste.hentFødteBarnInfoFor(any(), any(), any())).thenReturn(genererBarn(personinfo.getFamilierelasjoner(), mottattDato));
+        when(fødselTjeneste.hentFødteBarnInfoFor(any(), any(), any(), any())).thenReturn(genererBarn(personinfo.getFamilierelasjoner(), mottattDato));
 
         var fødslerRelatertTilBehandling = adapter.innhentAlleFødteForBehandlingIntervaller(FagsakYtelseType.FORELDREPENGER, aktørId, List.of(intervall));
 

--- a/domenetjenester/registerinnhenting/src/main/java/no/nav/foreldrepenger/domene/registerinnhenting/RegisterdataInnhenter.java
+++ b/domenetjenester/registerinnhenting/src/main/java/no/nav/foreldrepenger/domene/registerinnhenting/RegisterdataInnhenter.java
@@ -121,9 +121,14 @@ public class RegisterdataInnhenter {
 
     public void innhentPersonopplysninger(Behandling behandling) {
         var fødselsIntervall = familieHendelseTjeneste.forventetFødselsIntervaller(BehandlingReferanse.fra(behandling));
+        var rolleFiltrertFødselFREG = personopplysningInnhenter.innhentAlleFødteForIntervaller(behandling.getFagsakYtelseType(), behandling.getRelasjonsRolleType(), behandling.getAktørId(), fødselsIntervall);
         var filtrertFødselFREG = personopplysningInnhenter.innhentAlleFødteForIntervaller(behandling.getFagsakYtelseType(), behandling.getAktørId(), fødselsIntervall);
+        if (rolleFiltrertFødselFREG.size() != filtrertFødselFREG.size()) {
+            LOG.info("Innhent FamilieHendelse ulike antall barn - sak {} rolle {} barn/rolle {} barn/alle {}", behandling.getSaksnummer().getVerdi(),
+                behandling.getRelasjonsRolleType(), rolleFiltrertFødselFREG, filtrertFødselFREG);
+        }
         innhentPersoninformasjon(behandling, filtrertFødselFREG);
-        innhentFamiliehendelse(behandling.getId(), filtrertFødselFREG);
+        innhentFamiliehendelse(behandling.getId(), rolleFiltrertFødselFREG.isEmpty() ? filtrertFødselFREG : rolleFiltrertFødselFREG);
         innhentPleiepenger(behandling, filtrertFødselFREG);
         // Logikk avhengig av familiehendelse som bør være innhentet
         stønadsperioderInnhenter.innhentNesteSak(behandling);


### PR DESCRIPTION
Gjelder komplekst tilfeller der bruker er både mor og medmor for ulike barn født innenfor et kort intervall.
Neste steg, etter litt logg-studier, er å gjøre alle forventet-barn-innhenting rolle-spesifikk - slik at en sak der bruker har søkt som mor kun henter barn som er registrert med bruker som mor.