### PR TITLE
TFP-5796: Bruk gjeldende familiehendelsedato fra søknade for gjeldene…

### DIFF
--- a/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/uttaksgrunnlag/fp/FastsettUttaksgrunnlagTjeneste.java
+++ b/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/uttaksgrunnlag/fp/FastsettUttaksgrunnlagTjeneste.java
@@ -175,9 +175,13 @@ public class FastsettUttaksgrunnlagTjeneste {
         var originalFamiliehendelser = originalBehandlingOpt.get().getFamilieHendelser();
         var familiehendelsedatoSøkerTokUtgangspunktIOriginalBehandling = originalFamiliehendelser.getSøknadFamilieHendelse().getFamilieHendelseDato();
         if (!familiehendelsedatoSøkerTokUtgangspunktIGjeldendeBehandling.isEqual(familiehendelsedatoSøkerTokUtgangspunktIOriginalBehandling)) {
-            // Juster i henhold til gjeldende familiehendelsesdato gjeldende behandling tok utgangspunkt i og ikke orginal behandling
-            // Denne kan inntreffe hvis det kommer inn en ny førstegangssøknad hvor familiehendelsegrunnlaget for søknaden er endret
-            // Eksempler: Søker søker på ny termindato. Søker med utgangspunkt i fødselsdato. I begge tilfellene eksisteres det allerede en behandling på barnet.
+            // Hvis familiehendelsesdatoen for søknaden i gjeldende behandling er forskjellig fra den i original behandling,
+            // skal vi bruke datoen fra gjeldende behandling. Dette gjelder typisk i tilfeller hvor en ny førstegangssøknad
+            // har endret familiehendelsesgrunnlaget.
+            //
+            // Eksempler:
+            // - Søker sender inn ny førstegangssøknad med oppdatert termindato.
+            // - Søker sender inn ny førstegangssøknad som baserer på fødselsdato i stedet for tidligere termindato.
             return familiehendelsedatoSøkerTokUtgangspunktIGjeldendeBehandling;
         }
 

--- a/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/uttaksgrunnlag/fp/FastsettUttaksgrunnlagTjeneste.java
+++ b/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/uttaksgrunnlag/fp/FastsettUttaksgrunnlagTjeneste.java
@@ -1,9 +1,21 @@
 package no.nav.foreldrepenger.domene.uttak.uttaksgrunnlag.fp;
 
+import static no.nav.foreldrepenger.domene.uttak.uttaksgrunnlag.fp.OppgittPeriodeUtil.slåSammenLikePerioder;
+import static no.nav.foreldrepenger.domene.uttak.uttaksgrunnlag.fp.VedtaksperioderHelper.klipp;
+
+import java.time.LocalDate;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
 import jakarta.enterprise.context.Dependent;
 import jakarta.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import no.nav.foreldrepenger.behandlingskontroll.FagsakYtelseTypeRef;
-import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingÅrsakType;
 import no.nav.foreldrepenger.behandlingslager.behandling.personopplysning.RelasjonsRolleType;
 import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.AvklarteUttakDatoerEntitet;
 import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.YtelseFordelingAggregat;
@@ -15,22 +27,9 @@ import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakYtelseType;
 import no.nav.foreldrepenger.behandlingslager.uttak.UttaksperiodegrenseRepository;
 import no.nav.foreldrepenger.behandlingslager.uttak.fp.FpUttakRepository;
 import no.nav.foreldrepenger.domene.uttak.UttakRepositoryProvider;
-import no.nav.foreldrepenger.domene.uttak.input.FamilieHendelser;
 import no.nav.foreldrepenger.domene.uttak.input.ForeldrepengerGrunnlag;
 import no.nav.foreldrepenger.domene.uttak.input.UttakInput;
 import no.nav.foreldrepenger.skjæringstidspunkt.overganger.UtsettelseCore2021;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.time.LocalDate;
-import java.util.Comparator;
-import java.util.List;
-import java.util.Optional;
-import java.util.stream.Collectors;
-
-import static no.nav.foreldrepenger.domene.uttak.uttaksgrunnlag.fp.OppgittPeriodeUtil.finnesOverlapp;
-import static no.nav.foreldrepenger.domene.uttak.uttaksgrunnlag.fp.OppgittPeriodeUtil.slåSammenLikePerioder;
-import static no.nav.foreldrepenger.domene.uttak.uttaksgrunnlag.fp.VedtaksperioderHelper.klipp;
 
 @Dependent
 public class FastsettUttaksgrunnlagTjeneste {
@@ -97,14 +96,11 @@ public class FastsettUttaksgrunnlagTjeneste {
             }
         }
 
-        if (skalJustereFordelingEtterFamiliehendelse(input, justertePerioder)) {
+        if (gjelderTerminFødsel(input)) {
             justertePerioder = justerFordelingEtterFamilieHendelse(input.getYtelsespesifiktGrunnlag(), justertePerioder, ref.relasjonRolle(), fordeling.ønskerJustertVedFødsel());
-            LOG.info("Justerte perioder etter flytting ved endring i familiehendelse {}", justertePerioder);
         }
         justertePerioder = slåSammenLikePerioder(justertePerioder);
-
         justertePerioder = fjernOppholdsperioderFriEllerLiggendeTilSlutt(justertePerioder);
-
         justertePerioder = leggTilUtsettelserForPleiepenger(input, justertePerioder);
         return new OppgittFordelingEntitet(kopier(justertePerioder), fordeling.getErAnnenForelderInformert(), fordeling.ønskerJustertVedFødsel());
     }
@@ -121,69 +117,9 @@ public class FastsettUttaksgrunnlagTjeneste {
             .toList();
     }
 
-    private static boolean skalJustereFordelingEtterFamiliehendelse(UttakInput input, List<OppgittPeriodeEntitet> perioder) {
-        ForeldrepengerGrunnlag fpGrunnlag = input.getYtelsespesifiktGrunnlag();
-        if (input.getBehandlingReferanse().behandlingId().equals(3336608L)) {
-            return false;
-        }
-
-        if (!fpGrunnlag.getFamilieHendelser().gjelderTerminFødsel()) {
-            return false;
-        }
-
-        if (perioder.isEmpty()) {
-            LOG.info("Skal ikke fødselsjustere når gjeldende behandling ikke har uttak (f.eks. ved opphør, berørt, osv)");
-            return false;
-        }
-
-        if (finnesOverlapp(perioder)) {
-            LOG.warn("Finnes overlapp i oppgitte perioder fra søknad. Sannsynligvis feil i søknadsdialogen. "
-                + "Hvis periodene ikke kan slås sammen faller behandlingen ut til manuell behandling");
-            return false;
-        }
-
-        if (fpGrunnlag.getOriginalBehandling().isPresent()) {
-            if (nySøknadPåTermin(fpGrunnlag.getFamilieHendelser())) {
-                LOG.info("Skal ikke fødselsjustere ny søknad på termin");
-                return false;
-            }
-
-            var gjeldendeFamilieHendelseOriginalBehandling = fpGrunnlag.getOriginalBehandling().get().getFamilieHendelser().getGjeldendeFamilieHendelse();
-            var gjeldendeFamilieHendelse = fpGrunnlag.getFamilieHendelser().getGjeldendeFamilieHendelse();
-            if (gjeldendeFamilieHendelseOriginalBehandling.getFødselsdato().isEmpty() &&
-                input.getBehandlingÅrsaker().contains(BehandlingÅrsakType.RE_ENDRING_FRA_BRUKER) &&
-                gjeldendeFamilieHendelse.getFødselsdato().isPresent()) {
-                var mottattDato = perioder.stream()
-                    .filter(p -> p.getMottattDato() != null)
-                    .min(Comparator.comparing(OppgittPeriodeEntitet::getFom))
-                    .orElseThrow()
-                    .getMottattDato();
-                var fødselsdato = gjeldendeFamilieHendelse.getFødselsdato().get();
-
-                if (mottattDato.isAfter(fødselsdato)) {
-                    // TODO: return false? Ikke juster disse tilfellene?
-                    LOG.info(
-                        "Termin til fødsel: Original behandling ble søkt på termin, mens ny førstegangssøknad (med fødsel) er sendt inn ETTER registert fødsel {} med mottattdato {}",
-                        fødselsdato, mottattDato);
-                } else {
-                    LOG.info(
-                        "Termin til fødsel: Original behandling ble søkt på termin, mens ny førstegangssøknad (med fødsel) er sendt inn samme dato eller før registret fødsel {} med mottattdato {}",
-                        fødselsdato, mottattDato);
-                }
-
-                var førsteUttaksperiode = perioder.stream().min(Comparator.comparing(OppgittPeriodeEntitet::getFom)).orElseThrow();
-                if (fødselsdato.isEqual(førsteUttaksperiode.getFom())) {
-                    LOG.info("Termin til fødsel: Startdato for første uttaksperiode er lik fødseldato {}", fødselsdato);
-                } else if (førsteUttaksperiode.getFom().isBefore(fødselsdato)) {
-                    LOG.info("Termin til fødsel: Startdato for første uttaksperiode er før fødseldato {}", fødselsdato);
-                } else {
-                    LOG.info("Termin til fødsel: Startdato for første uttaksperiode er etter fødseldato {}", fødselsdato);
-                }
-                // TODO: Utled om en skal justere eller ikke (per nå justere vi)
-            }
-        }
-
-        return true;
+    private static boolean gjelderTerminFødsel(UttakInput input) {
+        var fpGrunnlag = (ForeldrepengerGrunnlag) input.getYtelsespesifiktGrunnlag();
+        return fpGrunnlag.getFamilieHendelser().gjelderTerminFødsel();
     }
 
     private List<OppgittPeriodeEntitet> leggTilUtsettelserForPleiepenger(UttakInput input, List<OppgittPeriodeEntitet> perioder) {
@@ -218,8 +154,7 @@ public class FastsettUttaksgrunnlagTjeneste {
                                                                             List<OppgittPeriodeEntitet> oppgittePerioder,
                                                                             RelasjonsRolleType relasjonsRolleType,
                                                                             boolean ønskerJustertVedFødsel) {
-        var gammelFamiliehendelse = gjeldenedFamiliehendelsedatoFraOrginalbehandling(fpGrunnlag)
-            .orElseGet(() -> fpGrunnlag.getFamilieHendelser().getSøknadFamilieHendelse().getFamilieHendelseDato());
+        var gammelFamiliehendelse = utledFamiliehendelsesdatoSomUttaksplanenTarUtgangspunktI(fpGrunnlag);
         var nyFamiliehendelse = fpGrunnlag.getFamilieHendelser().getGjeldendeFamilieHendelse().getFamilieHendelseDato();
         return JusterFordelingTjeneste.justerForFamiliehendelse(
             oppgittePerioder,
@@ -228,6 +163,25 @@ public class FastsettUttaksgrunnlagTjeneste {
             relasjonsRolleType,
             ønskerJustertVedFødsel
         );
+    }
+
+    private static LocalDate utledFamiliehendelsesdatoSomUttaksplanenTarUtgangspunktI(ForeldrepengerGrunnlag fpGrunnlag) {
+        var familiehendelsedatoSøkerTokUtgangspunktIGjeldendeBehandling = fpGrunnlag.getFamilieHendelser().getSøknadFamilieHendelse().getFamilieHendelseDato();
+        var originalBehandlingOpt = fpGrunnlag.getOriginalBehandling();
+        if (originalBehandlingOpt.isEmpty()) {
+            return familiehendelsedatoSøkerTokUtgangspunktIGjeldendeBehandling;
+        }
+
+        var originalFamiliehendelser = originalBehandlingOpt.get().getFamilieHendelser();
+        var familiehendelsedatoSøkerTokUtgangspunktIOriginalBehandling = originalFamiliehendelser.getSøknadFamilieHendelse().getFamilieHendelseDato();
+        if (!familiehendelsedatoSøkerTokUtgangspunktIGjeldendeBehandling.isEqual(familiehendelsedatoSøkerTokUtgangspunktIOriginalBehandling)) {
+            // Juster i henhold til gjeldende familiehendelsesdato gjeldende behandling tok utgangspunkt i og ikke orginal behandling
+            // Denne kan inntreffe hvis det kommer inn en ny førstegangssøknad hvor familiehendelsegrunnlaget for søknaden er endret
+            // Eksempler: Søker søker på ny termindato. Søker med utgangspunkt i fødselsdato. I begge tilfellene eksisteres det allerede en behandling på barnet.
+            return familiehendelsedatoSøkerTokUtgangspunktIGjeldendeBehandling;
+        }
+
+        return originalFamiliehendelser.getGjeldendeFamilieHendelse().getFamilieHendelseDato();
     }
 
     private List<OppgittPeriodeEntitet> oppgittePerioderFraForrigeBehandling(Long forrigeBehandling) {
@@ -252,16 +206,6 @@ public class FastsettUttaksgrunnlagTjeneste {
         //Kopier vedtaksperioder fom endringsdato.
         var uttakResultatEntitet = fpUttakRepository.hentUttakResultat(forrigeBehandling);
         return VedtaksperioderHelper.opprettOppgittePerioder(uttakResultatEntitet, oppgittePerioder, endringsdato, false);
-    }
-
-    private static Optional<LocalDate> gjeldenedFamiliehendelsedatoFraOrginalbehandling(ForeldrepengerGrunnlag fpGrunnlag) {
-        return fpGrunnlag.getOriginalBehandling().map(b -> b.getFamilieHendelser().getGjeldendeFamilieHendelse().getFamilieHendelseDato());
-    }
-
-    private static boolean nySøknadPåTermin(FamilieHendelser familiehendels) {
-        return familiehendels.getOverstyrtFamilieHendelse().isEmpty()
-            && familiehendels.getSøknadFamilieHendelse().getFødselsdato().isEmpty()
-            && familiehendels.getBekreftetFamilieHendelse().filter(fh -> fh.getFødselsdato().isPresent()).isEmpty();
     }
 
     private List<OppgittPeriodeEntitet> kopier(List<OppgittPeriodeEntitet> perioder) {

--- a/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/uttaksgrunnlag/fp/JusterFordelingTjeneste.java
+++ b/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/uttaksgrunnlag/fp/JusterFordelingTjeneste.java
@@ -29,7 +29,10 @@ final class JusterFordelingTjeneste {
                                                                 LocalDate nyFamiliehendelse,
                                                                 RelasjonsRolleType relasjonsRolleType,
                                                                 boolean ønskerJustertVedFødsel) {
-        if (gammelFamiliehendelse == null || nyFamiliehendelse == null || bareFpffEtterGammelFamiliehendelse(oppgittePerioder, gammelFamiliehendelse)) {
+        if (gammelFamiliehendelse == null || nyFamiliehendelse == null || oppgittePerioder.isEmpty()) {
+            return oppgittePerioder;
+        }
+        if (bareFpffEtterGammelFamiliehendelse(oppgittePerioder, gammelFamiliehendelse)) {
             return oppgittePerioder;
         }
         gammelFamiliehendelse = flyttFraHelgTilMandag(gammelFamiliehendelse);

--- a/domenetjenester/uttak/src/test/java/no/nav/foreldrepenger/domene/uttak/uttaksgrunnlag/fp/FastsettUttaksgrunnlagTjenesteTest.java
+++ b/domenetjenester/uttak/src/test/java/no/nav/foreldrepenger/domene/uttak/uttaksgrunnlag/fp/FastsettUttaksgrunnlagTjenesteTest.java
@@ -252,19 +252,61 @@ class FastsettUttaksgrunnlagTjenesteTest {
             .medFordeling(fordeling2)
             .lagre(repositoryProvider);
 
-        var familieHendelseRevurdering = FamilieHendelse.forFødsel(termindato2, null, List.of(), 1);
         var familieHendelseFørstegangsbehandling = FamilieHendelse.forFødsel(termindato1, null, List.of(), 1);
+        var familieHendelseRevurdering = FamilieHendelse.forFødsel(termindato2, null, List.of(), 1);
         var fpGrunnlag = new ForeldrepengerGrunnlag().medOriginalBehandling(new OriginalBehandling(førstegangsbehandling.getId(),
                 new FamilieHendelser().medSøknadHendelse(familieHendelseFørstegangsbehandling)))
             .medFamilieHendelser(new FamilieHendelser().medSøknadHendelse(familieHendelseRevurdering).medBekreftetHendelse(familieHendelseRevurdering));
-        var endringsdatoRevurderingUtleder = mock(EndringsdatoRevurderingUtleder.class);
         when(endringsdatoRevurderingUtleder.utledEndringsdato(any())).thenReturn(LocalDate.of(2024, 4, 15));
         var tjeneste = new FastsettUttaksgrunnlagTjeneste(repositoryProvider, endringsdatoUtleder, endringsdatoRevurderingUtleder);
         tjeneste.fastsettUttaksgrunnlag(lagInput(revurdering, fpGrunnlag));
 
         var resultat = repositoryProvider.getYtelsesFordelingRepository().hentAggregat(revurdering.getId());
 
-        assertThat(resultat.getGjeldendeFordeling().getPerioder().get(0).getFom()).isEqualTo(LocalDate.of(2024, 4, 15));
+        assertThat(resultat.getGjeldendeFordeling()).isEqualTo(fordeling2);
+    }
+
+    @Test
+    void skal_ikke_forskyve_søknadsperioder_hvis_gammel_førstegangsøknad_ble_søkt_på_termin_mens_ny_førstegangsøknad_blir_søkt_på_fødsel() {
+        //søkte uttaket her vil gjøre at fødselsjusteringen gir esxception på overlapp
+        var termindato1 = LocalDate.of(2024, 5, 4);
+        var fødselsdato =  LocalDate.of(2024, 4, 29);
+
+        var fordeling1 = new OppgittFordelingEntitet(List.of(
+            ny().medPeriode(LocalDate.of(2024, 4, 15), LocalDate.of(2024, 5, 3)).medPeriodeType(FORELDREPENGER_FØR_FØDSEL).build(),
+            ny().medPeriode(LocalDate.of(2024, 5, 6), LocalDate.of(2024, 9, 13)).medPeriodeType(MØDREKVOTE).build(),
+            ny().medPeriode(LocalDate.of(2024, 9, 16), LocalDate.of(2025, 1, 17)).medPeriodeType(FELLESPERIODE).build()
+        ), true);
+        var uttaksperiodeFørstegang = new UttakResultatPeriodeEntitet.Builder(termindato1, termindato1.plusWeeks(10))
+            .medResultatType(PeriodeResultatType.INNVILGET, PeriodeResultatÅrsak.KVOTE_ELLER_OVERFØRT_KVOTE)
+            .build();
+        var førstegangsbehandling = ScenarioMorSøkerForeldrepenger.forFødsel()
+            .medFordeling(fordeling1)
+            .medUttak(new UttakResultatPerioderEntitet().leggTilPeriode(uttaksperiodeFørstegang))
+            .lagre(repositoryProvider);
+        var fordeling2 = new OppgittFordelingEntitet(List.of(
+            ny().medPeriode(LocalDate.of(2024, 4, 15), LocalDate.of(2024, 4, 26)).medPeriodeType(FORELDREPENGER_FØR_FØDSEL).build(),
+            ny().medPeriode(LocalDate.of(2024, 4, 29), LocalDate.of(2024, 6, 11)).medPeriodeType(MØDREKVOTE).build(),
+            ny().medPeriode(LocalDate.of(2024, 7, 12), LocalDate.of(2024, 11, 14)).medPeriodeType(FELLESPERIODE).build(),
+            ny().medPeriode(LocalDate.of(2024, 11, 15), LocalDate.of(2025, 2, 11)).medPeriodeType(MØDREKVOTE).build()
+        ), true);
+        var revurdering = ScenarioMorSøkerForeldrepenger.forFødsel()
+            .medOriginalBehandling(førstegangsbehandling, BehandlingÅrsakType.RE_ENDRING_FRA_BRUKER)
+            .medFordeling(fordeling2)
+            .lagre(repositoryProvider);
+
+        var familieHendelseFørstegangsbehandling = FamilieHendelse.forFødsel(termindato1, null, List.of(), 1);
+        var familieHendelseRevurdering = FamilieHendelse.forFødsel(termindato1, fødselsdato, List.of(), 1);
+        var fpGrunnlag = new ForeldrepengerGrunnlag().medOriginalBehandling(new OriginalBehandling(førstegangsbehandling.getId(),
+                new FamilieHendelser().medSøknadHendelse(familieHendelseFørstegangsbehandling)))
+            .medFamilieHendelser(new FamilieHendelser().medSøknadHendelse(familieHendelseRevurdering).medBekreftetHendelse(familieHendelseRevurdering));
+        when(endringsdatoRevurderingUtleder.utledEndringsdato(any())).thenReturn(LocalDate.of(2024, 4, 15));
+        var fastsettUttaksgrunnlagTjeneste = new FastsettUttaksgrunnlagTjeneste(repositoryProvider, endringsdatoUtleder, endringsdatoRevurderingUtleder);
+        fastsettUttaksgrunnlagTjeneste.fastsettUttaksgrunnlag(lagInput(revurdering, fpGrunnlag));
+
+        var resultat = repositoryProvider.getYtelsesFordelingRepository().hentAggregat(revurdering.getId());
+
+        assertThat(resultat.getGjeldendeFordeling()).isEqualTo(fordeling2);
     }
 
     @Test


### PR DESCRIPTION
… behandling hvis orginalbehandling er ulik (fix for ny førstegangsøknad)


Dette vil forhåpentligvis være mer robust og fiks av justering ved ny førstegangsøknad på eksisterende behandling:
-  Gammel familiehendelse (dato som en skal justere FRA) utledes enten fra gjeldende behandling eller fra tidligere/orginal behandling.
   - Bruk fra original behandling hvis familiehendelsesdato for søknad er lik
   - Bruk fra gjeldende behandling hvis familiehendelsedato for søknad er ulik (søkt på nytt grunnlag)
- Ny familiehendelse (dato som en skal justere TIL) er alltid gjeldende familiehendelsedato.


Endringen er hvordan gammel familiehendelsedato/dato som en skal justere fra utledes.
   
   