### PR TITLE
chore: forenklinger i klage og anke

### DIFF
--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/events/KlageOppdatertEvent.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/events/KlageOppdatertEvent.java
@@ -1,0 +1,28 @@
+package no.nav.foreldrepenger.behandlingslager.behandling.events;
+
+import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
+import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingEvent;
+import no.nav.foreldrepenger.domene.typer.Saksnummer;
+
+public record KlageOppdatertEvent(Saksnummer saksnummer, Long fagsakId, Long behandlingId) implements BehandlingEvent {
+
+    public KlageOppdatertEvent(Behandling behandling) {
+        this(behandling.getSaksnummer(), behandling.getFagsakId(), behandling.getId());
+    }
+
+    @Override
+    public Long getFagsakId() {
+        return fagsakId;
+    }
+
+    @Override
+    public Saksnummer getSaksnummer() {
+        return saksnummer;
+    }
+
+    @Override
+    public Long getBehandlingId() {
+        return behandlingId;
+    }
+
+}

--- a/behandlingsprosess/src/main/java/no/nav/foreldrepenger/behandling/steg/anke/AnkeMerknaderSteg.java
+++ b/behandlingsprosess/src/main/java/no/nav/foreldrepenger/behandling/steg/anke/AnkeMerknaderSteg.java
@@ -40,35 +40,18 @@ public class AnkeMerknaderSteg implements BehandlingSteg {
     public BehandleStegResultat utførSteg(BehandlingskontrollKontekst kontekst) {
         var behandling = behandlingRepository.hentBehandling(kontekst.getBehandlingId());
 
-        // Litt komplisert sett med logikk mens det pågår migrering
-        if (klageAnkeVedtakTjeneste.erBehandletAvKabal(behandling)) {
-            if (klageAnkeVedtakTjeneste.harKjennelseTrygdretten(behandling)) {
-                if (klageAnkeVedtakTjeneste.erOversendtTrygdretten(behandling)) {
-                    return BehandleStegResultat.utførtUtenAksjonspunkter();
-                } else {
-                    throw new IllegalStateException("AnkeMerknaderSteg: KabalAnke Har lagret TR-kjennelse, mangler oversendelsesdato");
-                }
-            }
+        if (klageAnkeVedtakTjeneste.harKjennelseTrygdretten(behandling)) {
             if (klageAnkeVedtakTjeneste.erOversendtTrygdretten(behandling)) {
-                return BehandleStegResultat.utførtMedAksjonspunktResultat(ventPåTrygderetten());
+                return BehandleStegResultat.utførtUtenAksjonspunkter();
+            } else {
+                throw new IllegalStateException("AnkeMerknaderSteg: KabalAnke Har lagret TR-kjennelse, mangler oversendelsesdato");
             }
-            return BehandleStegResultat.utførtUtenAksjonspunkter();
-        } else {
-            if (klageAnkeVedtakTjeneste.skalOversendesTrygdretten(behandling) &&
-                !klageAnkeVedtakTjeneste.harSattOversendelseDato(behandling) && !klageAnkeVedtakTjeneste.harKjennelseTrygdretten(behandling)) {
-                throw new IllegalStateException("AnkeMerknaderSteg: FpsakAnke skal til TR men mangler oversendelsesdato");
-            }
-            if (!klageAnkeVedtakTjeneste.skalOversendesTrygdretten(behandling) &&
-                (klageAnkeVedtakTjeneste.harSattOversendelseDato(behandling) || klageAnkeVedtakTjeneste.harKjennelseTrygdretten(behandling))) {
-                throw new IllegalStateException("AnkeMerknaderSteg: FpsakAnke skal ikke til TR men har oversendelsesdato eller kjennelse");
-            }
-            if (klageAnkeVedtakTjeneste.skalOversendesTrygdretten(behandling) && klageAnkeVedtakTjeneste.harSattOversendelseDato(behandling)) {
-                return klageAnkeVedtakTjeneste.harKjennelseTrygdretten(behandling) ? BehandleStegResultat.utførtUtenAksjonspunkter() :
-                    BehandleStegResultat.utførtMedAksjonspunktResultat(ventPåTrygderetten());
-            }
-            return BehandleStegResultat.utførtUtenAksjonspunkter();
-
         }
+        if (klageAnkeVedtakTjeneste.erOversendtTrygdretten(behandling)) {
+            return BehandleStegResultat.utførtMedAksjonspunktResultat(ventPåTrygderetten());
+        }
+        return BehandleStegResultat.utførtUtenAksjonspunkter();
+
     }
 
     private AksjonspunktResultat ventPåTrygderetten() {

--- a/domenetjenester/datavarehus/src/main/java/no/nav/foreldrepenger/datavarehus/observer/DatavarehusEventObserver.java
+++ b/domenetjenester/datavarehus/src/main/java/no/nav/foreldrepenger/datavarehus/observer/DatavarehusEventObserver.java
@@ -4,24 +4,18 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.event.Observes;
 import jakarta.inject.Inject;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import no.nav.foreldrepenger.behandlingskontroll.events.AksjonspunktStatusEvent;
 import no.nav.foreldrepenger.behandlingskontroll.events.AutopunktStatusEvent;
 import no.nav.foreldrepenger.behandlingskontroll.events.BehandlingStatusEvent;
-import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.Aksjonspunkt;
-import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.AksjonspunktDefinisjon;
 import no.nav.foreldrepenger.behandlingslager.behandling.events.BehandlingEnhetEvent;
 import no.nav.foreldrepenger.behandlingslager.behandling.events.BehandlingRelasjonEvent;
 import no.nav.foreldrepenger.behandlingslager.behandling.events.BehandlingSaksbehandlerEvent;
 import no.nav.foreldrepenger.behandlingslager.behandling.events.BehandlingVedtakEvent;
+import no.nav.foreldrepenger.behandlingslager.behandling.events.KlageOppdatertEvent;
 import no.nav.foreldrepenger.behandlingslager.behandling.events.MottattDokumentPersistertEvent;
 import no.nav.foreldrepenger.datavarehus.tjeneste.DatavarehusTjeneste;
 
 @ApplicationScoped
 public class DatavarehusEventObserver {
-    protected final Logger LOG = LoggerFactory.getLogger(this.getClass());
 
     private DatavarehusTjeneste tjeneste;
 
@@ -34,23 +28,14 @@ public class DatavarehusEventObserver {
         this.tjeneste = datavarehusTjeneste;
     }
 
-    public void observerAksjonspunktStatusEvent(@Observes AksjonspunktStatusEvent event) {
-        var aksjonspunkter = event.getAksjonspunkter();
-        // Utvider behandlingStatus i DVH med VenteKategori
-        if (aksjonspunkter.stream().anyMatch(a -> a.erUtført() && gjelderKlage(a))) {
-            tjeneste.lagreNedBehandling(event.getBehandlingId());
-        }
-    }
-
     public void observerAutopunktStatusEvent(@Observes AutopunktStatusEvent event) {
         if (!event.getAksjonspunkter().isEmpty()) {
             tjeneste.lagreNedBehandling(event.getBehandlingId());
         }
     }
 
-    private static boolean gjelderKlage(Aksjonspunkt a) {
-        return AksjonspunktDefinisjon.VURDERING_AV_FORMKRAV_KLAGE_NFP.equals(a.getAksjonspunktDefinisjon()) ||
-            AksjonspunktDefinisjon.MANUELL_VURDERING_AV_KLAGE_NFP.equals(a.getAksjonspunktDefinisjon());
+    public void observerKlageOppdatertEvent(@Observes KlageOppdatertEvent event) {
+        tjeneste.lagreNedBehandling(event.getBehandlingId());
     }
 
     public void observerBehandlingEnhetEvent(@Observes BehandlingEnhetEvent event) {

--- a/domenetjenester/datavarehus/src/main/java/no/nav/foreldrepenger/datavarehus/tjeneste/DatavarehusTjenesteImpl.java
+++ b/domenetjenester/datavarehus/src/main/java/no/nav/foreldrepenger/datavarehus/tjeneste/DatavarehusTjenesteImpl.java
@@ -38,6 +38,7 @@ import no.nav.foreldrepenger.behandlingslager.behandling.familiehendelse.Familie
 import no.nav.foreldrepenger.behandlingslager.behandling.klage.KlageHjemmel;
 import no.nav.foreldrepenger.behandlingslager.behandling.klage.KlageMedholdÅrsak;
 import no.nav.foreldrepenger.behandlingslager.behandling.klage.KlageRepository;
+import no.nav.foreldrepenger.behandlingslager.behandling.klage.KlageResultatEntitet;
 import no.nav.foreldrepenger.behandlingslager.behandling.klage.KlageVurderingResultat;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepositoryProvider;
@@ -128,8 +129,10 @@ public class DatavarehusTjenesteImpl implements DatavarehusTjeneste {
 
     private void lagreNedBehandling(Behandling behandling, Optional<BehandlingVedtak> vedtak) {
         var familieHendelseGrunnlag = familieGrunnlagRepository.hentAggregatHvisEksisterer(behandling.getId());
-        var gjeldendeKlagevurderingresultat = klageRepository.hentKlageResultatHvisEksisterer(behandling.getId());
-        var gjeldendeAnkevurderingresultat = ankeRepository.hentAnkeResultat(behandling.getId());
+        Optional<KlageResultatEntitet> gjeldendeKlagevurderingresultat = behandling.getType().erKlageAnkeType()
+            ? klageRepository.hentKlageResultatHvisEksisterer(behandling.getId()) : Optional.empty();
+        Optional<AnkeResultatEntitet> gjeldendeAnkevurderingresultat = behandling.getType().erKlageAnkeType()
+            ? ankeRepository.hentAnkeResultat(behandling.getId()) : Optional.empty();
         var skjæringstidspunkt = familieHendelseGrunnlag.map(fhg -> skjæringstidspunkt(behandling, familieHendelseGrunnlag.get()));
         var mottatteDokumenter = mottatteDokumentRepository.hentMottatteDokument(behandling.getId()).stream()
             .filter(md -> md.getJournalpostId() != null && erRelevantDoument(behandling, md))

--- a/domenetjenester/dokumentbestiller/src/test/java/no/nav/foreldrepenger/dokumentbestiller/observers/SendDokumentForAutopunktEventObserverTest.java
+++ b/domenetjenester/dokumentbestiller/src/test/java/no/nav/foreldrepenger/dokumentbestiller/observers/SendDokumentForAutopunktEventObserverTest.java
@@ -9,8 +9,6 @@ import static org.mockito.Mockito.when;
 
 import java.util.List;
 
-import no.nav.foreldrepenger.behandlingskontroll.events.AutopunktStatusEvent;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -18,7 +16,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import no.nav.foreldrepenger.behandlingskontroll.BehandlingskontrollKontekst;
-import no.nav.foreldrepenger.behandlingskontroll.events.AksjonspunktStatusEvent;
+import no.nav.foreldrepenger.behandlingskontroll.events.AutopunktStatusEvent;
 import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.Aksjonspunkt;
 import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.AksjonspunktDefinisjon;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepository;

--- a/domenetjenester/produksjonsstyring/src/test/java/no/nav/foreldrepenger/produksjonsstyring/historikk/BehandlingskontrollAksjonspunktTypeAutopunktEventObserverTest.java
+++ b/domenetjenester/produksjonsstyring/src/test/java/no/nav/foreldrepenger/produksjonsstyring/historikk/BehandlingskontrollAksjonspunktTypeAutopunktEventObserverTest.java
@@ -14,8 +14,6 @@ import java.time.LocalDateTime;
 import java.time.Period;
 import java.util.List;
 
-import no.nav.foreldrepenger.behandlingskontroll.events.AutopunktStatusEvent;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -24,7 +22,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import no.nav.foreldrepenger.behandlingskontroll.BehandlingskontrollKontekst;
-import no.nav.foreldrepenger.behandlingskontroll.events.AksjonspunktStatusEvent;
+import no.nav.foreldrepenger.behandlingskontroll.events.AutopunktStatusEvent;
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
 import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.Aksjonspunkt;
 import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.AksjonspunktDefinisjon;

--- a/domenetjenester/vedtak/src/main/java/no/nav/foreldrepenger/domene/vedtak/impl/KlageAnkeVedtakTjeneste.java
+++ b/domenetjenester/vedtak/src/main/java/no/nav/foreldrepenger/domene/vedtak/impl/KlageAnkeVedtakTjeneste.java
@@ -1,7 +1,5 @@
 package no.nav.foreldrepenger.domene.vedtak.impl;
 
-import java.util.Set;
-
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 
@@ -37,13 +35,6 @@ public class KlageAnkeVedtakTjeneste {
         return BehandlingType.ANKE.equals(behandling.getType()) || BehandlingType.KLAGE.equals(behandling.getType());
     }
 
-    public boolean skalOversendesTrygdretten(Behandling behandling) {
-        return BehandlingType.ANKE.equals(behandling.getType()) &&
-            ankeRepository.hentAnkeVurderingResultat(behandling.getId())
-                .map(AnkeVurderingResultatEntitet::getAnkeVurdering)
-                .filter(Set.of(AnkeVurdering.ANKE_AVVIS, AnkeVurdering.ANKE_STADFESTE_YTELSESVEDTAK)::contains).isPresent();
-    }
-
     public boolean erOversendtTrygdretten(Behandling behandling) {
         return BehandlingType.ANKE.equals(behandling.getType()) &&
             ankeRepository.hentAnkeVurderingResultat(behandling.getId()).map(AnkeVurderingResultatEntitet::getSendtTrygderettDato).isPresent();
@@ -54,13 +45,6 @@ public class KlageAnkeVedtakTjeneste {
             ankeRepository.hentAnkeVurderingResultat(behandling.getId())
                 .map(AnkeVurderingResultatEntitet::getTrygderettVurdering)
                 .filter(v -> !AnkeVurdering.UDEFINERT.equals(v))
-                .isPresent();
-    }
-
-    public boolean harSattOversendelseDato(Behandling behandling) {
-        return BehandlingType.ANKE.equals(behandling.getType()) &&
-            ankeRepository.hentAnkeVurderingResultat(behandling.getId())
-                .map(AnkeVurderingResultatEntitet::getSendtTrygderettDato)
                 .isPresent();
     }
 

--- a/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/klage/KlageFormkravOppdatererTest.java
+++ b/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/klage/KlageFormkravOppdatererTest.java
@@ -2,7 +2,6 @@ package no.nav.foreldrepenger.web.app.tjenester.behandling.klage;
 
 import static no.nav.foreldrepenger.behandlingslager.behandling.historikk.HistorikkinnslagLinjeBuilder.format;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.time.LocalDate;
@@ -52,6 +51,10 @@ class KlageFormkravOppdatererTest extends EntityManagerAwareTest {
     private KlageRepository klageRepository;
     @Mock
     private FptilbakeRestKlient mockFptilbakeRestKlient;
+    @Mock
+    private BehandlingEventPubliserer eventPubliserer;
+    @Mock
+    private BehandlingskontrollTjeneste behandlingskontrollTjeneste;
 
     private KlageFormkravOppdaterer klageFormkravOppdaterer;
     private Behandling behandling;
@@ -65,11 +68,11 @@ class KlageFormkravOppdatererTest extends EntityManagerAwareTest {
         BehandlingRepository behandlingRepository = repositoryProvider.getBehandlingRepository();
         klageRepository = new KlageRepository(getEntityManager());
         KlageVurderingTjeneste klageVurderingTjeneste = new KlageVurderingTjeneste(null, null, behandlingRepository, klageRepository, null,
-            repositoryProvider.getBehandlingsresultatRepository(), mock(BehandlingEventPubliserer.class));
+            repositoryProvider.getBehandlingsresultatRepository(), eventPubliserer);
         var formHistorikk = new KlageHistorikkinnslag(repositoryProvider.getHistorikkinnslagRepository(), behandlingRepository,
             repositoryProvider.getBehandlingVedtakRepository(), mockFptilbakeRestKlient);
-        klageFormkravOppdaterer = new KlageFormkravOppdaterer(klageVurderingTjeneste, behandlingRepository, mock(BehandlingskontrollTjeneste.class),
-            formHistorikk);
+        klageFormkravOppdaterer = new KlageFormkravOppdaterer(klageVurderingTjeneste, behandlingRepository, behandlingskontrollTjeneste,
+            eventPubliserer, formHistorikk);
 
         scenario.leggTilAksjonspunkt(AksjonspunktDefinisjon.MANUELL_VURDERING_AV_KLAGE_NFP, BehandlingStegType.KLAGE_NFP);
         historikkinnslagRepository = repositoryProvider.getHistorikkinnslagRepository();

--- a/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/klage/KlagevurderingOppdatererTest.java
+++ b/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/klage/KlagevurderingOppdatererTest.java
@@ -1,7 +1,7 @@
 package no.nav.foreldrepenger.web.app.tjenester.behandling.klage;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -21,6 +21,7 @@ import no.nav.foreldrepenger.behandling.aksjonspunkt.AksjonspunktOppdaterParamet
 import no.nav.foreldrepenger.behandling.klage.KlageVurderingTjeneste;
 import no.nav.foreldrepenger.behandlingskontroll.BehandlingskontrollTjeneste;
 import no.nav.foreldrepenger.behandlingslager.aktør.OrganisasjonsEnhet;
+import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingResultatType;
 import no.nav.foreldrepenger.behandlingslager.behandling.historikk.HistorikkAktør;
 import no.nav.foreldrepenger.behandlingslager.behandling.klage.KlageRepository;
@@ -38,7 +39,6 @@ import no.nav.foreldrepenger.dokumentbestiller.DokumentBestilling;
 import no.nav.foreldrepenger.dokumentbestiller.DokumentMalType;
 import no.nav.foreldrepenger.produksjonsstyring.behandlingenhet.BehandlendeEnhetTjeneste;
 import no.nav.foreldrepenger.produksjonsstyring.tilbakekreving.FptilbakeRestKlient;
-import no.nav.foreldrepenger.web.app.tjenester.behandling.aksjonspunkt.BehandlingsutredningTjeneste;
 import no.nav.foreldrepenger.web.app.tjenester.behandling.klage.aksjonspunkt.KlageHistorikkinnslag;
 import no.nav.foreldrepenger.web.app.tjenester.behandling.klage.aksjonspunkt.KlageVurderingResultatAksjonspunktDto;
 import no.nav.foreldrepenger.web.app.tjenester.behandling.klage.aksjonspunkt.KlagevurderingOppdaterer;
@@ -53,7 +53,11 @@ class KlagevurderingOppdatererTest {
     @Mock
     private DokumentBestillerTjeneste dokumentBestillerTjeneste;
     @Mock
-    private BehandlingsutredningTjeneste behandlingsutredningTjeneste;
+    private BehandlendeEnhetTjeneste behandlendeEnhetTjeneste;
+    @Mock
+    private BehandlingEventPubliserer eventPubliserer;
+    @Mock
+    private BehandlingskontrollTjeneste behandlingskontrollTjeneste;
     @Mock
     private BehandlingProsesseringTjeneste behandlingProsesseringTjeneste;
 
@@ -99,8 +103,8 @@ class KlagevurderingOppdatererTest {
 
         // Verifiserer at behandlende enhet er byttet til Nav klageinstans
         var enhetCapture = ArgumentCaptor.forClass(OrganisasjonsEnhet.class);
-        verify(behandlingsutredningTjeneste).byttBehandlendeEnhet(anyLong(), enhetCapture.capture(), eq(""),
-                eq(HistorikkAktør.VEDTAKSLØSNINGEN));
+        verify(behandlendeEnhetTjeneste).oppdaterBehandlendeEnhet(any(Behandling.class), enhetCapture.capture(),
+                eq(HistorikkAktør.VEDTAKSLØSNINGEN), eq(""));
         var enhet = enhetCapture.getValue();
         assertThat(enhet.enhetId()).isEqualTo(BehandlendeEnhetTjeneste.getKlageInstans().enhetId());
         assertThat(enhet.enhetNavn()).isEqualTo(BehandlendeEnhetTjeneste.getKlageInstans().enhetNavn());
@@ -113,10 +117,10 @@ class KlagevurderingOppdatererTest {
         var behandlingRepository = repositoryProvider.getBehandlingRepository();
         var klageVurderingTjeneste = new KlageVurderingTjeneste(dokumentBestillerTjeneste, Mockito.mock(DokumentBehandlingTjeneste.class),
             behandlingRepository, klageRepository, behandlingProsesseringTjeneste,
-            repositoryProvider.getBehandlingsresultatRepository(), mock(BehandlingEventPubliserer.class));
+            repositoryProvider.getBehandlingsresultatRepository(), eventPubliserer);
         var klageHistorikk = new KlageHistorikkinnslag(repositoryProvider.getHistorikkinnslagRepository(),
             behandlingRepository, repositoryProvider.getBehandlingVedtakRepository(), mock(FptilbakeRestKlient.class));
-        return new KlagevurderingOppdaterer(klageHistorikk, behandlingsutredningTjeneste, mock(BehandlingskontrollTjeneste.class), klageVurderingTjeneste,
+        return new KlagevurderingOppdaterer(klageHistorikk, behandlendeEnhetTjeneste, eventPubliserer, behandlingskontrollTjeneste, klageVurderingTjeneste,
             behandlingRepository);
     }
 


### PR DESCRIPTION
Fjerner overgangskode for anker som ble migrert til Kabal. Nå har alle anker en Kabal-referanse
Lager en egen KlageOppdatert-event for å trigge lagring til DVH. 
Dermed er det ingen metoder som observer AksjonspunktStatus, bare AutopunktStatus. 