### PR TITLE
TFP-5383 videre automatisering av aktivitetskrav bfhr

### DIFF
--- a/domenetjenester/registerinnhenting/src/main/java/no/nav/foreldrepenger/domene/registerinnhenting/MorsAktivitetInnhenter.java
+++ b/domenetjenester/registerinnhenting/src/main/java/no/nav/foreldrepenger/domene/registerinnhenting/MorsAktivitetInnhenter.java
@@ -5,14 +5,12 @@ import static no.nav.foreldrepenger.behandlingslager.behandling.aktivitetskrav.A
 import static no.nav.foreldrepenger.behandlingslager.behandling.aktivitetskrav.AktivitetskravPermisjonType.PERMITTERING;
 import static no.nav.foreldrepenger.behandlingslager.behandling.aktivitetskrav.AktivitetskravPermisjonType.UDEFINERT;
 import static no.nav.foreldrepenger.behandlingslager.behandling.aktivitetskrav.AktivitetskravPermisjonType.UTDANNING;
-import static no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.periode.UttakPeriodeType.FELLESPERIODE;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -32,11 +30,9 @@ import no.nav.foreldrepenger.behandlingslager.behandling.aktivitetskrav.Aktivite
 import no.nav.foreldrepenger.behandlingslager.behandling.aktivitetskrav.AktivitetskravArbeidRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.aktivitetskrav.AktivitetskravGrunnlagEntitet;
 import no.nav.foreldrepenger.behandlingslager.behandling.aktivitetskrav.AktivitetskravPermisjonType;
-import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.MorsAktivitet;
 import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.YtelseFordelingAggregat;
 import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.YtelsesFordelingRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.periode.OppgittPeriodeEntitet;
-import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.periode.UttakPeriodeType;
 import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakYtelseType;
 import no.nav.foreldrepenger.behandlingslager.virksomhet.ArbeidType;
 import no.nav.foreldrepenger.domene.abakus.ArbeidsforholdTjeneste;
@@ -225,19 +221,11 @@ public class MorsAktivitetInnhenter {
     }
 
     private static List<OppgittPeriodeEntitet> hentPerioderMedAktivitetskrav(YtelseFordelingAggregat ytelseaggregat) {
-        return ytelseaggregat.getGjeldendeFordeling()
+        return ytelseaggregat.getOppgittFordeling()
             .getPerioder()
             .stream()
-            .filter(p -> skalInnhenteAktivitetskravGrunnlag(p, ytelseaggregat))
+            .filter(OppgittPeriodeEntitet::erAktivitetskravMedMorArbeid)
             .toList();
-    }
-
-    private static boolean skalInnhenteAktivitetskravGrunnlag(OppgittPeriodeEntitet p, YtelseFordelingAggregat ytelseaggregat) {
-        if (!MorsAktivitet.ARBEID.equals(p.getMorsAktivitet())) {
-            return false;
-        }
-        return !ytelseaggregat.harAnnenForelderRett() ? Objects.equals(UttakPeriodeType.FORELDREPENGER, p.getPeriodeType()) : Objects.equals(
-            FELLESPERIODE, p.getPeriodeType());
     }
 
     private AktivitetskravArbeidPerioderEntitet lagAktivitetskravPerioderBuilder(Map<String, List<ArbeidsforholdMedPermisjon>> mapAvOrgnrOgAvtaler,

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
         <fp-nare.version>2.6.3</fp-nare.version>
         <fp-inngangsvilkar.version>1.1.4</fp-inngangsvilkar.version>
         <beregning.version>5.8.4</beregning.version>
-        <fp-uttak.version>15.4.4</fp-uttak.version>
+        <fp-uttak.version>15.4.5</fp-uttak.version>
         <fp-stonadskonto.version>2.1.1</fp-stonadskonto.version>
         <svp-uttak.version>2.4.5</svp-uttak.version>
         <fp-ytelse-beregn.version>1.0.4</fp-ytelse-beregn.version>


### PR DESCRIPTION
https://github.com/navikt/fp-uttak/pull/411

Tenker at det enkleste er det beste.
Problemet vi kan få må denne løsningen, som bare sjekker periode, er at vi vil sende varsel til mor/innhente opplysninger om mor hvis vi får inn en søknad om aleneomsorg med morsaktivitet = arbeid, samt med oppgitt mor fnr.  Slike søknaden kan man ikke digitalt få inn i dag.
Ved å ikke sjekke rettighet løser vi en del problemer rundt endringssøknader/overstyringer