### PR TITLE
TFP-6103 skill ut aksjonspunktstyring fra behandlingskontroll

### DIFF
--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/aksjonspunkt/AksjonspunktDefinisjon.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/aksjonspunkt/AksjonspunktDefinisjon.java
@@ -512,9 +512,8 @@ public enum AksjonspunktDefinisjon implements Kodeverdi {
         Map.entry(AksjonspunktDefinisjon.SJEKK_MANGLENDE_FØDSEL, Set.of(AksjonspunktDefinisjon.AVKLAR_TERMINBEKREFTELSE)),
         Map.entry(AksjonspunktDefinisjon.AVKLAR_TERMINBEKREFTELSE, Set.of(AksjonspunktDefinisjon.SJEKK_MANGLENDE_FØDSEL))
         /* TODO: Vurder om disse skal tas med
-        , Map.entry(AksjonspunktDefinisjon.FORESLÅ_VEDTAK, Set.of(AksjonspunktDefinisjon.FORESLÅ_VEDTAK_MANUELT, AksjonspunktDefinisjon.VEDTAK_UTEN_TOTRINNSKONTROLL))
-        , Map.entry(AksjonspunktDefinisjon.VEDTAK_UTEN_TOTRINNSKONTROLL, Set.of(AksjonspunktDefinisjon.FORESLÅ_VEDTAK_MANUELT, AksjonspunktDefinisjon.FORESLÅ_VEDTAK))
-        , Map.entry(AksjonspunktDefinisjon.FORESLÅ_VEDTAK_MANUELT, Set.of(AksjonspunktDefinisjon.VEDTAK_UTEN_TOTRINNSKONTROLL, AksjonspunktDefinisjon.FORESLÅ_VEDTAK))
+        , Map.entry(AksjonspunktDefinisjon.FORESLÅ_VEDTAK, Set.of(AksjonspunktDefinisjon.FORESLÅ_VEDTAK_MANUELT))
+        , Map.entry(AksjonspunktDefinisjon.FORESLÅ_VEDTAK_MANUELT, Set.of(AksjonspunktDefinisjon.FORESLÅ_VEDTAK))
          */
     );
 

--- a/behandlingsprosess/src/main/java/no/nav/foreldrepenger/behandling/steg/foreslåvedtak/ForeslåVedtakTjeneste.java
+++ b/behandlingsprosess/src/main/java/no/nav/foreldrepenger/behandling/steg/foreslåvedtak/ForeslåVedtakTjeneste.java
@@ -132,7 +132,7 @@ class ForeslåVedtakTjeneste {
         } else {
             behandling.nullstillToTrinnsBehandling();
             LOG.info("To-trinn fjernet på behandling={}", behandling.getId());
-            if (skalOppretteForeslåVedtakManuelt(behandling, aksjonspunktDefinisjoner)) {
+            if (skalOppretteForeslåVedtakManuelt(behandling)) {
                 aksjonspunktDefinisjoner.add(AksjonspunktDefinisjon.FORESLÅ_VEDTAK_MANUELT);
             } else {
                 dokumentBehandlingTjeneste.nullstillVedtakFritekstHvisFinnes(behandling.getId());
@@ -140,7 +140,7 @@ class ForeslåVedtakTjeneste {
         }
     }
 
-    private boolean skalOppretteForeslåVedtakManuelt(Behandling behandling, List<AksjonspunktDefinisjon> aksjonspunktDefinisjoner) {
+    private boolean skalOppretteForeslåVedtakManuelt(Behandling behandling) {
         if (behandling.erRevurdering() && behandling.erManueltOpprettet()) {
             return true;
         }

--- a/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/beregnytelse/es/BeregneYtelseStegImplTest.java
+++ b/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/beregnytelse/es/BeregneYtelseStegImplTest.java
@@ -132,7 +132,8 @@ class BeregneYtelseStegImplTest {
         // Arrange
         var antallBarn = 1;
         var behandling = byggGrunnlag(antallBarn, LocalDate.now());
-        var kontekst = behandlingskontrollTjeneste.initBehandlingskontroll(behandling);
+        var lås = behandlingRepository.taSkriveLås(behandling);
+        var kontekst = behandlingskontrollTjeneste.initBehandlingskontroll(behandling, lås);
         var beregningResultat = LegacyESBeregningsresultat.builder()
                 .medBeregning(new LegacyESBeregning(1000L, antallBarn, 1000L, LocalDateTime.now()))
                 .buildFor(behandling, getBehandlingsresultat(behandling));
@@ -152,7 +153,8 @@ class BeregneYtelseStegImplTest {
         // Arrange
         var antallBarn = 1;
         var behandling = byggGrunnlag(antallBarn, LocalDate.now());
-        var kontekst = behandlingskontrollTjeneste.initBehandlingskontroll(behandling);
+        var lås = behandlingRepository.taSkriveLås(behandling);
+        var kontekst = behandlingskontrollTjeneste.initBehandlingskontroll(behandling, lås);
         var beregningResultat = LegacyESBeregningsresultat.builder()
                 .medBeregning(new LegacyESBeregning(1000L, antallBarn, 1000L, LocalDateTime.now(), false, null))
                 .medBeregning(new LegacyESBeregning(500L, antallBarn, 1000L, LocalDateTime.now(), true, 1000L))
@@ -176,7 +178,8 @@ class BeregneYtelseStegImplTest {
         // Arrange
         var antallBarn = 1;
         var behandling = byggGrunnlag(antallBarn, LocalDate.now());
-        var kontekst = behandlingskontrollTjeneste.initBehandlingskontroll(behandling);
+        var lås = behandlingRepository.taSkriveLås(behandling);
+        var kontekst = behandlingskontrollTjeneste.initBehandlingskontroll(behandling, lås);
         var beregningResultat = LegacyESBeregningsresultat.builder()
                 .medBeregning(new LegacyESBeregning(1000L, antallBarn, 1000L, LocalDateTime.now(), false, null))
                 .medBeregning(new LegacyESBeregning(500L, antallBarn, 1000L, LocalDateTime.now(), true, 1000L))
@@ -218,7 +221,8 @@ class BeregneYtelseStegImplTest {
 
     private BehandlingskontrollKontekst byggBehandlingsgrunnlagForFødsel(int antallBarn, LocalDate fødselsdato) {
         var behandling = byggGrunnlag(antallBarn, fødselsdato);
-        return behandlingskontrollTjeneste.initBehandlingskontroll(behandling);
+        var lås = behandlingRepository.taSkriveLås(behandling);
+        return behandlingskontrollTjeneste.initBehandlingskontroll(behandling, lås);
     }
 
 }

--- a/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/beregnytelse/fp/BeregneYtelseStegImplTest.java
+++ b/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/beregnytelse/fp/BeregneYtelseStegImplTest.java
@@ -88,7 +88,8 @@ class BeregneYtelseStegImplTest {
         when(beregnYtelseTjeneste.beregnYtelse(ArgumentMatchers.any())).thenReturn(opprettBeregningsresultat());
 
         var behandling = byggGrunnlag();
-        var kontekst = behandlingskontrollTjeneste.initBehandlingskontroll(behandling);
+        var lås = behandlingRepository.taSkriveLås(behandling);
+        var kontekst = behandlingskontrollTjeneste.initBehandlingskontroll(behandling, lås);
 
         // Act
         var stegResultat = steg.utførSteg(kontekst);
@@ -108,7 +109,8 @@ class BeregneYtelseStegImplTest {
     void skalSletteBeregningsresultatFPVedTilbakehopp() {
         // Arrange
         var behandling = byggGrunnlag();
-        var kontekst = behandlingskontrollTjeneste.initBehandlingskontroll(behandling);
+        var lås = behandlingRepository.taSkriveLås(behandling);
+        var kontekst = behandlingskontrollTjeneste.initBehandlingskontroll(behandling, lås);
         beregningsresultatRepository.lagre(behandling, opprettBeregningsresultat());
 
         // Act

--- a/domenetjenester/behandling-klage/src/main/java/no/nav/foreldrepenger/behandling/kabal/KabalTjeneste.java
+++ b/domenetjenester/behandling-klage/src/main/java/no/nav/foreldrepenger/behandling/kabal/KabalTjeneste.java
@@ -28,6 +28,7 @@ import no.nav.foreldrepenger.behandlingslager.behandling.klage.KlageResultatEnti
 import no.nav.foreldrepenger.behandlingslager.behandling.klage.KlageVurdering;
 import no.nav.foreldrepenger.behandlingslager.behandling.klage.KlageVurderingOmgjør;
 import no.nav.foreldrepenger.behandlingslager.behandling.klage.KlageVurdertAv;
+import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingLås;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.verge.VergeAggregat;
 import no.nav.foreldrepenger.behandlingslager.behandling.verge.VergeOrganisasjonEntitet;
@@ -95,11 +96,11 @@ public class KabalTjeneste {
         kabalKlient.sendTilKabal(request);
     }
 
-    public void lagreKlageUtfallFraKabal(Behandling behandling, KabalUtfall utfall) {
+    public void lagreKlageUtfallFraKabal(Behandling behandling, BehandlingLås lås, KabalUtfall utfall) {
         var builder = klageVurderingTjeneste.hentKlageVurderingResultatBuilder(behandling, KlageVurdertAv.NK)
             .medKlageVurdering(klageVurderingFraUtfall(utfall))
             .medKlageVurderingOmgjør(klageVurderingOmgjørFraUtfall(utfall));
-        klageVurderingTjeneste.oppdaterBekreftetVurderingAksjonspunkt(behandling, builder, KlageVurdertAv.NK);
+        klageVurderingTjeneste.oppdaterBekreftetVurderingAksjonspunkt(behandling, lås, builder, KlageVurdertAv.NK);
         opprettHistorikkinnslagKlage(behandling, utfall);
     }
 

--- a/domenetjenester/behandling-klage/src/main/java/no/nav/foreldrepenger/behandling/kabal/MottaFraKabalTask.java
+++ b/domenetjenester/behandling-klage/src/main/java/no/nav/foreldrepenger/behandling/kabal/MottaFraKabalTask.java
@@ -96,7 +96,7 @@ public class MottaFraKabalTask extends BehandlingProsessTask {
         var kontekst = behandlingskontrollTjeneste.initBehandlingskontroll(klageBehandling, lås);
         kabalTjeneste.settKabalReferanse(klageBehandling, ref);
         if (!UTEN_VURDERING.contains(utfall)) {
-            kabalTjeneste.lagreKlageUtfallFraKabal(klageBehandling, utfall);
+            kabalTjeneste.lagreKlageUtfallFraKabal(klageBehandling, lås, utfall);
         }
         if (KabalUtfall.TRUKKET.equals(utfall) || KabalUtfall.HEVET.equals(utfall)) {
             if (klageBehandling.isBehandlingPåVent()) {

--- a/domenetjenester/behandling-klage/src/main/java/no/nav/foreldrepenger/behandling/klage/KlageVurderingTjeneste.java
+++ b/domenetjenester/behandling-klage/src/main/java/no/nav/foreldrepenger/behandling/klage/KlageVurderingTjeneste.java
@@ -22,6 +22,7 @@ import no.nav.foreldrepenger.behandlingslager.behandling.klage.KlageVurderingBeh
 import no.nav.foreldrepenger.behandlingslager.behandling.klage.KlageVurderingOmgjør;
 import no.nav.foreldrepenger.behandlingslager.behandling.klage.KlageVurderingResultat;
 import no.nav.foreldrepenger.behandlingslager.behandling.klage.KlageVurdertAv;
+import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingLås;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepository;
 import no.nav.foreldrepenger.behandlingsprosess.prosessering.BehandlingProsesseringTjeneste;
 import no.nav.foreldrepenger.dokumentbestiller.DokumentBehandlingTjeneste;
@@ -117,16 +118,17 @@ public class KlageVurderingTjeneste {
         return eksisterende.map(KlageVurderingResultat::builder).orElse(KlageVurderingResultat.builder()).medKlageVurdertAv(vurdertAv);
     }
 
-    public void oppdaterBekreftetVurderingAksjonspunkt(Behandling behandling, KlageVurderingResultat.Builder builder, KlageVurdertAv vurdertAv) {
-        lagreKlageVurderingResultat(behandling, builder, vurdertAv, true);
+    public void oppdaterBekreftetVurderingAksjonspunkt(Behandling behandling, BehandlingLås lås, KlageVurderingResultat.Builder builder, KlageVurdertAv vurdertAv) {
+        lagreKlageVurderingResultat(behandling, lås, builder, vurdertAv, true);
     }
 
-    public void lagreKlageVurderingResultat(Behandling behandling, KlageVurderingResultat.Builder builder, KlageVurdertAv vurdertAv) {
-        lagreKlageVurderingResultat(behandling, builder, vurdertAv, false);
+    public void lagreKlageVurderingResultat(Behandling behandling, BehandlingLås lås, KlageVurderingResultat.Builder builder, KlageVurdertAv vurdertAv) {
+        lagreKlageVurderingResultat(behandling, lås, builder, vurdertAv, false);
     }
 
-    private void lagreKlageVurderingResultat(Behandling behandling, KlageVurderingResultat.Builder builder, KlageVurdertAv vurdertAv,
-            boolean erVurderingOppdaterer) {
+    private void lagreKlageVurderingResultat(Behandling behandling, BehandlingLås lås,
+                                             KlageVurderingResultat.Builder builder, KlageVurdertAv vurdertAv,
+                                             boolean erVurderingOppdaterer) {
         var aksjonspunkt = KlageVurdertAv.NK.equals(vurdertAv) ? null : AksjonspunktDefinisjon.MANUELL_VURDERING_AV_KLAGE_NFP;
         var vurderingsteg = KlageVurdertAv.NK.equals(vurdertAv) ? BehandlingStegType.KLAGE_NK : BehandlingStegType.KLAGE_NFP;
 
@@ -147,12 +149,12 @@ public class KlageVurderingTjeneste {
         }
         if (tilbakeføres) {
             behandlingRepository.lagre(behandling, behandlingRepository.taSkriveLås(behandling));
-            tilbakeførBehandling(behandling, vurderingsteg);
+            tilbakeførBehandling(behandling, lås, vurderingsteg);
         }
     }
 
-    private void tilbakeførBehandling(Behandling behandling, BehandlingStegType vurderingSteg) {
-        behandlingProsesseringTjeneste.reposisjonerBehandlingTilbakeTil(behandling, vurderingSteg);
+    private void tilbakeførBehandling(Behandling behandling, BehandlingLås lås, BehandlingStegType vurderingSteg) {
+        behandlingProsesseringTjeneste.reposisjonerBehandlingTilbakeTil(behandling, lås, vurderingSteg);
         behandlingProsesseringTjeneste.opprettTasksForFortsettBehandling(behandling);
     }
 

--- a/domenetjenester/behandling-prosessering/src/main/java/no/nav/foreldrepenger/behandlingsprosess/prosessering/BehandlingProsesseringTjeneste.java
+++ b/domenetjenester/behandling-prosessering/src/main/java/no/nav/foreldrepenger/behandlingsprosess/prosessering/BehandlingProsesseringTjeneste.java
@@ -9,6 +9,7 @@ import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingStegType;
 import no.nav.foreldrepenger.behandlingslager.behandling.EndringsresultatSnapshot;
 import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.AksjonspunktDefinisjon;
 import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.Venteårsak;
+import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingLås;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTaskGruppe;
 
 /**
@@ -49,7 +50,7 @@ public interface BehandlingProsesseringTjeneste {
     void utledDiffOgReposisjonerBehandlingVedEndringer(Behandling behandling, EndringsresultatSnapshot snapshot);
 
     // Spole til spesifikt steg
-    void reposisjonerBehandlingTilbakeTil(Behandling behandling, BehandlingStegType stegType);
+    void reposisjonerBehandlingTilbakeTil(Behandling behandling, BehandlingLås lås, BehandlingStegType stegType);
 
     /**
      * Returnerer tasks for oppdatering/fortsett for bruk med

--- a/domenetjenester/behandling-prosessering/src/main/java/no/nav/foreldrepenger/behandlingsprosess/prosessering/tjeneste/BehandlingProsesseringTjenesteImpl.java
+++ b/domenetjenester/behandling-prosessering/src/main/java/no/nav/foreldrepenger/behandlingsprosess/prosessering/tjeneste/BehandlingProsesseringTjenesteImpl.java
@@ -20,6 +20,7 @@ import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingStegType;
 import no.nav.foreldrepenger.behandlingslager.behandling.EndringsresultatSnapshot;
 import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.AksjonspunktDefinisjon;
 import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.Venteårsak;
+import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingLås;
 import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakYtelseType;
 import no.nav.foreldrepenger.behandlingsprosess.prosessering.BehandlingProsesseringTjeneste;
 import no.nav.foreldrepenger.behandlingsprosess.prosessering.task.FortsettBehandlingTask;
@@ -133,9 +134,9 @@ public class BehandlingProsesseringTjenesteImpl implements BehandlingProsesserin
     }
 
     @Override
-    public void reposisjonerBehandlingTilbakeTil(Behandling behandling, BehandlingStegType stegType) {
+    public void reposisjonerBehandlingTilbakeTil(Behandling behandling, BehandlingLås lås, BehandlingStegType stegType) {
         if (erStegAktueltForBehandling(behandling, stegType) && !erBehandlingFørSteg(behandling, stegType)) {
-            var kontekst = behandlingskontrollTjeneste.initBehandlingskontroll(behandling);
+            var kontekst = behandlingskontrollTjeneste.initBehandlingskontroll(behandling, lås);
             behandlingskontrollTjeneste.behandlingTilbakeføringTilTidligereBehandlingSteg(kontekst, stegType);
         }
     }

--- a/domenetjenester/behandling-revurdering/src/main/java/no/nav/foreldrepenger/behandling/revurdering/flytkontroll/TilbakeførTilDekningsgradStegTask.java
+++ b/domenetjenester/behandling-revurdering/src/main/java/no/nav/foreldrepenger/behandling/revurdering/flytkontroll/TilbakeførTilDekningsgradStegTask.java
@@ -52,7 +52,7 @@ public class TilbakeførTilDekningsgradStegTask extends FagsakProsessTask {
     @Override
     protected void prosesser(ProsessTaskData prosessTaskData, Long fagsakId) {
         var behandling = behandlingRepository.hentSisteYtelsesBehandlingForFagsakId(fagsakId).orElseThrow();
-        behandlingRepository.taSkriveLås(behandling);
+        var lås = behandlingRepository.taSkriveLås(behandling);
         if (behandling.erSaksbehandlingAvsluttet() || SpesialBehandling.erSpesialBehandling(behandling)) {
             return;
         }
@@ -78,7 +78,7 @@ public class TilbakeførTilDekningsgradStegTask extends FagsakProsessTask {
         if (behandling.isBehandlingPåVent()) {
             behandlingProsesseringTjeneste.taBehandlingAvVent(behandling);
         }
-        behandlingProsesseringTjeneste.reposisjonerBehandlingTilbakeTil(behandling, BehandlingStegType.DEKNINGSGRAD);
+        behandlingProsesseringTjeneste.reposisjonerBehandlingTilbakeTil(behandling, lås, BehandlingStegType.DEKNINGSGRAD);
         behandlingProsesseringTjeneste.opprettTasksForFortsettBehandling(behandling);
     }
 

--- a/domenetjenester/behandling-revurdering/src/main/java/no/nav/foreldrepenger/behandling/revurdering/ytelse/es/RevurderingTjenesteImpl.java
+++ b/domenetjenester/behandling-revurdering/src/main/java/no/nav/foreldrepenger/behandling/revurdering/ytelse/es/RevurderingTjenesteImpl.java
@@ -81,11 +81,13 @@ public class RevurderingTjenesteImpl implements RevurderingTjeneste {
             .orElseThrow(() -> RevurderingFeil.tjenesteFinnerIkkeBehandlingForRevurdering(fagsak.getId()));
 
         // lås original behandling først slik at ingen andre forsøker på samme
-        behandlingskontrollTjeneste.initBehandlingskontroll(origBehandling);
+        var originalLås = behandlingRepository.taSkriveLås(origBehandling.getId());
+        behandlingskontrollTjeneste.initBehandlingskontroll(origBehandling, originalLås);
 
         // deretter opprett kontekst for revurdering og opprett
         var revurdering = revurderingTjenesteFelles.opprettRevurderingsbehandling(revurderingsÅrsak, origBehandling, manueltOpprettet, enhet, opprettetAv);
-        var kontekst = behandlingskontrollTjeneste.initBehandlingskontroll(revurdering);
+        var revurderingLås = behandlingRepository.taSkriveLås(revurdering.getId());
+        var kontekst = behandlingskontrollTjeneste.initBehandlingskontroll(revurdering, revurderingLås);
         behandlingskontrollTjeneste.opprettBehandling(kontekst, revurdering);
         revurderingTjenesteFelles.opprettHistorikkInnslagForNyRevurdering(revurdering, revurderingsÅrsak, manueltOpprettet);
 

--- a/domenetjenester/behandling-revurdering/src/main/java/no/nav/foreldrepenger/behandling/revurdering/ytelse/fp/RevurderingTjenesteImpl.java
+++ b/domenetjenester/behandling-revurdering/src/main/java/no/nav/foreldrepenger/behandling/revurdering/ytelse/fp/RevurderingTjenesteImpl.java
@@ -114,12 +114,14 @@ public class RevurderingTjenesteImpl implements RevurderingTjeneste {
             .orElseThrow(() -> RevurderingFeil.tjenesteFinnerIkkeBehandlingForRevurdering(fagsak.getId()));
 
         // lås original behandling først
-        behandlingskontrollTjeneste.initBehandlingskontroll(origBehandling);
+        var originalLås = behandlingRepository.taSkriveLås(origBehandling.getId());
+        behandlingskontrollTjeneste.initBehandlingskontroll(origBehandling, originalLås);
 
         // deretter opprett revurdering
         var revurdering = revurderingTjenesteFelles.opprettRevurderingsbehandling(revurderingsÅrsak, origBehandling,
             manueltOpprettet, enhet, opprettetAv);
-        var kontekst = behandlingskontrollTjeneste.initBehandlingskontroll(revurdering);
+        var revurderingLås = behandlingRepository.taSkriveLås(revurdering.getId());
+        var kontekst = behandlingskontrollTjeneste.initBehandlingskontroll(revurdering, revurderingLås);
         behandlingskontrollTjeneste.opprettBehandling(kontekst, revurdering);
         revurderingTjenesteFelles.opprettHistorikkInnslagForNyRevurdering(revurdering, revurderingsÅrsak, manueltOpprettet);
 

--- a/domenetjenester/behandling-revurdering/src/main/java/no/nav/foreldrepenger/behandling/revurdering/ytelse/svp/RevurderingTjenesteImpl.java
+++ b/domenetjenester/behandling-revurdering/src/main/java/no/nav/foreldrepenger/behandling/revurdering/ytelse/svp/RevurderingTjenesteImpl.java
@@ -92,12 +92,14 @@ public class RevurderingTjenesteImpl implements RevurderingTjeneste {
             .orElseThrow(() -> RevurderingFeil.tjenesteFinnerIkkeBehandlingForRevurdering(fagsak.getId()));
 
         // lås original behandling først
-        behandlingskontrollTjeneste.initBehandlingskontroll(origBehandling);
+        var originalLås = behandlingRepository.taSkriveLås(origBehandling.getId());
+        behandlingskontrollTjeneste.initBehandlingskontroll(origBehandling, originalLås);
 
         // deretter opprett revurdering
         var revurdering = revurderingTjenesteFelles.opprettRevurderingsbehandling(revurderingsÅrsak, origBehandling,
             manueltOpprettet, enhet, opprettetAv);
-        var kontekst = behandlingskontrollTjeneste.initBehandlingskontroll(revurdering);
+        var revurderingLås = behandlingRepository.taSkriveLås(revurdering.getId());
+        var kontekst = behandlingskontrollTjeneste.initBehandlingskontroll(revurdering, revurderingLås);
         behandlingskontrollTjeneste.opprettBehandling(kontekst, revurdering);
         revurderingTjenesteFelles.opprettHistorikkInnslagForNyRevurdering(revurdering, revurderingsÅrsak, manueltOpprettet);
 

--- a/domenetjenester/behandlingskontroll/src/main/java/no/nav/foreldrepenger/behandlingskontroll/AksjonspunktkontrollTjeneste.java
+++ b/domenetjenester/behandlingskontroll/src/main/java/no/nav/foreldrepenger/behandlingskontroll/AksjonspunktkontrollTjeneste.java
@@ -1,0 +1,51 @@
+package no.nav.foreldrepenger.behandlingskontroll;
+
+import java.util.List;
+
+import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
+import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingStegType;
+import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.Aksjonspunkt;
+import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.AksjonspunktDefinisjon;
+import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingLås;
+
+public interface AksjonspunktkontrollTjeneste {
+
+    /**
+     * Oppretter og håndterer nye aksjonspunkt
+     */
+    List<Aksjonspunkt> lagreAksjonspunkterFunnet(Behandling behandling, BehandlingLås skriveLås, BehandlingStegType behandlingStegType,
+                                                 List<AksjonspunktDefinisjon> aksjonspunkter);
+
+    /**
+     * Oppretter og håndterer nye overstyringsaksjonspunkt
+     */
+    List<Aksjonspunkt> lagreAksjonspunkterFunnet(Behandling behandling, BehandlingLås skriveLås, List<AksjonspunktDefinisjon> aksjonspunkter);
+
+    /**
+     * Lagrer og håndterer utførte aksjonspunkt uten begrunnelse. Dersom man skal
+     * lagre begrunnelse - bruk apRepository + aksjonspunkterUtført
+     */
+    void lagreAksjonspunkterUtført(Behandling behandling, BehandlingLås skriveLås, Aksjonspunkt aksjonspunkt, String begrunnelse);
+
+    /**
+     * Lagrer og håndterer avbrutte aksjonspunkt
+     */
+    void lagreAksjonspunkterAvbrutt(Behandling behandling, BehandlingLås skriveLås, List<Aksjonspunkt> aksjonspunkter);
+
+    /**
+     * Lagrer og håndterer reåpning av aksjonspunkt
+     */
+    void lagreAksjonspunkterReåpnet(Behandling behandling, BehandlingLås skriveLås, List<Aksjonspunkt> aksjonspunkter);
+
+    /**
+     * Lagrer og håndterer aksjonspunktresultater fra utledning utenom steg
+     */
+    void lagreAksjonspunktResultat(Behandling behandling, BehandlingLås skriveLås, BehandlingStegType behandlingStegType,
+            List<AksjonspunktResultat> aksjonspunktResultater);
+
+    /**
+     * Lagrer og publiserer totrinns-setting for aksjonspunkt
+     */
+    void setAksjonspunkterToTrinn(Behandling behandling, BehandlingLås skriveLås, List<Aksjonspunkt> aksjonspunkter, boolean totrinn);
+
+}

--- a/domenetjenester/behandlingskontroll/src/main/java/no/nav/foreldrepenger/behandlingskontroll/BehandlingskontrollTjeneste.java
+++ b/domenetjenester/behandlingskontroll/src/main/java/no/nav/foreldrepenger/behandlingskontroll/BehandlingskontrollTjeneste.java
@@ -2,7 +2,6 @@ package no.nav.foreldrepenger.behandlingskontroll;
 
 import java.time.LocalDateTime;
 import java.util.Collection;
-import java.util.List;
 import java.util.function.Consumer;
 
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
@@ -40,7 +39,7 @@ public interface BehandlingskontrollTjeneste {
      * (inngang- og utgang-kriterier) vil steget kjøres på nytt.
      *
      * @param kontekst - kontekst for prosessering. Opprettes gjennom
-     *                 {@link #initBehandlingskontroll(Behandling)}
+     *                 {@link #initBehandlingskontroll(Behandling, BehandlingLås)}
      */
     void prosesserBehandling(BehandlingskontrollKontekst kontekst);
 
@@ -49,7 +48,7 @@ public interface BehandlingskontrollTjeneste {
      * Vil kalle gjenopptaSteg for angitt steg, senere vanlig framdrift
      *
      * @param kontekst           - kontekst for prosessering. Opprettes gjennom
-     *                           {@link #initBehandlingskontroll(Behandling)}
+     *                           {@link #initBehandlingskontroll(Behandling, BehandlingLås skriveLås)}
      * @param behandlingStegType - precondition steg
      */
     void prosesserBehandlingGjenopptaHvisStegVenter(BehandlingskontrollKontekst kontekst, BehandlingStegType behandlingStegType);
@@ -84,46 +83,6 @@ public interface BehandlingskontrollTjeneste {
      *                               gitt BehandlingType).
      */
     void behandlingFramføringTilSenereBehandlingSteg(BehandlingskontrollKontekst kontekst, BehandlingStegType senereSteg);
-
-    /**
-     * Oppretter og håndterer nye aksjonspunkt
-     */
-    List<Aksjonspunkt> lagreAksjonspunkterFunnet(BehandlingskontrollKontekst kontekst, BehandlingStegType behandlingStegType,
-            List<AksjonspunktDefinisjon> aksjonspunkter);
-
-    /**
-     * Oppretter og håndterer nye overstyringsaksjonspunkt
-     */
-    List<Aksjonspunkt> lagreAksjonspunkterFunnet(BehandlingskontrollKontekst kontekst, List<AksjonspunktDefinisjon> aksjonspunkter);
-
-    /**
-     * Lagrer og håndterer utførte aksjonspunkt uten begrunnelse. Dersom man skal
-     * lagre begrunnelse - bruk apRepository + aksjonspunkterUtført
-     */
-    void lagreAksjonspunkterUtført(BehandlingskontrollKontekst kontekst, Aksjonspunkt aksjonspunkt, String begrunnelse);
-
-    /**
-     * Lagrer og håndterer avbrutte aksjonspunkt
-     */
-    void lagreAksjonspunkterAvbrutt(BehandlingskontrollKontekst kontekst, List<Aksjonspunkt> aksjonspunkter);
-
-    /**
-     * Lagrer og håndterer reåpning av aksjonspunkt
-     */
-    void lagreAksjonspunkterReåpnet(BehandlingskontrollKontekst kontekst, List<Aksjonspunkt> aksjonspunkter, boolean beholdToTrinnVurdering,
-            boolean setTotrinn);
-
-    /**
-     * Lagrer og håndterer aksjonspunktresultater fra utledning utenom steg
-     */
-    void lagreAksjonspunktResultat(BehandlingskontrollKontekst kontekst, BehandlingStegType behandlingStegType,
-            List<AksjonspunktResultat> aksjonspunktResultater);
-
-    /**
-     * Lagrer og publiserer totrinns-setting for aksjonspunkt
-     */
-    void setAksjonspunktToTrinn(BehandlingskontrollKontekst kontekst, Aksjonspunkt aksjonspunkt, boolean totrinn);
-
 
     /**
      * Lagrer en ny behandling i behandlingRepository og fyrer av event om at en

--- a/domenetjenester/behandlingskontroll/src/main/java/no/nav/foreldrepenger/behandlingskontroll/events/AksjonspunktStatusEvent.java
+++ b/domenetjenester/behandlingskontroll/src/main/java/no/nav/foreldrepenger/behandlingskontroll/events/AksjonspunktStatusEvent.java
@@ -4,6 +4,7 @@ import java.util.Collections;
 import java.util.List;
 
 import no.nav.foreldrepenger.behandlingskontroll.BehandlingskontrollKontekst;
+import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingEvent;
 import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.Aksjonspunkt;
 import no.nav.foreldrepenger.domene.typer.Saksnummer;
@@ -16,9 +17,17 @@ public class AksjonspunktStatusEvent implements BehandlingEvent {
     private final List<Aksjonspunkt> aksjonspunkter;
 
     public AksjonspunktStatusEvent(BehandlingskontrollKontekst kontekst, List<Aksjonspunkt> aksjonspunkter) {
-        this.behandlingId = kontekst.getBehandlingId();
-        this.saksnummer = kontekst.getSaksnummer();
-        this.fagsakId = kontekst.getFagsakId();
+        this(kontekst.getBehandlingId(), kontekst.getSaksnummer(), kontekst.getFagsakId(), aksjonspunkter);
+    }
+
+    public AksjonspunktStatusEvent(Behandling behandling, List<Aksjonspunkt> aksjonspunkter) {
+        this(behandling.getId(), behandling.getSaksnummer(), behandling.getFagsakId(), aksjonspunkter);
+    }
+
+    public AksjonspunktStatusEvent(Long behandlingId, Saksnummer saksnummer, Long fagsakId, List<Aksjonspunkt> aksjonspunkter) {
+        this.behandlingId = behandlingId;
+        this.saksnummer = saksnummer;
+        this.fagsakId = fagsakId;
         this.aksjonspunkter = Collections.unmodifiableList(aksjonspunkter);
     }
 

--- a/domenetjenester/behandlingskontroll/src/main/java/no/nav/foreldrepenger/behandlingskontroll/impl/AksjonspunktResultatOppretter.java
+++ b/domenetjenester/behandlingskontroll/src/main/java/no/nav/foreldrepenger/behandlingskontroll/impl/AksjonspunktResultatOppretter.java
@@ -27,7 +27,7 @@ class AksjonspunktResultatOppretter {
 
     private final AksjonspunktKontrollRepository aksjonspunktKontrollRepository;
 
-    private Map<AksjonspunktDefinisjon, Aksjonspunkt> eksisterende = new LinkedHashMap<>();
+    private final Map<AksjonspunktDefinisjon, Aksjonspunkt> eksisterende = new LinkedHashMap<>();
 
     AksjonspunktResultatOppretter(AksjonspunktKontrollRepository aksjonspunktKontrollRepository, Behandling behandling) {
         this.behandling = Objects.requireNonNull(behandling, "behandling");
@@ -77,7 +77,8 @@ class AksjonspunktResultatOppretter {
         }
         var oppdatert = eksisterende.get(resultat.getAksjonspunktDefinisjon());
         if (oppdatert == null) {
-            oppdatert = aksjonspunktKontrollRepository.leggTilAksjonspunkt(behandling, resultat.getAksjonspunktDefinisjon(), behandlingStegType);
+            oppdatert = behandlingStegType == null ? aksjonspunktKontrollRepository.leggTilAksjonspunkt(behandling, resultat.getAksjonspunktDefinisjon())
+                : aksjonspunktKontrollRepository.leggTilAksjonspunkt(behandling, resultat.getAksjonspunktDefinisjon(), behandlingStegType);
             eksisterende.putIfAbsent(oppdatert.getAksjonspunktDefinisjon(), oppdatert);
         }
         switch (resultat.getMålStatus()) {

--- a/domenetjenester/behandlingskontroll/src/main/java/no/nav/foreldrepenger/behandlingskontroll/impl/AksjonspunktkontrollTjenesteImpl.java
+++ b/domenetjenester/behandlingskontroll/src/main/java/no/nav/foreldrepenger/behandlingskontroll/impl/AksjonspunktkontrollTjenesteImpl.java
@@ -1,0 +1,150 @@
+package no.nav.foreldrepenger.behandlingskontroll.impl;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import no.nav.foreldrepenger.behandlingskontroll.AksjonspunktResultat;
+import no.nav.foreldrepenger.behandlingskontroll.AksjonspunktkontrollTjeneste;
+import no.nav.foreldrepenger.behandlingskontroll.events.AksjonspunktStatusEvent;
+import no.nav.foreldrepenger.behandlingskontroll.spi.BehandlingskontrollServiceProvider;
+import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
+import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingStegType;
+import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.Aksjonspunkt;
+import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.AksjonspunktDefinisjon;
+import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.AksjonspunktKontrollRepository;
+import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.AksjonspunktStatus;
+import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingLås;
+import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepository;
+
+/**
+ * ALLE ENDRINGER I DENNE KLASSEN SKAL KLARERES OG KODE-REVIEWES MED ANSVARLIG
+ * APPLIKASJONSARKITEKT (SE UTVIKLERHÅNDBOK).
+ */
+@ApplicationScoped
+public class AksjonspunktkontrollTjenesteImpl implements AksjonspunktkontrollTjeneste {
+
+    private AksjonspunktKontrollRepository aksjonspunktKontrollRepository;
+    private BehandlingRepository behandlingRepository;
+    private BehandlingskontrollEventPubliserer eventPubliserer;
+
+    AksjonspunktkontrollTjenesteImpl() {
+        // for CDI proxy
+    }
+
+    /**
+     * SE KOMMENTAR ØVERST
+     */
+    @Inject
+    public AksjonspunktkontrollTjenesteImpl(BehandlingskontrollServiceProvider serviceProvider) {
+        this.behandlingRepository = serviceProvider.getBehandlingRepository();
+        this.aksjonspunktKontrollRepository = serviceProvider.getAksjonspunktKontrollRepository();
+        this.eventPubliserer = serviceProvider.getEventPubliserer();
+    }
+
+    @Override
+    public List<Aksjonspunkt> lagreAksjonspunkterFunnet(Behandling behandling, BehandlingLås skriveLås,
+                                                        List<AksjonspunktDefinisjon> aksjonspunkter) {
+        var aksjonspunktResultater = aksjonspunkter.stream().map(AksjonspunktResultat::opprettForAksjonspunkt).toList();
+        var endret = internLagreAksjonspunktResultat(behandling, skriveLås, null, aksjonspunktResultater);
+        return endret.stream()
+            .filter(a -> aksjonspunkter.contains(a.getAksjonspunktDefinisjon()))
+            .toList();
+    }
+
+    @Override
+    public List<Aksjonspunkt> lagreAksjonspunkterFunnet(Behandling behandling, BehandlingLås skriveLås,
+                                                        BehandlingStegType behandlingStegType,
+                                                        List<AksjonspunktDefinisjon> aksjonspunkter) {
+        var aksjonspunktResultater = aksjonspunkter.stream().map(AksjonspunktResultat::opprettForAksjonspunkt).toList();
+        var endret = internLagreAksjonspunktResultat(behandling, skriveLås, behandlingStegType, aksjonspunktResultater);
+        return endret.stream()
+            .filter(a -> aksjonspunkter.contains(a.getAksjonspunktDefinisjon()))
+            .toList();
+    }
+
+    @Override
+    public void lagreAksjonspunkterUtført(Behandling behandling, BehandlingLås skriveLås, Aksjonspunkt aksjonspunkt, String begrunnelse) {
+        Objects.requireNonNull(aksjonspunkt);
+        if (aksjonspunkt.erAutopunkt()) {
+            throw new IllegalArgumentException("Utviklerfeil: aksjonspunkt er autopunkt " + aksjonspunkt.getAksjonspunktDefinisjon());
+        }
+        List<Aksjonspunkt> utførte = new ArrayList<>();
+
+        if (!aksjonspunkt.erUtført() || !Objects.equals(aksjonspunkt.getBegrunnelse(), begrunnelse)) {
+            aksjonspunktKontrollRepository.setTilUtført(aksjonspunkt, begrunnelse);
+            utførte.add(aksjonspunkt);
+        }
+
+        behandlingRepository.lagre(behandling, skriveLås);
+        aksjonspunkterEndretStatus(behandling, utførte);
+    }
+
+    @Override
+    public void lagreAksjonspunkterAvbrutt(Behandling behandling, BehandlingLås skriveLås, List<Aksjonspunkt> aksjonspunkter) {
+        var aksjonspunktResultater = aksjonspunkter.stream()
+            .filter(a -> !a.erAvbrutt())
+            .map(a -> AksjonspunktResultat.opprettForAksjonspunkt(a.getAksjonspunktDefinisjon(), AksjonspunktStatus.AVBRUTT))
+            .toList();
+        internLagreAksjonspunktResultat(behandling, skriveLås, null, aksjonspunktResultater);
+    }
+
+    @Override
+    public void lagreAksjonspunkterReåpnet(Behandling behandling, BehandlingLås skriveLås, List<Aksjonspunkt> aksjonspunkter) {
+        var aksjonspunktResultater = aksjonspunkter.stream()
+            .filter(a -> !a.erOpprettet())
+            .map(Aksjonspunkt::getAksjonspunktDefinisjon)
+            .map(AksjonspunktResultat::opprettForAksjonspunkt)
+            .toList();
+        internLagreAksjonspunktResultat(behandling, skriveLås, null, aksjonspunktResultater);
+    }
+
+
+    @Override
+    public void lagreAksjonspunktResultat(Behandling behandling, BehandlingLås skriveLås, BehandlingStegType behandlingStegType,
+            List<AksjonspunktResultat> aksjonspunktResultater) {
+        internLagreAksjonspunktResultat(behandling, skriveLås, behandlingStegType, aksjonspunktResultater);
+    }
+
+    @Override
+    public void setAksjonspunkterToTrinn(Behandling behandling, BehandlingLås skriveLås, List<Aksjonspunkt> aksjonspunkter, boolean totrinn) {
+        var skalEndres = aksjonspunkter.stream()
+            .filter(a -> a.isToTrinnsBehandling() != totrinn)
+            .toList();
+        if (skalEndres.isEmpty()) {
+            return;
+        }
+        for (var aksjonspunkt : aksjonspunkter) {
+            if (!aksjonspunkt.erÅpentAksjonspunkt()) {
+                aksjonspunktKontrollRepository.setReåpnet(aksjonspunkt);
+            }
+            aksjonspunktKontrollRepository.setToTrinnsBehandlingKreves(aksjonspunkt, totrinn);
+        }
+        behandlingRepository.lagre(behandling, skriveLås);
+        aksjonspunkterEndretStatus(behandling, skalEndres);
+    }
+
+    private List<Aksjonspunkt> internLagreAksjonspunktResultat(Behandling behandling, BehandlingLås skriveLås,
+                                                               BehandlingStegType behandlingStegType,
+                                                               List<AksjonspunktResultat> aksjonspunktResultater) {
+        if (aksjonspunktResultater.stream().map(AksjonspunktResultat::getAksjonspunktDefinisjon).anyMatch(AksjonspunktDefinisjon::erAutopunkt)) {
+            throw new IllegalArgumentException("Utviklerfeil: aksjonspunktResultater inneholder autopunkt "
+                + aksjonspunktResultater.stream().map(AksjonspunktResultat::getAksjonspunktDefinisjon).toList());
+        }
+        var apHåndterer = new AksjonspunktResultatOppretter(aksjonspunktKontrollRepository, behandling);
+        var endret = apHåndterer.opprettAksjonspunkter(aksjonspunktResultater, behandlingStegType);
+        behandlingRepository.lagre(behandling, skriveLås);
+        aksjonspunkterEndretStatus(behandling, endret);
+        return endret;
+    }
+
+    void aksjonspunkterEndretStatus(Behandling behandling, List<Aksjonspunkt> aksjonspunkter) {
+        // handlinger som skal skje når funnet
+        if (!aksjonspunkter.isEmpty()) {
+            eventPubliserer.fireEvent(new AksjonspunktStatusEvent(behandling, aksjonspunkter));
+        }
+    }
+}

--- a/domenetjenester/behandlingskontroll/src/test/java/no/nav/foreldrepenger/behandlingskontroll/impl/BehandlingModellTest.java
+++ b/domenetjenester/behandlingskontroll/src/test/java/no/nav/foreldrepenger/behandlingskontroll/impl/BehandlingModellTest.java
@@ -317,13 +317,13 @@ class BehandlingModellTest {
     }
 
     private BehandlingStegVisitorUtenLagring lagVisitor(Behandling behandling) {
-        var kontekst = kontrollTjeneste.initBehandlingskontroll(behandling);
+        var kontekst = kontrollTjeneste.initBehandlingskontroll(behandling, serviceProvider.taLås(behandling.getId()));
         var lokalServiceProvider = new BehandlingskontrollServiceProvider(serviceProvider.getEntityManager(), null);
         return new BehandlingStegVisitorUtenLagring(lokalServiceProvider, kontekst);
     }
 
     private BehandlingStegVisitorVenterUtenLagring lagVisitorVenter(Behandling behandling) {
-        var kontekst = kontrollTjeneste.initBehandlingskontroll(behandling);
+        var kontekst = kontrollTjeneste.initBehandlingskontroll(behandling, serviceProvider.taLås(behandling.getId()));
         var lokalServiceProvider = new BehandlingskontrollServiceProvider(serviceProvider.getEntityManager(), null);
         return new BehandlingStegVisitorVenterUtenLagring(lokalServiceProvider, kontekst);
     }

--- a/domenetjenester/behandlingskontroll/src/test/java/no/nav/foreldrepenger/behandlingskontroll/impl/BehandlingskontrollEventPublisererTest.java
+++ b/domenetjenester/behandlingskontroll/src/test/java/no/nav/foreldrepenger/behandlingskontroll/impl/BehandlingskontrollEventPublisererTest.java
@@ -66,17 +66,15 @@ class BehandlingskontrollEventPublisererTest {
         var scenario = TestScenario.forEngangsstønad();
         var behandling = scenario.lagre(serviceProvider);
 
-        var kontekst = kontrollTjeneste.initBehandlingskontroll(behandling);
+        var kontekst = kontrollTjeneste.initBehandlingskontroll(behandling, serviceProvider.taLås(behandling.getId()));
 
         var stegType = BehandlingStegType.SØKERS_RELASJON_TIL_BARN;
 
         var aksjonspunkt = serviceProvider.getAksjonspunktKontrollRepository().leggTilAksjonspunkt(behandling,
                 AksjonspunktDefinisjon.AUTO_MANUELT_SATT_PÅ_VENT, stegType);
-        kontrollTjeneste.aksjonspunkterEndretStatus(kontekst, List.of(aksjonspunkt));
+        kontrollTjeneste.autopunkterEndretStatus(kontekst, List.of(aksjonspunkt));
 
-        var ads = new AksjonspunktDefinisjon[]{AksjonspunktDefinisjon.AUTO_MANUELT_SATT_PÅ_VENT};
-        assertThat(ads).isNotNull();
-        TestEventObserver.containsExactly(ads);
+        TestEventObserver.containsExactly(AksjonspunktDefinisjon.AUTO_MANUELT_SATT_PÅ_VENT);
     }
 
     @Test
@@ -86,7 +84,7 @@ class BehandlingskontrollEventPublisererTest {
 
         var behandling = scenario.lagre(serviceProvider);
 
-        var kontekst = kontrollTjeneste.initBehandlingskontroll(behandling);
+        var kontekst = kontrollTjeneste.initBehandlingskontroll(behandling, serviceProvider.taLås(behandling.getId()));
 
         // Act
         kontrollTjeneste.prosesserBehandling(kontekst);
@@ -108,7 +106,7 @@ class BehandlingskontrollEventPublisererTest {
 
         var behandling = scenario.lagre(serviceProvider);
 
-        var kontekst = kontrollTjeneste.initBehandlingskontroll(behandling);
+        var kontekst = kontrollTjeneste.initBehandlingskontroll(behandling, serviceProvider.taLås(behandling.getId()));
 
         // Act
         kontrollTjeneste.prosesserBehandling(kontekst);
@@ -145,7 +143,7 @@ class BehandlingskontrollEventPublisererTest {
 
         var behandling = scenario.lagre(serviceProvider);
 
-        var kontekst = kontrollTjeneste.initBehandlingskontroll(behandling);
+        var kontekst = kontrollTjeneste.initBehandlingskontroll(behandling, serviceProvider.taLås(behandling.getId()));
 
         // Act
         kontrollTjeneste.prosesserBehandling(kontekst);
@@ -164,7 +162,7 @@ class BehandlingskontrollEventPublisererTest {
 
         var behandling = scenario.lagre(serviceProvider);
 
-        var kontekst = kontrollTjeneste.initBehandlingskontroll(behandling);
+        var kontekst = kontrollTjeneste.initBehandlingskontroll(behandling, serviceProvider.taLås(behandling.getId()));
 
         // Act
         kontrollTjeneste.prosesserBehandling(kontekst);
@@ -185,7 +183,7 @@ class BehandlingskontrollEventPublisererTest {
 
         var behandling = scenario.lagre(serviceProvider);
 
-        var kontekst = kontrollTjeneste.initBehandlingskontroll(behandling);
+        var kontekst = kontrollTjeneste.initBehandlingskontroll(behandling, serviceProvider.taLås(behandling.getId()));
 
         // Act
         kontrollTjeneste.prosesserBehandling(kontekst);

--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/Behandlingsoppretter.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/Behandlingsoppretter.java
@@ -147,7 +147,8 @@ public class Behandlingsoppretter {
     }
 
     public void henleggBehandling(Behandling behandling) {
-        var kontekst = behandlingskontrollTjeneste.initBehandlingskontroll(behandling);
+        var lås = behandlingRepository.taSkriveLås(behandling);
+        var kontekst = behandlingskontrollTjeneste.initBehandlingskontroll(behandling, lås);
         behandlingskontrollTjeneste.taBehandlingAvVentSetAlleAutopunktUtførtForHenleggelse(behandling, kontekst);
         behandlingskontrollTjeneste.henleggBehandling(kontekst, BehandlingResultatType.MERGET_OG_HENLAGT);
     }

--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/dokumentmottak/impl/DokumentmottakerEndringssøknad.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/dokumentmottak/impl/DokumentmottakerEndringssøknad.java
@@ -57,7 +57,8 @@ class DokumentmottakerEndringssøknad extends DokumentmottakerYtelsesesrelatertD
             // Oppdater åpen behandling med Endringssøknad
             dokumentmottakerFelles.leggTilBehandlingsårsak(behandling, brukÅrsakType);
             if (!mottattDokument.getElektroniskRegistrert()) {
-                kompletthetskontroller.flyttTilbakeTilRegistreringPapirsøknad(behandling);
+                var lås = behandlingRepository.taSkriveLås(behandling.getId());
+                kompletthetskontroller.flyttTilbakeTilRegistreringPapirsøknad(behandling, lås);
                 return;
             }
             kompletthetskontroller.persisterDokumentOgVurderKompletthet(behandling, mottattDokument);

--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/dokumentmottak/impl/DokumentmottakerSøknad.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/dokumentmottak/impl/DokumentmottakerSøknad.java
@@ -49,8 +49,9 @@ public abstract class DokumentmottakerSøknad extends DokumentmottakerYtelsesesr
             }
             if (!mottattDokument.getElektroniskRegistrert()) { //#S3a
                 if (kompletthetskontroller.støtterBehandlingstypePapirsøknad(behandling)) {
+                    var lås = behandlingRepository.taSkriveLås(behandling.getId());
                     dokumentmottakerFelles.oppdaterMottattDokumentMedBehandling(mottattDokument, behandling.getId());
-                    kompletthetskontroller.flyttTilbakeTilRegistreringPapirsøknad(behandling);
+                    kompletthetskontroller.flyttTilbakeTilRegistreringPapirsøknad(behandling, lås);
                 } else { //#S3b
                     dokumentmottakerFelles.opprettTaskForÅVurdereDokument(fagsak, behandling, mottattDokument);
                 }

--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/dokumentmottak/impl/Kompletthetskontroller.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/dokumentmottak/impl/Kompletthetskontroller.java
@@ -22,6 +22,7 @@ import no.nav.foreldrepenger.behandlingslager.behandling.MottattDokument;
 import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.Aksjonspunkt;
 import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.AksjonspunktDefinisjon;
 import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.AksjonspunktType;
+import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingLås;
 import no.nav.foreldrepenger.behandlingsprosess.prosessering.BehandlingProsesseringTjeneste;
 import no.nav.foreldrepenger.domene.registerinnhenting.impl.Endringskontroller;
 import no.nav.foreldrepenger.kompletthet.KompletthetResultat;
@@ -122,11 +123,11 @@ public class Kompletthetskontroller {
         }
     }
 
-    void flyttTilbakeTilRegistreringPapirsøknad(Behandling behandling) {
+    void flyttTilbakeTilRegistreringPapirsøknad(Behandling behandling, BehandlingLås lås) {
         if (behandling.isBehandlingPåVent()) {
             behandlingProsesseringTjeneste.taBehandlingAvVent(behandling);
         }
-        behandlingProsesseringTjeneste.reposisjonerBehandlingTilbakeTil(behandling, BehandlingStegType.REGISTRER_SØKNAD);
+        behandlingProsesseringTjeneste.reposisjonerBehandlingTilbakeTil(behandling, lås, BehandlingStegType.REGISTRER_SØKNAD);
         dokumentmottakerFelles.opprettTaskForÅStarteBehandling(behandling);
     }
 

--- a/domenetjenester/mottak/src/test/java/no/nav/foreldrepenger/mottak/dokumentmottak/impl/DokumentmottakerSøknadDefaultTest.java
+++ b/domenetjenester/mottak/src/test/java/no/nav/foreldrepenger/mottak/dokumentmottak/impl/DokumentmottakerSøknadDefaultTest.java
@@ -183,7 +183,7 @@ class DokumentmottakerSøknadDefaultTest extends EntityManagerAwareTest {
 
         // Assert
         verify(dokumentmottaker).oppdaterÅpenBehandlingMedDokument(behandling, mottattDokument, null);
-        verify(kompletthetskontroller).flyttTilbakeTilRegistreringPapirsøknad(behandling);
+        verify(kompletthetskontroller).flyttTilbakeTilRegistreringPapirsøknad(eq(behandling), any());
     }
 
     @Test

--- a/domenetjenester/registerinnhenting/src/test/java/no/nav/foreldrepenger/domene/registerinnhenting/RegisterdataEndringshåndtererTest.java
+++ b/domenetjenester/registerinnhenting/src/test/java/no/nav/foreldrepenger/domene/registerinnhenting/RegisterdataEndringshåndtererTest.java
@@ -121,7 +121,7 @@ class RegisterdataEndringshåndtererTest extends EntityManagerAwareTest {
             .utledDiffOgReposisjonerBehandlingVedEndringer(behandling, snapshotFør, false);
 
         // Assert
-        verify(endringskontroller, times(1)).spolTilStartpunkt(any(Behandling.class), any(), any());
+        verify(endringskontroller, times(1)).spolTilStartpunkt(any(Behandling.class), any(), any(), any());
     }
 
     @Test
@@ -183,7 +183,7 @@ class RegisterdataEndringshåndtererTest extends EntityManagerAwareTest {
             .utledDiffOgReposisjonerBehandlingVedEndringer(behandling, null, false);
 
         // Assert
-        verify(endringskontroller, times(1)).spolTilStartpunkt(any(Behandling.class), any(EndringsresultatDiff.class), eq(StartpunktType.SØKERS_RELASJON_TIL_BARNET));
+        verify(endringskontroller, times(1)).spolTilStartpunkt(any(Behandling.class), any(), any(EndringsresultatDiff.class), eq(StartpunktType.SØKERS_RELASJON_TIL_BARNET));
     }
 
     @Test

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/arbeidInntektsmelding/ArbeidOgInntektsmeldingProsessTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/arbeidInntektsmelding/ArbeidOgInntektsmeldingProsessTjeneste.java
@@ -5,7 +5,7 @@ import java.util.List;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 
-import no.nav.foreldrepenger.behandlingskontroll.BehandlingskontrollTjeneste;
+import no.nav.foreldrepenger.behandlingskontroll.AksjonspunktkontrollTjeneste;
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingStatus;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingStegType;
@@ -22,7 +22,7 @@ public class ArbeidOgInntektsmeldingProsessTjeneste {
     private BehandlingRepository behandlingRepository;
     private BehandlingsutredningTjeneste behandlingsutredningTjeneste;
     private BehandlingProsesseringTjeneste behandlingProsesseringTjeneste;
-    private BehandlingskontrollTjeneste behandlingskontrollTjeneste;
+    private AksjonspunktkontrollTjeneste aksjonspunktkontrollTjeneste;
 
     ArbeidOgInntektsmeldingProsessTjeneste() {
         // CDI
@@ -32,11 +32,11 @@ public class ArbeidOgInntektsmeldingProsessTjeneste {
     ArbeidOgInntektsmeldingProsessTjeneste(BehandlingRepository behandlingRepository,
                                            BehandlingsutredningTjeneste behandlingsutredningTjeneste,
                                            BehandlingProsesseringTjeneste behandlingProsesseringTjeneste,
-                                           BehandlingskontrollTjeneste behandlingskontrollTjeneste) {
+                                           AksjonspunktkontrollTjeneste aksjonspunktkontrollTjeneste) {
         this.behandlingRepository = behandlingRepository;
         this.behandlingsutredningTjeneste = behandlingsutredningTjeneste;
         this.behandlingProsesseringTjeneste = behandlingProsesseringTjeneste;
-        this.behandlingskontrollTjeneste = behandlingskontrollTjeneste;
+        this.aksjonspunktkontrollTjeneste = aksjonspunktkontrollTjeneste;
     }
 
     public void tillTilbakeOgOpprettAksjonspunkt(BehandlingIdVersjonDto dto, boolean erOverstyringSomLagerAP) {
@@ -47,9 +47,9 @@ public class ArbeidOgInntektsmeldingProsessTjeneste {
         validerAtOperasjonErLovlig(behandling, erOverstyringSomLagerAP);
 
         behandlingsutredningTjeneste.kanEndreBehandling(behandling, dto.getBehandlingVersjon());
-        var kontekst = behandlingskontrollTjeneste.initBehandlingskontroll(behandling, lås);
-        behandlingProsesseringTjeneste.reposisjonerBehandlingTilbakeTil(behandling, BehandlingStegType.KONTROLLER_FAKTA_ARBEIDSFORHOLD_INNTEKTSMELDING);
-        behandlingskontrollTjeneste.lagreAksjonspunkterFunnet(kontekst, List.of(AksjonspunktDefinisjon.VURDER_ARBEIDSFORHOLD_INNTEKTSMELDING));
+        behandlingProsesseringTjeneste.reposisjonerBehandlingTilbakeTil(behandling, lås, BehandlingStegType.KONTROLLER_FAKTA_ARBEIDSFORHOLD_INNTEKTSMELDING);
+        aksjonspunktkontrollTjeneste.lagreAksjonspunkterFunnet(behandling, lås, BehandlingStegType.KONTROLLER_FAKTA_ARBEIDSFORHOLD_INNTEKTSMELDING,
+            List.of(AksjonspunktDefinisjon.VURDER_ARBEIDSFORHOLD_INNTEKTSMELDING));
         behandlingProsesseringTjeneste.opprettTasksForFortsettBehandling(behandling);
     }
 

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/klage/KlageRestTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/klage/KlageRestTjeneste.java
@@ -132,6 +132,7 @@ public class KlageRestTjeneste {
 
         var vurdertAv = AksjonspunktDefinisjon.MANUELL_VURDERING_AV_KLAGE_NFP.getKode().equals(apDto.getKode()) ? KlageVurdertAv.NFP
                 : KlageVurdertAv.NK;
+        var lås = behandlingRepository.taSkriveLås(apDto.getBehandlingUuid());
         var behandling = behandlingRepository.hentBehandling(apDto.getBehandlingUuid());
         var builder = klageVurderingTjeneste.hentKlageVurderingResultatBuilder(behandling, vurdertAv);
 
@@ -151,7 +152,7 @@ public class KlageRestTjeneste {
 
         builder.medFritekstTilBrev(apDto.getFritekstTilBrev());
 
-        klageVurderingTjeneste.lagreKlageVurderingResultat(behandling, builder, vurdertAv);
+        klageVurderingTjeneste.lagreKlageVurderingResultat(behandling, lås, builder, vurdertAv);
         return Response.ok().build();
     }
 
@@ -173,6 +174,7 @@ public class KlageRestTjeneste {
 
         var vurdertAv = AksjonspunktDefinisjon.VURDERING_AV_FORMKRAV_KLAGE_NFP.getKode().equals(apDto.getKode()) ? KlageVurdertAv.NFP
             : KlageVurdertAv.NK;
+        var lås = behandlingRepository.taSkriveLås(apDto.behandlingUuid());
         var behandling = behandlingRepository.hentBehandling(apDto.behandlingUuid());
         var klageResultat = klageVurderingTjeneste.hentEvtOpprettKlageResultat(behandling);
         var lagretFormkrav = klageVurderingTjeneste.hentKlageFormkrav(behandling, vurdertAv);
@@ -196,7 +198,7 @@ public class KlageRestTjeneste {
 
         vurderingResultatBuilder.medFritekstTilBrev(apDto.fritekstTilBrev());
 
-        klageVurderingTjeneste.lagreKlageVurderingResultat(behandling, vurderingResultatBuilder, vurdertAv);
+        klageVurderingTjeneste.lagreKlageVurderingResultat(behandling, lås, vurderingResultatBuilder, vurdertAv);
         return Response.ok().build();
     }
 

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/klage/aksjonspunkt/KlageFormkravOppdaterer.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/klage/aksjonspunkt/KlageFormkravOppdaterer.java
@@ -2,6 +2,7 @@ package no.nav.foreldrepenger.web.app.tjenester.behandling.klage.aksjonspunkt;
 
 import static no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.AksjonspunktDefinisjon.VURDERING_AV_FORMKRAV_KLAGE_NFP;
 
+import java.util.List;
 import java.util.Optional;
 
 import jakarta.enterprise.context.ApplicationScoped;
@@ -14,7 +15,7 @@ import no.nav.foreldrepenger.behandling.aksjonspunkt.AksjonspunktOppdateringTran
 import no.nav.foreldrepenger.behandling.aksjonspunkt.DtoTilServiceAdapter;
 import no.nav.foreldrepenger.behandling.aksjonspunkt.OppdateringResultat;
 import no.nav.foreldrepenger.behandling.klage.KlageVurderingTjeneste;
-import no.nav.foreldrepenger.behandlingskontroll.BehandlingskontrollTjeneste;
+import no.nav.foreldrepenger.behandlingskontroll.AksjonspunktkontrollTjeneste;
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingÅrsak;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingÅrsakType;
@@ -25,6 +26,7 @@ import no.nav.foreldrepenger.behandlingslager.behandling.klage.KlageAvvistÅrsak
 import no.nav.foreldrepenger.behandlingslager.behandling.klage.KlageResultatEntitet;
 import no.nav.foreldrepenger.behandlingslager.behandling.klage.KlageVurdering;
 import no.nav.foreldrepenger.behandlingslager.behandling.klage.KlageVurdertAv;
+import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingLås;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepository;
 
 @ApplicationScoped
@@ -33,7 +35,7 @@ public class KlageFormkravOppdaterer implements AksjonspunktOppdaterer<KlageForm
 
     private KlageVurderingTjeneste klageVurderingTjeneste;
     private BehandlingRepository behandlingRepository;
-    private BehandlingskontrollTjeneste behandlingskontrollTjeneste;
+    private AksjonspunktkontrollTjeneste aksjonspunktkontrollTjeneste;
     private BehandlingEventPubliserer eventPubliserer;
 
     private KlageHistorikkinnslag klageFormkravHistorikk;
@@ -45,12 +47,12 @@ public class KlageFormkravOppdaterer implements AksjonspunktOppdaterer<KlageForm
     @Inject
     public KlageFormkravOppdaterer(KlageVurderingTjeneste klageVurderingTjeneste,
                                    BehandlingRepository behandlingRepository,
-                                   BehandlingskontrollTjeneste behandlingskontrollTjeneste,
+                                   AksjonspunktkontrollTjeneste aksjonspunktkontrollTjeneste,
                                    BehandlingEventPubliserer eventPubliserer,
                                    KlageHistorikkinnslag klageFormkravHistorikk) {
         this.behandlingRepository = behandlingRepository;
         this.klageVurderingTjeneste = klageVurderingTjeneste;
-        this.behandlingskontrollTjeneste = behandlingskontrollTjeneste;
+        this.aksjonspunktkontrollTjeneste = aksjonspunktkontrollTjeneste;
         this.eventPubliserer = eventPubliserer;
         this.klageFormkravHistorikk = klageFormkravHistorikk;
     }
@@ -59,7 +61,7 @@ public class KlageFormkravOppdaterer implements AksjonspunktOppdaterer<KlageForm
     public OppdateringResultat oppdater(KlageFormkravAksjonspunktDto dto, AksjonspunktOppdaterParameter param) {
         var apDefFormkrav = dto.getAksjonspunktDefinisjon();
         var klageVurdertAv = getKlageVurdertAv(apDefFormkrav);
-
+        var skriveLås = behandlingRepository.taSkriveLås(param.getBehandlingId());
         var klageBehandling = behandlingRepository.hentBehandling(param.getBehandlingId());
         var klageResultat = klageVurderingTjeneste.hentEvtOpprettKlageResultat(klageBehandling);
 
@@ -72,7 +74,7 @@ public class KlageFormkravOppdaterer implements AksjonspunktOppdaterer<KlageForm
         klageFormkravHistorikk.opprettHistorikkinnslagFormkrav(klageBehandling, apDefFormkrav, dto, klageFormkrav, klageResultat, dto.getBegrunnelse());
         var optionalAvvistÅrsak = vurderOgLagreFormkrav(dto, klageBehandling, klageResultat, klageVurdertAv);
         if (optionalAvvistÅrsak.isPresent()) {
-            lagreKlageVurderingResultatMedAvvistKlage(klageBehandling, klageVurdertAv, dto.fritekstTilBrev() != null ? dto.fritekstTilBrev() : null);
+            lagreKlageVurderingResultatMedAvvistKlage(klageBehandling, skriveLås, klageVurdertAv, dto.fritekstTilBrev() != null ? dto.fritekstTilBrev() : null);
             eventPubliserer.publiserBehandlingEvent(new KlageOppdatertEvent(klageBehandling));
             return OppdateringResultat.medFremoverHoppTotrinn(AksjonspunktOppdateringTransisjon.FORESLÅ_VEDTAK);
         }
@@ -80,21 +82,20 @@ public class KlageFormkravOppdaterer implements AksjonspunktOppdaterer<KlageForm
         klageVurderingTjeneste.hentKlageVurderingResultat(klageBehandling, klageVurdertAv).ifPresent(klageVurderingResultat -> {
             if (klageVurderingResultat.getFritekstTilBrev() != null) {
                 var vurderingResultatBuilder = klageVurderingTjeneste.hentKlageVurderingResultatBuilder(klageBehandling, klageVurdertAv).medFritekstTilBrev(null);
-                klageVurderingTjeneste.lagreKlageVurderingResultat(klageBehandling, vurderingResultatBuilder, klageVurdertAv);
+                klageVurderingTjeneste.lagreKlageVurderingResultat(klageBehandling, skriveLås, vurderingResultatBuilder, klageVurdertAv);
             }
         });
         klageBehandling.getÅpentAksjonspunktMedDefinisjonOptional(apDefFormkrav)
             .filter(Aksjonspunkt::isToTrinnsBehandling)
-            .ifPresent(ap -> fjernToTrinnsbehandling(klageBehandling, ap));
+            .ifPresent(ap -> fjernToTrinnsbehandling(klageBehandling, skriveLås, ap));
 
         eventPubliserer.publiserBehandlingEvent(new KlageOppdatertEvent(klageBehandling));
 
         return OppdateringResultat.utenTransisjon().build();
     }
 
-    private void fjernToTrinnsbehandling(Behandling behandling, Aksjonspunkt aksjonspunkt) {
-        var kontekst = behandlingskontrollTjeneste.initBehandlingskontroll(behandling);
-        behandlingskontrollTjeneste.setAksjonspunktToTrinn(kontekst, aksjonspunkt, false);
+    private void fjernToTrinnsbehandling(Behandling behandling, BehandlingLås skriveLås, Aksjonspunkt aksjonspunkt) {
+        aksjonspunktkontrollTjeneste.setAksjonspunkterToTrinn(behandling, skriveLås, List.of(aksjonspunkt), false);
     }
 
     private Optional<KlageAvvistÅrsak> vurderOgLagreFormkrav(KlageFormkravAksjonspunktDto dto,
@@ -147,11 +148,12 @@ public class KlageFormkravOppdaterer implements AksjonspunktOppdaterer<KlageForm
         return Optional.empty();
     }
 
-    private void lagreKlageVurderingResultatMedAvvistKlage(Behandling klageBehandling, KlageVurdertAv vurdertAv, String fritekstTilBrev) {
+    private void lagreKlageVurderingResultatMedAvvistKlage(Behandling klageBehandling, BehandlingLås lås,
+                                                           KlageVurdertAv vurdertAv, String fritekstTilBrev) {
         var builder = klageVurderingTjeneste.hentKlageVurderingResultatBuilder(klageBehandling, vurdertAv)
             .medKlageVurdering(KlageVurdering.AVVIS_KLAGE)
             .medFritekstTilBrev(fritekstTilBrev);
-        klageVurderingTjeneste.oppdaterBekreftetVurderingAksjonspunkt(klageBehandling, builder, vurdertAv);
+        klageVurderingTjeneste.oppdaterBekreftetVurderingAksjonspunkt(klageBehandling, lås, builder, vurdertAv);
     }
 
     private KlageVurdertAv getKlageVurdertAv(AksjonspunktDefinisjon apdef) {

--- a/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/klage/KlageFormkravOppdatererTest.java
+++ b/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/klage/KlageFormkravOppdatererTest.java
@@ -19,7 +19,7 @@ import no.nav.foreldrepenger.behandling.BehandlingEventPubliserer;
 import no.nav.foreldrepenger.behandling.BehandlingReferanse;
 import no.nav.foreldrepenger.behandling.aksjonspunkt.AksjonspunktOppdaterParameter;
 import no.nav.foreldrepenger.behandling.klage.KlageVurderingTjeneste;
-import no.nav.foreldrepenger.behandlingskontroll.BehandlingskontrollTjeneste;
+import no.nav.foreldrepenger.behandlingskontroll.AksjonspunktkontrollTjeneste;
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingStegType;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingType;
@@ -54,7 +54,7 @@ class KlageFormkravOppdatererTest extends EntityManagerAwareTest {
     @Mock
     private BehandlingEventPubliserer eventPubliserer;
     @Mock
-    private BehandlingskontrollTjeneste behandlingskontrollTjeneste;
+    private AksjonspunktkontrollTjeneste aksjonspunktkontrollTjeneste;
 
     private KlageFormkravOppdaterer klageFormkravOppdaterer;
     private Behandling behandling;
@@ -71,7 +71,7 @@ class KlageFormkravOppdatererTest extends EntityManagerAwareTest {
             repositoryProvider.getBehandlingsresultatRepository(), eventPubliserer);
         var formHistorikk = new KlageHistorikkinnslag(repositoryProvider.getHistorikkinnslagRepository(), behandlingRepository,
             repositoryProvider.getBehandlingVedtakRepository(), mockFptilbakeRestKlient);
-        klageFormkravOppdaterer = new KlageFormkravOppdaterer(klageVurderingTjeneste, behandlingRepository, behandlingskontrollTjeneste,
+        klageFormkravOppdaterer = new KlageFormkravOppdaterer(klageVurderingTjeneste, behandlingRepository, aksjonspunktkontrollTjeneste,
             eventPubliserer, formHistorikk);
 
         scenario.leggTilAksjonspunkt(AksjonspunktDefinisjon.MANUELL_VURDERING_AV_KLAGE_NFP, BehandlingStegType.KLAGE_NFP);

--- a/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/klage/KlagevurderingOppdatererTest.java
+++ b/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/klage/KlagevurderingOppdatererTest.java
@@ -19,7 +19,7 @@ import no.nav.foreldrepenger.behandling.BehandlingEventPubliserer;
 import no.nav.foreldrepenger.behandling.BehandlingReferanse;
 import no.nav.foreldrepenger.behandling.aksjonspunkt.AksjonspunktOppdaterParameter;
 import no.nav.foreldrepenger.behandling.klage.KlageVurderingTjeneste;
-import no.nav.foreldrepenger.behandlingskontroll.BehandlingskontrollTjeneste;
+import no.nav.foreldrepenger.behandlingskontroll.AksjonspunktkontrollTjeneste;
 import no.nav.foreldrepenger.behandlingslager.aktør.OrganisasjonsEnhet;
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingResultatType;
@@ -57,7 +57,7 @@ class KlagevurderingOppdatererTest {
     @Mock
     private BehandlingEventPubliserer eventPubliserer;
     @Mock
-    private BehandlingskontrollTjeneste behandlingskontrollTjeneste;
+    private AksjonspunktkontrollTjeneste aksjonspunktkontrollTjeneste;
     @Mock
     private BehandlingProsesseringTjeneste behandlingProsesseringTjeneste;
 
@@ -120,7 +120,7 @@ class KlagevurderingOppdatererTest {
             repositoryProvider.getBehandlingsresultatRepository(), eventPubliserer);
         var klageHistorikk = new KlageHistorikkinnslag(repositoryProvider.getHistorikkinnslagRepository(),
             behandlingRepository, repositoryProvider.getBehandlingVedtakRepository(), mock(FptilbakeRestKlient.class));
-        return new KlagevurderingOppdaterer(klageHistorikk, behandlendeEnhetTjeneste, eventPubliserer, behandlingskontrollTjeneste, klageVurderingTjeneste,
+        return new KlagevurderingOppdaterer(klageHistorikk, behandlendeEnhetTjeneste, eventPubliserer, aksjonspunktkontrollTjeneste, klageVurderingTjeneste,
             behandlingRepository);
     }
 

--- a/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/vedtak/aksjonspunkt/ForeslåOgFatteVedtakAksjonspunktTest.java
+++ b/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/vedtak/aksjonspunkt/ForeslåOgFatteVedtakAksjonspunktTest.java
@@ -13,8 +13,8 @@ import org.junit.jupiter.api.Test;
 
 import no.nav.foreldrepenger.behandling.BehandlingReferanse;
 import no.nav.foreldrepenger.behandling.aksjonspunkt.AksjonspunktOppdaterParameter;
+import no.nav.foreldrepenger.behandlingskontroll.impl.AksjonspunktkontrollTjenesteImpl;
 import no.nav.foreldrepenger.behandlingskontroll.impl.BehandlingskontrollEventPubliserer;
-import no.nav.foreldrepenger.behandlingskontroll.impl.BehandlingskontrollTjenesteImpl;
 import no.nav.foreldrepenger.behandlingskontroll.spi.BehandlingskontrollServiceProvider;
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingStegType;
@@ -59,7 +59,7 @@ class ForeslåOgFatteVedtakAksjonspunktTest extends EntityManagerAwareTest {
     @BeforeEach
     void setup() {
         var em = getEntityManager();
-        var behandlingskontrollTjeneste = new BehandlingskontrollTjenesteImpl(
+        var behandlingskontrollTjeneste = new AksjonspunktkontrollTjenesteImpl(
             new BehandlingskontrollServiceProvider(em, mock(BehandlingskontrollEventPubliserer.class)));
         var lagretVedtakRepository = new LagretVedtakRepository(em);
         repositoryProvider = new BehandlingRepositoryProvider(em);


### PR DESCRIPTION
To ting: 
* Trekker ut lagre-aksjonspunkt-metodene fra behandlingskontroll
* Reduser bruk av initBehandlingkontroll uten lås. Best å ta lås i starten av rest-metode eller task-start.

Neste: Skille ut BehandlingPåVent-metodene og Henlegg-metodene. Rydde Aksjonspunkt-oppretting internt.
