### PR TITLE
TFP-3721 henleggelse - innledene rydding

### DIFF
--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/events/BehandlingHenlagtEvent.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/events/BehandlingHenlagtEvent.java
@@ -1,0 +1,39 @@
+package no.nav.foreldrepenger.behandlingslager.behandling.events;
+
+import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
+import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingEvent;
+import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingResultatType;
+import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingType;
+import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakYtelseType;
+import no.nav.foreldrepenger.domene.typer.Saksnummer;
+
+public record BehandlingHenlagtEvent(Saksnummer saksnummer, Long fagsakId, Long behandlingId, FagsakYtelseType ytelseType,
+                                     BehandlingType behandlingType, BehandlingResultatType behandlingResultatType) implements BehandlingEvent {
+
+    public BehandlingHenlagtEvent(Behandling behandling, BehandlingResultatType behandlingResultatType) {
+        this(behandling.getSaksnummer(), behandling.getFagsakId(), behandling.getId(),
+            behandling.getFagsakYtelseType(), behandling.getType(), behandlingResultatType);
+    }
+
+    public BehandlingHenlagtEvent {
+        if (!behandlingResultatType.erHenlagt()) {
+            throw new IllegalArgumentException("BehandlingResultatType " + behandlingResultatType().getNavn() + " er ikke en henleggelse");
+        }
+    }
+
+    @Override
+    public Long getFagsakId() {
+        return fagsakId;
+    }
+
+    @Override
+    public Saksnummer getSaksnummer() {
+        return saksnummer;
+    }
+
+    @Override
+    public Long getBehandlingId() {
+        return behandlingId;
+    }
+
+}

--- a/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/iverksettevedtak/HenleggBehandlingUtenSøknadTest.java
+++ b/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/iverksettevedtak/HenleggBehandlingUtenSøknadTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.mock;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import no.nav.foreldrepenger.behandling.BehandlingEventPubliserer;
 import no.nav.foreldrepenger.behandlingskontroll.impl.BehandlingskontrollTjenesteImpl;
 import no.nav.foreldrepenger.behandlingskontroll.spi.BehandlingskontrollServiceProvider;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingResultatType;
@@ -18,9 +19,7 @@ import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.Aksjonspun
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepositoryProvider;
 import no.nav.foreldrepenger.behandlingslager.testutilities.behandling.ScenarioMorSøkerForeldrepenger;
 import no.nav.foreldrepenger.dbstoette.EntityManagerAwareTest;
-import no.nav.foreldrepenger.dokumentbestiller.DokumentBestillerTjeneste;
 import no.nav.foreldrepenger.domene.typer.AktørId;
-import no.nav.vedtak.felles.prosesstask.api.ProsessTaskTjeneste;
 
 class HenleggBehandlingUtenSøknadTest extends EntityManagerAwareTest {
 
@@ -34,7 +33,7 @@ class HenleggBehandlingUtenSøknadTest extends EntityManagerAwareTest {
         var serviceProvider = new BehandlingskontrollServiceProvider(getEntityManager(), null);
         var behandlingskontrollTjenesteImpl = new BehandlingskontrollTjenesteImpl(serviceProvider);
         henleggBehandlingTjeneste = new HenleggBehandlingTjeneste(repositoryProvider, behandlingskontrollTjenesteImpl,
-                mock(DokumentBestillerTjeneste.class), mock(ProsessTaskTjeneste.class));
+                mock(BehandlingEventPubliserer.class));
     }
 
     @Test
@@ -47,7 +46,7 @@ class HenleggBehandlingUtenSøknadTest extends EntityManagerAwareTest {
         var behandling = scenario.lagre(repositoryProvider);
         forceOppdaterBehandlingSteg(behandling, BehandlingStegType.REGISTRER_SØKNAD);
         var behandlingsresultat = BehandlingResultatType.HENLAGT_SØKNAD_TRUKKET;
-        henleggBehandlingTjeneste.henleggBehandling(behandling.getId(), behandlingsresultat, "begrunnelse");
+        henleggBehandlingTjeneste.henleggBehandlingManuell(behandling.getId(), behandlingsresultat, "begrunnelse");
         assertThat(behandling.getAksjonspunkter()).hasSize(1);
         assertThat(behandling.getAksjonspunkter().stream().map(Aksjonspunkt::getStatus).filter(AksjonspunktStatus.AVBRUTT::equals).count())
                 .isEqualTo(1);

--- a/domenetjenester/behandling-klage/src/main/java/no/nav/foreldrepenger/behandling/kabal/MottaFraKabalTask.java
+++ b/domenetjenester/behandling-klage/src/main/java/no/nav/foreldrepenger/behandling/kabal/MottaFraKabalTask.java
@@ -100,7 +100,7 @@ public class MottaFraKabalTask extends BehandlingProsessTask {
         }
         if (KabalUtfall.TRUKKET.equals(utfall) || KabalUtfall.HEVET.equals(utfall)) {
             if (klageBehandling.isBehandlingPåVent()) {
-                behandlingskontrollTjeneste.taBehandlingAvVentSetAlleAutopunktUtførtForHenleggelse(klageBehandling, kontekst);
+                behandlingskontrollTjeneste.taBehandlingAvVentSetAlleAutopunktAvbruttForHenleggelse(klageBehandling, kontekst);
             }
             if (erIkkeHenlagt(klageBehandling)) {
                 behandlingskontrollTjeneste.henleggBehandling(kontekst, BehandlingResultatType.HENLAGT_KLAGE_TRUKKET);
@@ -170,7 +170,7 @@ public class MottaFraKabalTask extends BehandlingProsessTask {
         kabalTjeneste.settKabalReferanse(ankeBehandling, ref);
         if (KabalUtfall.TRUKKET.equals(utfall) || KabalUtfall.HEVET.equals(utfall)) {
             if (ankeBehandling.isBehandlingPåVent()) {
-                behandlingskontrollTjeneste.taBehandlingAvVentSetAlleAutopunktUtførtForHenleggelse(ankeBehandling, kontekst);
+                behandlingskontrollTjeneste.taBehandlingAvVentSetAlleAutopunktAvbruttForHenleggelse(ankeBehandling, kontekst);
             }
             if (erIkkeHenlagt(ankeBehandling)) {
                 behandlingskontrollTjeneste.henleggBehandling(kontekst, BehandlingResultatType.HENLAGT_ANKE_TRUKKET);
@@ -202,7 +202,7 @@ public class MottaFraKabalTask extends BehandlingProsessTask {
         var kontekst = behandlingskontrollTjeneste.initBehandlingskontroll(behandling, lås);
         kabalTjeneste.settKabalReferanse(behandling, ref);
         if (behandling.isBehandlingPåVent()) {
-            behandlingskontrollTjeneste.taBehandlingAvVentSetAlleAutopunktUtførtForHenleggelse(behandling, kontekst);
+            behandlingskontrollTjeneste.taBehandlingAvVentSetAlleAutopunktAvbruttForHenleggelse(behandling, kontekst);
         }
         if (erIkkeHenlagt(behandling)) {
             behandlingskontrollTjeneste.henleggBehandling(kontekst, BehandlingResultatType.HENLAGT_FEILOPPRETTET);

--- a/domenetjenester/behandling/src/main/java/no/nav/foreldrepenger/behandling/aksjonspunkt/OppdateringResultat.java
+++ b/domenetjenester/behandling/src/main/java/no/nav/foreldrepenger/behandling/aksjonspunkt/OppdateringResultat.java
@@ -4,8 +4,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
-import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingResultatType;
-import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingStegType;
 import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.AksjonspunktDefinisjon;
 import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.AksjonspunktStatus;
 import no.nav.foreldrepenger.behandlingslager.behandling.vilkår.Avslagsårsak;
@@ -16,35 +14,23 @@ public class OppdateringResultat {
 
     private static final String MULTI_ENDRING = "Kan ikke fjerne vilkårtype med resultat som er lagt til i samme transisjon";
 
-    private BehandlingStegType nesteSteg;
     private final List<VilkårType> vilkårTyperNyeIkkeVurdert = new ArrayList<>();
     private final List<VilkårOppdateringResultat> vilkårUtfallSomSkalLeggesTil = new ArrayList<>();
     private final List<VilkårType> vilkårTyperSomSkalFjernes = new ArrayList<>(); // Eksisterer for å håndtere vilkåropprydding for Omsorg
     private OverhoppKontroll overhoppKontroll;
-    private BehandlingResultatType henleggelseResultat;
-    private String henleggingsbegrunnelse;
     private boolean beholdAksjonspunktÅpent = false;
     private boolean totrinnsKontroll = false;
     private AksjonspunktOppdateringTransisjon transisjon;
     private final List<OppdateringAksjonspunktResultat> ekstraAksjonspunktResultat = new ArrayList<>();
 
-    private OppdateringResultat(BehandlingStegType nesteSteg, OverhoppKontroll overhoppKontroll, AksjonspunktOppdateringTransisjon transisjon,
-            boolean totrinn) {
+    private OppdateringResultat(OverhoppKontroll overhoppKontroll, AksjonspunktOppdateringTransisjon transisjon, boolean totrinn) {
         this.overhoppKontroll = overhoppKontroll;
-        this.nesteSteg = nesteSteg;
         this.transisjon = transisjon;
         this.totrinnsKontroll = totrinn;
     }
 
     private OppdateringResultat(OverhoppKontroll overhoppKontroll) {
         this.overhoppKontroll = overhoppKontroll;
-        this.nesteSteg = null;
-    }
-
-    private OppdateringResultat(OverhoppKontroll overhoppKontroll, BehandlingResultatType henleggelseResultat, String henleggingsbegrunnelse) {
-        this.overhoppKontroll = overhoppKontroll;
-        this.henleggelseResultat = henleggelseResultat;
-        this.henleggingsbegrunnelse = henleggingsbegrunnelse;
     }
 
     /**
@@ -66,7 +52,7 @@ public class OppdateringResultat {
      * Brukes typisk ved avslag på Vilår for å hoppe fram til uttak/vedtak
      */
     public static OppdateringResultat medFremoverHopp(AksjonspunktOppdateringTransisjon transisjon) {
-        return new OppdateringResultat(null, OverhoppKontroll.FREMOVERHOPP, transisjon, false);
+        return new OppdateringResultat(OverhoppKontroll.FREMOVERHOPP, transisjon, false);
     }
 
     /**
@@ -74,19 +60,7 @@ public class OppdateringResultat {
      * setter totrinnskontroll
      */
     public static OppdateringResultat medFremoverHoppTotrinn(AksjonspunktOppdateringTransisjon transisjon) {
-        return new OppdateringResultat(null, OverhoppKontroll.FREMOVERHOPP, transisjon, true);
-    }
-
-    /**
-     * Vil avbryte alle åpne aksjonspunkt hoppe til iverksetting og avslutte uten
-     * vedtak
-     */
-    public static OppdateringResultat medHenleggelse(BehandlingResultatType henleggelseResultat, String henleggingsbegrunnelse) {
-        return new OppdateringResultat(OverhoppKontroll.HENLEGGELSE, henleggelseResultat, henleggingsbegrunnelse);
-    }
-
-    public BehandlingStegType getNesteSteg() {
-        return nesteSteg;
+        return new OppdateringResultat(OverhoppKontroll.FREMOVERHOPP, transisjon, true);
     }
 
     public AksjonspunktOppdateringTransisjon getTransisjon() {
@@ -95,14 +69,6 @@ public class OppdateringResultat {
 
     public OverhoppKontroll getOverhoppKontroll() {
         return overhoppKontroll;
-    }
-
-    public BehandlingResultatType getHenleggelseResultat() {
-        return henleggelseResultat;
-    }
-
-    public String getHenleggingsbegrunnelse() {
-        return henleggingsbegrunnelse;
     }
 
     public boolean skalUtføreAksjonspunkt() {
@@ -142,10 +108,6 @@ public class OppdateringResultat {
         public Builder medBeholdAksjonspunktÅpent(boolean holdÅpent) {
             resultat.beholdAksjonspunktÅpent = holdÅpent;
             return this;
-        }
-
-        public Builder medBeholdAksjonspunktÅpent() {
-            return medBeholdAksjonspunktÅpent(true);
         }
 
         public Builder leggTilIkkeVurdertVilkår(VilkårType vilkårType) {
@@ -259,11 +221,8 @@ public class OppdateringResultat {
     @Override
     public String toString() {
         return "OppdateringResultat{" +
-                "nesteSteg=" + nesteSteg +
-                ", transisjon=" + transisjon +
+                "transisjon=" + transisjon +
                 ", overhoppKontroll=" + overhoppKontroll +
-                ", henleggelseResultat=" + henleggelseResultat +
-                ", henleggingsbegrunnelse='" + henleggingsbegrunnelse + '\'' +
                 '}';
     }
 }

--- a/domenetjenester/behandling/src/main/java/no/nav/foreldrepenger/behandling/aksjonspunkt/OverhoppKontroll.java
+++ b/domenetjenester/behandling/src/main/java/no/nav/foreldrepenger/behandling/aksjonspunkt/OverhoppKontroll.java
@@ -3,6 +3,5 @@ package no.nav.foreldrepenger.behandling.aksjonspunkt;
 public enum OverhoppKontroll {
     UTEN_OVERHOPP,
     FREMOVERHOPP,
-    OPPDATER,
-    HENLEGGELSE
+    OPPDATER
 }

--- a/domenetjenester/behandling/src/main/java/no/nav/foreldrepenger/behandling/aksjonspunkt/OverhoppResultat.java
+++ b/domenetjenester/behandling/src/main/java/no/nav/foreldrepenger/behandling/aksjonspunkt/OverhoppResultat.java
@@ -32,12 +32,6 @@ public class OverhoppResultat {
                 .findFirst();
     }
 
-    public Optional<OppdateringResultat> finnHenleggelse() {
-        return oppdatereResultater.stream()
-                .filter(delresultat -> delresultat.getOverhoppKontroll().equals(OverhoppKontroll.HENLEGGELSE))
-                .findFirst();
-    }
-
     public Set<OppdateringAksjonspunktResultat> finnEkstraAksjonspunktResultat() {
         return oppdatereResultater.stream()
             .map(OppdateringResultat::getEkstraAksjonspunktResultat)

--- a/domenetjenester/behandlingskontroll/src/main/java/no/nav/foreldrepenger/behandlingskontroll/BehandlingskontrollTjeneste.java
+++ b/domenetjenester/behandlingskontroll/src/main/java/no/nav/foreldrepenger/behandlingskontroll/BehandlingskontrollTjeneste.java
@@ -148,7 +148,7 @@ public interface BehandlingskontrollTjeneste {
      */
     void taBehandlingAvVentSetAlleAutopunktUtført(Behandling behandling, BehandlingskontrollKontekst kontekst);
 
-    void taBehandlingAvVentSetAlleAutopunktUtførtForHenleggelse(Behandling behandling, BehandlingskontrollKontekst kontekst);
+    void taBehandlingAvVentSetAlleAutopunktAvbruttForHenleggelse(Behandling behandling, BehandlingskontrollKontekst kontekst);
 
     /** Henlegg en behandling. */
     void henleggBehandling(BehandlingskontrollKontekst kontekst, BehandlingResultatType årsakKode);

--- a/domenetjenester/behandlingskontroll/src/main/java/no/nav/foreldrepenger/behandlingskontroll/impl/BehandlingskontrollTjenesteImpl.java
+++ b/domenetjenester/behandlingskontroll/src/main/java/no/nav/foreldrepenger/behandlingskontroll/impl/BehandlingskontrollTjenesteImpl.java
@@ -311,28 +311,15 @@ public class BehandlingskontrollTjenesteImpl implements BehandlingskontrollTjene
 
     @Override
     public void taBehandlingAvVentSetAlleAutopunktUtført(Behandling behandling, BehandlingskontrollKontekst kontekst) {
-        doForberedGjenopptak(behandling, kontekst, false);
-    }
-
-    @Override
-    public void taBehandlingAvVentSetAlleAutopunktUtførtForHenleggelse(Behandling behandling, BehandlingskontrollKontekst kontekst) {
-        doForberedGjenopptak(behandling, kontekst, true);
-    }
-
-    private void doForberedGjenopptak(Behandling behandling, BehandlingskontrollKontekst kontekst, boolean erHenleggelse) {
         var aksjonspunkterSomMedførerTilbakehopp = behandling.getÅpneAksjonspunkter().stream()
-                .filter(a -> a.getAksjonspunktDefinisjon().tilbakehoppVedGjenopptakelse())
-                .toList();
+            .filter(a -> a.getAksjonspunktDefinisjon().tilbakehoppVedGjenopptakelse())
+            .toList();
 
         if (aksjonspunkterSomMedførerTilbakehopp.size() > 1) {
             throw new TekniskException("FP-105126",
                 String.format("BehandlingId %s har flere enn et aksjonspunkt, hvor aksjonspunktet fører til tilbakehopp ved gjenopptakelse. Kan ikke gjenopptas.", behandling.getId()));
         }
-        if (erHenleggelse) {
-            lagreAutopunkterAvbrutt(kontekst, behandling, behandling.getÅpneAksjonspunkter(AksjonspunktType.AUTOPUNKT));
-        } else {
-            lagreAutopunkterUtført(kontekst, behandling, behandling.getÅpneAksjonspunkter(AksjonspunktType.AUTOPUNKT));
-        }
+        lagreAutopunkterUtført(kontekst, behandling, behandling.getÅpneAksjonspunkter(AksjonspunktType.AUTOPUNKT));
         if (aksjonspunkterSomMedførerTilbakehopp.size() == 1) {
             var ap = aksjonspunkterSomMedførerTilbakehopp.getFirst();
             var behandlingStegFunnet = ap.getBehandlingStegFunnet();
@@ -340,6 +327,11 @@ public class BehandlingskontrollTjenesteImpl implements BehandlingskontrollTjene
             // I tilfelle tilbakehopp reåpner autopunkt - de skal reutledes av steget.
             lagreAutopunkterUtført(kontekst, behandling, behandling.getÅpneAksjonspunkter(AksjonspunktType.AUTOPUNKT));
         }
+    }
+
+    @Override
+    public void taBehandlingAvVentSetAlleAutopunktAvbruttForHenleggelse(Behandling behandling, BehandlingskontrollKontekst kontekst) {
+        lagreAutopunkterAvbrutt(kontekst, behandling, behandling.getÅpneAksjonspunkter(AksjonspunktType.AUTOPUNKT));
     }
 
     @Override

--- a/domenetjenester/dokumentbestiller/src/main/java/no/nav/foreldrepenger/dokumentbestiller/observers/SendBrevVedHenleggelseObserver.java
+++ b/domenetjenester/dokumentbestiller/src/main/java/no/nav/foreldrepenger/dokumentbestiller/observers/SendBrevVedHenleggelseObserver.java
@@ -1,0 +1,60 @@
+package no.nav.foreldrepenger.dokumentbestiller.observers;
+
+import java.util.Set;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+import jakarta.inject.Inject;
+
+import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
+import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingResultatType;
+import no.nav.foreldrepenger.behandlingslager.behandling.events.BehandlingHenlagtEvent;
+import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepository;
+import no.nav.foreldrepenger.dokumentbestiller.DokumentBestillerTjeneste;
+import no.nav.foreldrepenger.dokumentbestiller.DokumentBestilling;
+import no.nav.foreldrepenger.dokumentbestiller.DokumentMalType;
+
+/**
+ * Observerer Aksjonspunkt og sender brev ved behov
+ */
+@ApplicationScoped
+public class SendBrevVedHenleggelseObserver {
+
+    private static final Set<BehandlingResultatType> SEND_BREV_VED_HENLEGGELSE = Set.of(
+        BehandlingResultatType.HENLAGT_SØKNAD_TRUKKET,
+        BehandlingResultatType.HENLAGT_KLAGE_TRUKKET,
+        BehandlingResultatType.HENLAGT_INNSYN_TRUKKET
+    );
+
+    private BehandlingRepository behandlingRepository;
+    private DokumentBestillerTjeneste dokumentBestillerTjeneste;
+
+
+    public SendBrevVedHenleggelseObserver() {
+        //CDI
+    }
+
+    @Inject
+    public SendBrevVedHenleggelseObserver(BehandlingRepository behandlingRepository,
+                                          DokumentBestillerTjeneste dokumentBestillerTjeneste) {
+        this.behandlingRepository = behandlingRepository;
+        this.dokumentBestillerTjeneste = dokumentBestillerTjeneste;
+    }
+
+    public void sendBrevForHenleggelse(@Observes BehandlingHenlagtEvent event) {
+        if (SEND_BREV_VED_HENLEGGELSE.contains(event.behandlingResultatType())) {
+            var behandling = behandlingRepository.hentBehandling(event.getBehandlingId());
+            sendHenleggelsesbrev(behandling);
+        }
+    }
+
+    private void sendHenleggelsesbrev(Behandling behandling) {
+        var dokumentBestilling = DokumentBestilling.builder()
+            .medBehandlingUuid(behandling.getUuid())
+            .medSaksnummer(behandling.getSaksnummer())
+            .medDokumentMal(DokumentMalType.INFO_OM_HENLEGGELSE)
+            .build();
+        dokumentBestillerTjeneste.bestillDokument(dokumentBestilling);
+    }
+
+}

--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/Behandlingsoppretter.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/Behandlingsoppretter.java
@@ -149,7 +149,7 @@ public class Behandlingsoppretter {
     public void henleggBehandling(Behandling behandling) {
         var lås = behandlingRepository.taSkriveLås(behandling);
         var kontekst = behandlingskontrollTjeneste.initBehandlingskontroll(behandling, lås);
-        behandlingskontrollTjeneste.taBehandlingAvVentSetAlleAutopunktUtførtForHenleggelse(behandling, kontekst);
+        behandlingskontrollTjeneste.taBehandlingAvVentSetAlleAutopunktAvbruttForHenleggelse(behandling, kontekst);
         behandlingskontrollTjeneste.henleggBehandling(kontekst, BehandlingResultatType.MERGET_OG_HENLAGT);
     }
 

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/BehandlingRestTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/BehandlingRestTjeneste.java
@@ -205,10 +205,11 @@ public class BehandlingRestTjeneste {
     @BeskyttetRessurs(actionType = ActionType.UPDATE, resourceType = ResourceType.FAGSAK, sporingslogg = true)
     public void henleggBehandling(@TilpassetAbacAttributt(supplierClass = LocalBehandlingIdAbacDataSupplier.class)
         @Parameter(description = "Henleggelsesårsak") @Valid HenleggBehandlingDto dto) {
+        var lås = behandlingsprosessTjeneste.låsBehandling(dto.getBehandlingUuid());
         var behandling = getBehandling(dto);
         behandlingsutredningTjeneste.kanEndreBehandling(behandling, dto.getBehandlingVersjon());
         var årsakKode = tilHenleggBehandlingResultatType(dto.getÅrsakKode());
-        henleggBehandlingTjeneste.henleggBehandling(behandling.getId(), årsakKode, dto.getBegrunnelse());
+        henleggBehandlingTjeneste.henleggBehandlingManuell(behandling, lås, årsakKode, dto.getBegrunnelse());
     }
 
     private Behandling getBehandling(DtoMedBehandlingId dto) {

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/aksjonspunkt/AksjonspunktTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/aksjonspunkt/AksjonspunktTjeneste.java
@@ -141,19 +141,10 @@ public class AksjonspunktTjeneste {
     }
 
     private void håndterOverhopp(Behandling behandling, OverhoppResultat overhoppResultat, BehandlingskontrollKontekst kontekst) {
-        // TODO (essv): PKMANTIS-1992 Skrive om alle overhopp til å bruke stegTransisjon (se fremoverTransisjon nedenfor)
-        var funnetHenleggelse = overhoppResultat.finnHenleggelse();
-        if (funnetHenleggelse.isPresent()) {
-            var henleggelse = funnetHenleggelse.get();
-            henleggBehandlingTjeneste.henleggBehandling(kontekst.getBehandlingId(),
-                henleggelse.getHenleggelseResultat(), henleggelse.getHenleggingsbegrunnelse());
-        } else {
-            var fremoverTransisjon = overhoppResultat.finnFremoverTransisjon();
-            if (fremoverTransisjon.isPresent()) {
-                var riktigSteg = utledFremhoppSteg(behandling, fremoverTransisjon.get());
-                behandlingskontrollTjeneste.fremoverTransisjon(riktigSteg, kontekst);
-            }
-        }
+        overhoppResultat.finnFremoverTransisjon().ifPresent(framoverTransisjon -> {
+            var riktigSteg = utledFremhoppSteg(behandling, framoverTransisjon);
+            behandlingskontrollTjeneste.fremoverTransisjon(riktigSteg, kontekst);
+        });
     }
 
     public void overstyrAksjonspunkter(Collection<OverstyringAksjonspunktDto> overstyrteAksjonspunkter, Behandling behandling, BehandlingLås skriveLås) {

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/aksjonspunkt/BehandlingsprosessTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/aksjonspunkt/BehandlingsprosessTjeneste.java
@@ -12,6 +12,7 @@ import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingStatus;
 import no.nav.foreldrepenger.behandlingslager.behandling.historikk.HistorikkAktør;
 import no.nav.foreldrepenger.behandlingslager.behandling.historikk.Historikkinnslag;
 import no.nav.foreldrepenger.behandlingslager.behandling.historikk.HistorikkinnslagRepository;
+import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingLås;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepository;
 import no.nav.foreldrepenger.behandlingsprosess.prosessering.BehandlingProsesseringTjeneste;
 import no.nav.foreldrepenger.behandlingsprosess.prosessering.ProsesseringAsynkTjeneste;
@@ -155,6 +156,10 @@ public class BehandlingsprosessTjeneste {
 
     public Behandling hentBehandling(UUID behandlingUuid) {
         return behandlingRepository.hentBehandling(behandlingUuid);
+    }
+
+    public BehandlingLås låsBehandling(UUID behandlingUuid) {
+        return behandlingRepository.taSkriveLås(behandlingUuid);
     }
 
     /**

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/forvaltning/ForvaltningBehandlingRestTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/forvaltning/ForvaltningBehandlingRestTjeneste.java
@@ -21,7 +21,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import no.nav.foreldrepenger.behandling.steg.iverksettevedtak.HenleggFlyttFagsakTask;
+import no.nav.foreldrepenger.behandling.steg.iverksettevedtak.HenleggBehandlingTask;
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingResultatType;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingStegStatus;
@@ -114,7 +114,7 @@ public class ForvaltningBehandlingRestTjeneste {
         var behandlinger = behandlingRepository.hentÅpneBehandlingerForFagsakId(fagsak.getId());
         if (!behandlinger.isEmpty()) {
             LOG.info("Henlegger behandlinger for fagsak med saksnummer: {} ", saksnummer.getVerdi());
-            behandlinger.forEach(behandling -> opprettHenleggelseTask(behandling, BehandlingResultatType.HENLAGT_FEILOPPRETTET));
+            behandlinger.forEach(this::opprettHenleggelseTask);
         }
         return Response.ok().build();
     }
@@ -133,15 +133,15 @@ public class ForvaltningBehandlingRestTjeneste {
         var behandling = behandlingRepository.hentBehandling(dto.getBehandlingUuid());
         if (!behandling.erSaksbehandlingAvsluttet()) {
             LOG.info("Henlegger behandling for fagsak med saksnummer: {} ", behandling.getSaksnummer().getVerdi());
-            opprettHenleggelseTask(behandling, BehandlingResultatType.HENLAGT_FEILOPPRETTET);
+            opprettHenleggelseTask(behandling);
         }
         return Response.ok().build();
     }
 
-    private void opprettHenleggelseTask(Behandling behandling, BehandlingResultatType henleggelseType) {
-        var prosessTaskData = ProsessTaskData.forProsessTask(HenleggFlyttFagsakTask.class);
+    private void opprettHenleggelseTask(Behandling behandling) {
+        var prosessTaskData = ProsessTaskData.forProsessTask(HenleggBehandlingTask.class);
         prosessTaskData.setBehandling(behandling.getSaksnummer().getVerdi(), behandling.getFagsakId(), behandling.getId());
-        prosessTaskData.setProperty(HenleggFlyttFagsakTask.HENLEGGELSE_TYPE_KEY, henleggelseType.getKode());
+        prosessTaskData.setProperty(HenleggBehandlingTask.HENLEGGELSE_TYPE_KEY, BehandlingResultatType.HENLAGT_FEILOPPRETTET.getKode());
 
         taskTjeneste.lagre(prosessTaskData);
     }


### PR DESCRIPTION
Flytter brevsending fra Henlegg-tjeneste til observer - samme pattern som SendBrevForAutopunkt
Flytter startBerørt fra Henlegg-tjeneste til observer - samme sted som gjør tilsvarende for BehandlingVedtatt
En del rydding i ubrukt kode.

Neste steg: Flytte behandlingresultat ut av behandlingskontroll (opprinnelig mål), flytte og øke bruken av Henlegg-tjeneste