### PR TITLE
TFP-6103 rydde opp i autopunktmetoder

### DIFF
--- a/domenetjenester/behandling-prosessering/src/main/java/no/nav/foreldrepenger/behandlingsprosess/prosessering/BehandlingProsesseringTjeneste.java
+++ b/domenetjenester/behandling-prosessering/src/main/java/no/nav/foreldrepenger/behandlingsprosess/prosessering/BehandlingProsesseringTjeneste.java
@@ -41,7 +41,10 @@ public interface BehandlingProsesseringTjeneste {
     // AV/PÅ Vent
     void taBehandlingAvVent(Behandling behandling);
 
-    void settBehandlingPåVent(Behandling behandling, AksjonspunktDefinisjon apDef, LocalDateTime fristTid, Venteårsak venteårsak);
+    // Steg ikke vesentlig
+    void settBehandlingPåVentUtenSteg(Behandling behandling, AksjonspunktDefinisjon apDef, LocalDateTime fristTid, Venteårsak venteårsak);
+    // Steg kan ha betydning for gjenopptak
+    void settBehandlingPåVent(Behandling behandling, BehandlingStegType steg, AksjonspunktDefinisjon apDef, LocalDateTime fristTid, Venteårsak venteårsak);
 
     // For snapshot av grunnlag før man gjør andre endringer enn registerinnhenting
     EndringsresultatSnapshot taSnapshotAvBehandlingsgrunnlag(Behandling behandling);

--- a/domenetjenester/behandling-prosessering/src/main/java/no/nav/foreldrepenger/behandlingsprosess/prosessering/HenleggBehandlingTjeneste.java
+++ b/domenetjenester/behandling-prosessering/src/main/java/no/nav/foreldrepenger/behandlingsprosess/prosessering/HenleggBehandlingTjeneste.java
@@ -65,7 +65,7 @@ public class HenleggBehandlingTjeneste {
 
         // Avbryt alle åpne autopunkt
         if (behandling.isBehandlingPåVent()) {
-            behandlingskontrollTjeneste.taBehandlingAvVentSetAlleAutopunktAvbruttForHenleggelse(behandling, kontekst);
+            behandlingskontrollTjeneste.taBehandlingAvVentSetAlleAutopunktAvbruttForHenleggelse(kontekst, behandling);
         }
 
         doForberedHenleggelse(behandling, lås, resultat, historikkAktør, begrunnelse);

--- a/domenetjenester/behandling-prosessering/src/main/java/no/nav/foreldrepenger/behandlingsprosess/prosessering/task/FortsettBehandlingTask.java
+++ b/domenetjenester/behandling-prosessering/src/main/java/no/nav/foreldrepenger/behandlingsprosess/prosessering/task/FortsettBehandlingTask.java
@@ -62,7 +62,7 @@ public class FortsettBehandlingTask implements ProsessTaskHandler {
             var stegtype = getBehandlingStegType(gjenoppta);
             if (gjenoppta != null || manuellFortsettelse) {
                 if (behandling.isBehandlingPåVent()) { // Autopunkt
-                    behandlingskontrollTjeneste.taBehandlingAvVentSetAlleAutopunktUtført(behandling, kontekst);
+                    behandlingskontrollTjeneste.taBehandlingAvVentSetAlleAutopunktUtført(kontekst, behandling);
                 }
             } else {
                 Optional.ofNullable(data.getPropertyValue(UTFORT_AUTOPUNKT))

--- a/domenetjenester/behandling-prosessering/src/main/java/no/nav/foreldrepenger/behandlingsprosess/prosessering/task/GjenopptaBehandlingTask.java
+++ b/domenetjenester/behandling-prosessering/src/main/java/no/nav/foreldrepenger/behandlingsprosess/prosessering/task/GjenopptaBehandlingTask.java
@@ -3,11 +3,11 @@ package no.nav.foreldrepenger.behandlingsprosess.prosessering.task;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 
-import no.nav.foreldrepenger.behandlingskontroll.BehandlingskontrollTjeneste;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingLåsRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepository;
 import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakProsesstaskRekkefølge;
 import no.nav.foreldrepenger.behandlingslager.task.BehandlingProsessTask;
+import no.nav.foreldrepenger.behandlingsprosess.prosessering.BehandlingProsesseringTjeneste;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTask;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTaskData;
 
@@ -21,31 +21,28 @@ import no.nav.vedtak.felles.prosesstask.api.ProsessTaskData;
 public class GjenopptaBehandlingTask extends BehandlingProsessTask {
 
     private BehandlingRepository behandlingRepository;
-    private BehandlingskontrollTjeneste behandlingskontrollTjeneste;
+    private BehandlingProsesseringTjeneste behandlingProsesseringTjeneste;
 
     GjenopptaBehandlingTask() {
         // for CDI proxy
     }
 
     @Inject
-    public GjenopptaBehandlingTask(BehandlingRepository behandlingRepository,
-            BehandlingLåsRepository låsRepository,
-            BehandlingskontrollTjeneste behandlingskontrollTjeneste) {
+    public GjenopptaBehandlingTask(BehandlingRepository behandlingRepository, BehandlingLåsRepository låsRepository,
+                                   BehandlingProsesseringTjeneste behandlingProsesseringTjeneste) {
         super(låsRepository);
         this.behandlingRepository = behandlingRepository;
-        this.behandlingskontrollTjeneste = behandlingskontrollTjeneste;
+        this.behandlingProsesseringTjeneste = behandlingProsesseringTjeneste;
     }
 
     @Override
     protected void prosesser(ProsessTaskData prosessTaskData, Long behandlingId) {
 
-        var lås = behandlingRepository.taSkriveLås(behandlingId);
+        behandlingRepository.taSkriveLås(behandlingId);
         var behandling = behandlingRepository.hentBehandling(behandlingId);
-        var kontekst = behandlingskontrollTjeneste.initBehandlingskontroll(behandling, lås);
-
 
         if (behandling.isBehandlingPåVent()) {
-            behandlingskontrollTjeneste.taBehandlingAvVentSetAlleAutopunktUtført(behandling, kontekst);
+            behandlingProsesseringTjeneste.taBehandlingAvVent(behandling);
         }
     }
 

--- a/domenetjenester/behandling-prosessering/src/test/java/no/nav/foreldrepenger/behandlingsprosess/prosessering/HenleggBehandlingTjenesteTest.java
+++ b/domenetjenester/behandling-prosessering/src/test/java/no/nav/foreldrepenger/behandlingsprosess/prosessering/HenleggBehandlingTjenesteTest.java
@@ -23,7 +23,6 @@ import org.mockito.Mock;
 import no.nav.foreldrepenger.behandling.BehandlingEventPubliserer;
 import no.nav.foreldrepenger.behandlingskontroll.BehandlingModell;
 import no.nav.foreldrepenger.behandlingskontroll.impl.AksjonspunktkontrollTjenesteImpl;
-import no.nav.foreldrepenger.behandlingskontroll.impl.BehandlingModellRepository;
 import no.nav.foreldrepenger.behandlingskontroll.impl.BehandlingskontrollTjenesteImpl;
 import no.nav.foreldrepenger.behandlingskontroll.spi.BehandlingskontrollServiceProvider;
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
@@ -53,9 +52,6 @@ class HenleggBehandlingTjenesteTest {
 
     @Mock
     private BehandlingEventPubliserer eventPubliserer;
-
-    @Inject
-    private BehandlingModellRepository behandlingModellRepository;
 
     @Mock
     private BehandlingModell modell;

--- a/domenetjenester/behandling-prosessering/src/test/java/no/nav/foreldrepenger/behandlingsprosess/prosessering/task/GjenopptaBehandlingTaskTest.java
+++ b/domenetjenester/behandling-prosessering/src/test/java/no/nav/foreldrepenger/behandlingsprosess/prosessering/task/GjenopptaBehandlingTaskTest.java
@@ -12,12 +12,13 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import no.nav.foreldrepenger.behandlingskontroll.BehandlingskontrollTjeneste;
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
+import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.AksjonspunktDefinisjon;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingLås;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingLåsRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepository;
 import no.nav.foreldrepenger.behandlingslager.testutilities.behandling.ScenarioMorSøkerEngangsstønad;
+import no.nav.foreldrepenger.behandlingsprosess.prosessering.BehandlingProsesseringTjeneste;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTaskData;
 
 @ExtendWith(MockitoExtension.class)
@@ -28,19 +29,19 @@ class GjenopptaBehandlingTaskTest {
     @Mock
     private BehandlingRepository mockBehandlingRepository;
     @Mock
-    private BehandlingskontrollTjeneste mockBehandlingskontrollTjeneste;
+    private BehandlingProsesseringTjeneste mockBehandlingProsesseringTjeneste;
 
     @BeforeEach
-    public void setup() {
-        task = new GjenopptaBehandlingTask(mockBehandlingRepository, mock(BehandlingLåsRepository.class), mockBehandlingskontrollTjeneste);
+    void setup() {
+        task = new GjenopptaBehandlingTask(mockBehandlingRepository, mock(BehandlingLåsRepository.class), mockBehandlingProsesseringTjeneste);
     }
 
     @Test
     void skal_gjenoppta_behandling() {
         final Long behandlingId = 10L;
 
-        var scenario = ScenarioMorSøkerEngangsstønad
-                .forFødsel();
+        var scenario = ScenarioMorSøkerEngangsstønad.forFødsel();
+        scenario.leggTilAksjonspunkt(AksjonspunktDefinisjon.AUTO_MANUELT_SATT_PÅ_VENT, null);
         var behandling = scenario.lagMocked();
         when(mockBehandlingRepository.hentBehandling(anyLong())).thenReturn(behandling);
         when(mockBehandlingRepository.taSkriveLås(anyLong())).thenReturn(new BehandlingLås(behandlingId));
@@ -50,7 +51,7 @@ class GjenopptaBehandlingTaskTest {
 
         task.doTask(prosessTaskData);
 
-        verify(mockBehandlingskontrollTjeneste).initBehandlingskontroll(any(Behandling.class), any(BehandlingLås.class));
+        verify(mockBehandlingProsesseringTjeneste).taBehandlingAvVent(any(Behandling.class));
     }
 
 }

--- a/domenetjenester/behandling-revurdering/src/main/java/no/nav/foreldrepenger/behandling/revurdering/etterkontroll/tjeneste/fp/EtterkontrollTjenesteImpl.java
+++ b/domenetjenester/behandling-revurdering/src/main/java/no/nav/foreldrepenger/behandling/revurdering/etterkontroll/tjeneste/fp/EtterkontrollTjenesteImpl.java
@@ -14,7 +14,6 @@ import no.nav.foreldrepenger.behandling.BehandlingRevurderingTjeneste;
 import no.nav.foreldrepenger.behandling.revurdering.RevurderingHistorikk;
 import no.nav.foreldrepenger.behandling.revurdering.RevurderingTjeneste;
 import no.nav.foreldrepenger.behandling.revurdering.etterkontroll.tjeneste.EtterkontrollTjeneste;
-import no.nav.foreldrepenger.behandlingskontroll.BehandlingskontrollTjeneste;
 import no.nav.foreldrepenger.behandlingskontroll.FagsakYtelseTypeRef;
 import no.nav.foreldrepenger.behandlingslager.aktør.FødtBarnInfo;
 import no.nav.foreldrepenger.behandlingslager.aktør.OrganisasjonsEnhet;
@@ -39,7 +38,6 @@ public class EtterkontrollTjenesteImpl implements EtterkontrollTjeneste {
     private BehandlingProsesseringTjeneste behandlingProsesseringTjeneste;
     private ForeldrepengerUttakTjeneste foreldrepengerUttakTjeneste;
     private RevurderingHistorikk revurderingHistorikk;
-    private BehandlingskontrollTjeneste behandlingskontrollTjeneste;
     private RevurderingTjeneste revurderingTjeneste;
 
     private BehandlingRevurderingTjeneste behandlingRevurderingTjeneste;
@@ -52,7 +50,6 @@ public class EtterkontrollTjenesteImpl implements EtterkontrollTjeneste {
     public EtterkontrollTjenesteImpl(HistorikkinnslagRepository historikkinnslagRepository,
                                      BehandlingRevurderingTjeneste behandlingRevurderingTjeneste,
                                      ForeldrepengerUttakTjeneste foreldrepengerUttakTjeneste,
-                                     BehandlingskontrollTjeneste behandlingskontrollTjeneste,
                                      @FagsakYtelseTypeRef(FagsakYtelseType.FORELDREPENGER) RevurderingTjeneste revurderingTjeneste,
                                      BehandlingProsesseringTjeneste behandlingProsesseringTjeneste) {
         this.behandlingProsesseringTjeneste = behandlingProsesseringTjeneste;
@@ -60,7 +57,6 @@ public class EtterkontrollTjenesteImpl implements EtterkontrollTjeneste {
         this.revurderingTjeneste = revurderingTjeneste;
         this.behandlingRevurderingTjeneste = behandlingRevurderingTjeneste;
         this.foreldrepengerUttakTjeneste = foreldrepengerUttakTjeneste;
-        this.behandlingskontrollTjeneste = behandlingskontrollTjeneste;
     }
 
     @Override
@@ -146,8 +142,7 @@ public class EtterkontrollTjenesteImpl implements EtterkontrollTjeneste {
     }
 
     public void enkøBehandling(Behandling behandling) {
-        behandlingskontrollTjeneste.settBehandlingPåVent(behandling, AksjonspunktDefinisjon.AUTO_KØET_BEHANDLING, null, null,
-                Venteårsak.VENT_ÅPEN_BEHANDLING);
+        behandlingProsesseringTjeneste.settBehandlingPåVentUtenSteg(behandling, AksjonspunktDefinisjon.AUTO_KØET_BEHANDLING,  null, Venteårsak.VENT_ÅPEN_BEHANDLING);
     }
 
 }

--- a/domenetjenester/behandling-revurdering/src/main/java/no/nav/foreldrepenger/behandling/revurdering/flytkontroll/BehandlingFlytkontroll.java
+++ b/domenetjenester/behandling-revurdering/src/main/java/no/nav/foreldrepenger/behandling/revurdering/flytkontroll/BehandlingFlytkontroll.java
@@ -9,7 +9,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import no.nav.foreldrepenger.behandling.BehandlingRevurderingTjeneste;
-import no.nav.foreldrepenger.behandlingskontroll.BehandlingskontrollTjeneste;
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingStegType;
 import no.nav.foreldrepenger.behandlingslager.behandling.SpesialBehandling;
@@ -34,7 +33,6 @@ public class BehandlingFlytkontroll {
     private static final BehandlingStegType SYNK_STEG = StartpunktType.UTTAKSVILKÅR.getBehandlingSteg();
 
     private BehandlingRevurderingTjeneste behandlingRevurderingTjeneste;
-    private BehandlingskontrollTjeneste behandlingskontrollTjeneste;
     private BehandlingProsesseringTjeneste behandlingProsesseringTjeneste;
     private BehandlingRepository behandlingRepository;
 
@@ -44,10 +42,8 @@ public class BehandlingFlytkontroll {
 
     @Inject
     public BehandlingFlytkontroll(BehandlingRevurderingTjeneste behandlingRevurderingTjeneste,
-                                  BehandlingskontrollTjeneste behandlingskontrollTjeneste,
                                   BehandlingProsesseringTjeneste behandlingProsesseringTjeneste,
                                   BehandlingRepository behandlingRepository) {
-        this.behandlingskontrollTjeneste = behandlingskontrollTjeneste;
         this.behandlingRevurderingTjeneste = behandlingRevurderingTjeneste;
         this.behandlingRepository = behandlingRepository;
         this.behandlingProsesseringTjeneste = behandlingProsesseringTjeneste;
@@ -97,8 +93,7 @@ public class BehandlingFlytkontroll {
     }
 
     public void settNyRevurderingPåVent(Behandling behandling) {
-        behandlingskontrollTjeneste.settBehandlingPåVent(behandling, AksjonspunktDefinisjon.AUTO_KØET_BEHANDLING, null, null,
-                Venteårsak.VENT_ÅPEN_BEHANDLING);
+        behandlingProsesseringTjeneste.settBehandlingPåVentUtenSteg(behandling, AksjonspunktDefinisjon.AUTO_KØET_BEHANDLING, null, Venteårsak.VENT_ÅPEN_BEHANDLING);
     }
 
     public boolean finnesÅpenBerørtForFagsak(Long fagsakId, Long behandlingId) {

--- a/domenetjenester/behandling-revurdering/src/test/java/no/nav/foreldrepenger/behandling/revurdering/flytkontroll/BehandlingFlytkontrollTest.java
+++ b/domenetjenester/behandling-revurdering/src/test/java/no/nav/foreldrepenger/behandling/revurdering/flytkontroll/BehandlingFlytkontrollTest.java
@@ -17,7 +17,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import no.nav.foreldrepenger.behandling.BehandlingRevurderingTjeneste;
-import no.nav.foreldrepenger.behandlingskontroll.BehandlingskontrollTjeneste;
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingÅrsakType;
 import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.AksjonspunktDefinisjon;
@@ -37,7 +36,6 @@ class BehandlingFlytkontrollTest {
     private final BehandlingRepository behandlingRepository = mock(BehandlingRepository.class);
     private final BehandlingRevurderingTjeneste behandlingRevurderingTjeneste = mock(
         BehandlingRevurderingTjeneste.class);
-    private final BehandlingskontrollTjeneste behandlingskontrollTjeneste = mock(BehandlingskontrollTjeneste.class);
     private final BehandlingProsesseringTjeneste behandlingProsesseringTjeneste = mock(BehandlingProsesseringTjeneste.class);
     private BehandlingFlytkontroll flytkontroll;
     private final Behandling behandling = mock(Behandling.class);
@@ -65,8 +63,7 @@ class BehandlingFlytkontrollTest {
         when(fagsakAnnenPart.getId()).thenReturn(FAGSAK_AP_ID);
         when(behandlingRepository.hentBehandling(BEHANDLING_ID)).thenReturn(behandling);
         when(behandlingRepository.hentBehandling(EGEN_BERØRT_ID)).thenReturn(behandlingSammeSakBerørt);
-        flytkontroll = new BehandlingFlytkontroll(behandlingRevurderingTjeneste, behandlingskontrollTjeneste,
-                behandlingProsesseringTjeneste, behandlingRepository);
+        flytkontroll = new BehandlingFlytkontroll(behandlingRevurderingTjeneste, behandlingProsesseringTjeneste, behandlingRepository);
     }
 
     @Test
@@ -222,7 +219,7 @@ class BehandlingFlytkontrollTest {
         when(behandlingRepository.hentÅpneYtelseBehandlingerForFagsakId(FAGSAK_ID)).thenReturn(
                 List.of(behandlingSammeSak));
         assertThat(flytkontroll.nyRevurderingSkalVente(fagsak)).isFalse();
-        verifyNoInteractions(behandlingskontrollTjeneste);
+        verifyNoInteractions(behandlingProsesseringTjeneste);
     }
 
     @Test

--- a/domenetjenester/behandling-revurdering/src/test/java/no/nav/foreldrepenger/behandling/revurdering/ytelse/es/RevurderingTjenesteImplTest.java
+++ b/domenetjenester/behandling-revurdering/src/test/java/no/nav/foreldrepenger/behandling/revurdering/ytelse/es/RevurderingTjenesteImplTest.java
@@ -36,7 +36,7 @@ class RevurderingTjenesteImplTest {
     private RevurderingTjeneste revurderingTjeneste;
 
     @BeforeEach
-    public void setup(EntityManager entityManager) {
+    void setup(EntityManager entityManager) {
         repositoryProvider = new BehandlingRepositoryProvider(entityManager);
         var grunnlagProvider = new BehandlingGrunnlagRepositoryProvider(entityManager);
         behandlingRepository = new BehandlingRepository(entityManager);
@@ -47,9 +47,9 @@ class RevurderingTjenesteImplTest {
         var vergeRepository = new VergeRepository(entityManager);
         var fagsakRelasjonTjeneste = new FagsakRelasjonTjeneste(repositoryProvider);
         var behandlingRevurderingTjeneste = new BehandlingRevurderingTjeneste(repositoryProvider, fagsakRelasjonTjeneste);
-        var revurderingTjenesteFelles = new RevurderingTjenesteFelles(repositoryProvider, behandlingRevurderingTjeneste);
-        revurderingTjeneste = new RevurderingTjenesteImpl(behandlingRepository, grunnlagProvider,
-                new BehandlingskontrollTjenesteImpl(serviceProvider), revurderingEndringES, revurderingTjenesteFelles,
+        var behandlingskontrollTjeneste = new BehandlingskontrollTjenesteImpl(serviceProvider);
+        var revurderingTjenesteFelles = new RevurderingTjenesteFelles(repositoryProvider, behandlingRevurderingTjeneste, behandlingskontrollTjeneste);
+        revurderingTjeneste = new RevurderingTjenesteImpl(behandlingRepository, grunnlagProvider, revurderingEndringES, revurderingTjenesteFelles,
                 vergeRepository);
     }
 

--- a/domenetjenester/behandling-revurdering/src/test/java/no/nav/foreldrepenger/behandling/revurdering/ytelse/fp/RevurderingTjenesteImplTest.java
+++ b/domenetjenester/behandling-revurdering/src/test/java/no/nav/foreldrepenger/behandling/revurdering/ytelse/fp/RevurderingTjenesteImplTest.java
@@ -123,10 +123,9 @@ class RevurderingTjenesteImplTest {
         revurderingTestUtil.avsluttBehandling(behandlingSomSkalRevurderes);
 
         var behandlingskontrollTjeneste = new BehandlingskontrollTjenesteImpl(serviceProvider);
-        var revurderingTjenesteFelles = new RevurderingTjenesteFelles(repositoryProvider, behandlingRevurderingTjeneste);
+        var revurderingTjenesteFelles = new RevurderingTjenesteFelles(repositoryProvider, behandlingRevurderingTjeneste, behandlingskontrollTjeneste);
         RevurderingTjeneste revurderingTjeneste = new RevurderingTjenesteImpl(repositoryProvider,
-                grunnlagRepositoryProvider, behandlingskontrollTjeneste,
-                iayTjeneste, revurderingEndringES, revurderingTjenesteFelles, vergeRepository);
+                grunnlagRepositoryProvider, iayTjeneste, revurderingEndringES, revurderingTjenesteFelles, vergeRepository);
 
         // Act
         var revurdering = revurderingTjeneste

--- a/domenetjenester/behandling-revurdering/src/test/java/no/nav/foreldrepenger/behandling/revurdering/ytelse/svp/RevurderingBehandlingsresultatutlederTest.java
+++ b/domenetjenester/behandling-revurdering/src/test/java/no/nav/foreldrepenger/behandling/revurdering/ytelse/svp/RevurderingBehandlingsresultatutlederTest.java
@@ -139,11 +139,9 @@ class RevurderingBehandlingsresultatutlederTest {
                 beregningTjeneste,
                 medlemTjeneste, dekningsgradTjeneste, uttakTjeneste);
 
-        var behandlingskontrollTjeneste = new BehandlingskontrollTjenesteImpl(
-                serviceProvider);
-        var revurderingTjenesteFelles = new RevurderingTjenesteFelles(repositoryProvider, behandlingRevurderingTjeneste);
-        revurderingTjeneste = new RevurderingTjenesteImpl(repositoryProvider, grunnlagRepositoryProvider, behandlingskontrollTjeneste,
-                iayTjeneste, revurderingEndring, revurderingTjenesteFelles, vergeRepository);
+        var behandlingskontrollTjeneste = new BehandlingskontrollTjenesteImpl(serviceProvider);
+        var revurderingTjenesteFelles = new RevurderingTjenesteFelles(repositoryProvider, behandlingRevurderingTjeneste, behandlingskontrollTjeneste);
+        revurderingTjeneste = new RevurderingTjenesteImpl(repositoryProvider, grunnlagRepositoryProvider, iayTjeneste, revurderingEndring, revurderingTjenesteFelles, vergeRepository);
         revurdering = revurderingTjeneste
                 .opprettAutomatiskRevurdering(behandlingSomSkalRevurderes.getFagsak(),
                         BehandlingÅrsakType.RE_HENDELSE_FØDSEL, new OrganisasjonsEnhet("1234", "Test"));

--- a/domenetjenester/behandlingskontroll/src/main/java/no/nav/foreldrepenger/behandlingskontroll/BehandlingskontrollTjeneste.java
+++ b/domenetjenester/behandlingskontroll/src/main/java/no/nav/foreldrepenger/behandlingskontroll/BehandlingskontrollTjeneste.java
@@ -16,17 +16,8 @@ import no.nav.foreldrepenger.behandlingslager.fagsak.Fagsak;
 public interface BehandlingskontrollTjeneste {
 
     /**
-     * Initierer ny behandlingskontroll for en ny behandling, som ikke er lagret i
-     * behandlingsRepository og derfor ikke har fått tildelt behandlingId
-     * Vil forsøke ta skrivelås - som helst bør være tatt før man leser opp behandlingen
-     *
-     * @param behandling - må være med.
-     */
-    BehandlingskontrollKontekst initBehandlingskontroll(Behandling behandling);
-
-    /**
-     * Initierer ny behandlingskontroll for en ny behandling, som ikke er lagret i
-     * behandlingsRepository og derfor ikke har fått tildelt behandlingId
+     * Initierer ny behandlingskontroll for en behandling, som ikke nødvendigvis er lagret i
+     * behandlingsRepository (og fått tildelt behandlingId)
      *
      * @param behandling - må være med
      * @param skriveLås - behandlingen må være låst - helst med behandlingId før den er lest opp fra behandlingRepository
@@ -111,8 +102,8 @@ public interface BehandlingskontrollTjeneste {
      * @param venteårsak             Årsak til ventingen.
      *
      */
-    Aksjonspunkt settBehandlingPåVentUtenSteg(Behandling behandling, AksjonspunktDefinisjon aksjonspunktDefinisjon, LocalDateTime fristTid,
-            Venteårsak venteårsak);
+    Aksjonspunkt settBehandlingPåVentUtenSteg(BehandlingskontrollKontekst kontekst, Behandling behandling,
+                                              AksjonspunktDefinisjon aksjonspunktDefinisjon, LocalDateTime fristTid, Venteårsak venteårsak);
 
     /**
      * Setter behandlingen på vent med angitt hvilket steg det står i. NB IKKE BRUK FRA STEG
@@ -124,16 +115,15 @@ public interface BehandlingskontrollTjeneste {
      * @param venteårsak             Årsak til ventingen.
      *
      */
-    Aksjonspunkt settBehandlingPåVent(Behandling behandling, AksjonspunktDefinisjon aksjonspunktDefinisjon, BehandlingStegType stegType,
-            LocalDateTime fristTid,
-            Venteårsak venteårsak);
+    Aksjonspunkt settBehandlingPåVent(BehandlingskontrollKontekst kontekst, Behandling behandling, BehandlingStegType stegType,
+                                      AksjonspunktDefinisjon aksjonspunktDefinisjon, LocalDateTime fristTid, Venteårsak venteårsak);
 
     /**
      * Setter autopunkter av en spesifikk aksjonspunktdefinisjon til utført.
      * Dette klargjør kun behandligen for prosessering, men vil ikke drive prosessen videre.
      * Disse metodene bør bare brukes ved eksplisitt behov - bruk heller {@link #taBehandlingAvVentSetAlleAutopunktUtført}
      *
-     * @param kontekst     Kontekst for prosessering med skrivelås for behandlingen
+     * @param behandling   Kontekst for prosessering med skrivelås for behandlingen
      * @param aksjonspunkt Åpent aksjonspunkt som skal lukkes (utføres eller avbrytes)
      */
     void settAutopunktTilUtført(BehandlingskontrollKontekst kontekst, Behandling behandling, Aksjonspunkt aksjonspunkt);
@@ -145,14 +135,14 @@ public interface BehandlingskontrollTjeneste {
      * Setter autopunkt til utført og foretar tilbakeføring ved gjenopptak dersom autopunkt har tilbakehoppVedGjenopptakelse = true.
      * Behandlingen skal være klar til prosessering uten åpne autopunkt når kallet er ferdig.
      */
-    void taBehandlingAvVentSetAlleAutopunktUtført(Behandling behandling, BehandlingskontrollKontekst kontekst);
+    void taBehandlingAvVentSetAlleAutopunktUtført(BehandlingskontrollKontekst kontekst, Behandling behandling);
 
-    void taBehandlingAvVentSetAlleAutopunktAvbruttForHenleggelse(Behandling behandling, BehandlingskontrollKontekst kontekst);
+    void taBehandlingAvVentSetAlleAutopunktAvbruttForHenleggelse(BehandlingskontrollKontekst kontekst, Behandling behandling);
 
     /** Henlegg en behandling. */
     void henleggBehandling(BehandlingskontrollKontekst kontekst);
 
     void henleggBehandlingFraSteg(BehandlingskontrollKontekst kontekst);
 
-    void fremoverTransisjon(BehandlingStegType målSteg, BehandlingskontrollKontekst kontekst);
+    void fremoverTransisjon(BehandlingskontrollKontekst kontekst, BehandlingStegType målSteg);
 }

--- a/domenetjenester/dokumentbestiller/src/main/java/no/nav/foreldrepenger/dokumentbestiller/VarselRevurderingTjeneste.java
+++ b/domenetjenester/dokumentbestiller/src/main/java/no/nav/foreldrepenger/dokumentbestiller/VarselRevurderingTjeneste.java
@@ -8,28 +8,28 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 
 import no.nav.foreldrepenger.behandling.BehandlingReferanse;
-import no.nav.foreldrepenger.behandlingskontroll.BehandlingskontrollTjeneste;
 import no.nav.foreldrepenger.behandlingslager.behandling.RevurderingVarslingÅrsak;
 import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.AksjonspunktDefinisjon;
 import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.Venteårsak;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepository;
+import no.nav.foreldrepenger.behandlingsprosess.prosessering.BehandlingProsesseringTjeneste;
 import no.nav.foreldrepenger.konfig.KonfigVerdi;
 
 @ApplicationScoped
 public class VarselRevurderingTjeneste {
 
     private Period defaultVenteFrist;
-    private BehandlingskontrollTjeneste behandlingskontrollTjeneste;
+    private BehandlingProsesseringTjeneste behandlingProsesseringTjeneste;
     private DokumentBestillerTjeneste dokumentBestillerTjeneste;
     private BehandlingRepository behandlingRepository;
 
     @Inject
     public VarselRevurderingTjeneste(@KonfigVerdi(value = "behandling.default.ventefrist.periode", defaultVerdi = "P4W") Period defaultVenteFrist,
-                                     BehandlingskontrollTjeneste behandlingskontrollTjeneste,
+                                     BehandlingProsesseringTjeneste behandlingProsesseringTjeneste,
                                      DokumentBestillerTjeneste dokumentBestillerTjeneste,
                                      BehandlingRepository behandlingRepository) {
         this.defaultVenteFrist = defaultVenteFrist;
-        this.behandlingskontrollTjeneste = behandlingskontrollTjeneste;
+        this.behandlingProsesseringTjeneste = behandlingProsesseringTjeneste;
         this.dokumentBestillerTjeneste = dokumentBestillerTjeneste;
         this.behandlingRepository = behandlingRepository;
     }
@@ -51,8 +51,9 @@ public class VarselRevurderingTjeneste {
     }
 
     private void settBehandlingPaVent(BehandlingReferanse ref, LocalDate frist, Venteårsak venteårsak) {
+        behandlingRepository.taSkriveLås(ref.behandlingId());
         var behandling = behandlingRepository.hentBehandling(ref.behandlingId());
-        behandlingskontrollTjeneste.settBehandlingPåVentUtenSteg(behandling, AksjonspunktDefinisjon.AUTO_MANUELT_SATT_PÅ_VENT,
+        behandlingProsesseringTjeneste.settBehandlingPåVentUtenSteg(behandling, AksjonspunktDefinisjon.AUTO_MANUELT_SATT_PÅ_VENT,
             bestemFristForBehandlingVent(frist), venteårsak);
     }
 

--- a/domenetjenester/dokumentbestiller/src/test/java/no/nav/foreldrepenger/dokumentbestiller/DokumentBehandlingTjenesteTest.java
+++ b/domenetjenester/dokumentbestiller/src/test/java/no/nav/foreldrepenger/dokumentbestiller/DokumentBehandlingTjenesteTest.java
@@ -12,7 +12,6 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 
-import no.nav.foreldrepenger.behandlingskontroll.BehandlingskontrollTjeneste;
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingType;
 import no.nav.foreldrepenger.behandlingslager.behandling.dokument.BehandlingDokumentEntitet;
@@ -21,6 +20,7 @@ import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRe
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepositoryProvider;
 import no.nav.foreldrepenger.behandlingslager.testutilities.behandling.AbstractTestScenario;
 import no.nav.foreldrepenger.behandlingslager.testutilities.behandling.ScenarioMorSøkerEngangsstønad;
+import no.nav.foreldrepenger.behandlingsprosess.prosessering.BehandlingProsesseringTjeneste;
 import no.nav.foreldrepenger.dbstoette.CdiDbAwareTest;
 
 @CdiDbAwareTest
@@ -30,7 +30,7 @@ class DokumentBehandlingTjenesteTest {
     @Inject
     private BehandlingRepositoryProvider repositoryProvider;
     @Mock
-    private BehandlingskontrollTjeneste behandlingskontrollTjeneste;
+    private BehandlingProsesseringTjeneste behandlingProsesseringTjeneste;
 
     private AbstractTestScenario<?> scenario;
     private BehandlingDokumentRepository behandlingDokumentRepository;
@@ -43,7 +43,7 @@ class DokumentBehandlingTjenesteTest {
     void setUp() {
         behandlingRepository = repositoryProvider.getBehandlingRepository();
         behandlingDokumentRepository = new BehandlingDokumentRepository(repositoryProvider.getEntityManager());
-        dokumentBehandlingTjeneste = new DokumentBehandlingTjeneste(repositoryProvider, behandlingskontrollTjeneste, behandlingDokumentRepository);
+        dokumentBehandlingTjeneste = new DokumentBehandlingTjeneste(repositoryProvider, behandlingProsesseringTjeneste, behandlingDokumentRepository);
         this.scenario = ScenarioMorSøkerEngangsstønad
                 .forFødsel()
                 .medFødselAdopsjonsdato(Collections.singletonList(LocalDate.now().minusDays(3)));

--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/Behandlingsoppretter.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/Behandlingsoppretter.java
@@ -9,7 +9,6 @@ import jakarta.inject.Inject;
 
 import no.nav.foreldrepenger.behandling.BehandlingRevurderingTjeneste;
 import no.nav.foreldrepenger.behandling.revurdering.RevurderingTjeneste;
-import no.nav.foreldrepenger.behandlingskontroll.BehandlingskontrollTjeneste;
 import no.nav.foreldrepenger.behandlingskontroll.FagsakYtelseTypeRef;
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingResultatType;
@@ -30,6 +29,7 @@ import no.nav.foreldrepenger.behandlingslager.behandling.vedtak.BehandlingVedtak
 import no.nav.foreldrepenger.behandlingslager.behandling.vedtak.VedtakResultatType;
 import no.nav.foreldrepenger.behandlingslager.fagsak.Fagsak;
 import no.nav.foreldrepenger.behandlingsprosess.prosessering.BehandlingOpprettingTjeneste;
+import no.nav.foreldrepenger.behandlingsprosess.prosessering.BehandlingProsesseringTjeneste;
 import no.nav.foreldrepenger.behandlingsprosess.prosessering.HenleggBehandlingTjeneste;
 import no.nav.foreldrepenger.mottak.dokumentmottak.MottatteDokumentTjeneste;
 import no.nav.foreldrepenger.mottak.dokumentpersiterer.impl.MottattDokumentPersisterer;
@@ -39,7 +39,7 @@ import no.nav.foreldrepenger.produksjonsstyring.behandlingenhet.BehandlendeEnhet
 public class Behandlingsoppretter {
 
     private BehandlingRepository behandlingRepository;
-    private BehandlingskontrollTjeneste behandlingskontrollTjeneste;
+    private BehandlingProsesseringTjeneste behandlingProsesseringTjeneste;
     private BehandlingOpprettingTjeneste behandlingOpprettingTjeneste;
     private MottattDokumentPersisterer mottattDokumentPersisterer;
     private MottatteDokumentTjeneste mottatteDokumentTjeneste;
@@ -56,14 +56,14 @@ public class Behandlingsoppretter {
 
     @Inject
     public Behandlingsoppretter(BehandlingRepositoryProvider behandlingRepositoryProvider,
-                                BehandlingskontrollTjeneste behandlingskontrollTjeneste,
+                                BehandlingProsesseringTjeneste behandlingProsesseringTjeneste,
                                 BehandlingOpprettingTjeneste behandlingOpprettingTjeneste,
                                 MottattDokumentPersisterer mottattDokumentPersisterer,
                                 MottatteDokumentTjeneste mottatteDokumentTjeneste,
                                 BehandlendeEnhetTjeneste behandlendeEnhetTjeneste,
                                 BehandlingRevurderingTjeneste behandlingRevurderingTjeneste,
                                 HenleggBehandlingTjeneste henleggBehandlingTjeneste) {
-        this.behandlingskontrollTjeneste = behandlingskontrollTjeneste;
+        this.behandlingProsesseringTjeneste = behandlingProsesseringTjeneste;
         this.behandlingOpprettingTjeneste = behandlingOpprettingTjeneste;
         this.mottattDokumentPersisterer = mottattDokumentPersisterer;
         this.behandlingRepository = behandlingRepositoryProvider.getBehandlingRepository();
@@ -207,7 +207,7 @@ public class Behandlingsoppretter {
 
 
     public void settSomKøet(Behandling nyKøetBehandling) {
-        behandlingskontrollTjeneste.settBehandlingPåVent(nyKøetBehandling, AksjonspunktDefinisjon.AUTO_KØET_BEHANDLING, null, null, Venteårsak.VENT_ÅPEN_BEHANDLING);
+        behandlingProsesseringTjeneste.settBehandlingPåVentUtenSteg(nyKøetBehandling, AksjonspunktDefinisjon.AUTO_KØET_BEHANDLING, null, Venteårsak.VENT_ÅPEN_BEHANDLING);
     }
 
     public boolean erOpphørtBehandling(Behandling behandling) {

--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/dokumentmottak/impl/Kompletthetskontroller.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/dokumentmottak/impl/Kompletthetskontroller.java
@@ -76,7 +76,8 @@ public class Kompletthetskontroller {
         if (!kompletthetResultat.erOppfylt() && behandling.harÅpentAksjonspunktMedType(AksjonspunktDefinisjon.AUTO_VENTER_PÅ_KOMPLETT_SØKNAD)) {
             var åpenKompletthet = behandling.getAksjonspunktMedDefinisjonOptional(AksjonspunktDefinisjon.AUTO_VENTER_PÅ_KOMPLETT_SØKNAD).orElseThrow();
             if (!kompletthetResultat.erFristUtløpt() && !Objects.equals(åpenKompletthet.getVenteårsak(), kompletthetResultat.venteårsak())) {
-                behandlingProsesseringTjeneste.settBehandlingPåVent(behandling, AksjonspunktDefinisjon.AUTO_VENTER_PÅ_KOMPLETT_SØKNAD, kompletthetResultat.ventefrist(), kompletthetResultat.venteårsak());
+                behandlingProsesseringTjeneste.settBehandlingPåVent(behandling, behandling.getAktivtBehandlingSteg(),
+                    AksjonspunktDefinisjon.AUTO_VENTER_PÅ_KOMPLETT_SØKNAD, kompletthetResultat.ventefrist(), kompletthetResultat.venteårsak());
             }
         }
         if (kompletthetResultat.erOppfylt() && (erTidligKompletthetssjekkEllerPassert(behandling)

--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/sakskompleks/KøKontroller.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/sakskompleks/KøKontroller.java
@@ -7,7 +7,6 @@ import jakarta.inject.Inject;
 
 import no.nav.foreldrepenger.behandling.BehandlingRevurderingTjeneste;
 import no.nav.foreldrepenger.behandling.revurdering.flytkontroll.BehandlingFlytkontroll;
-import no.nav.foreldrepenger.behandlingskontroll.BehandlingskontrollTjeneste;
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingType;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingÅrsakType;
@@ -39,7 +38,6 @@ public class KøKontroller {
 
     private BehandlingProsesseringTjeneste behandlingProsesseringTjeneste;
     private BehandlingRevurderingTjeneste behandlingRevurderingTjeneste;
-    private BehandlingskontrollTjeneste behandlingskontrollTjeneste;
     private BehandlingRepository behandlingRepository;
     private YtelsesFordelingRepository ytelsesFordelingRepository;
     private Behandlingsoppretter behandlingsoppretter;
@@ -53,14 +51,12 @@ public class KøKontroller {
 
     @Inject
     public KøKontroller(BehandlingProsesseringTjeneste prosesseringTjeneste,
-                        BehandlingskontrollTjeneste behandlingskontrollTjeneste,
                         BehandlingRepositoryProvider repositoryProvider,
                         ProsessTaskTjeneste taskTjeneste,
                         BehandlingRevurderingTjeneste behandlingRevurderingTjeneste,
                         Behandlingsoppretter behandlingsoppretter,
                         BehandlingFlytkontroll flytkontroll) {
         this.behandlingProsesseringTjeneste = prosesseringTjeneste;
-        this.behandlingskontrollTjeneste = behandlingskontrollTjeneste;
         this.behandlingRevurderingTjeneste = behandlingRevurderingTjeneste;
         this.behandlingRepository = repositoryProvider.getBehandlingRepository();
         this.ytelsesFordelingRepository = repositoryProvider.getYtelsesFordelingRepository();
@@ -87,13 +83,12 @@ public class KøKontroller {
     }
 
     public void enkøBehandling(Behandling behandling) {
-        behandlingskontrollTjeneste.settBehandlingPåVent(behandling, AksjonspunktDefinisjon.AUTO_KØET_BEHANDLING, null, null, Venteårsak.VENT_ÅPEN_BEHANDLING);
+        behandlingProsesseringTjeneste.settBehandlingPåVentUtenSteg(behandling, AksjonspunktDefinisjon.AUTO_KØET_BEHANDLING, null, Venteårsak.VENT_ÅPEN_BEHANDLING);
     }
 
     public void submitBerørtBehandling(Behandling behandling, Optional<Behandling> åpenBehandling) {
         if (!behandling.harNoenBehandlingÅrsaker(BehandlingÅrsakType.alleTekniskeÅrsaker())) throw new IllegalArgumentException("Behandling er ikke berørt");
-        åpenBehandling.ifPresent(b -> behandlingskontrollTjeneste.settBehandlingPåVent(b, AksjonspunktDefinisjon.AUTO_KØET_BEHANDLING,
-            null, null, Venteårsak.VENT_ÅPEN_BEHANDLING));
+        åpenBehandling.ifPresent(b -> behandlingProsesseringTjeneste.settBehandlingPåVentUtenSteg(b, AksjonspunktDefinisjon.AUTO_KØET_BEHANDLING, null, Venteårsak.VENT_ÅPEN_BEHANDLING));
         behandlingProsesseringTjeneste.opprettTasksForStartBehandling(behandling);
     }
 
@@ -160,7 +155,6 @@ public class KøKontroller {
     public void oppdaterVedHenleggelseOmNødvendigOgFortsettBehandling(Long behandlingId) {
         var lås = behandlingRepository.taSkriveLås(behandlingId);
         var behandling = behandlingRepository.hentBehandling(behandlingId);
-        behandlingskontrollTjeneste.initBehandlingskontroll(behandling, lås);
         oppdaterVedHenleggelseOmNødvendigOgFortsettBehandling(behandling);
     }
 

--- a/domenetjenester/mottak/src/test/java/no/nav/foreldrepenger/mottak/sakskompleks/BerørtBehandlingKontrollerTest.java
+++ b/domenetjenester/mottak/src/test/java/no/nav/foreldrepenger/mottak/sakskompleks/BerørtBehandlingKontrollerTest.java
@@ -15,8 +15,6 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
-import no.nav.foreldrepenger.behandlingslager.behandling.historikk.HistorikkinnslagRepository;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -27,7 +25,6 @@ import org.mockito.quality.Strictness;
 
 import no.nav.foreldrepenger.behandling.BehandlingRevurderingTjeneste;
 import no.nav.foreldrepenger.behandling.revurdering.BerørtBehandlingTjeneste;
-import no.nav.foreldrepenger.behandlingskontroll.BehandlingskontrollTjeneste;
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingResultatType;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingType;
@@ -36,6 +33,7 @@ import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingsresultatRepo
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingÅrsakType;
 import no.nav.foreldrepenger.behandlingslager.behandling.KonsekvensForYtelsen;
 import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.AksjonspunktDefinisjon;
+import no.nav.foreldrepenger.behandlingslager.behandling.historikk.HistorikkinnslagRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepositoryProvider;
 import no.nav.foreldrepenger.behandlingslager.behandling.søknad.SøknadRepository;
@@ -68,8 +66,6 @@ class BerørtBehandlingKontrollerTest {
     private BehandlingsresultatRepository behandlingsresultatRepository;
     @Mock
     private HistorikkinnslagRepository historikkinnslagRepository;
-    @Mock
-    private BehandlingskontrollTjeneste behandlingskontrollTjeneste;
     @Mock
     private BerørtBehandlingTjeneste berørtBehandlingTjeneste;
     @Mock
@@ -141,7 +137,7 @@ class BerørtBehandlingKontrollerTest {
         when(ytelseFordelingTjeneste.hentAggregat(anyLong())).thenReturn(YtelseFordelingAggregat.oppdatere(Optional.empty()).medSakskompleksDekningsgrad(
             Dekningsgrad._100).build());
 
-        var køkontroller = new KøKontroller(behandlingProsesseringTjeneste, behandlingskontrollTjeneste, repositoryProvider, null, behandlingRevurderingTjeneste,
+        var køkontroller = new KøKontroller(behandlingProsesseringTjeneste, repositoryProvider, null, behandlingRevurderingTjeneste,
             behandlingsoppretter, null);
         berørtBehandlingKontroller =
             new BerørtBehandlingKontroller(repositoryProvider, behandlingRevurderingTjeneste, berørtBehandlingTjeneste, behandlingsoppretter,

--- a/domenetjenester/mottak/src/test/java/no/nav/foreldrepenger/mottak/sakskompleks/KøKontrollerTest.java
+++ b/domenetjenester/mottak/src/test/java/no/nav/foreldrepenger/mottak/sakskompleks/KøKontrollerTest.java
@@ -16,13 +16,12 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import no.nav.foreldrepenger.behandling.BehandlingRevurderingTjeneste;
 import no.nav.foreldrepenger.behandling.revurdering.flytkontroll.BehandlingFlytkontroll;
-import no.nav.foreldrepenger.behandlingskontroll.BehandlingskontrollTjeneste;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingType;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingÅrsakType;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepositoryProvider;
-import no.nav.foreldrepenger.behandling.BehandlingRevurderingTjeneste;
 import no.nav.foreldrepenger.behandlingslager.behandling.søknad.SøknadRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.YtelsesFordelingRepository;
 import no.nav.foreldrepenger.behandlingslager.testutilities.behandling.ScenarioFarSøkerForeldrepenger;
@@ -43,8 +42,6 @@ class KøKontrollerTest {
     @Mock
     private BehandlingRepositoryProvider behandlingRepositoryProvider;
     @Mock
-    private BehandlingskontrollTjeneste behandlingskontrollTjeneste;
-    @Mock
     private SøknadRepository søknadRepository;
     @Mock
     private YtelsesFordelingRepository ytelsesFordelingRepository;
@@ -62,8 +59,8 @@ class KøKontrollerTest {
         when(behandlingRepositoryProvider.getBehandlingRepository()).thenReturn(behandlingRepository);
         when(behandlingRepositoryProvider.getSøknadRepository()).thenReturn(søknadRepository);
         when(behandlingRepositoryProvider.getYtelsesFordelingRepository()).thenReturn(ytelsesFordelingRepository);
-        køKontroller = new KøKontroller(behandlingProsesseringTjeneste, behandlingskontrollTjeneste,
-                behandlingRepositoryProvider, taskTjeneste, behandlingRevurderingTjeneste, behandlingsoppretter, flytkontroll);
+        køKontroller = new KøKontroller(behandlingProsesseringTjeneste, behandlingRepositoryProvider, taskTjeneste,
+            behandlingRevurderingTjeneste, behandlingsoppretter, flytkontroll);
     }
 
     @Test

--- a/domenetjenester/registerinnhenting/src/test/java/no/nav/foreldrepenger/domene/registerinnhenting/impl/EndringskontrollerTest.java
+++ b/domenetjenester/registerinnhenting/src/test/java/no/nav/foreldrepenger/domene/registerinnhenting/impl/EndringskontrollerTest.java
@@ -28,6 +28,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import no.nav.foreldrepenger.behandlingskontroll.AksjonspunktkontrollTjeneste;
 import no.nav.foreldrepenger.behandlingskontroll.BehandlingModellTjeneste;
+import no.nav.foreldrepenger.behandlingskontroll.BehandlingskontrollKontekst;
 import no.nav.foreldrepenger.behandlingskontroll.BehandlingskontrollTjeneste;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingStegStatus;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingStegType;
@@ -263,6 +264,7 @@ class EndringskontrollerTest {
         when(behandlingModellTjenesteMock.erStegAEtterStegB(any(), any(), any(), any())).thenReturn(false); // Opptjening er etter SRTB
         when(behandlingModellTjenesteMock.skalAksjonspunktLøsesIEllerEtterSteg(FagsakYtelseType.FORELDREPENGER, BehandlingType.FØRSTEGANGSSØKNAD,
             BehandlingStegType.SØKERS_RELASJON_TIL_BARN, AksjonspunktDefinisjon.AVKLAR_TERMINBEKREFTELSE)).thenReturn(true);
+        when(behandlingskontrollTjenesteMock.initBehandlingskontroll(any(), any())).thenReturn(new BehandlingskontrollKontekst(behandling, lås));
 
         // Blir ikke reutledet
         when(kontrollerFaktaTjenesteMock.utledAksjonspunkterFomSteg(any(), any(), any())).thenReturn(Collections.emptyList());

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/aksjonspunkt/AksjonspunktTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/aksjonspunkt/AksjonspunktTjeneste.java
@@ -138,7 +138,7 @@ public class AksjonspunktTjeneste {
     private void håndterOverhopp(Behandling behandling, OverhoppResultat overhoppResultat, BehandlingskontrollKontekst kontekst) {
         overhoppResultat.finnFremoverTransisjon().ifPresent(framoverTransisjon -> {
             var riktigSteg = utledFremhoppSteg(behandling, framoverTransisjon);
-            behandlingskontrollTjeneste.fremoverTransisjon(riktigSteg, kontekst);
+            behandlingskontrollTjeneste.fremoverTransisjon(kontekst, riktigSteg);
         });
     }
 

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/aksjonspunkt/BehandlingsutredningTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/aksjonspunkt/BehandlingsutredningTjeneste.java
@@ -9,7 +9,6 @@ import java.util.Objects;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 
-import no.nav.foreldrepenger.behandlingskontroll.BehandlingskontrollTjeneste;
 import no.nav.foreldrepenger.behandlingslager.aktør.OrganisasjonsEnhet;
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
 import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.Aksjonspunkt;
@@ -18,6 +17,7 @@ import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.Venteårsa
 import no.nav.foreldrepenger.behandlingslager.behandling.historikk.HistorikkAktør;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepositoryProvider;
+import no.nav.foreldrepenger.behandlingsprosess.prosessering.BehandlingProsesseringTjeneste;
 import no.nav.foreldrepenger.domene.typer.Saksnummer;
 import no.nav.foreldrepenger.konfig.KonfigVerdi;
 import no.nav.foreldrepenger.produksjonsstyring.behandlingenhet.BehandlendeEnhetTjeneste;
@@ -29,7 +29,7 @@ public class BehandlingsutredningTjeneste {
 
     private Period defaultVenteFrist;
     private BehandlingRepository behandlingRepository;
-    private BehandlingskontrollTjeneste behandlingskontrollTjeneste;
+    private BehandlingProsesseringTjeneste behandlingProsesseringTjeneste;
     private BehandlendeEnhetTjeneste behandlendeEnhetTjeneste;
 
     BehandlingsutredningTjeneste() {
@@ -40,11 +40,11 @@ public class BehandlingsutredningTjeneste {
     public BehandlingsutredningTjeneste(@KonfigVerdi(value = "behandling.default.ventefrist.periode", defaultVerdi = "P4W") Period defaultVenteFrist,
                                         BehandlingRepositoryProvider behandlingRepositoryProvider,
                                         BehandlendeEnhetTjeneste behandlendeEnhetTjeneste,
-                                        BehandlingskontrollTjeneste behandlingskontrollTjeneste) {
+                                        BehandlingProsesseringTjeneste behandlingProsesseringTjeneste) {
         this.defaultVenteFrist = defaultVenteFrist;
         Objects.requireNonNull(behandlingRepositoryProvider, "behandlingRepositoryProvider");
         this.behandlingRepository = behandlingRepositoryProvider.getBehandlingRepository();
-        this.behandlingskontrollTjeneste = behandlingskontrollTjeneste;
+        this.behandlingProsesseringTjeneste = behandlingProsesseringTjeneste;
         this.behandlendeEnhetTjeneste = behandlendeEnhetTjeneste;
     }
 
@@ -73,7 +73,7 @@ public class BehandlingsutredningTjeneste {
         var behandlingStegFunnet = behandling.getAksjonspunktMedDefinisjonOptional(apDef)
             .map(Aksjonspunkt::getBehandlingStegFunnet)
             .orElse(null); // Dersom autopunkt ikke allerede er opprettet, så er det ikke tilknyttet steg
-        behandlingskontrollTjeneste.settBehandlingPåVent(behandling, apDef, behandlingStegFunnet, fristTid, venteårsak);
+        behandlingProsesseringTjeneste.settBehandlingPåVent(behandling, behandlingStegFunnet, apDef, fristTid, venteårsak);
     }
 
     public void endreBehandlingPaVent(Long behandlingsId, LocalDate frist, Venteårsak venteårsak) {

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/innsyn/aksjonspunkt/VurderInnsynOppdaterer.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/innsyn/aksjonspunkt/VurderInnsynOppdaterer.java
@@ -11,13 +11,13 @@ import no.nav.foreldrepenger.behandling.aksjonspunkt.AksjonspunktOppdaterParamet
 import no.nav.foreldrepenger.behandling.aksjonspunkt.AksjonspunktOppdaterer;
 import no.nav.foreldrepenger.behandling.aksjonspunkt.DtoTilServiceAdapter;
 import no.nav.foreldrepenger.behandling.aksjonspunkt.OppdateringResultat;
-import no.nav.foreldrepenger.behandlingskontroll.BehandlingskontrollTjeneste;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingStegType;
 import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.AksjonspunktDefinisjon;
 import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.Venteårsak;
 import no.nav.foreldrepenger.behandlingslager.behandling.innsyn.InnsynDokumentEntitet;
 import no.nav.foreldrepenger.behandlingslager.behandling.innsyn.InnsynEntitet;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepository;
+import no.nav.foreldrepenger.behandlingsprosess.prosessering.BehandlingProsesseringTjeneste;
 import no.nav.foreldrepenger.domene.vedtak.innsyn.InnsynTjeneste;
 import no.nav.foreldrepenger.validering.FeltFeilDto;
 import no.nav.foreldrepenger.validering.Valideringsfeil;
@@ -26,7 +26,7 @@ import no.nav.foreldrepenger.validering.Valideringsfeil;
 @DtoTilServiceAdapter(dto = VurderInnsynDto.class, adapter = AksjonspunktOppdaterer.class)
 public class VurderInnsynOppdaterer implements AksjonspunktOppdaterer<VurderInnsynDto> {
 
-    private BehandlingskontrollTjeneste behandlingskontrollTjeneste;
+    private BehandlingProsesseringTjeneste behandlingProsesseringTjeneste;
     private InnsynTjeneste innsynTjeneste;
     private BehandlingRepository behandlingRepository;
 
@@ -35,10 +35,10 @@ public class VurderInnsynOppdaterer implements AksjonspunktOppdaterer<VurderInns
     }
 
     @Inject
-    public VurderInnsynOppdaterer(BehandlingskontrollTjeneste behandlingskontrollTjeneste,
+    public VurderInnsynOppdaterer(BehandlingProsesseringTjeneste behandlingProsesseringTjeneste,
                                   InnsynTjeneste innsynTjeneste,
                                   BehandlingRepository behandlingRepository) {
-        this.behandlingskontrollTjeneste = behandlingskontrollTjeneste;
+        this.behandlingProsesseringTjeneste = behandlingProsesseringTjeneste;
         this.innsynTjeneste = innsynTjeneste;
         this.behandlingRepository = behandlingRepository;
     }
@@ -58,8 +58,8 @@ public class VurderInnsynOppdaterer implements AksjonspunktOppdaterer<VurderInns
         innsynTjeneste.lagreVurderInnsynResultat(behandling, builder.build());
 
         if (dto.isSattPaVent()) {
-            behandlingskontrollTjeneste.settBehandlingPåVent(behandling, AksjonspunktDefinisjon.VENT_PÅ_SCANNING,
-                BehandlingStegType.VURDER_INNSYN, frist(dto.getFristDato()), Venteårsak.SCANN);
+            behandlingProsesseringTjeneste.settBehandlingPåVent(behandling, BehandlingStegType.VURDER_INNSYN,
+                AksjonspunktDefinisjon.VENT_PÅ_SCANNING, frist(dto.getFristDato()), Venteårsak.SCANN);
         }
 
         return OppdateringResultat.utenOverhopp();

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/brev/BrevRestTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/brev/BrevRestTjeneste.java
@@ -104,6 +104,7 @@ public class BrevRestTjeneste {
     @Operation(description = "Bestiller generering og sending av brevet", tags = "brev")
     @BeskyttetRessurs(actionType = ActionType.UPDATE, resourceType = ResourceType.FAGSAK, sporingslogg = true)
     public void bestillDokument(@TilpassetAbacAttributt(supplierClass = BrevAbacDataSupplier.class) @Parameter(description = "Inneholder kode til brevmal og data som skal flettes inn i brevet") @Valid BestillDokumentDto bestillBrevDto) {
+        behandlingRepository.taSkriveLås(bestillBrevDto.behandlingUuid());
         var behandling = behandlingRepository.hentBehandling(bestillBrevDto.behandlingUuid());
         LOG.info("Brev med brevmalkode={} bestilt på behandlingId={}", bestillBrevDto.brevmalkode(), behandling.getId());
 

--- a/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/aksjonspunkt/BehandlingsutredningTjenesteTest.java
+++ b/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/aksjonspunkt/BehandlingsutredningTjenesteTest.java
@@ -15,8 +15,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 
-import no.nav.foreldrepenger.behandlingskontroll.impl.BehandlingskontrollTjenesteImpl;
-import no.nav.foreldrepenger.behandlingskontroll.spi.BehandlingskontrollServiceProvider;
 import no.nav.foreldrepenger.behandlingslager.aktør.OrganisasjonsEnhet;
 import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.Aksjonspunkt;
 import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.Venteårsak;
@@ -25,6 +23,7 @@ import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRe
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepositoryProvider;
 import no.nav.foreldrepenger.behandlingslager.fagsak.Fagsak;
 import no.nav.foreldrepenger.behandlingslager.testutilities.behandling.ScenarioMorSøkerEngangsstønad;
+import no.nav.foreldrepenger.behandlingsprosess.prosessering.BehandlingProsesseringTjeneste;
 import no.nav.foreldrepenger.dbstoette.CdiDbAwareTest;
 import no.nav.foreldrepenger.produksjonsstyring.behandlingenhet.BehandlendeEnhetTjeneste;
 import no.nav.vedtak.exception.FunksjonellException;
@@ -39,7 +38,7 @@ class BehandlingsutredningTjenesteTest {
     private BehandlingRepository behandlingRepository;
 
     @Inject
-    private BehandlingskontrollServiceProvider behandlingskontrollServiceProvider;
+    private BehandlingProsesseringTjeneste behandlingProsesseringTjeneste;
 
     @Mock
     private BehandlendeEnhetTjeneste behandlendeEnhetTjeneste;
@@ -56,8 +55,6 @@ class BehandlingsutredningTjenesteTest {
                 .lagre(repositoryProvider);
         behandlingId = behandling.getId();
 
-        var behandlingskontrollTjenesteImpl = new BehandlingskontrollTjenesteImpl(behandlingskontrollServiceProvider);
-
         lenient().when(behandlendeEnhetTjeneste.finnBehandlendeEnhetFor(any(Fagsak.class)))
                 .thenReturn(new OrganisasjonsEnhet("1234", "Testlokasjon"));
 
@@ -65,7 +62,7 @@ class BehandlingsutredningTjenesteTest {
                 Period.parse("P4W"),
                 repositoryProvider,
                 behandlendeEnhetTjeneste,
-                behandlingskontrollTjenesteImpl);
+                behandlingProsesseringTjeneste);
     }
 
     @Test

--- a/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/innsyn/VurderInnsynOppdatererTest.java
+++ b/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/innsyn/VurderInnsynOppdatererTest.java
@@ -29,6 +29,7 @@ import no.nav.foreldrepenger.behandlingslager.fagsak.Fagsak;
 import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakRepository;
 import no.nav.foreldrepenger.behandlingslager.testutilities.behandling.ScenarioMorSøkerEngangsstønad;
 import no.nav.foreldrepenger.behandlingsprosess.prosessering.BehandlingOpprettingTjeneste;
+import no.nav.foreldrepenger.behandlingsprosess.prosessering.BehandlingProsesseringTjeneste;
 import no.nav.foreldrepenger.dbstoette.CdiDbAwareTest;
 import no.nav.foreldrepenger.domene.vedtak.innsyn.InnsynTjeneste;
 import no.nav.foreldrepenger.produksjonsstyring.behandlingenhet.BehandlendeEnhetTjeneste;
@@ -53,6 +54,8 @@ class VurderInnsynOppdatererTest {
     private BehandlingsresultatRepository behandlingsresultatRepository;
     @Inject
     private BehandlingskontrollTjeneste behandlingskontrollTjeneste;
+    @Inject
+    private BehandlingProsesseringTjeneste behandlingProsesseringTjeneste;
 
     private BehandlendeEnhetTjeneste behandlendeEnhetTjeneste = Mockito.mock(BehandlendeEnhetTjeneste.class);
     private InnsynTjeneste innsynTjeneste;
@@ -65,7 +68,7 @@ class VurderInnsynOppdatererTest {
         var oppretter = new BehandlingOpprettingTjeneste(behandlingskontrollTjeneste, behandlendeEnhetTjeneste, repositoryProvider.getHistorikkinnslagRepository(),
                 mock(ProsessTaskTjeneste.class));
         innsynTjeneste = new InnsynTjeneste(oppretter, fagsakRepository, behandlingRepository, behandlingsresultatRepository, innsynRepository);
-        oppdaterer = new VurderInnsynOppdaterer(behandlingskontrollTjeneste, innsynTjeneste, behandlingRepository);
+        oppdaterer = new VurderInnsynOppdaterer(behandlingProsesseringTjeneste, innsynTjeneste, behandlingRepository);
     }
 
     @Test


### PR DESCRIPTION
Gjøre grensesnittet til behandlingskontrll mer konsekvent (kontekst, behandling, ...)
Bedre støtte i BehandlingProsessering - flest mulig tjenester kaller den - 
Fjerner en del dobbel-bruk av prosessering og kontroll.