### PR TITLE
Fiks: Revurderinger der originabehandling ikke finnes i kalkulus kan …

### DIFF
--- a/domenetjenester/beregningsgrunnlag/src/main/java/no/nav/foreldrepenger/domene/migrering/BeregningMigreringTjeneste.java
+++ b/domenetjenester/beregningsgrunnlag/src/main/java/no/nav/foreldrepenger/domene/migrering/BeregningMigreringTjeneste.java
@@ -84,8 +84,9 @@ public class BeregningMigreringTjeneste {
             return false;
         }
         var originalKobling = referanse.getOriginalBehandlingId().flatMap(koblingRepository::hentKobling);
-        if (referanse.erRevurdering() && originalKobling.isEmpty()) {
-            // Revurderinger er avhengig av at originalkobling ligger i kalkulus så vi har et grunnlag å basere oss på
+        var originaltBeregningsgrunnlagIFpsak = referanse.getOriginalBehandlingId().flatMap(beregningsgrunnlagRepository::hentBeregningsgrunnlagGrunnlagEntitet);
+        if (referanse.erRevurdering() && originalKobling.isEmpty() && originaltBeregningsgrunnlagIFpsak.isPresent()) {
+            // Revurderinger er avhengig av at originalt beregningsgrunnlag ligger i kalkulus så vi har et grunnlag å basere oss på
             LOG.info("Revurdering der orginal behandling ikke er migrert, beregner i fpsak");
             return false;
         }


### PR DESCRIPTION
…kjøres i kalkulus så lenge originalbehandlingen ikke hadde et beregningsgrunnlag