### PR TITLE
chore: fjerne midlertidig kode for SVP utbet.grad

### DIFF
--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/beregning/BeregningsresultatAndel.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/beregning/BeregningsresultatAndel.java
@@ -1,6 +1,7 @@
 package no.nav.foreldrepenger.behandlingslager.behandling.beregning;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -130,6 +131,18 @@ public class BeregningsresultatAndel extends BaseEntitet {
 
     public int getDagsatsFraBg() {
         return dagsatsFraBg;
+    }
+
+    public int getUtledetDagsatsFraBg() {
+        if (getDagsats() == 0 || utbetalingsgrad.compareTo(BigDecimal.ZERO) == 0) {
+            return dagsatsFraBg;
+        } else if (getDagsats() == getDagsatsFraBg() && utbetalingsgrad.compareTo(BigDecimal.valueOf(100)) < 0) {
+            // Tilfelle der utbetalingsgrad er mindre enn 100% men dagsatsFraBg er lik dagsats. Regn ut dagsatsFraBg
+            var utledet = BigDecimal.valueOf(dagsats).multiply(BigDecimal.valueOf(100)).divide(utbetalingsgrad, 0, RoundingMode.HALF_UP);
+            return utledet.intValue();
+        } else {
+            return dagsatsFraBg;
+        }
     }
 
     public AktivitetStatus getAktivitetStatus() {

--- a/domenetjenester/mottak/src/test/java/no/nav/foreldrepenger/mottak/vedtak/kafka/VedtaksHendelseHåndtererTest.java
+++ b/domenetjenester/mottak/src/test/java/no/nav/foreldrepenger/mottak/vedtak/kafka/VedtaksHendelseHåndtererTest.java
@@ -5,7 +5,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
-import static org.mockito.Mockito.when;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
@@ -13,7 +12,6 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Optional;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -31,7 +29,6 @@ import no.nav.abakus.vedtak.ytelse.Status;
 import no.nav.abakus.vedtak.ytelse.Ytelser;
 import no.nav.abakus.vedtak.ytelse.v1.YtelseV1;
 import no.nav.abakus.vedtak.ytelse.v1.anvisning.Anvisning;
-import no.nav.foreldrepenger.behandling.BehandlingReferanse;
 import no.nav.foreldrepenger.behandling.FagsakTjeneste;
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingResultatType;
@@ -62,7 +59,6 @@ import no.nav.foreldrepenger.domene.modell.BeregningsgrunnlagPeriode;
 import no.nav.foreldrepenger.domene.modell.BeregningsgrunnlagPrStatusOgAndel;
 import no.nav.foreldrepenger.domene.modell.kodeverk.AndelKilde;
 import no.nav.foreldrepenger.domene.modell.kodeverk.BeregningsgrunnlagTilstand;
-import no.nav.foreldrepenger.domene.prosess.BeregningTjeneste;
 import no.nav.foreldrepenger.domene.tid.ÅpenDatoIntervallEntitet;
 import no.nav.foreldrepenger.domene.typer.InternArbeidsforholdRef;
 import no.nav.foreldrepenger.mottak.vedtak.overlapp.HåndterOverlappPleiepengerTask;
@@ -82,8 +78,6 @@ class VedtaksHendelseHåndtererTest extends EntityManagerAwareTest {
     @Mock
     private ProsessTaskTjeneste taskTjeneste;
     @Mock
-    private BeregningTjeneste beregningTjeneste;
-    @Mock
     private HendelsemottakRepository mottakRepository;
     private BeregningsresultatRepository beregningsresultatRepository;
     private OverlappVedtakRepository overlappInfotrygdRepository;
@@ -101,7 +95,7 @@ class VedtaksHendelseHåndtererTest extends EntityManagerAwareTest {
         var fagsakTjeneste = new FagsakTjeneste(new FagsakRepository(getEntityManager()),
             new SøknadRepository(getEntityManager(), behandlingRepository));
         var overlappOppgaveTjeneste = new OverlappOppgaveTjeneste(oppgaveTjenesteMock);
-        var overlappTjeneste = new LoggOverlappEksterneYtelserTjeneste(beregningTjeneste, beregningsresultatRepository, null,
+        var overlappTjeneste = new LoggOverlappEksterneYtelserTjeneste(beregningsresultatRepository, null,
             null, null, null, null,
             overlappInfotrygdRepository, behandlingRepository, overlappOppgaveTjeneste);
         lenient().when(mottakRepository.hendelseErNy(any())).thenReturn(true);
@@ -377,8 +371,7 @@ class VedtaksHendelseHåndtererTest extends EntityManagerAwareTest {
                         .medArbeidsgiver(Arbeidsgiver.virksomhet("999999999")))
                     .medAktivitetStatus(no.nav.foreldrepenger.domene.modell.kodeverk.AktivitetStatus.ARBEIDSTAKER).build()).build())
             .build();
-        var gr = BeregningsgrunnlagGrunnlagBuilder.nytt().medBeregningsgrunnlag(beregningsgrunnlag).build(BeregningsgrunnlagTilstand.FASTSATT);
-        when(beregningTjeneste.hent(BehandlingReferanse.fra(b))).thenReturn(Optional.of(gr));
+        BeregningsgrunnlagGrunnlagBuilder.nytt().medBeregningsgrunnlag(beregningsgrunnlag).build(BeregningsgrunnlagTilstand.FASTSATT);
     }
 
     private BeregningsresultatEntitet lagBeregningsresultat(LocalDate periodeFom, LocalDate periodeTom, BigDecimal utbetalingsgrad) {

--- a/domenetjenester/mottak/src/test/java/no/nav/foreldrepenger/mottak/vedtak/overlapp/LoggOverlappEksterneYtelserTjenesteTest.java
+++ b/domenetjenester/mottak/src/test/java/no/nav/foreldrepenger/mottak/vedtak/overlapp/LoggOverlappEksterneYtelserTjenesteTest.java
@@ -95,7 +95,7 @@ class LoggOverlappEksterneYtelserTjenesteTest extends EntityManagerAwareTest {
         var behandlingRepository = new BehandlingRepository(getEntityManager());
         beregningsresultatRepository = new BeregningsresultatRepository(getEntityManager());
         var overlappOppgaveTjeneste = new OverlappOppgaveTjeneste(oppgaveTjenesteMock);
-        overlappendeInfotrygdYtelseTjeneste = new LoggOverlappEksterneYtelserTjeneste(null,
+        overlappendeInfotrygdYtelseTjeneste = new LoggOverlappEksterneYtelserTjeneste(
             beregningsresultatRepository, personinfoAdapter, infotrygdPSGrTjenesteMock, infotrygdSPGrTjenesteMock,
             abakusMock, spøkelseMock, overlappRepository, behandlingRepository, overlappOppgaveTjeneste);
         førsteUttaksdatoFp = LocalDate.now().minusMonths(4).minusWeeks(2);

--- a/domenetjenester/vedtak/src/main/java/no/nav/foreldrepenger/domene/vedtak/observer/VedtattYtelseMapper.java
+++ b/domenetjenester/vedtak/src/main/java/no/nav/foreldrepenger/domene/vedtak/observer/VedtattYtelseMapper.java
@@ -35,42 +35,21 @@ class VedtattYtelseMapper {
         return new VedtattYtelseMapper(arbeidsforholdReferanser);
     }
 
-    List<Anvisning> mapForeldrepenger(BeregningsresultatEntitet tilkjent) {
+    List<Anvisning> mapTilkjent(BeregningsresultatEntitet tilkjent) {
         return tilkjent.getBeregningsresultatPerioder().stream()
             .filter(periode -> periode.getDagsats() > 0)
-            .map(this::mapForeldrepengerPeriode)
+            .map(this::mapPeriode)
             .toList();
     }
 
-    private Anvisning mapForeldrepengerPeriode(BeregningsresultatPeriode periode) {
-        return mapPeriode(periode, periode.getKalkulertUtbetalingsgrad());
-    }
-
-    List<Anvisning> mapSvangerskapspenger(BeregningsresultatEntitet tilkjent) {
-        return tilkjent.getBeregningsresultatPerioder().stream()
-            .filter(periode -> periode.getDagsats() > 0)
-            .map(this::mapSvangerskapspengerPeriode)
-            .toList();
-    }
-
-    private Anvisning mapSvangerskapspengerPeriode(BeregningsresultatPeriode periode) {
-        var stipulertBruttoDagsats = periode.getBeregningsresultatAndelList().stream()
-            .filter(a -> a.getDagsats() > 0 && a.getUtbetalingsgrad().compareTo(BigDecimal.ZERO) > 0)
-            .map(a -> BigDecimal.valueOf(a.getDagsats()).multiply(BigDecimal.valueOf(100)).divide(a.getUtbetalingsgrad(), 10, RoundingMode.HALF_EVEN))
-            .reduce(BigDecimal::add)
-            .orElse(BigDecimal.ZERO);
-        var stipulertUtbetalingsgrad = BigDecimal.valueOf(100).multiply(BigDecimal.valueOf(periode.getDagsats())).divide(stipulertBruttoDagsats, 10, RoundingMode.HALF_EVEN);
-        return mapPeriode(periode, stipulertUtbetalingsgrad.setScale(2, RoundingMode.HALF_EVEN));
-    }
-
-    private Anvisning mapPeriode(BeregningsresultatPeriode periode, BigDecimal utbetalingsgrad) {
+    private Anvisning mapPeriode(BeregningsresultatPeriode periode) {
         var anvisning = new Anvisning();
         var p = new Periode();
         p.setFom(periode.getBeregningsresultatPeriodeFom());
         p.setTom(periode.getBeregningsresultatPeriodeTom());
         anvisning.setPeriode(p);
         anvisning.setDagsats(new Desimaltall(BigDecimal.valueOf(periode.getDagsats())));
-        anvisning.setUtbetalingsgrad(new Desimaltall(utbetalingsgrad));
+        anvisning.setUtbetalingsgrad(new Desimaltall(periode.getKalkulertUtbetalingsgrad()));
         anvisning.setAndeler(mapAndeler(periode.getBeregningsresultatAndelList()));
         return anvisning;
     }

--- a/domenetjenester/vedtak/src/main/java/no/nav/foreldrepenger/domene/vedtak/observer/VedtattYtelseTjeneste.java
+++ b/domenetjenester/vedtak/src/main/java/no/nav/foreldrepenger/domene/vedtak/observer/VedtattYtelseTjeneste.java
@@ -79,13 +79,7 @@ public class VedtattYtelseTjeneste {
         var arbeidsforholdReferanser = inntektArbeidYtelseTjeneste.finnGrunnlag(behandling.getId())
                 .flatMap(InntektArbeidYtelseGrunnlag::getArbeidsforholdInformasjon)
                 .map(ArbeidsforholdInformasjon::getArbeidsforholdReferanser).orElse(List.of());
-        if (FagsakYtelseType.FORELDREPENGER.equals(behandling.getFagsakYtelseType())) {
-            return VedtattYtelseMapper.medArbeidsforhold(arbeidsforholdReferanser).mapForeldrepenger(tilkjentYtelse);
-        } else if (FagsakYtelseType.SVANGERSKAPSPENGER.equals(behandling.getFagsakYtelseType())) {
-            return VedtattYtelseMapper.medArbeidsforhold(arbeidsforholdReferanser).mapSvangerskapspenger(tilkjentYtelse);
-        } else {
-            return List.of();
-        }
+        return VedtattYtelseMapper.medArbeidsforhold(arbeidsforholdReferanser).mapTilkjent(tilkjentYtelse);
     }
 
 

--- a/domenetjenester/vedtak/src/test/java/no/nav/foreldrepenger/domene/vedtak/observer/VedtattYtelseForeldrepengerMapperTest.java
+++ b/domenetjenester/vedtak/src/test/java/no/nav/foreldrepenger/domene/vedtak/observer/VedtattYtelseForeldrepengerMapperTest.java
@@ -1,5 +1,7 @@
 package no.nav.foreldrepenger.domene.vedtak.observer;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.ArrayList;
@@ -18,8 +20,6 @@ import no.nav.foreldrepenger.behandlingslager.virksomhet.Arbeidsgiver;
 import no.nav.foreldrepenger.domene.iay.modell.ArbeidsforholdReferanse;
 import no.nav.foreldrepenger.domene.typer.EksternArbeidsforholdRef;
 import no.nav.foreldrepenger.domene.typer.InternArbeidsforholdRef;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 class VedtattYtelseForeldrepengerMapperTest {
 
@@ -55,8 +55,7 @@ class VedtattYtelseForeldrepengerMapperTest {
             .build(periode);
 
         var arbeidsforholdReferanser = List.of(arbeidsforholdReferanse);
-        var anvisninger = VedtattYtelseMapper.medArbeidsforhold(arbeidsforholdReferanser)
-            .mapForeldrepenger(resultat);
+        var anvisninger = VedtattYtelseMapper.medArbeidsforhold(arbeidsforholdReferanser).mapTilkjent(resultat);
 
         assertThat(anvisninger).hasSize(1);
         assertThat(anvisninger.get(0).getAndeler()).hasSize(1);
@@ -95,8 +94,7 @@ class VedtattYtelseForeldrepengerMapperTest {
         fullRefusjon(arbeidsgiver2, periode, arbeidsforholdRef2, dagsats2);
 
         var arbeidsforholdReferanser = List.of(arbeidsforholdReferanse1, arbeidsforholdReferanse2);
-        var anvisninger = VedtattYtelseMapper.medArbeidsforhold(arbeidsforholdReferanser)
-            .mapForeldrepenger(resultat);
+        var anvisninger = VedtattYtelseMapper.medArbeidsforhold(arbeidsforholdReferanser).mapTilkjent(resultat);
 
         assertThat(anvisninger).hasSize(1);
         assertThat(anvisninger.get(0).getAndeler()).hasSize(2);
@@ -140,8 +138,7 @@ class VedtattYtelseForeldrepengerMapperTest {
         fullRefusjon(arbeidsgiver, periode, arbeidsforholdRef, dagsats);
 
         var arbeidsforholdReferanser = List.of(arbeidsforholdReferanse);
-        var anvisninger = VedtattYtelseMapper.medArbeidsforhold(arbeidsforholdReferanser)
-            .mapForeldrepenger(resultat);
+        var anvisninger = VedtattYtelseMapper.medArbeidsforhold(arbeidsforholdReferanser).mapTilkjent(resultat);
 
         assertThat(anvisninger).hasSize(1);
         assertThat(anvisninger.get(0).getAndeler()).hasSize(1);
@@ -172,8 +169,7 @@ class VedtattYtelseForeldrepengerMapperTest {
         fullRefusjon(arbeidsgiver, periode, arbeidsforholdRef, dagsats);
 
         var arbeidsforholdReferanser = new ArrayList<ArbeidsforholdReferanse>();
-        var anvisninger = VedtattYtelseMapper.medArbeidsforhold(arbeidsforholdReferanser)
-            .mapForeldrepenger(resultat);
+        var anvisninger = VedtattYtelseMapper.medArbeidsforhold(arbeidsforholdReferanser).mapTilkjent(resultat);
 
         assertThat(anvisninger).hasSize(1);
         assertThat(anvisninger.get(0).getAndeler()).hasSize(1);
@@ -212,8 +208,7 @@ class VedtattYtelseForeldrepengerMapperTest {
             .build(periode);
 
         var arbeidsforholdReferanser = new ArrayList<ArbeidsforholdReferanse>();
-        var anvisninger = VedtattYtelseMapper.medArbeidsforhold(arbeidsforholdReferanser)
-            .mapForeldrepenger(resultat);
+        var anvisninger = VedtattYtelseMapper.medArbeidsforhold(arbeidsforholdReferanser).mapTilkjent(resultat);
 
         assertThat(anvisninger).hasSize(1);
         assertThat(anvisninger.get(0).getAndeler()).hasSize(1);


### PR DESCRIPTION
SVP hadde alltid utbetalingsgrad 100% fra høsten 2019 til feb/mars 2023. Før/etter denne perioden er utbet.grad OK. 
Denne PR'en oppstår ifm omlegging til Kalkulus og at det kommer OMS-vedtak som overlapper SVP.
* fjerner kompenserende kode som regnet ut utbetalingsgrad pr andel ut fra beregningsgrunnlaget.
* ny metode for å regne ut samlet utbetalingsgrad for en periode med 1 vs N andeler (med ulik utbet.grad)

FP har ok data: dagsats = utbetalingsgrad * dagsatsFraBg
Det er fortsatt kompensasjon for at SVP-beregningresultat alltid har dagsatsFraBG = dagsats, tross redusert utbetaling.
SVP-situasjonsn bør fikses i regler (fp-ytelse-tilkjent) + input til reglene for SVP.