### PR TITLE
TFP-5179 moderniser ES-beregning fase 1

### DIFF
--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/beregning/LegacyESBeregning.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/beregning/LegacyESBeregning.java
@@ -29,8 +29,15 @@ public class LegacyESBeregning extends BaseEntitet {
     @Column(name = "versjon", nullable = false)
     private long versjon;
 
+    @Column(name = "behandling_id", updatable = false) // Todo: legg til nullable = false, unique = true
+    private Long behandlingId;
+
+    @Convert(converter = BooleanToStringConverter.class)
+    @Column(name = "aktiv", nullable = false)
+    private boolean aktiv = true;
+
     @ManyToOne(optional = false)
-    @JoinColumn(name = "beregning_resultat_id", nullable = false, updatable = false)
+    @JoinColumn(name = "beregning_resultat_id", updatable = false)
     private LegacyESBeregningsresultat beregningResultat;
 
     @Column(name = "sats_verdi", nullable = false)
@@ -60,16 +67,19 @@ public class LegacyESBeregning extends BaseEntitet {
         // for hibernate
     }
 
-    public LegacyESBeregning(long satsVerdi, long antallBarn, long beregnetTilkjentYtelse, LocalDateTime beregnetTidspunkt, boolean overstyrt, Long opprinneligBeregnetTilkjentYtelse) {
-        this(null, satsVerdi, antallBarn, beregnetTilkjentYtelse, beregnetTidspunkt, overstyrt, opprinneligBeregnetTilkjentYtelse);
+    public LegacyESBeregning(Long behandlingId,
+                             long satsVerdi, long antallBarn, long beregnetTilkjentYtelse, LocalDateTime beregnetTidspunkt, boolean overstyrt, Long opprinneligBeregnetTilkjentYtelse) {
+        this(behandlingId, null, satsVerdi, antallBarn, beregnetTilkjentYtelse, beregnetTidspunkt, overstyrt, opprinneligBeregnetTilkjentYtelse);
     }
 
-    public LegacyESBeregning(long satsVerdi, long antallBarn, long beregnetTilkjentYtelse, LocalDateTime beregnetTidspunkt) {
-        this(null, satsVerdi, antallBarn, beregnetTilkjentYtelse, beregnetTidspunkt, false, null);
+    public LegacyESBeregning(Long behandlingId, long satsVerdi, long antallBarn, long beregnetTilkjentYtelse, LocalDateTime beregnetTidspunkt) {
+        this(behandlingId, null, satsVerdi, antallBarn, beregnetTilkjentYtelse, beregnetTidspunkt, false, null);
     }
 
-    LegacyESBeregning(LegacyESBeregningsresultat beregningResultat, long satsVerdi, long antallBarn, long beregnetTilkjentYtelse, LocalDateTime beregnetTidspunkt, boolean overstyrt, Long opprinneligBeregnetTilkjentYtelse) {
+    LegacyESBeregning(Long behandlingId, LegacyESBeregningsresultat beregningResultat, long satsVerdi, long antallBarn, long beregnetTilkjentYtelse, LocalDateTime beregnetTidspunkt, boolean overstyrt, Long opprinneligBeregnetTilkjentYtelse) {
+        Objects.requireNonNull(behandlingId, "behandlingId må være satt");
         Objects.requireNonNull(beregnetTidspunkt, "beregnetTidspunkt må være satt");
+        this.behandlingId = behandlingId;
         this.beregningResultat = beregningResultat;
         this.satsVerdi = satsVerdi;
         this.antallBarn = antallBarn;
@@ -85,6 +95,18 @@ public class LegacyESBeregning extends BaseEntitet {
 
     public Long getId() {
         return id;
+    }
+
+    public Long getBehandlingId() {
+        return behandlingId;
+    }
+
+    public boolean erAktivt() {
+        return aktiv;
+    }
+
+    public void setAktiv(boolean aktiv) {
+        this.aktiv = aktiv;
     }
 
     public long getSatsVerdi() {

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/beregning/LegacyESBeregningsresultat.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/beregning/LegacyESBeregningsresultat.java
@@ -137,17 +137,17 @@ public class LegacyESBeregningsresultat extends BaseEntitet {
                     // samme behandling som originalt, oppdaterer original
                     return eksisterendeResultat; // samme som før
                 }
-                oppdaterBeregninger(eksisterendeResultat);
+                oppdaterBeregninger(behandlingsresultat.getBehandlingId(), eksisterendeResultat);
                 return eksisterendeResultat;
             }
-            oppdaterBeregninger(resultatMal);
+            oppdaterBeregninger(behandlingsresultat.getBehandlingId(), resultatMal);
             behandlingsresultat.medOppdatertBeregningResultat(resultatMal);
             return resultatMal;
         }
 
-        private void oppdaterBeregninger(LegacyESBeregningsresultat resultat) {
+        private void oppdaterBeregninger(Long behandlingId, LegacyESBeregningsresultat resultat) {
             var nye = oppdaterteBeregninger.stream()
-                .map(beregning -> new LegacyESBeregning(resultat, beregning.getSatsVerdi(), beregning.getAntallBarn(),
+                .map(beregning -> new LegacyESBeregning(behandlingId, resultat, beregning.getSatsVerdi(), beregning.getAntallBarn(),
                     beregning.getBeregnetTilkjentYtelse(), beregning.getBeregnetTidspunkt(), beregning.isOverstyrt(),
                     beregning.getOpprinneligBeregnetTilkjentYtelse()))
                 .collect(toSet());

--- a/behandlingslager/testutil/src/test/java/no/nav/foreldrepenger/behandlingslager/behandling/BehandlingRepositoryTest.java
+++ b/behandlingslager/testutil/src/test/java/no/nav/foreldrepenger/behandlingslager/behandling/BehandlingRepositoryTest.java
@@ -737,7 +737,7 @@ class BehandlingRepositoryTest extends EntityManagerAwareTest {
 
         if (innvilget) {
             LegacyESBeregningsresultat.builder()
-                .medBeregning(new LegacyESBeregning(48500L, 1L, 48500L, LocalDateTime.now()))
+                .medBeregning(new LegacyESBeregning(behandling.getId(), 48500L, 1L, 48500L, LocalDateTime.now()))
                 .buildFor(behandling, behandlingsresultat);
             beregningRepository.lagre(behandlingsresultat.getBeregningResultat(), lås);
         }

--- a/behandlingslager/testutil/src/test/java/no/nav/foreldrepenger/behandlingslager/behandling/BeregningResultatTest.java
+++ b/behandlingslager/testutil/src/test/java/no/nav/foreldrepenger/behandlingslager/behandling/BeregningResultatTest.java
@@ -65,9 +65,9 @@ class BeregningResultatTest extends EntityManagerAwareTest {
 
     @Test
     void skal_koble_beregning_til_beregningsresultat() {
-        var beregning = new LegacyESBeregning(1000L, antallBarn, antallBarn*1000, LocalDateTime.now());
-        assertThat(beregning.getBeregningResultat()).isNull();
         var behandling1 = opprettBehandling();
+        var beregning = new LegacyESBeregning(behandling1.getId(), 1000L, antallBarn, antallBarn*1000, LocalDateTime.now());
+        assertThat(beregning.getBeregningResultat()).isNull();
         var beregningResultat = LegacyESBeregningsresultat.builder().medBeregning(beregning)
             .buildFor(behandling1, null);
         assertThat(beregning.getBeregningResultat()).isNull();
@@ -85,8 +85,8 @@ class BeregningResultatTest extends EntityManagerAwareTest {
     void skal_opprette_nytt_beregningsresultat_med_beregning_dersom_ikke_finnes_fra_før() {
         // Act
         // TX_1: Opprette nytt beregningsresultat med beregningsinfo
-        var beregning = new LegacyESBeregning(sats, antallBarn, tilkjentYtelse, LocalDateTime.now());
         var behandling1 = opprettBehandling();
+        var beregning = new LegacyESBeregning(behandling1.getId(), sats, antallBarn, tilkjentYtelse, LocalDateTime.now());
         var beregningResultat = LegacyESBeregningsresultat.builder()
                 .medBeregning(beregning)
                 .buildFor(behandling1, null);
@@ -103,8 +103,8 @@ class BeregningResultatTest extends EntityManagerAwareTest {
     void skal_gjenbruke_beregningsresultat_fra_tidligere_behandling_ved_opprettelse_av_ny_behandling() {
         // Act
         // TX_1: Opprette nytt beregningsresultat
-        var beregning = new LegacyESBeregning(sats, antallBarn, tilkjentYtelse, LocalDateTime.now());
         var behandling1 = opprettBehandling();
+        var beregning = new LegacyESBeregning(behandling1.getId(), sats, antallBarn, tilkjentYtelse, LocalDateTime.now());
         var beregningResultat = LegacyESBeregningsresultat.builder().medBeregning(beregning).buildFor(behandling1, null);
         lagreBeregningResultat(behandling1, beregningResultat);
 
@@ -134,8 +134,8 @@ class BeregningResultatTest extends EntityManagerAwareTest {
     void skal_opprette_nytt_beregningsresultat_dersom_gjenbrukt_resultat_fra_tidligere_behandling_oppdateres() {
         // Act
         // TX_1: Opprette nytt beregningsresultat
-        var beregning1 = new LegacyESBeregning(sats, antallBarn, tilkjentYtelse, LocalDateTime.now());
         var behandling1 = opprettBehandling();
+        var beregning1 = new LegacyESBeregning(behandling1.getId(), sats, antallBarn, tilkjentYtelse, LocalDateTime.now());
         var beregningResultat = LegacyESBeregningsresultat.builder().medBeregning(beregning1)
             .buildFor(behandling1, null);
         lagreBeregningResultat(behandling1, beregningResultat);
@@ -150,7 +150,7 @@ class BeregningResultatTest extends EntityManagerAwareTest {
 
         // TX_3: Oppdatere nyTerminbekreftelse behandling med beregning
         behandling2 = behandlingRepository.hentBehandling(behandling2.getId());
-        var beregning2 = new LegacyESBeregning(sats + 1, antallBarn, tilkjentYtelse, LocalDateTime.now());
+        var beregning2 = new LegacyESBeregning(behandling2.getId(), sats + 1, antallBarn, tilkjentYtelse, LocalDateTime.now());
         LegacyESBeregningsresultat.builder().medBeregning(beregning2).buildFor(behandling2, getBehandlingsresultat(behandling2));
         lagreBeregningResultat(behandling2, getBehandlingsresultat(behandling2).getBeregningResultat());
 
@@ -169,8 +169,8 @@ class BeregningResultatTest extends EntityManagerAwareTest {
     void skal_ikke_opprette_nytt_beregningsresultat_dersom_resultat_fra_tidligere_behandling_allerede_er_oppdatert() {
         // Act
         // TX_1: Opprette nytt beregningsresultat
-        var beregning1 = new LegacyESBeregning(sats, antallBarn, tilkjentYtelse, LocalDateTime.now());
         var behandling1 = opprettBehandling();
+        var beregning1 = new LegacyESBeregning(behandling1.getId(), sats, antallBarn, tilkjentYtelse, LocalDateTime.now());
         var beregningResultat = LegacyESBeregningsresultat.builder().medBeregning(beregning1).buildFor(behandling1, null);
         lagreBeregningResultat(behandling1, beregningResultat);
 
@@ -184,13 +184,13 @@ class BeregningResultatTest extends EntityManagerAwareTest {
 
         // TX_3: Oppdatere nyTerminbekreftelse behandling med beregning
         behandling2 = behandlingRepository.hentBehandling(behandling2.getId());
-        var beregning2 = new LegacyESBeregning(sats + 1, antallBarn, tilkjentYtelse, LocalDateTime.now());
+        var beregning2 = new LegacyESBeregning(behandling2.getId(), sats + 1, antallBarn, tilkjentYtelse, LocalDateTime.now());
         LegacyESBeregningsresultat.builder().medBeregning(beregning2).buildFor(behandling2, getBehandlingsresultat(behandling2));
         lagreBeregningResultat(behandling2, getBehandlingsresultat(behandling2).getBeregningResultat());
 
         // TX_4: Oppdatere nyTerminbekreftelse behandling med beregning (samme som TX_3, men nyTerminbekreftelse beregning med nyTerminbekreftelse verdi)
         behandling2 = behandlingRepository.hentBehandling(behandling2.getId());
-        var beregning3 = new LegacyESBeregning(sats + 2, antallBarn, tilkjentYtelse, LocalDateTime.now());
+        var beregning3 = new LegacyESBeregning(behandling2.getId(), sats + 2, antallBarn, tilkjentYtelse, LocalDateTime.now());
         LegacyESBeregningsresultat.builder().medBeregning(beregning3).buildFor(behandling2, getBehandlingsresultat(behandling2));
         lagreBeregningResultat(behandling2, getBehandlingsresultat(behandling2).getBeregningResultat());
 
@@ -213,8 +213,8 @@ class BeregningResultatTest extends EntityManagerAwareTest {
     void skal_bevare_vilkårresultat_ved_oppdatering_av_beregingsresultat() {
         // Act
         // TX_1: Opprette Behandlingsresultat med Beregningsresultat
-        var beregning1 = new LegacyESBeregning(sats, antallBarn, tilkjentYtelse, LocalDateTime.now());
         var behandling1 = opprettBehandling();
+        var beregning1 = new LegacyESBeregning(behandling1.getId(), sats, antallBarn, tilkjentYtelse, LocalDateTime.now());
         var beregningResultat1 = LegacyESBeregningsresultat.builder().medBeregning(beregning1)
             .buildFor(behandling1, null);
         lagreBeregningResultat(behandling1, beregningResultat1);
@@ -230,7 +230,7 @@ class BeregningResultatTest extends EntityManagerAwareTest {
 
         // TX_3: Oppdatere Behandlingsresultat med BeregningResultat
         behandling1 = behandlingRepository.hentBehandling(behandling1.getId());
-        var oppdatertBeregning = new LegacyESBeregning(sats + 1, antallBarn, tilkjentYtelse, LocalDateTime.now());
+        var oppdatertBeregning = new LegacyESBeregning(behandling1.getId(), sats + 1, antallBarn, tilkjentYtelse, LocalDateTime.now());
         var beregningResultat2 = LegacyESBeregningsresultat.builder().medBeregning(oppdatertBeregning).buildFor(behandling1, getBehandlingsresultat(behandling1));
         lagreBeregningResultat(behandling1, beregningResultat2);
 

--- a/behandlingsprosess/src/main/java/no/nav/foreldrepenger/behandling/steg/beregnytelse/es/BeregneYtelseEngangsstønadStegImpl.java
+++ b/behandlingsprosess/src/main/java/no/nav/foreldrepenger/behandling/steg/beregnytelse/es/BeregneYtelseEngangsstønadStegImpl.java
@@ -77,7 +77,7 @@ public class BeregneYtelseEngangsstønadStegImpl implements BeregneYtelseSteg {
             var satsDato = getSatsDato(behandlingId);
             var sats = satsRepository.finnEksaktSats(BeregningSatsType.ENGANG, satsDato);
             var beregnetYtelse = sats.getVerdi() * antallBarn;
-            var beregning = new LegacyESBeregning(sats.getVerdi(), antallBarn, beregnetYtelse, LocalDateTime.now());
+            var beregning = new LegacyESBeregning(behandlingId, sats.getVerdi(), antallBarn, beregnetYtelse, LocalDateTime.now());
 
             var behandling = behandlingRepository.hentBehandling(behandlingId);
             var behResultat = resultatRepository.hentHvisEksisterer(behandlingId).orElse(null);

--- a/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/beregnytelse/es/BeregneYtelseStegImplTest.java
+++ b/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/beregnytelse/es/BeregneYtelseStegImplTest.java
@@ -135,7 +135,7 @@ class BeregneYtelseStegImplTest {
         var lås = behandlingRepository.taSkriveLås(behandling);
         var kontekst = behandlingskontrollTjeneste.initBehandlingskontroll(behandling, lås);
         var beregningResultat = LegacyESBeregningsresultat.builder()
-                .medBeregning(new LegacyESBeregning(1000L, antallBarn, 1000L, LocalDateTime.now()))
+                .medBeregning(new LegacyESBeregning(behandling.getId(), 1000L, antallBarn, 1000L, LocalDateTime.now()))
                 .buildFor(behandling, getBehandlingsresultat(behandling));
         beregningRepository.lagre(beregningResultat, kontekst.getSkriveLås());
         behandlingRepository.lagre(behandling, kontekst.getSkriveLås());
@@ -156,8 +156,8 @@ class BeregneYtelseStegImplTest {
         var lås = behandlingRepository.taSkriveLås(behandling);
         var kontekst = behandlingskontrollTjeneste.initBehandlingskontroll(behandling, lås);
         var beregningResultat = LegacyESBeregningsresultat.builder()
-                .medBeregning(new LegacyESBeregning(1000L, antallBarn, 1000L, LocalDateTime.now(), false, null))
-                .medBeregning(new LegacyESBeregning(500L, antallBarn, 1000L, LocalDateTime.now(), true, 1000L))
+                .medBeregning(new LegacyESBeregning(behandling.getId(), 1000L, antallBarn, 1000L, LocalDateTime.now(), false, null))
+                .medBeregning(new LegacyESBeregning(behandling.getId(), 500L, antallBarn, 1000L, LocalDateTime.now(), true, 1000L))
                 .buildFor(behandling, getBehandlingsresultat(behandling));
         beregningRepository.lagre(beregningResultat, kontekst.getSkriveLås());
         behandlingRepository.lagre(behandling, kontekst.getSkriveLås());
@@ -181,8 +181,8 @@ class BeregneYtelseStegImplTest {
         var lås = behandlingRepository.taSkriveLås(behandling);
         var kontekst = behandlingskontrollTjeneste.initBehandlingskontroll(behandling, lås);
         var beregningResultat = LegacyESBeregningsresultat.builder()
-                .medBeregning(new LegacyESBeregning(1000L, antallBarn, 1000L, LocalDateTime.now(), false, null))
-                .medBeregning(new LegacyESBeregning(500L, antallBarn, 1000L, LocalDateTime.now(), true, 1000L))
+                .medBeregning(new LegacyESBeregning(behandling.getId(), 1000L, antallBarn, 1000L, LocalDateTime.now(), false, null))
+                .medBeregning(new LegacyESBeregning(behandling.getId(), 500L, antallBarn, 1000L, LocalDateTime.now(), true, 1000L))
                 .buildFor(behandling, getBehandlingsresultat(behandling));
         beregningRepository.lagre(beregningResultat, kontekst.getSkriveLås());
         behandlingRepository.lagre(behandling, kontekst.getSkriveLås());

--- a/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/vedtak/FatteVedtakStegTest.java
+++ b/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/vedtak/FatteVedtakStegTest.java
@@ -487,7 +487,7 @@ class FatteVedtakStegTest {
                 .medBehandlendeEnhet(BEHANDLENDE_ENHET)
                 .medBehandlingsresultat(Behandlingsresultat.builder().medBehandlingResultatType(BehandlingResultatType.INNVILGET))
                 .lagre(repositoryProvider);
-        var beregning = new LegacyESBeregning(1L, 1L, 1L, LocalDateTime.now());
+        var beregning = new LegacyESBeregning(behandling.getId(), 1L, 1L, 1L, LocalDateTime.now());
         var bres = repositoryProvider.getBehandlingsresultatRepository().hentHvisEksisterer(behandling.getId()).orElse(null);
         var beregningResultat = LegacyESBeregningsresultat.builder().medBeregning(beregning).buildFor(behandling, bres);
         beregningRepository.lagre(beregningResultat, repositoryProvider.getBehandlingRepository().taSkriveLås(behandling));
@@ -528,7 +528,7 @@ class FatteVedtakStegTest {
             behandlingRepository.lagre(vilkårResultat, lås);
             var bres = repositoryProvider.getBehandlingsresultatRepository().hentHvisEksisterer(behandling.getId()).orElse(null);
             var beregningResultat = LegacyESBeregningsresultat.builder()
-                    .medBeregning(new LegacyESBeregning(48500L, antallBarn, 48500L * antallBarn, LocalDateTime.now()))
+                    .medBeregning(new LegacyESBeregning(behandling.getId(), 48500L, antallBarn, 48500L * antallBarn, LocalDateTime.now()))
                     .buildFor(behandling, bres);
             beregningRepository.lagre(beregningResultat, lås);
             Behandlingsresultat.builderEndreEksisterende(getBehandlingsresultat(behandling))

--- a/domenetjenester/behandling-revurdering/src/test/java/no/nav/foreldrepenger/behandling/revurdering/etterkontroll/es/AutomatiskEtterkontrollTaskTest.java
+++ b/domenetjenester/behandling-revurdering/src/test/java/no/nav/foreldrepenger/behandling/revurdering/etterkontroll/es/AutomatiskEtterkontrollTaskTest.java
@@ -276,7 +276,7 @@ class AutomatiskEtterkontrollTaskTest {
         repositoryProvider.getBehandlingVedtakRepository().lagre(vedtak, lås);
 
         var sats = satsRepository.finnEksaktSats(BeregningSatsType.ENGANG, LocalDate.now()).getVerdi();
-        var beregning = new LegacyESBeregning(sats, antallBarn, antallBarn * sats, LocalDateTime.now());
+        var beregning = new LegacyESBeregning(behandling.getId(), sats, antallBarn, antallBarn * sats, LocalDateTime.now());
         var beregningResultat = LegacyESBeregningsresultat.builder()
                 .medBeregning(beregning)
                 .buildFor(behandling, behandling.getBehandlingsresultat());

--- a/domenetjenester/behandling-revurdering/src/test/java/no/nav/foreldrepenger/behandling/revurdering/satsregulering/SatsReguleringUtil.java
+++ b/domenetjenester/behandling-revurdering/src/test/java/no/nav/foreldrepenger/behandling/revurdering/satsregulering/SatsReguleringUtil.java
@@ -262,7 +262,7 @@ public class SatsReguleringUtil {
         var lås = repositoryProvider.getBehandlingRepository().taSkriveLås(behandling);
         repositoryProvider.getBehandlingRepository().lagre(behandling, lås);
 
-        var beregning = new LegacyESBeregning(sats, 1, sats, LocalDateTime.now());
+        var beregning = new LegacyESBeregning(behandling.getId(), sats, 1, sats, LocalDateTime.now());
         var beregningResultat = LegacyESBeregningsresultat.builder().medBeregning(beregning)
             .buildFor(behandling, repositoryProvider.getBehandlingsresultatRepository().hent(behandling.getId()));
         beregningRepository.lagre(beregningResultat, lås);

--- a/domenetjenester/behandling-revurdering/src/test/java/no/nav/foreldrepenger/behandling/revurdering/ytelse/es/RevurderingEndringTest.java
+++ b/domenetjenester/behandling-revurdering/src/test/java/no/nav/foreldrepenger/behandling/revurdering/ytelse/es/RevurderingEndringTest.java
@@ -194,7 +194,7 @@ class RevurderingEndringTest {
     }
 
     private LegacyESBeregningsresultat opprettBeregning(Behandling behandling, long antallBarn) {
-        var beregning = new LegacyESBeregning(1000L, antallBarn, antallBarn * 1000, LocalDateTime.now());
+        var beregning = new LegacyESBeregning(behandling.getId(), 1000L, antallBarn, antallBarn * 1000, LocalDateTime.now());
         var behandlingsresultat = repositoryProvider.getBehandlingsresultatRepository().hent(behandling.getId());
         return LegacyESBeregningsresultat.builder().medBeregning(beregning).buildFor(behandling, behandlingsresultat);
     }

--- a/domenetjenester/datavarehus/src/test/java/no/nav/foreldrepenger/datavarehus/xml/es/VedtakXmlTest.java
+++ b/domenetjenester/datavarehus/src/test/java/no/nav/foreldrepenger/datavarehus/xml/es/VedtakXmlTest.java
@@ -217,7 +217,7 @@ class VedtakXmlTest {
         var behandlingsresultat = opprettBehandlingsresultat(behandling, BehandlingResultatType.INNVILGET);
         entityManager.persist(behandlingsresultat);
         opprettBehandlingsvedtak(behandling, behandlingsresultat);
-        var beregning = new LegacyESBeregning(1L, 1L, 1L, LocalDateTime.now());
+        var beregning = new LegacyESBeregning(behandling.getId(), 1L, 1L, 1L, LocalDateTime.now());
         var bres = behandlingsresultatRepository.hentHvisEksisterer(behandling.getId()).orElse(null);
         var beregningResultat = LegacyESBeregningsresultat.builder().medBeregning(beregning).buildFor(behandling, bres);
         beregningRepository.lagre(beregningResultat, behandlingRepository.taSkriveLås(behandling));
@@ -231,7 +231,7 @@ class VedtakXmlTest {
         var behandlingsresultat = opprettBehandlingsresultat(behandling, BehandlingResultatType.INNVILGET);
         behandlingRepository.lagre(behandling, behandlingRepository.taSkriveLås(behandling));
         opprettBehandlingsvedtak(behandling, behandlingsresultat);
-        var beregning = new LegacyESBeregning(1L, 1L, 1L, LocalDateTime.now());
+        var beregning = new LegacyESBeregning(behandling.getId(), 1L, 1L, 1L, LocalDateTime.now());
         var bres = behandlingsresultatRepository.hentHvisEksisterer(behandling.getId()).orElse(null);
         var beregningResultat = LegacyESBeregningsresultat.builder().medBeregning(beregning).buildFor(behandling, bres);
         beregningRepository.lagre(beregningResultat, behandlingRepository.taSkriveLås(behandling));
@@ -266,7 +266,7 @@ class VedtakXmlTest {
                 .buildFor(behandling);
             var bres = behandlingsresultatRepository.hentHvisEksisterer(behandling.getId()).orElse(null);
             LegacyESBeregningsresultat.builder()
-                    .medBeregning(new LegacyESBeregning(48500L, 1L, 48500L, LocalDateTime.now()))
+                    .medBeregning(new LegacyESBeregning(behandling.getId(), 48500L, 1L, 48500L, LocalDateTime.now()))
                     .buildFor(behandling, bres);
         } else {
             VilkårResultat.builder()
@@ -287,7 +287,7 @@ class VedtakXmlTest {
         var behandlingsresultat = opprettBehandlingsresultat(behandling, BehandlingResultatType.INNVILGET);
         behandlingRepository.lagre(behandling, behandlingRepository.taSkriveLås(behandling));
         opprettBehandlingsvedtak(behandling, behandlingsresultat);
-        var beregning = new LegacyESBeregning(1L, 1L, 1L, LocalDateTime.now());
+        var beregning = new LegacyESBeregning(behandling.getId(), 1L, 1L, 1L, LocalDateTime.now());
         var bres = behandlingsresultatRepository.hentHvisEksisterer(behandling.getId()).orElse(null);
         var beregningResultat = LegacyESBeregningsresultat.builder().medBeregning(beregning).buildFor(behandling, bres);
         beregningRepository.lagre(beregningResultat, behandlingRepository.taSkriveLås(behandling));
@@ -335,7 +335,7 @@ class VedtakXmlTest {
         var behandlingsresultat = opprettBehandlingsresultat(behandling, BehandlingResultatType.INNVILGET);
         behandlingRepository.lagre(behandling, behandlingRepository.taSkriveLås(behandling));
         opprettBehandlingsvedtak(behandling, behandlingsresultat);
-        var beregning = new LegacyESBeregning(1L, 1L, 1L, LocalDateTime.now());
+        var beregning = new LegacyESBeregning(behandling.getId(), 1L, 1L, 1L, LocalDateTime.now());
         var bres = behandlingsresultatRepository.hentHvisEksisterer(behandling.getId()).orElse(null);
         var beregningResultat = LegacyESBeregningsresultat.builder().medBeregning(beregning).buildFor(behandling, bres);
         beregningRepository.lagre(beregningResultat, behandlingRepository.taSkriveLås(behandling));

--- a/domenetjenester/mottak/src/test/java/no/nav/foreldrepenger/mottak/dokumentmottak/impl/DokumentmottakerKlageTest.java
+++ b/domenetjenester/mottak/src/test/java/no/nav/foreldrepenger/mottak/dokumentmottak/impl/DokumentmottakerKlageTest.java
@@ -199,7 +199,7 @@ class DokumentmottakerKlageTest {
                 .buildFor(behandling);
         var behandlingsresultat = behandling.getBehandlingsresultat();
         LegacyESBeregningsresultat.builder()
-                .medBeregning(new LegacyESBeregning(48500L, 1L, 48500L, LocalDateTime.now()))
+                .medBeregning(new LegacyESBeregning(behandling.getId(), 48500L, 1L, 48500L, LocalDateTime.now()))
                 .buildFor(behandling, behandlingsresultat);
         var vedtak = BehandlingVedtak.builder()
                 .medVedtakResultatType(VedtakResultatType.INNVILGET)

--- a/domenetjenester/okonomistotte/src/test/java/no/nav/foreldrepenger/økonomistøtte/OppdragInputTjenesteTest.java
+++ b/domenetjenester/okonomistotte/src/test/java/no/nav/foreldrepenger/økonomistøtte/OppdragInputTjenesteTest.java
@@ -76,7 +76,7 @@ class OppdragInputTjenesteTest {
     private OppdragInputTjeneste oppdragInputTjeneste;
 
     @BeforeEach
-    public void setup() {
+    void setup() {
         behandling = Behandling.nyBehandlingFor(
             Fagsak.opprettNy(FagsakYtelseType.ENGANGSTØNAD, NavBruker.opprettNyNB(AktørId.dummy()), new Saksnummer("123456789")),
             BehandlingType.FØRSTEGANGSSØKNAD).build();
@@ -102,10 +102,10 @@ class OppdragInputTjenesteTest {
 
     @Test
     @DisplayName("Simulering oppdrag input for ES fødsel uten tidligere utbetalinger.")
-    public void oppdragInputSimuleringESFørstegang() {
+    void oppdragInputSimuleringESFørstegang() {
         // Prepare
         when(beregningRepository.getSisteBeregning(behandlingId)).thenReturn(
-            Optional.of(new LegacyESBeregning(TILKJENT_YTELSE, 1, TILKJENT_YTELSE, LocalDateTime.now())));
+            Optional.of(new LegacyESBeregning(behandlingId, TILKJENT_YTELSE, 1, TILKJENT_YTELSE, LocalDateTime.now())));
 
         // Act
         var input = oppdragInputTjeneste.lagSimuleringInput(behandlingId);
@@ -123,11 +123,11 @@ class OppdragInputTjenesteTest {
 
     @Test
     @DisplayName("Simulering oppdrag input for ES fødsel med en tidligere utbetaling.")
-    public void oppdragInputSimuleringESRevurderingMedTidligereOppdrag() {
+    void oppdragInputSimuleringESRevurderingMedTidligereOppdrag() {
         // Prepare
         var saksnummer = behandling.getSaksnummer();
         when(beregningRepository.getSisteBeregning(behandlingId)).thenReturn(
-            Optional.of(new LegacyESBeregning(TILKJENT_YTELSE, 1, TILKJENT_YTELSE, LocalDateTime.now())));
+            Optional.of(new LegacyESBeregning(behandlingId, TILKJENT_YTELSE, 1, TILKJENT_YTELSE, LocalDateTime.now())));
 
         var oppdragskontroll = lagOppdragskontroll(saksnummer);
         var oppdrag = lagOppdrag(oppdragskontroll, saksnummer);
@@ -149,11 +149,11 @@ class OppdragInputTjenesteTest {
 
     @Test
     @DisplayName("Simulering oppdrag input for ES fødsel med to tidligere utbetalinger.")
-    public void oppdragInputSimuleringESRevurderingMedToTidligereOppdrag() {
+    void oppdragInputSimuleringESRevurderingMedToTidligereOppdrag() {
         // Prepare
         var saksnummer = behandling.getSaksnummer();
         when(beregningRepository.getSisteBeregning(behandlingId)).thenReturn(
-            Optional.of(new LegacyESBeregning(TILKJENT_YTELSE, 1, TILKJENT_YTELSE, LocalDateTime.now())));
+            Optional.of(new LegacyESBeregning(behandlingId, TILKJENT_YTELSE, 1, TILKJENT_YTELSE, LocalDateTime.now())));
 
         var oppdragskontroll = lagOppdragskontroll(saksnummer);
         var oppdrag = lagOppdrag(oppdragskontroll, saksnummer);
@@ -181,11 +181,11 @@ class OppdragInputTjenesteTest {
 
     @Test
     @DisplayName("Simulering oppdrag input for ES fødsel med to tidligere utbetalinger men med en positiv kvittering.")
-    public void oppdragInputSimuleringESRevurderingMedToTidligereOppdragMenKunEnPositivKvittering() {
+    void oppdragInputSimuleringESRevurderingMedToTidligereOppdragMenKunEnPositivKvittering() {
         // Prepare
         var saksnummer = behandling.getSaksnummer();
         when(beregningRepository.getSisteBeregning(behandlingId)).thenReturn(
-            Optional.of(new LegacyESBeregning(TILKJENT_YTELSE, 1, TILKJENT_YTELSE, LocalDateTime.now())));
+            Optional.of(new LegacyESBeregning(behandlingId, TILKJENT_YTELSE, 1, TILKJENT_YTELSE, LocalDateTime.now())));
 
         var oppdragskontroll = lagOppdragskontroll(saksnummer);
         var oppdrag = lagOppdrag(oppdragskontroll, saksnummer);

--- a/domenetjenester/okonomistotte/src/test/java/no/nav/foreldrepenger/økonomistøtte/SimulerOppdragTjenesteESTest.java
+++ b/domenetjenester/okonomistotte/src/test/java/no/nav/foreldrepenger/økonomistøtte/SimulerOppdragTjenesteESTest.java
@@ -60,7 +60,7 @@ class SimulerOppdragTjenesteESTest {
     private long behandlingId;
 
     @BeforeEach
-    public void setup() {
+    void setup() {
         var behandling = Behandling.nyBehandlingFor(
             Fagsak.opprettNy(FagsakYtelseType.ENGANGSTØNAD, NavBruker.opprettNyNB(AktørId.dummy()), new Saksnummer("123456789")),
             BehandlingType.FØRSTEGANGSSØKNAD).build();
@@ -74,7 +74,7 @@ class SimulerOppdragTjenesteESTest {
             .build()));
         when(personinfoAdapter.hentFnrForAktør(any())).thenReturn(PersonIdent.fra("0987654321"));
         when(beregningRepository.getSisteBeregning(behandlingId)).thenReturn(
-            Optional.of(new LegacyESBeregning(15000, 1, 15000, LocalDateTime.now())));
+            Optional.of(new LegacyESBeregning(behandlingId, 15000, 1, 15000, LocalDateTime.now())));
         var familieHendelseGrunnlag = mock(FamilieHendelseGrunnlagEntitet.class);
         when(familieHendelseRepository.hentAggregatHvisEksisterer(behandlingId)).thenReturn(Optional.of(familieHendelseGrunnlag));
         var familieHendelse = mock(FamilieHendelseEntitet.class);

--- a/migreringer/src/main/resources/db/migration/defaultDS/4.1/V4.1_41__TFP-5179-esberegning-behandling.sql
+++ b/migreringer/src/main/resources/db/migration/defaultDS/4.1/V4.1_41__TFP-5179-esberegning-behandling.sql
@@ -1,0 +1,13 @@
+ALTER TABLE BR_LEGACY_ES_BEREGNING MODIFY(BEREGNING_RESULTAT_ID NULL);
+
+alter table BR_LEGACY_ES_BEREGNING ADD (
+    BEHANDLING_ID NUMBER(19)
+        constraint FK_BEREGNING_2 references BEHANDLING,
+    AKTIV VARCHAR2(1 char) default 'J' not null
+        constraint CHK_AKTIV_ESBEREGN check (aktiv IN ('J', 'N')));
+
+comment on column BR_LEGACY_ES_BEREGNING.AKTIV is 'Om beregning er aktiv';
+comment on column BR_LEGACY_ES_BEREGNING.BEHANDLING_ID is 'FK behandling';
+
+create index IDX_BEREGNING_2
+    on BR_LEGACY_ES_BEREGNING (BEHANDLING_ID);

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/forvaltning/ForvaltningUttrekkRestTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/forvaltning/ForvaltningUttrekkRestTjeneste.java
@@ -311,4 +311,40 @@ public class ForvaltningUttrekkRestTjeneste {
         return Response.ok(restanse).build();
     }
 
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    @Operation(description = "Flytt behandling til steg", tags = "FORVALTNING-uttrekk")
+    @Path("/populerESBeregningMedBehandlingId")
+    @BeskyttetRessurs(actionType = ActionType.READ, resourceType = ResourceType.DRIFT, sporingslogg = true)
+    public Response populerESBeregningMedBehandlingId() {
+        var antall = entityManager.createNativeQuery("""
+            merge into BR_LEGACY_ES_BEREGNING a
+            using (select behandling_id bid, beregning_resultat_id brid
+                   from BEHANDLING_RESULTAT where beregning_resultat_id is not null) b
+            on (a.beregning_resultat_id = b.brid)
+            when matched then update set a.behandling_id = b.bid
+            """)
+            .executeUpdate();
+        return Response.ok(antall).build();
+    }
+
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    @Operation(description = "Flytt behandling til steg", tags = "FORVALTNING-uttrekk")
+    @Path("/deaktiverInaktiveESBeregning")
+    @BeskyttetRessurs(actionType = ActionType.READ, resourceType = ResourceType.DRIFT, sporingslogg = true)
+    public Response deaktiverESBeregning() {
+        var antall = entityManager.createNativeQuery("""
+            update BR_LEGACY_ES_BEREGNING b
+            set b.aktiv = 'N'
+            where exists (select * from fpsak.BR_LEGACY_ES_BEREGNING bi
+                          where bi.beregning_resultat_id = b.beregning_resultat_id
+                          and bi.beregnet_tidspunkt > b.beregnet_tidspunkt )
+            """)
+            .executeUpdate();
+        return Response.ok(antall).build();
+    }
+
 }

--- a/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/formidling/tilkjentytelse/TilkjentYtelseFormidlingDtoTjenesteTest.java
+++ b/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/formidling/tilkjentytelse/TilkjentYtelseFormidlingDtoTjenesteTest.java
@@ -64,7 +64,7 @@ class TilkjentYtelseFormidlingDtoTjenesteTest {
     @Test
     void skal_teste_engangsstønad_mapping() {
         // Arrange
-        var resultat = new LegacyESBeregning(93000, 1, 93000, LocalDateTime.now());
+        var resultat = new LegacyESBeregning(1L, 93000, 1, 93000, LocalDateTime.now());
 
         // Act
         var mappetResultat = TilkjentYtelseFormidlingDtoTjeneste.mapEngangsstønad(resultat);


### PR DESCRIPTION
Gjelder beregning av engangsstønad - som nå finnes fra et felt i behandlingresultat - til et aggregat som har en serie av beregninger. Overstyring er sanert, (9 behandlinger), beregninger slettes ved tilbakehopp - legger opp til aktiv = N

Fase 1 (denne) er å legge til behandling_id og aktivt-flagg - sikre at de lagres og legge inn kode for å populere.

Fase 2 blir å skille ES-beregning fra behandlingResultat + buildere og en liten jungel + unmappe aggregatet.
Fase 3 blir å fjerne unmapped kolonner og  1 tabell - men kan delayes til den store oppryddingen etter kalkulus.