### PR TITLE
TFP-6303 saksmerking haster

### DIFF
--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/fagsak/egenskaper/FagsakMarkering.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/fagsak/egenskaper/FagsakMarkering.java
@@ -19,7 +19,8 @@ public enum FagsakMarkering implements EgenskapVerdi, Kodeverdi {
     DØD_DØDFØDSEL("Død eller dødfødsel", "Død"),
     PRAKSIS_UTSETTELSE("Praksis utsettelse", "Utsettelse"),
     BARE_FAR_RETT("Bare far har rett", "BareFar"),
-    SELVSTENDIG_NÆRING("Næringsdrivende", "Næring");
+    SELVSTENDIG_NÆRING("Næringsdrivende", "Næring"),
+    HASTER("Haster", "Haster");
 
     @JsonIgnore
     private final String kortNavn;

--- a/domenetjenester/vedtak/src/test/java/no/nav/foreldrepenger/domene/vedtak/intern/AvsluttBehandlingTest.java
+++ b/domenetjenester/vedtak/src/test/java/no/nav/foreldrepenger/domene/vedtak/intern/AvsluttBehandlingTest.java
@@ -12,7 +12,6 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -39,10 +38,9 @@ import no.nav.foreldrepenger.behandlingslager.behandling.vedtak.BehandlingVedtak
 import no.nav.foreldrepenger.behandlingslager.behandling.vedtak.IverksettingStatus;
 import no.nav.foreldrepenger.behandlingslager.behandling.vedtak.VedtakResultatType;
 import no.nav.foreldrepenger.behandlingslager.fagsak.Fagsak;
+import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakEgenskapRepository;
 import no.nav.foreldrepenger.behandlingslager.testutilities.behandling.ScenarioMorSøkerEngangsstønad;
 import no.nav.foreldrepenger.behandlingsprosess.prosessering.BehandlingProsesseringTjeneste;
-import no.nav.foreldrepenger.domene.arbeidsforhold.InntektArbeidYtelseTjeneste;
-import no.nav.foreldrepenger.domene.prosess.BeregningTjeneste;
 import no.nav.foreldrepenger.domene.vedtak.impl.VurderBehandlingerUnderIverksettelse;
 
 @ExtendWith(MockitoExtension.class)
@@ -59,6 +57,8 @@ class AvsluttBehandlingTest {
 
     @Mock
     private OppdatereFagsakRelasjonVedVedtak oppdatereFagsakRelasjonVedVedtak;
+    @Mock
+    private FagsakEgenskapRepository fagsakEgenskapRepository;
 
     private AvsluttBehandling avsluttBehandling;
     private Behandling behandling;
@@ -77,7 +77,7 @@ class AvsluttBehandlingTest {
                 repositoryProvider);
 
         avsluttBehandling = new AvsluttBehandling(repositoryProvider, behandlingskontrollTjeneste, behandlingVedtakEventPubliserer,
-            vurderBehandlingerUnderIverksettelse, behandlingProsesseringTjeneste, oppdatereFagsakRelasjonVedVedtak);
+            vurderBehandlingerUnderIverksettelse, behandlingProsesseringTjeneste, oppdatereFagsakRelasjonVedVedtak, fagsakEgenskapRepository);
 
         when(behandlingskontrollTjeneste.initBehandlingskontroll(Mockito.any(Behandling.class), Mockito.any(BehandlingLås.class)))
             .thenAnswer(invocation -> {

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/dto/BehandlingOperasjonerDto.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/dto/BehandlingOperasjonerDto.java
@@ -9,6 +9,7 @@ public record BehandlingOperasjonerDto(UUID uuid,
                                        boolean behandlingKanHenlegges,
                                        boolean behandlingKanGjenopptas,
                                        boolean behandlingKanOpnesForEndringer,
+                                       boolean behandlingKanMerkesHaster,
                                        boolean behandlingKanSettesPaVent,
                                        boolean behandlingKanSendeMelding,
                                        boolean behandlingFraBeslutter,
@@ -17,13 +18,13 @@ public record BehandlingOperasjonerDto(UUID uuid,
 
 
     public BehandlingOperasjonerDto(UUID uuid) {
-        this(uuid, false, false, false,
+        this(uuid, false, false, false, false,
             false, false, false, false,
             false, VergeBehandlingsmenyEnum.SKJUL);
     }
 
     public BehandlingOperasjonerDto(UUID uuid, boolean behandlingTilGodkjenning) {
-        this(uuid, false, false, false,
+        this(uuid, false, false, false, false,
             false, false, false, false,
             behandlingTilGodkjenning, VergeBehandlingsmenyEnum.SKJUL);
     }

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/dto/behandling/BehandlingDtoTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/dto/behandling/BehandlingDtoTjeneste.java
@@ -267,6 +267,7 @@ public class BehandlingDtoTjeneste {
         dto.leggTil(post(BehandlingRestTjeneste.GJENOPPTA_PATH, "gjenoppta-behandling", new GjenopptaBehandlingDto()));
         dto.leggTil(post(BehandlingRestTjeneste.SETT_PA_VENT_PATH, "sett-behandling-pa-vent", new SettBehandlingPaVentDto()));
         dto.leggTil(post(BehandlingRestTjeneste.ENDRE_VENTEFRIST_PATH, "endre-pa-vent", new SettBehandlingPaVentDto()));
+        dto.leggTil(post(BehandlingRestTjeneste.HASTER_PATH, "merk-haster", new ReåpneBehandlingDto()));
         dto.leggTil(post(AksjonspunktRestTjeneste.AKSJONSPUNKT_PATH, "lagre-aksjonspunkter", new BekreftedeAksjonspunkterDto()));
 
         var uuidDto = new UuidDto(behandling.getUuid());

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/dto/behandling/FagsakBehandlingDtoTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/dto/behandling/FagsakBehandlingDtoTjeneste.java
@@ -251,6 +251,7 @@ public class FagsakBehandlingDtoTjeneste {
             SpesialBehandling.kanHenlegges(b) && behandlingIkkeHosKlageInstans, // Henlegges
             b.isBehandlingPåVent() && !b.erKøet() && behandlingIkkeHosKlageInstans, // Gjenopptas
             kanÅpnesForEndring, // Åpnes for endring
+            b.erYtelseBehandling(), // Merkes med Haster
             !b.isBehandlingPåVent(), // Settes på vent
             true, // Sende melding
             !b.isBehandlingPåVent() && totrinnRetur, // Fra beslutter

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/los/LosBehandlingDtoTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/los/LosBehandlingDtoTjeneste.java
@@ -350,12 +350,13 @@ public class LosBehandlingDtoTjeneste {
             case SELVSTENDIG_NÆRING -> FagsakEgenskap.NÆRING;
             case BARE_FAR_RETT -> FagsakEgenskap.BARE_FAR_RETT;
             case PRAKSIS_UTSETTELSE -> FagsakEgenskap.PRAKSIS_UTSETTELSE;
+            case HASTER -> FagsakEgenskap.HASTER;
         };
     }
 
     // Bør matche LOS sin LokalFagsakEgenskap 1:1
     public enum FagsakEgenskap {
-        EØS_BOSATT_NORGE, BOSATT_UTLAND, SAMMENSATT_KONTROLL, DØD, NÆRING, BARE_FAR_RETT, PRAKSIS_UTSETTELSE;
+        EØS_BOSATT_NORGE, BOSATT_UTLAND, SAMMENSATT_KONTROLL, DØD, NÆRING, BARE_FAR_RETT, PRAKSIS_UTSETTELSE, HASTER;
 
     }
 

--- a/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/BehandlingRestTjenesteESTest.java
+++ b/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/BehandlingRestTjenesteESTest.java
@@ -25,6 +25,7 @@ import no.nav.foreldrepenger.behandlingslager.behandling.personopplysning.Sivils
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepositoryProvider;
 import no.nav.foreldrepenger.behandlingslager.behandling.tilbakekreving.TilbakekrevingRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.verge.VergeRepository;
+import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakEgenskapRepository;
 import no.nav.foreldrepenger.behandlingslager.testutilities.behandling.ScenarioMorSøkerEngangsstønad;
 import no.nav.foreldrepenger.behandlingslager.testutilities.behandling.personopplysning.Personopplysning;
 import no.nav.foreldrepenger.behandlingsprosess.prosessering.BehandlingOpprettingTjeneste;
@@ -89,7 +90,8 @@ class BehandlingRestTjenesteESTest {
 
         henleggBehandlingTjeneste = mock(HenleggBehandlingTjeneste.class);
         behandlingRestTjeneste = new BehandlingRestTjeneste(behandlingsutredningTjeneste, behandlingsoppretterTjeneste,
-            behandlingOpprettingTjeneste, behandlingsprosessTjenste, fagsakTjeneste, henleggBehandlingTjeneste, behandlingDtoTjeneste);
+            behandlingOpprettingTjeneste, behandlingsprosessTjenste, fagsakTjeneste, henleggBehandlingTjeneste, behandlingDtoTjeneste,
+            mock(FagsakEgenskapRepository.class));
     }
 
     @Test


### PR DESCRIPTION
Saksmerking Haster:
* Endepunkt som kan kalles av veileder (fra behandlingsmeny med eget innslag) - lenke "merk-haster"
* BehandlingOperasjoner - har ny verdi behandlingKanMerkesHaster for å avgjøre om menyinnslag skal vises 
* Ellers tilgjengelig slik som andre saksmarkeringer
* Kan bare settes for ytelsesbehandlinger + vil fjernes automatisk når alle åpne ytelsesbehandlinger avsluttet
* Tilgjengelig for LOS