### PR TITLE
TFP-5780 oppdater beregning og opptjening

### DIFF
--- a/domenetjenester/behandling-prosessering/src/main/java/no/nav/foreldrepenger/behandlingsprosess/oppdateringsjobber/GjenopplivBehandlingerBatchTjeneste.java
+++ b/domenetjenester/behandling-prosessering/src/main/java/no/nav/foreldrepenger/behandlingsprosess/oppdateringsjobber/GjenopplivBehandlingerBatchTjeneste.java
@@ -1,12 +1,11 @@
-package no.nav.foreldrepenger.behandlingsprosess.hjelpemetoder;
-
-import java.util.Properties;
+package no.nav.foreldrepenger.behandlingsprosess.oppdateringsjobber;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
-
 import no.nav.foreldrepenger.batch.BatchTjeneste;
 import no.nav.foreldrepenger.behandlingsprosess.dagligejobber.gjenopptak.AutomatiskGjenopptagelseTjeneste;
+
+import java.util.Properties;
 
 /**
  * Batchservice som finner alle behandlinger som ikke er aktive og lager en
@@ -19,7 +18,7 @@ public class GjenopplivBehandlingerBatchTjeneste implements BatchTjeneste {
 
     static final String BATCHNAME = "BVL007";
 
-    private AutomatiskGjenopptagelseTjeneste automatiskGjenopptagelseTjeneste;
+    private final AutomatiskGjenopptagelseTjeneste automatiskGjenopptagelseTjeneste;
 
     @Inject
     public GjenopplivBehandlingerBatchTjeneste(AutomatiskGjenopptagelseTjeneste automatiskGjenopptagelseTjeneste) {

--- a/domenetjenester/behandling-prosessering/src/main/java/no/nav/foreldrepenger/behandlingsprosess/oppdateringsjobber/OppdaterEtterAordningFristBeregning.java
+++ b/domenetjenester/behandling-prosessering/src/main/java/no/nav/foreldrepenger/behandlingsprosess/oppdateringsjobber/OppdaterEtterAordningFristBeregning.java
@@ -1,0 +1,149 @@
+package no.nav.foreldrepenger.behandlingsprosess.oppdateringsjobber;
+
+import static java.time.temporal.TemporalAdjusters.next;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import jakarta.enterprise.context.Dependent;
+import jakarta.inject.Inject;
+import jakarta.persistence.EntityManager;
+
+import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
+import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingStegType;
+import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.AksjonspunktDefinisjon;
+import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.AksjonspunktStatus;
+import no.nav.foreldrepenger.behandlingslager.behandling.historikk.HistorikkAktør;
+import no.nav.foreldrepenger.behandlingslager.behandling.historikk.Historikkinnslag;
+import no.nav.foreldrepenger.behandlingslager.behandling.historikk.HistorikkinnslagRepository;
+import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepository;
+import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakProsesstaskRekkefølge;
+import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakYtelseType;
+import no.nav.foreldrepenger.behandlingslager.hendelser.StartpunktType;
+import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
+import no.nav.foreldrepenger.behandlingsprosess.prosessering.BehandlingProsesseringTjeneste;
+import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.Virkedager;
+import no.nav.vedtak.felles.prosesstask.api.ProsessTask;
+import no.nav.vedtak.felles.prosesstask.api.ProsessTaskData;
+import no.nav.vedtak.felles.prosesstask.api.ProsessTaskHandler;
+import no.nav.vedtak.felles.prosesstask.api.ProsessTaskTjeneste;
+
+@Dependent
+@ProsessTask(value = "batch.oppdater.aordningfrist", prioritet = 4, maxFailedRuns = 1)
+@FagsakProsesstaskRekkefølge(gruppeSekvens = false)
+class OppdaterEtterAordningFristBeregning implements ProsessTaskHandler {
+
+    private static final int A_ORDNING_FRIST_DAG = 5;
+
+    private static final Set<AksjonspunktDefinisjon> REFRESH = Set.of(AksjonspunktDefinisjon.AVKLAR_AKTIVITETER,
+        AksjonspunktDefinisjon.VURDER_FAKTA_FOR_ATFL_SN, AksjonspunktDefinisjon.VURDER_PERIODER_MED_OPPTJENING,
+        AksjonspunktDefinisjon.FASTSETT_BEREGNINGSGRUNNLAG_ARBEIDSTAKER_FRILANS,
+        AksjonspunktDefinisjon.FASTSETT_BEREGNINGSGRUNNLAG_TIDSBEGRENSET_ARBEIDSFORHOLD);
+
+    private final BehandlingProsesseringTjeneste prosesseringTjeneste;
+    private final EntityManager entityManager;
+    private final BehandlingRepository behandlingRepository;
+    private final HistorikkinnslagRepository historikkinnslagRepository;
+    private final ProsessTaskTjeneste prosessTaskTjeneste;
+
+    @Inject
+    public OppdaterEtterAordningFristBeregning(BehandlingProsesseringTjeneste prosesseringTjeneste,
+                                               EntityManager entityManager,
+                                               ProsessTaskTjeneste prosessTaskTjeneste) {
+        this.prosesseringTjeneste = prosesseringTjeneste;
+        this.entityManager = entityManager;
+        this.behandlingRepository = new BehandlingRepository(entityManager);
+        this.historikkinnslagRepository = new HistorikkinnslagRepository(entityManager);
+        this.prosessTaskTjeneste = prosessTaskTjeneste;
+    }
+
+    @Override
+    public void doTask(ProsessTaskData prosessTaskData) {
+        var rapporteringsfrist = finnFristDato(LocalDate.now());
+        var nesteVirkedagEtterFrist = Virkedager.plusVirkedager(rapporteringsfrist, 1);
+
+        finnBehandlingerForOppdatering(nesteVirkedagEtterFrist.getDayOfMonth())
+            .filter(b -> !b.isBehandlingPåVent())
+            .forEach(this::rullTilbakeBehandling);
+
+        // Kjør neste task om en måned
+        var nesteMånedFrist = finnFristDato(LocalDate.now().plusMonths(1));
+        var nesteKjøring = Virkedager.plusVirkedager(nesteMånedFrist, 2);
+        var nesteTask = ProsessTaskData.forProsessTask(OppdaterEtterAordningFristBeregning.class);
+        nesteTask.setNesteKjøringEtter(nesteKjøring.atStartOfDay());
+        prosessTaskTjeneste.lagre(nesteTask);
+    }
+
+    private void rullTilbakeBehandling(Behandling behandling) {
+        var lås = behandlingRepository.taSkriveLås(behandling.getId());
+        if (behandling.isBehandlingPåVent()) {
+            prosesseringTjeneste.taBehandlingAvVent(behandling);
+        }
+        var tilSteg = finnStegÅHoppeTil(behandling);
+        lagHistorikkinnslag(behandling, tilSteg.getNavn());
+        prosesseringTjeneste.reposisjonerBehandlingTilbakeTil(behandling, lås, tilSteg);
+        prosesseringTjeneste.opprettTasksForGjenopptaOppdaterFortsett(behandling, LocalDateTime.now());
+    }
+
+    private BehandlingStegType finnStegÅHoppeTil(Behandling behandling) {
+        if (behandling.harÅpentAksjonspunktMedType(AksjonspunktDefinisjon.VURDER_PERIODER_MED_OPPTJENING)) {
+            return BehandlingStegType.VURDER_OPPTJENING_FAKTA;
+        } else if (FagsakYtelseType.SVANGERSKAPSPENGER.equals(behandling.getFagsakYtelseType())) {
+            // SVP har ikke dekningsgradsteg
+            return BehandlingStegType.VURDER_SAMLET;
+        } else {
+            // Ved start i uttak / tilkjent må vi kopiere beregningsgrunnlaget fra originalbehandling i KOFAK steget
+            var harStartPunktEtterBeregning =
+                StartpunktType.UTTAKSVILKÅR.equals(behandling.getStartpunkt()) || StartpunktType.TILKJENT_YTELSE.equals(behandling.getStartpunkt());
+            return harStartPunktEtterBeregning ? BehandlingStegType.KONTROLLER_FAKTA : BehandlingStegType.DEKNINGSGRAD;
+        }
+    }
+
+    private LocalDate finnFristDato(LocalDate dato) {
+        var rapporteringsfrist = dato.withDayOfMonth(A_ORDNING_FRIST_DAG);
+        return DayOfWeek.from(rapporteringsfrist).getValue() > DayOfWeek.FRIDAY.getValue()
+            ? rapporteringsfrist.with(next(DayOfWeek.MONDAY))
+            : rapporteringsfrist;
+    }
+
+    private void lagHistorikkinnslag(Behandling behandling, String tilStegNavn) {
+        var fraStegNavn = behandling.getAktivtBehandlingSteg() != null ? behandling.getAktivtBehandlingSteg().getNavn() : null;
+        var historikkinnslag = new Historikkinnslag.Builder()
+            .medAktør(HistorikkAktør.VEDTAKSLØSNINGEN)
+            .medFagsakId(behandling.getFagsakId())
+            .medBehandlingId(behandling.getId())
+            .medTittel("Behandlingen er flyttet")
+            .addLinje(String.format("Behandlingen er flyttet fra __%s__ tilbake til __%s__", fraStegNavn, tilStegNavn))
+            .build();
+        historikkinnslagRepository.lagre(historikkinnslag);
+    }
+
+    @SuppressWarnings("unchecked") // getresultList
+    private Stream<Behandling> finnBehandlingerForOppdatering(int offset) {
+        var sql = """
+            select * from (
+              select distinct b.*
+              from behandling b
+              join aksjonspunkt a on a.behandling_id = b.id
+              join behandling_resultat br on br.behandling_id = b.id
+              join opptjening o on br.inngangsvilkar_resultat_id = o.vilkar_resultat_id
+              where aksjonspunkt_def in (:apkode)
+                and aksjonspunkt_status = :astatus
+                and o.aktiv = 'J'
+                and trunc(tom+1, 'mm') + :offset < sysdate
+                and sist_oppdatert_tidspunkt < trunc(tom+1, 'mm') + :offset
+                and sist_oppdatert_tidspunkt < sysdate
+            )
+          """;
+
+        var query = entityManager.createNativeQuery(sql, Behandling.class)
+            .setParameter("offset", offset)
+            .setParameter("apkode", REFRESH.stream().map(Kodeverdi::getKode).toList())
+            .setParameter("astatus", AksjonspunktStatus.OPPRETTET.getKode());
+        return query.getResultStream();
+    }
+
+}

--- a/domenetjenester/behandling-prosessering/src/main/java/no/nav/foreldrepenger/behandlingsprosess/oppdateringsjobber/OppdaterEtterAordningFristBeregningTask.java
+++ b/domenetjenester/behandling-prosessering/src/main/java/no/nav/foreldrepenger/behandlingsprosess/oppdateringsjobber/OppdaterEtterAordningFristBeregningTask.java
@@ -34,7 +34,7 @@ import no.nav.vedtak.felles.prosesstask.api.ProsessTaskTjeneste;
 @Dependent
 @ProsessTask(value = "batch.oppdater.aordningfrist", prioritet = 4, maxFailedRuns = 1)
 @FagsakProsesstaskRekkefølge(gruppeSekvens = false)
-class OppdaterEtterAordningFristBeregning implements ProsessTaskHandler {
+class OppdaterEtterAordningFristBeregningTask implements ProsessTaskHandler {
 
     private static final int A_ORDNING_FRIST_DAG = 5;
 
@@ -50,9 +50,9 @@ class OppdaterEtterAordningFristBeregning implements ProsessTaskHandler {
     private final ProsessTaskTjeneste prosessTaskTjeneste;
 
     @Inject
-    public OppdaterEtterAordningFristBeregning(BehandlingProsesseringTjeneste prosesseringTjeneste,
-                                               EntityManager entityManager,
-                                               ProsessTaskTjeneste prosessTaskTjeneste) {
+    public OppdaterEtterAordningFristBeregningTask(BehandlingProsesseringTjeneste prosesseringTjeneste,
+                                                   EntityManager entityManager,
+                                                   ProsessTaskTjeneste prosessTaskTjeneste) {
         this.prosesseringTjeneste = prosesseringTjeneste;
         this.entityManager = entityManager;
         this.behandlingRepository = new BehandlingRepository(entityManager);
@@ -72,7 +72,7 @@ class OppdaterEtterAordningFristBeregning implements ProsessTaskHandler {
         // Kjør neste task om en måned
         var nesteMånedFrist = finnFristDato(LocalDate.now().plusMonths(1));
         var nesteKjøring = Virkedager.plusVirkedager(nesteMånedFrist, 2);
-        var nesteTask = ProsessTaskData.forProsessTask(OppdaterEtterAordningFristBeregning.class);
+        var nesteTask = ProsessTaskData.forProsessTask(OppdaterEtterAordningFristBeregningTask.class);
         nesteTask.setNesteKjøringEtter(nesteKjøring.atStartOfDay());
         prosessTaskTjeneste.lagre(nesteTask);
     }

--- a/domenetjenester/behandling-prosessering/src/test/java/no/nav/foreldrepenger/behandlingsprosess/dagligejobber/gjenopptak/AutomatiskGjenopptagelseBatchTjenesteTest.java
+++ b/domenetjenester/behandling-prosessering/src/test/java/no/nav/foreldrepenger/behandlingsprosess/dagligejobber/gjenopptak/AutomatiskGjenopptagelseBatchTjenesteTest.java
@@ -18,7 +18,7 @@ class AutomatiskGjenopptagelseBatchTjenesteTest {
     private static final String BATCHNAME = AutomatiskGjenopptagelseBatchTjeneste.BATCHNAME;
 
     @BeforeEach
-    public void setup() {
+    void setup() {
         mockTjeneste = mock(AutomatiskGjenopptagelseTjeneste.class);
         batchTjeneste = new AutomatiskGjenopptagelseBatchTjeneste(mockTjeneste);
     }

--- a/domenetjenester/behandling-prosessering/src/test/java/no/nav/foreldrepenger/behandlingsprosess/oppdateringsjobber/GjenopplivBehandlingerBatchTjenesteTest.java
+++ b/domenetjenester/behandling-prosessering/src/test/java/no/nav/foreldrepenger/behandlingsprosess/oppdateringsjobber/GjenopplivBehandlingerBatchTjenesteTest.java
@@ -1,4 +1,4 @@
-package no.nav.foreldrepenger.behandlingsprosess.hjelpemetoder;
+package no.nav.foreldrepenger.behandlingsprosess.oppdateringsjobber;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
@@ -21,7 +21,7 @@ class GjenopplivBehandlingerBatchTjenesteTest {
 
 
     @BeforeEach
-    public void setup() {
+    void setup() {
         mockTjeneste = mock(AutomatiskGjenopptagelseTjeneste.class);
         batchTjeneste = new GjenopplivBehandlingerBatchTjeneste(mockTjeneste);
     }

--- a/domenetjenester/behandling-prosessering/src/test/java/no/nav/foreldrepenger/behandlingsprosess/oppdateringsjobber/OppdaterEtterAordningenFristBeregningTaskTest.java
+++ b/domenetjenester/behandling-prosessering/src/test/java/no/nav/foreldrepenger/behandlingsprosess/oppdateringsjobber/OppdaterEtterAordningenFristBeregningTaskTest.java
@@ -1,0 +1,62 @@
+package no.nav.foreldrepenger.behandlingsprosess.oppdateringsjobber;
+
+import static no.nav.foreldrepenger.behandlingslager.behandling.InternalManipulerBehandling.forceOppdaterBehandlingSteg;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+
+import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingStegType;
+import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingType;
+import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.AksjonspunktDefinisjon;
+import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepositoryProvider;
+import no.nav.foreldrepenger.behandlingslager.behandling.vilkår.VilkårType;
+import no.nav.foreldrepenger.behandlingslager.behandling.vilkår.VilkårUtfallType;
+import no.nav.foreldrepenger.behandlingslager.testutilities.behandling.ScenarioMorSøkerForeldrepenger;
+import no.nav.foreldrepenger.behandlingsprosess.prosessering.BehandlingProsesseringTjeneste;
+import no.nav.foreldrepenger.dbstoette.CdiDbAwareTest;
+import no.nav.foreldrepenger.dbstoette.EntityManagerAwareTest;
+import no.nav.foreldrepenger.domene.typer.AktørId;
+import no.nav.vedtak.felles.prosesstask.api.ProsessTaskData;
+import no.nav.vedtak.felles.prosesstask.api.ProsessTaskTjeneste;
+
+@CdiDbAwareTest
+class OppdaterEtterAordningenFristBeregningTaskTest extends EntityManagerAwareTest {
+
+    @Mock
+    private ProsessTaskTjeneste prosessTaskTjeneste;
+    @Mock
+    private BehandlingProsesseringTjeneste behandlingProsesseringTjeneste;
+
+    @Test
+    void kan_henlegge_behandling_uten_søknad_som_er_satt_på_vent() {
+        var repositoryProvider = new BehandlingRepositoryProvider(getEntityManager());
+        var oppdateringTask = new OppdaterEtterAordningFristBeregningTask(behandlingProsesseringTjeneste, getEntityManager(), prosessTaskTjeneste);
+
+        var scenario = ScenarioMorSøkerForeldrepenger // Oppretter scenario uten søknad for å simulere sitausjoner som
+            // f.eks der inntektsmelding kommer først.
+            .forFødselUtenSøknad(AktørId.dummy())
+            .medBehandlingType(BehandlingType.FØRSTEGANGSSØKNAD);
+        scenario.leggTilAksjonspunkt(AksjonspunktDefinisjon.FASTSETT_BEREGNINGSGRUNNLAG_ARBEIDSTAKER_FRILANS, BehandlingStegType.FORESLÅ_BEREGNINGSGRUNNLAG);
+        scenario.leggTilVilkår(VilkårType.OPPTJENINGSPERIODEVILKÅR, VilkårUtfallType.OPPFYLT);
+        var behandling = scenario.lagre(repositoryProvider);
+        repositoryProvider.getBehandlingRepository().oppdaterSistOppdatertTidspunkt(behandling, LocalDateTime.now().minusWeeks(4).minusDays(1));
+        repositoryProvider.getOpptjeningRepository().lagreOpptjeningsperiode(behandling, LocalDate.now().minusMonths(10), LocalDate.now().minusDays(1), false);
+        forceOppdaterBehandlingSteg(behandling, BehandlingStegType.FORESLÅ_BEREGNINGSGRUNNLAG);
+        var lås = repositoryProvider.getBehandlingRepository().taSkriveLås(behandling.getId());
+        repositoryProvider.getBehandlingRepository().lagre(behandling, lås);
+
+        oppdateringTask.doTask(ProsessTaskData.forProsessTask(OppdaterEtterAordningFristBeregningTask.class));
+
+        verify(behandlingProsesseringTjeneste, times(1)).reposisjonerBehandlingTilbakeTil(eq(behandling), any(), eq(BehandlingStegType.DEKNINGSGRAD));
+        verify(behandlingProsesseringTjeneste, times(1)).opprettTasksForGjenopptaOppdaterFortsett(eq(behandling), any());
+        verify(prosessTaskTjeneste, times(1)).lagre(any(ProsessTaskData.class));
+    }
+
+}


### PR DESCRIPTION
Dette er for å få med inntekter og arbeidsforhold som ikke var rapportert da aksjonspunkt ble opprettet.
Erfaringsmessig vil denne føre til at ca 10% av åpne aksjonspunkt forsvinner.
@pekern se om du er enig i hvilke aksjonspunkter som har nytte av en oppdatering etter at rapporteringsfrist er utløpt.
Har tatt med opptjening + 4 fra beregning. Utelukker de som er på vent.
Ta gjerne en titt på steg vi hopper til.

Ser videre på noe tilsvarende for KOARB - men der har vi ikke en opptjeningsperiode å se på.