### PR TITLE
TFP-6071: omdøpe AvklarTerminbekreftelse til SjekkTerminbekreftelse

### DIFF
--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/aksjonspunkt/AksjonspunktDefinisjon.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/aksjonspunkt/AksjonspunktDefinisjon.java
@@ -44,8 +44,11 @@ public enum AksjonspunktDefinisjon implements Kodeverdi {
 
     // Gruppe : 500
 
-    AVKLAR_TERMINBEKREFTELSE(AksjonspunktKodeDefinisjon.AVKLAR_TERMINBEKREFTELSE_KODE,
+    SJEKK_TERMINBEKREFTELSE(AksjonspunktKodeDefinisjon.SJEKK_TERMINBEKREFTELSE_KODE,
             AksjonspunktType.MANUELL, "Avklar terminbekreftelse", BehandlingStegType.SØKERS_RELASJON_TIL_BARN, VurderingspunktType.INN,
+            VilkårType.FØDSELSVILKÅRET_MOR, SkjermlenkeType.FAKTA_OM_FOEDSEL, ENTRINN, EnumSet.of(ES, FP)),
+    SJEKK_MANGLENDE_FØDSEL(AksjonspunktKodeDefinisjon.SJEKK_MANGLENDE_FØDSEL_KODE,
+            AksjonspunktType.MANUELL, "Sjekk manglende fødsel", BehandlingStegType.SØKERS_RELASJON_TIL_BARN, VurderingspunktType.INN,
             VilkårType.FØDSELSVILKÅRET_MOR, SkjermlenkeType.FAKTA_OM_FOEDSEL, ENTRINN, EnumSet.of(ES, FP)),
     AVKLAR_ADOPSJONSDOKUMENTAJON(AksjonspunktKodeDefinisjon.AVKLAR_ADOPSJONSDOKUMENTAJON_KODE,
             AksjonspunktType.MANUELL, "Avklar adopsjonsdokumentasjon", BehandlingStegType.SØKERS_RELASJON_TIL_BARN, VurderingspunktType.INN,
@@ -95,9 +98,6 @@ public enum AksjonspunktDefinisjon implements Kodeverdi {
     VARSEL_REVURDERING_MANUELL( // Kun ES
             AksjonspunktKodeDefinisjon.VARSEL_REVURDERING_MANUELL_KODE, AksjonspunktType.MANUELL, "Varsel om revurdering opprettet manuelt",
             BehandlingStegType.VARSEL_REVURDERING, VurderingspunktType.UT, UTEN_VILKÅR, UTEN_SKJERMLENKE, ENTRINN, EnumSet.of(ES)),
-    SJEKK_MANGLENDE_FØDSEL(AksjonspunktKodeDefinisjon.SJEKK_MANGLENDE_FØDSEL_KODE,
-            AksjonspunktType.MANUELL, "Sjekk manglende fødsel", BehandlingStegType.SØKERS_RELASJON_TIL_BARN, VurderingspunktType.INN,
-            VilkårType.FØDSELSVILKÅRET_MOR, SkjermlenkeType.FAKTA_OM_FOEDSEL, ENTRINN, EnumSet.of(ES, FP)),
     FORESLÅ_VEDTAK_MANUELT(AksjonspunktKodeDefinisjon.FORESLÅ_VEDTAK_MANUELT_KODE,
             AksjonspunktType.MANUELL, "Foreslå vedtak manuelt", BehandlingStegType.FORESLÅ_VEDTAK, VurderingspunktType.UT, UTEN_VILKÅR, SkjermlenkeType.VEDTAK,
             ENTRINN, EnumSet.of(ES, FP, SVP)),
@@ -509,8 +509,8 @@ public enum AksjonspunktDefinisjon implements Kodeverdi {
 
 
     private static final Map<AksjonspunktDefinisjon, Set<AksjonspunktDefinisjon>> UTELUKKENDE_AP_MAP = Map.ofEntries(
-        Map.entry(AksjonspunktDefinisjon.SJEKK_MANGLENDE_FØDSEL, Set.of(AksjonspunktDefinisjon.AVKLAR_TERMINBEKREFTELSE)),
-        Map.entry(AksjonspunktDefinisjon.AVKLAR_TERMINBEKREFTELSE, Set.of(AksjonspunktDefinisjon.SJEKK_MANGLENDE_FØDSEL))
+        Map.entry(AksjonspunktDefinisjon.SJEKK_MANGLENDE_FØDSEL, Set.of(AksjonspunktDefinisjon.SJEKK_TERMINBEKREFTELSE)),
+        Map.entry(AksjonspunktDefinisjon.SJEKK_TERMINBEKREFTELSE, Set.of(AksjonspunktDefinisjon.SJEKK_MANGLENDE_FØDSEL))
         /* TODO: Vurder om disse skal tas med
         , Map.entry(AksjonspunktDefinisjon.FORESLÅ_VEDTAK, Set.of(AksjonspunktDefinisjon.FORESLÅ_VEDTAK_MANUELT))
         , Map.entry(AksjonspunktDefinisjon.FORESLÅ_VEDTAK_MANUELT, Set.of(AksjonspunktDefinisjon.FORESLÅ_VEDTAK))

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/aksjonspunkt/AksjonspunktKodeDefinisjon.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/aksjonspunkt/AksjonspunktKodeDefinisjon.java
@@ -28,11 +28,13 @@ public class AksjonspunktKodeDefinisjon {
     public static final String AVKLAR_ADOPSJONSDOKUMENTAJON_KODE = "5004";
     public static final String AVKLAR_OM_ADOPSJON_GJELDER_EKTEFELLES_BARN_KODE = "5005";
     public static final String AVKLAR_OM_SØKER_ER_MANN_SOM_ADOPTERER_ALENE_KODE = "5006";
-    public static final String AVKLAR_TERMINBEKREFTELSE_KODE = "5001";
     public static final String AVKLAR_VILKÅR_FOR_OMSORGSOVERTAKELSE_KODE = "5008";
     public static final String AVKLAR_VILKÅR_FOR_FORELDREANSVAR_KODE = "5054";
     public static final String AVKLAR_VERGE_KODE = "5030";
     public static final String AVKLAR_OM_SØKER_HAR_MOTTATT_STØTTE_KODE = "5031";
+
+    public static final String SJEKK_TERMINBEKREFTELSE_KODE = "5001";
+    public static final String SJEKK_MANGLENDE_FØDSEL_KODE = "5027";
 
     public static final String FATTER_VEDTAK_KODE = "5016";
 
@@ -65,8 +67,6 @@ public class AksjonspunktKodeDefinisjon {
 
     public static final String VARSEL_REVURDERING_MANUELL_KODE = "5026";
     public static final String KONTROLLER_REVURDERINGSBEHANDLING_VARSEL_VED_UGUNST_KODE = "5055";
-
-    public static final String SJEKK_MANGLENDE_FØDSEL_KODE = "5027";
 
     public static final String VENT_PÅ_SCANNING_KODE = "7007";
     public static final String VENT_PGA_FOR_TIDLIG_SØKNAD_KODE = "7008";

--- a/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/foreslåvedtak/ForeslåVedtakTjenesteTest.java
+++ b/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/foreslåvedtak/ForeslåVedtakTjenesteTest.java
@@ -126,7 +126,7 @@ class ForeslåVedtakTjenesteTest {
     @Test
     void foreslåVedtakManueltDersomAksjonspunktLøstAvSaksbehandler() {
         // Arrange
-        var ap = AksjonspunktTestSupport.leggTilAksjonspunkt(behandling, AksjonspunktDefinisjon.AVKLAR_TERMINBEKREFTELSE);
+        var ap = AksjonspunktTestSupport.leggTilAksjonspunkt(behandling, AksjonspunktDefinisjon.SJEKK_TERMINBEKREFTELSE);
         ap.setEndretAv("saksbehandler");
         AksjonspunktTestSupport.setTilUtført(ap, "begrunnelse");
 

--- a/domenetjenester/behandling-revurdering/src/test/java/no/nav/foreldrepenger/behandling/revurdering/ytelse/fp/RevurderingBehandlingsresultatutlederTest.java
+++ b/domenetjenester/behandling-revurdering/src/test/java/no/nav/foreldrepenger/behandling/revurdering/ytelse/fp/RevurderingBehandlingsresultatutlederTest.java
@@ -121,7 +121,7 @@ class RevurderingBehandlingsresultatutlederTest {
             .medDefaultFordeling(endringsdato)
             .medAvklarteUttakDatoer(new AvklarteUttakDatoerEntitet.Builder().medOpprinneligEndringsdato(endringsdato).build());
         scenario.medBehandlingVedtak().medVedtakstidspunkt(LocalDateTime.now()).medVedtakResultatType(VedtakResultatType.INNVILGET);
-        scenario.leggTilAksjonspunkt(AksjonspunktDefinisjon.AVKLAR_TERMINBEKREFTELSE, BehandlingStegType.KONTROLLER_FAKTA);
+        scenario.leggTilAksjonspunkt(AksjonspunktDefinisjon.SJEKK_TERMINBEKREFTELSE, BehandlingStegType.KONTROLLER_FAKTA);
         var førstegangsbehandling = scenario.lagre(repositoryProvider);
         opptjeningRepository.lagreOpptjeningsperiode(førstegangsbehandling, LocalDate.now().minusYears(1), LocalDate.now(), false);
         revurderingTestUtil.avsluttBehandling(førstegangsbehandling);

--- a/domenetjenester/behandling-revurdering/src/test/java/no/nav/foreldrepenger/behandling/revurdering/ytelse/svp/RevurderingBehandlingsresultatutlederTest.java
+++ b/domenetjenester/behandling-revurdering/src/test/java/no/nav/foreldrepenger/behandling/revurdering/ytelse/svp/RevurderingBehandlingsresultatutlederTest.java
@@ -126,7 +126,7 @@ class RevurderingBehandlingsresultatutlederTest {
         scenario.medBehandlingVedtak()
                 .medVedtakstidspunkt(LocalDateTime.now())
                 .medVedtakResultatType(VedtakResultatType.INNVILGET);
-        scenario.leggTilAksjonspunkt(AksjonspunktDefinisjon.AVKLAR_TERMINBEKREFTELSE,
+        scenario.leggTilAksjonspunkt(AksjonspunktDefinisjon.SJEKK_TERMINBEKREFTELSE,
                 BehandlingStegType.KONTROLLER_FAKTA);
         behandlingSomSkalRevurderes = scenario.lagre(repositoryProvider);
         repositoryProvider.getOpptjeningRepository()

--- a/domenetjenester/behandlingskontroll/src/test/java/no/nav/foreldrepenger/behandlingskontroll/impl/BehandlingskontrollEventPublisererTest.java
+++ b/domenetjenester/behandlingskontroll/src/test/java/no/nav/foreldrepenger/behandlingskontroll/impl/BehandlingskontrollEventPublisererTest.java
@@ -219,7 +219,7 @@ class BehandlingskontrollEventPublisererTest {
 
     private BehandlingModellImpl byggModell() {
         // Arrange - noen utvalge, tilfeldige aksjonspunkter
-        var a0_0 = AksjonspunktDefinisjon.AVKLAR_TERMINBEKREFTELSE;
+        var a0_0 = AksjonspunktDefinisjon.SJEKK_TERMINBEKREFTELSE;
         var a0_1 = AksjonspunktDefinisjon.SJEKK_MANGLENDE_FØDSEL;
         var a1_0 = AksjonspunktDefinisjon.AVKLAR_ADOPSJONSDOKUMENTAJON;
         var a1_1 = AksjonspunktDefinisjon.AVKLAR_VERGE;

--- a/domenetjenester/datavarehus/src/test/java/no/nav/foreldrepenger/datavarehus/tjeneste/DatavarehusTjenesteImplTest.java
+++ b/domenetjenester/datavarehus/src/test/java/no/nav/foreldrepenger/datavarehus/tjeneste/DatavarehusTjenesteImplTest.java
@@ -79,7 +79,7 @@ class DatavarehusTjenesteImplTest {
     void lagreNedBehandling() {
         var scenario = ScenarioMorSøkerEngangsstønad.forFødsel();
         scenario.leggTilAksjonspunkt(AKSJONSPUNKT_DEF, BehandlingStegType.SØKERS_RELASJON_TIL_BARN);
-        scenario.leggTilAksjonspunkt(AksjonspunktDefinisjon.AVKLAR_TERMINBEKREFTELSE, BehandlingStegType.SØKERS_RELASJON_TIL_BARN);
+        scenario.leggTilAksjonspunkt(AksjonspunktDefinisjon.SJEKK_TERMINBEKREFTELSE, BehandlingStegType.SØKERS_RELASJON_TIL_BARN);
         scenario.medBehandlendeEnhet(BEHANDLENDE_ENHET);
         var behandling = scenario.lagMocked();
         forceOppdaterBehandlingSteg(behandling, BEHANDLING_STEG_TYPE);
@@ -100,7 +100,7 @@ class DatavarehusTjenesteImplTest {
     void lagreNedBehandlingMedMottattSøknadDokument() {
         var scenario = ScenarioMorSøkerEngangsstønad.forFødsel();
         scenario.leggTilAksjonspunkt(AKSJONSPUNKT_DEF, BehandlingStegType.SØKERS_RELASJON_TIL_BARN);
-        scenario.leggTilAksjonspunkt(AksjonspunktDefinisjon.AVKLAR_TERMINBEKREFTELSE, BehandlingStegType.SØKERS_RELASJON_TIL_BARN);
+        scenario.leggTilAksjonspunkt(AksjonspunktDefinisjon.SJEKK_TERMINBEKREFTELSE, BehandlingStegType.SØKERS_RELASJON_TIL_BARN);
         scenario.medBehandlendeEnhet(BEHANDLENDE_ENHET);
         var behandling = scenario.lagMocked();
         forceOppdaterBehandlingSteg(behandling, BEHANDLING_STEG_TYPE);
@@ -132,7 +132,7 @@ class DatavarehusTjenesteImplTest {
     void lagreNedBehandlingMedId() {
         var scenario = ScenarioMorSøkerEngangsstønad.forFødsel();
         scenario.leggTilAksjonspunkt(AKSJONSPUNKT_DEF, BehandlingStegType.SØKERS_RELASJON_TIL_BARN);
-        scenario.leggTilAksjonspunkt(AksjonspunktDefinisjon.AVKLAR_TERMINBEKREFTELSE, BehandlingStegType.SØKERS_RELASJON_TIL_BARN);
+        scenario.leggTilAksjonspunkt(AksjonspunktDefinisjon.SJEKK_TERMINBEKREFTELSE, BehandlingStegType.SØKERS_RELASJON_TIL_BARN);
         scenario.medBehandlendeEnhet(BEHANDLENDE_ENHET);
 
         var behandling = scenario.lagMocked();

--- a/domenetjenester/familie-hendelse/src/main/java/no/nav/foreldrepenger/familiehendelse/aksjonspunkt/SjekkManglendeFødselOppdaterer.java
+++ b/domenetjenester/familie-hendelse/src/main/java/no/nav/foreldrepenger/familiehendelse/aksjonspunkt/SjekkManglendeFødselOppdaterer.java
@@ -26,7 +26,7 @@ import no.nav.foreldrepenger.behandlingslager.behandling.historikk.Historikkinns
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.skjermlenke.SkjermlenkeType;
 import no.nav.foreldrepenger.familiehendelse.FamilieHendelseTjeneste;
-import no.nav.foreldrepenger.familiehendelse.aksjonspunkt.dto.SjekkManglendeFodselDto;
+import no.nav.foreldrepenger.familiehendelse.aksjonspunkt.dto.SjekkManglendeFødselAksjonspunktDto;
 import no.nav.foreldrepenger.familiehendelse.aksjonspunkt.dto.DokumentertBarnDto;
 import no.nav.foreldrepenger.skjæringstidspunkt.OpplysningsPeriodeTjeneste;
 import no.nav.vedtak.exception.FunksjonellException;
@@ -35,8 +35,8 @@ import static no.nav.foreldrepenger.behandlingslager.behandling.historikk.Histor
 import static no.nav.foreldrepenger.behandlingslager.behandling.historikk.HistorikkinnslagLinjeBuilder.fraTilEquals;
 
 @ApplicationScoped
-@DtoTilServiceAdapter(dto = SjekkManglendeFodselDto.class, adapter = AksjonspunktOppdaterer.class)
-public class SjekkManglendeFødselOppdaterer implements AksjonspunktOppdaterer<SjekkManglendeFodselDto> {
+@DtoTilServiceAdapter(dto = SjekkManglendeFødselAksjonspunktDto.class, adapter = AksjonspunktOppdaterer.class)
+public class SjekkManglendeFødselOppdaterer implements AksjonspunktOppdaterer<SjekkManglendeFødselAksjonspunktDto> {
 
     private FamilieHendelseTjeneste familieHendelseTjeneste;
     private OpplysningsPeriodeTjeneste opplysningsPeriodeTjeneste;
@@ -59,7 +59,7 @@ public class SjekkManglendeFødselOppdaterer implements AksjonspunktOppdaterer<S
     }
 
     @Override
-    public OppdateringResultat oppdater(SjekkManglendeFodselDto dto, AksjonspunktOppdaterParameter param) {
+    public OppdateringResultat oppdater(SjekkManglendeFødselAksjonspunktDto dto, AksjonspunktOppdaterParameter param) {
         valider(dto);
 
         var behandlingId = param.getBehandlingId();
@@ -93,7 +93,7 @@ public class SjekkManglendeFødselOppdaterer implements AksjonspunktOppdaterer<S
         }
     }
 
-    private void valider(SjekkManglendeFodselDto dto) {
+    private void valider(SjekkManglendeFødselAksjonspunktDto dto) {
         if (Boolean.TRUE.equals(dto.getErBarnFødt())) {
             if (dto.getBarn() == null || dto.getBarn().isEmpty()) {
                 throw new FunksjonellException("FP-076343", "Mangler barn", "Oppgi mellom 1 og 9 barn");
@@ -107,7 +107,7 @@ public class SjekkManglendeFødselOppdaterer implements AksjonspunktOppdaterer<S
         }
     }
 
-    private List<? extends UidentifisertBarn> utledFødselsdata(SjekkManglendeFodselDto dto, FamilieHendelseGrunnlagEntitet grunnlag) {
+    private List<? extends UidentifisertBarn> utledFødselsdata(SjekkManglendeFødselAksjonspunktDto dto, FamilieHendelseGrunnlagEntitet grunnlag) {
         var termindato = grunnlag.getGjeldendeTerminbekreftelse().map(TerminbekreftelseEntitet::getTermindato);
 
         var barn = dto.getBarn().stream().map(FødselStatus::new).sorted().toList();
@@ -132,7 +132,7 @@ public class SjekkManglendeFødselOppdaterer implements AksjonspunktOppdaterer<S
         return Optional.of(grunnlag.getOverstyrtVersjon().filter(o -> !o.getBarna().isEmpty()).isPresent());
     }
 
-    private void opprettHistorikkinnslag(SjekkManglendeFodselDto dto,
+    private void opprettHistorikkinnslag(SjekkManglendeFødselAksjonspunktDto dto,
                                          BehandlingReferanse behandlingReferanse,
                                          FamilieHendelseGrunnlagEntitet grunnlag,
                                          Behandling behandling) {
@@ -158,7 +158,7 @@ public class SjekkManglendeFødselOppdaterer implements AksjonspunktOppdaterer<S
 
     private void lagHistorikkForBarn(Historikkinnslag.Builder historikkinnslag,
                                      FamilieHendelseGrunnlagEntitet grunnlag,
-                                     SjekkManglendeFodselDto dto) {
+                                     SjekkManglendeFødselAksjonspunktDto dto) {
         var oppdatertFødselStatus = dto.getBarn().stream().map(FødselStatus::new).sorted().toList();
         var gjeldendeFødselStatus = grunnlag.getGjeldendeBarna().stream().map(FødselStatus::new).sorted().toList();
 

--- a/domenetjenester/familie-hendelse/src/main/java/no/nav/foreldrepenger/familiehendelse/aksjonspunkt/SjekkTerminbekreftelseOppdaterer.java
+++ b/domenetjenester/familie-hendelse/src/main/java/no/nav/foreldrepenger/familiehendelse/aksjonspunkt/SjekkTerminbekreftelseOppdaterer.java
@@ -21,33 +21,33 @@ import no.nav.foreldrepenger.behandlingslager.behandling.historikk.Historikkinns
 import no.nav.foreldrepenger.behandlingslager.behandling.historikk.HistorikkinnslagRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.skjermlenke.SkjermlenkeType;
 import no.nav.foreldrepenger.familiehendelse.FamilieHendelseTjeneste;
-import no.nav.foreldrepenger.familiehendelse.aksjonspunkt.dto.BekreftTerminbekreftelseAksjonspunktDto;
+import no.nav.foreldrepenger.familiehendelse.aksjonspunkt.dto.SjekkTerminbekreftelseDto;
 import no.nav.foreldrepenger.skjæringstidspunkt.OpplysningsPeriodeTjeneste;
 
 @ApplicationScoped
-@DtoTilServiceAdapter(dto = BekreftTerminbekreftelseAksjonspunktDto.class, adapter = AksjonspunktOppdaterer.class)
-public class BekreftTerminbekreftelseOppdaterer implements AksjonspunktOppdaterer<BekreftTerminbekreftelseAksjonspunktDto> {
+@DtoTilServiceAdapter(dto = SjekkTerminbekreftelseDto.class, adapter = AksjonspunktOppdaterer.class)
+public class SjekkTerminbekreftelseOppdaterer implements AksjonspunktOppdaterer<SjekkTerminbekreftelseDto> {
 
 
     private HistorikkinnslagRepository historikkinnslagRepository;
     private FamilieHendelseTjeneste familieHendelseTjeneste;
     private OpplysningsPeriodeTjeneste opplysningsPeriodeTjeneste;
 
-    BekreftTerminbekreftelseOppdaterer() {
+    SjekkTerminbekreftelseOppdaterer() {
         // for CDI proxy
     }
 
     @Inject
-    public BekreftTerminbekreftelseOppdaterer(HistorikkinnslagRepository historikkinnslagRepository,
-                                              OpplysningsPeriodeTjeneste opplysningsPeriodeTjeneste,
-                                              FamilieHendelseTjeneste familieHendelseTjeneste) {
+    public SjekkTerminbekreftelseOppdaterer(HistorikkinnslagRepository historikkinnslagRepository,
+                                            OpplysningsPeriodeTjeneste opplysningsPeriodeTjeneste,
+                                            FamilieHendelseTjeneste familieHendelseTjeneste) {
         this.historikkinnslagRepository = historikkinnslagRepository;
         this.familieHendelseTjeneste = familieHendelseTjeneste;
         this.opplysningsPeriodeTjeneste = opplysningsPeriodeTjeneste;
     }
 
     @Override
-    public OppdateringResultat oppdater(BekreftTerminbekreftelseAksjonspunktDto dto, AksjonspunktOppdaterParameter param) {
+    public OppdateringResultat oppdater(SjekkTerminbekreftelseDto dto, AksjonspunktOppdaterParameter param) {
         var behandlingReferanse = param.getRef();
         var behandlingId = behandlingReferanse.behandlingId();
         var grunnlag = familieHendelseTjeneste.hentAggregat(behandlingId);
@@ -96,7 +96,7 @@ public class BekreftTerminbekreftelseOppdaterer implements AksjonspunktOppdatere
         return builder.build();
     }
 
-    private Historikkinnslag lagHistorikkinnslag(BekreftTerminbekreftelseAksjonspunktDto dto,
+    private Historikkinnslag lagHistorikkinnslag(SjekkTerminbekreftelseDto dto,
                                                  BehandlingReferanse behandlingReferanse,
                                                  FamilieHendelseGrunnlagEntitet grunnlag,
                                                  boolean erEndret) {

--- a/domenetjenester/familie-hendelse/src/main/java/no/nav/foreldrepenger/familiehendelse/aksjonspunkt/SjekkTerminbekreftelseOppdaterer.java
+++ b/domenetjenester/familie-hendelse/src/main/java/no/nav/foreldrepenger/familiehendelse/aksjonspunkt/SjekkTerminbekreftelseOppdaterer.java
@@ -21,12 +21,12 @@ import no.nav.foreldrepenger.behandlingslager.behandling.historikk.Historikkinns
 import no.nav.foreldrepenger.behandlingslager.behandling.historikk.HistorikkinnslagRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.skjermlenke.SkjermlenkeType;
 import no.nav.foreldrepenger.familiehendelse.FamilieHendelseTjeneste;
-import no.nav.foreldrepenger.familiehendelse.aksjonspunkt.dto.SjekkTerminbekreftelseDto;
+import no.nav.foreldrepenger.familiehendelse.aksjonspunkt.dto.SjekkTerminbekreftelseAksjonspunktDto;
 import no.nav.foreldrepenger.skjæringstidspunkt.OpplysningsPeriodeTjeneste;
 
 @ApplicationScoped
-@DtoTilServiceAdapter(dto = SjekkTerminbekreftelseDto.class, adapter = AksjonspunktOppdaterer.class)
-public class SjekkTerminbekreftelseOppdaterer implements AksjonspunktOppdaterer<SjekkTerminbekreftelseDto> {
+@DtoTilServiceAdapter(dto = SjekkTerminbekreftelseAksjonspunktDto.class, adapter = AksjonspunktOppdaterer.class)
+public class SjekkTerminbekreftelseOppdaterer implements AksjonspunktOppdaterer<SjekkTerminbekreftelseAksjonspunktDto> {
 
 
     private HistorikkinnslagRepository historikkinnslagRepository;
@@ -47,7 +47,7 @@ public class SjekkTerminbekreftelseOppdaterer implements AksjonspunktOppdaterer<
     }
 
     @Override
-    public OppdateringResultat oppdater(SjekkTerminbekreftelseDto dto, AksjonspunktOppdaterParameter param) {
+    public OppdateringResultat oppdater(SjekkTerminbekreftelseAksjonspunktDto dto, AksjonspunktOppdaterParameter param) {
         var behandlingReferanse = param.getRef();
         var behandlingId = behandlingReferanse.behandlingId();
         var grunnlag = familieHendelseTjeneste.hentAggregat(behandlingId);
@@ -96,7 +96,7 @@ public class SjekkTerminbekreftelseOppdaterer implements AksjonspunktOppdaterer<
         return builder.build();
     }
 
-    private Historikkinnslag lagHistorikkinnslag(SjekkTerminbekreftelseDto dto,
+    private Historikkinnslag lagHistorikkinnslag(SjekkTerminbekreftelseAksjonspunktDto dto,
                                                  BehandlingReferanse behandlingReferanse,
                                                  FamilieHendelseGrunnlagEntitet grunnlag,
                                                  boolean erEndret) {

--- a/domenetjenester/familie-hendelse/src/main/java/no/nav/foreldrepenger/familiehendelse/aksjonspunkt/dto/SjekkManglendeFødselAksjonspunktDto.java
+++ b/domenetjenester/familie-hendelse/src/main/java/no/nav/foreldrepenger/familiehendelse/aksjonspunkt/dto/SjekkManglendeFødselAksjonspunktDto.java
@@ -14,7 +14,7 @@ import no.nav.foreldrepenger.behandling.aksjonspunkt.BekreftetAksjonspunktDto;
 import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.AksjonspunktKodeDefinisjon;
 
 @JsonTypeName(AksjonspunktKodeDefinisjon.SJEKK_MANGLENDE_FØDSEL_KODE)
-public class SjekkManglendeFodselDto extends BekreftetAksjonspunktDto {
+public class SjekkManglendeFødselAksjonspunktDto extends BekreftetAksjonspunktDto {
 
     @NotNull
     @JsonProperty("erBarnFødt")
@@ -26,11 +26,11 @@ public class SjekkManglendeFodselDto extends BekreftetAksjonspunktDto {
     @JsonAlias("uidentifiserteBarn")
     private List<DokumentertBarnDto> barn;
 
-    SjekkManglendeFodselDto() {
+    SjekkManglendeFødselAksjonspunktDto() {
         //For Jackson
     }
 
-    public SjekkManglendeFodselDto(String begrunnelse, Boolean dokumentasjonForeligger, List<DokumentertBarnDto> barn) {
+    public SjekkManglendeFødselAksjonspunktDto(String begrunnelse, Boolean dokumentasjonForeligger, List<DokumentertBarnDto> barn) {
         super(begrunnelse);
         this.erBarnFødt = dokumentasjonForeligger;
         this.barn = barn;

--- a/domenetjenester/familie-hendelse/src/main/java/no/nav/foreldrepenger/familiehendelse/aksjonspunkt/dto/SjekkTerminbekreftelseAksjonspunktDto.java
+++ b/domenetjenester/familie-hendelse/src/main/java/no/nav/foreldrepenger/familiehendelse/aksjonspunkt/dto/SjekkTerminbekreftelseAksjonspunktDto.java
@@ -12,7 +12,7 @@ import no.nav.foreldrepenger.behandling.aksjonspunkt.BekreftetAksjonspunktDto;
 import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.AksjonspunktKodeDefinisjon;
 
 @JsonTypeName(AksjonspunktKodeDefinisjon.SJEKK_TERMINBEKREFTELSE_KODE)
-public class SjekkTerminbekreftelseDto extends BekreftetAksjonspunktDto {
+public class SjekkTerminbekreftelseAksjonspunktDto extends BekreftetAksjonspunktDto {
 
     @NotNull
     private LocalDate utstedtdato;
@@ -25,11 +25,11 @@ public class SjekkTerminbekreftelseDto extends BekreftetAksjonspunktDto {
     @Max(9)
     private int antallBarn;
 
-    SjekkTerminbekreftelseDto() {
+    SjekkTerminbekreftelseAksjonspunktDto() {
         // For Jackson
     }
 
-    public SjekkTerminbekreftelseDto(String begrunnelse, LocalDate termindato, LocalDate utstedtdato, int antallBarn) {
+    public SjekkTerminbekreftelseAksjonspunktDto(String begrunnelse, LocalDate termindato, LocalDate utstedtdato, int antallBarn) {
         super(begrunnelse);
         this.termindato = termindato;
         this.utstedtdato = utstedtdato;

--- a/domenetjenester/familie-hendelse/src/main/java/no/nav/foreldrepenger/familiehendelse/aksjonspunkt/dto/SjekkTerminbekreftelseDto.java
+++ b/domenetjenester/familie-hendelse/src/main/java/no/nav/foreldrepenger/familiehendelse/aksjonspunkt/dto/SjekkTerminbekreftelseDto.java
@@ -11,9 +11,8 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 import no.nav.foreldrepenger.behandling.aksjonspunkt.BekreftetAksjonspunktDto;
 import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.AksjonspunktKodeDefinisjon;
 
-@JsonTypeName(AksjonspunktKodeDefinisjon.AVKLAR_TERMINBEKREFTELSE_KODE)
-public class BekreftTerminbekreftelseAksjonspunktDto extends BekreftetAksjonspunktDto {
-
+@JsonTypeName(AksjonspunktKodeDefinisjon.SJEKK_TERMINBEKREFTELSE_KODE)
+public class SjekkTerminbekreftelseDto extends BekreftetAksjonspunktDto {
 
     @NotNull
     private LocalDate utstedtdato;
@@ -26,16 +25,11 @@ public class BekreftTerminbekreftelseAksjonspunktDto extends BekreftetAksjonspun
     @Max(9)
     private int antallBarn;
 
-    BekreftTerminbekreftelseAksjonspunktDto() {
+    SjekkTerminbekreftelseDto() {
         // For Jackson
     }
 
-    public BekreftTerminbekreftelseAksjonspunktDto(
-                                                    String begrunnelse,
-                                                    LocalDate termindato,
-                                                    LocalDate utstedtdato,
-                                                    int antallBarn) {
-
+    public SjekkTerminbekreftelseDto(String begrunnelse, LocalDate termindato, LocalDate utstedtdato, int antallBarn) {
         super(begrunnelse);
         this.termindato = termindato;
         this.utstedtdato = utstedtdato;
@@ -53,6 +47,4 @@ public class BekreftTerminbekreftelseAksjonspunktDto extends BekreftetAksjonspun
     public int getAntallBarn() {
         return antallBarn;
     }
-
-
 }

--- a/domenetjenester/familie-hendelse/src/main/java/no/nav/foreldrepenger/familiehendelse/kontrollerfakta/fødsel/AksjonspunktUtlederForEngangsstønadFødsel.java
+++ b/domenetjenester/familie-hendelse/src/main/java/no/nav/foreldrepenger/familiehendelse/kontrollerfakta/fødsel/AksjonspunktUtlederForEngangsstønadFødsel.java
@@ -1,6 +1,6 @@
 package no.nav.foreldrepenger.familiehendelse.kontrollerfakta.fødsel;
 
-import static no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.AksjonspunktDefinisjon.AVKLAR_TERMINBEKREFTELSE;
+import static no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.AksjonspunktDefinisjon.SJEKK_TERMINBEKREFTELSE;
 
 import java.util.List;
 
@@ -29,6 +29,6 @@ public class AksjonspunktUtlederForEngangsstønadFødsel extends AksjonspunktUtl
 
     @Override
     protected List<AksjonspunktUtlederResultat> utledAksjonspunkterForTerminbekreftelse(AksjonspunktUtlederInput param) {
-        return AksjonspunktUtlederResultat.opprettListeForAksjonspunkt(AVKLAR_TERMINBEKREFTELSE);
+        return AksjonspunktUtlederResultat.opprettListeForAksjonspunkt(SJEKK_TERMINBEKREFTELSE);
     }
 }

--- a/domenetjenester/familie-hendelse/src/main/java/no/nav/foreldrepenger/familiehendelse/kontrollerfakta/fødsel/AksjonspunktUtlederForForeldrepengerFødsel.java
+++ b/domenetjenester/familie-hendelse/src/main/java/no/nav/foreldrepenger/familiehendelse/kontrollerfakta/fødsel/AksjonspunktUtlederForForeldrepengerFødsel.java
@@ -37,7 +37,7 @@ public class AksjonspunktUtlederForForeldrepengerFødsel extends AksjonspunktUtl
     @Override
     protected List<AksjonspunktUtlederResultat> utledAksjonspunkterForTerminbekreftelse(AksjonspunktUtlederInput param) {
         if (farSøkerOgMorIkkeRett(param) || erSøkerRegistrertArbeidstakerMedLøpendeArbeidsforholdIAARegisteret(param) == NEI) {
-            return AksjonspunktUtlederResultat.opprettListeForAksjonspunkt(AksjonspunktDefinisjon.AVKLAR_TERMINBEKREFTELSE);
+            return AksjonspunktUtlederResultat.opprettListeForAksjonspunkt(AksjonspunktDefinisjon.SJEKK_TERMINBEKREFTELSE);
         }
         return List.of();
     }

--- a/domenetjenester/familie-hendelse/src/test/java/no/nav/foreldrepenger/familiehendelse/aksjonspunkt/SjekkManglendeFødselOppdatererTest.java
+++ b/domenetjenester/familie-hendelse/src/test/java/no/nav/foreldrepenger/familiehendelse/aksjonspunkt/SjekkManglendeFødselOppdatererTest.java
@@ -31,7 +31,7 @@ import no.nav.foreldrepenger.behandlingslager.testutilities.behandling.ScenarioF
 import no.nav.foreldrepenger.behandlingslager.testutilities.behandling.ScenarioMorSøkerEngangsstønad;
 import no.nav.foreldrepenger.dbstoette.EntityManagerAwareTest;
 import no.nav.foreldrepenger.familiehendelse.FamilieHendelseTjeneste;
-import no.nav.foreldrepenger.familiehendelse.aksjonspunkt.dto.SjekkManglendeFodselDto;
+import no.nav.foreldrepenger.familiehendelse.aksjonspunkt.dto.SjekkManglendeFødselAksjonspunktDto;
 import no.nav.foreldrepenger.familiehendelse.aksjonspunkt.dto.DokumentertBarnDto;
 import no.nav.foreldrepenger.familiehendelse.event.FamiliehendelseEventPubliserer;
 import no.nav.foreldrepenger.skjæringstidspunkt.OpplysningsPeriodeTjeneste;
@@ -66,7 +66,7 @@ class SjekkManglendeFødselOppdatererTest extends EntityManagerAwareTest {
         var behandling = scenario.lagre(repositoryProvider);
 
         // Dto
-        var dto = new SjekkManglendeFodselDto("begrunnelse", false, null);
+        var dto = new SjekkManglendeFødselAksjonspunktDto("begrunnelse", false, null);
         var aksjonspunkt = behandling.getAksjonspunktFor(SJEKK_MANGLENDE_FØDSEL);
 
         // Act
@@ -105,7 +105,7 @@ class SjekkManglendeFødselOppdatererTest extends EntityManagerAwareTest {
 
         // Dto
         var barn = List.of(new DokumentertBarnDto(fødselsdatoFraSøknad, null));
-        var dto = new SjekkManglendeFodselDto("begrunnelse", true, barn);
+        var dto = new SjekkManglendeFødselAksjonspunktDto("begrunnelse", true, barn);
         var aksjonspunkt = behandling.getAksjonspunktFor(SJEKK_MANGLENDE_FØDSEL);
 
         // Act
@@ -148,7 +148,7 @@ class SjekkManglendeFødselOppdatererTest extends EntityManagerAwareTest {
 
         // Dto
         var barn = List.of(new DokumentertBarnDto(fødselsdatoFraPDL, null), new DokumentertBarnDto(fødselsdatoFraPDL, null));
-        var dto = new SjekkManglendeFodselDto("begrunnelse", true, barn);
+        var dto = new SjekkManglendeFødselAksjonspunktDto("begrunnelse", true, barn);
         var aksjonspunkt = behandling.getAksjonspunktFor(SJEKK_MANGLENDE_FØDSEL);
 
         // Act
@@ -188,7 +188,7 @@ class SjekkManglendeFødselOppdatererTest extends EntityManagerAwareTest {
 
         // Dto
         var barn = List.of(new DokumentertBarnDto(avklartFødseldato, null), new DokumentertBarnDto(avklartFødseldato, null));
-        var dto = new SjekkManglendeFodselDto("begrunnelse", true, barn);
+        var dto = new SjekkManglendeFødselAksjonspunktDto("begrunnelse", true, barn);
         var aksjonspunkt = behandling.getAksjonspunktFor(SJEKK_MANGLENDE_FØDSEL);
 
         // Act
@@ -231,7 +231,7 @@ class SjekkManglendeFødselOppdatererTest extends EntityManagerAwareTest {
         // Dto
         var barn = List.of(new DokumentertBarnDto(fødselsdatoFraSøknad, dødsdatoFraSBH));
 
-        var dto = new SjekkManglendeFodselDto("begrunnelse", true, barn);
+        var dto = new SjekkManglendeFødselAksjonspunktDto("begrunnelse", true, barn);
         var aksjonspunkt = behandling.getAksjonspunktFor(SJEKK_MANGLENDE_FØDSEL);
 
         // Act
@@ -272,7 +272,7 @@ class SjekkManglendeFødselOppdatererTest extends EntityManagerAwareTest {
 
         var barn = List.of(new DokumentertBarnDto(fødselsdatoFraSBH, null));
 
-        var dto = new SjekkManglendeFodselDto("begrunnelse", true, barn);
+        var dto = new SjekkManglendeFødselAksjonspunktDto("begrunnelse", true, barn);
         var aksjonspunkt = behandling.getAksjonspunktFor(SJEKK_MANGLENDE_FØDSEL);
 
         // Act
@@ -309,7 +309,7 @@ class SjekkManglendeFødselOppdatererTest extends EntityManagerAwareTest {
         var behandling = scenario.lagre(repositoryProvider);
 
         var barn = List.of(new DokumentertBarnDto(fødselsdatoFraSøknad, null));
-        var dto = new SjekkManglendeFodselDto("begrunnelse", true, barn);
+        var dto = new SjekkManglendeFødselAksjonspunktDto("begrunnelse", true, barn);
         var aksjonspunkt = behandling.getAksjonspunktFor(SJEKK_MANGLENDE_FØDSEL);
 
         // Act
@@ -343,9 +343,9 @@ class SjekkManglendeFødselOppdatererTest extends EntityManagerAwareTest {
         var oppdaterer = new SjekkManglendeFødselOppdaterer(mock(OpplysningsPeriodeTjeneste.class), familieHendelseTjeneste,
             repositoryProvider.getHistorikkinnslagRepository(), repositoryProvider.getBehandlingRepository());
 
-        var dtoManglerBarn = new SjekkManglendeFodselDto("begrunnelse", true, List.of());
-        var dtoForMangeBarn = new SjekkManglendeFodselDto("begrunnelse", true, Collections.nCopies(10, new DokumentertBarnDto(now(), null)));
-        var dtoDødFørFødsel = new SjekkManglendeFodselDto("begrunnelse", true, List.of(new DokumentertBarnDto(now(), now().minusDays(1))));
+        var dtoManglerBarn = new SjekkManglendeFødselAksjonspunktDto("begrunnelse", true, List.of());
+        var dtoForMangeBarn = new SjekkManglendeFødselAksjonspunktDto("begrunnelse", true, Collections.nCopies(10, new DokumentertBarnDto(now(), null)));
+        var dtoDødFørFødsel = new SjekkManglendeFødselAksjonspunktDto("begrunnelse", true, List.of(new DokumentertBarnDto(now(), now().minusDays(1))));
 
         var aksjonspunkt = behandling.getAksjonspunktFor(SJEKK_MANGLENDE_FØDSEL);
         var param = new AksjonspunktOppdaterParameter(BehandlingReferanse.fra(behandling), dtoManglerBarn, aksjonspunkt);

--- a/domenetjenester/familie-hendelse/src/test/java/no/nav/foreldrepenger/familiehendelse/aksjonspunkt/SjekkTerminbekreftelseAksjonspunktDtoTest.java
+++ b/domenetjenester/familie-hendelse/src/test/java/no/nav/foreldrepenger/familiehendelse/aksjonspunkt/SjekkTerminbekreftelseAksjonspunktDtoTest.java
@@ -7,9 +7,9 @@ import java.time.LocalDate;
 import org.junit.jupiter.api.Test;
 
 import no.nav.foreldrepenger.domene.json.StandardJsonConfig;
-import no.nav.foreldrepenger.familiehendelse.aksjonspunkt.dto.SjekkTerminbekreftelseDto;
+import no.nav.foreldrepenger.familiehendelse.aksjonspunkt.dto.SjekkTerminbekreftelseAksjonspunktDto;
 
-class SjekkTerminbekreftelseDtoTest {
+class SjekkTerminbekreftelseAksjonspunktDtoTest {
 
     @Test
     void test_av_json_mapping() {
@@ -17,7 +17,7 @@ class SjekkTerminbekreftelseDtoTest {
 
         var json = StandardJsonConfig.toJson(terminbekreftelseAksjonspunktDto);
 
-        var objektFraJson =  StandardJsonConfig.fromJson(json, SjekkTerminbekreftelseDto.class);
+        var objektFraJson =  StandardJsonConfig.fromJson(json, SjekkTerminbekreftelseAksjonspunktDto.class);
 
         assertThat(objektFraJson.getAntallBarn()).isEqualTo(terminbekreftelseAksjonspunktDto.getAntallBarn());
         assertThat(objektFraJson.getTermindato()).isEqualTo(terminbekreftelseAksjonspunktDto.getTermindato());
@@ -25,8 +25,8 @@ class SjekkTerminbekreftelseDtoTest {
         assertThat(objektFraJson.getBegrunnelse()).isEqualTo(terminbekreftelseAksjonspunktDto.getBegrunnelse());
     }
 
-    private SjekkTerminbekreftelseDto bekreftFødselAksjonspunktDto() {
-        return new SjekkTerminbekreftelseDto("Test", LocalDate.now().plusDays(30), LocalDate.now().minusDays(10), 1);
+    private SjekkTerminbekreftelseAksjonspunktDto bekreftFødselAksjonspunktDto() {
+        return new SjekkTerminbekreftelseAksjonspunktDto("Test", LocalDate.now().plusDays(30), LocalDate.now().minusDays(10), 1);
     }
 
 }

--- a/domenetjenester/familie-hendelse/src/test/java/no/nav/foreldrepenger/familiehendelse/aksjonspunkt/SjekkTerminbekreftelseDtoTest.java
+++ b/domenetjenester/familie-hendelse/src/test/java/no/nav/foreldrepenger/familiehendelse/aksjonspunkt/SjekkTerminbekreftelseDtoTest.java
@@ -7,9 +7,9 @@ import java.time.LocalDate;
 import org.junit.jupiter.api.Test;
 
 import no.nav.foreldrepenger.domene.json.StandardJsonConfig;
-import no.nav.foreldrepenger.familiehendelse.aksjonspunkt.dto.BekreftTerminbekreftelseAksjonspunktDto;
+import no.nav.foreldrepenger.familiehendelse.aksjonspunkt.dto.SjekkTerminbekreftelseDto;
 
-class BekreftTerminbekreftelseAksjonspunktDtoTest {
+class SjekkTerminbekreftelseDtoTest {
 
     @Test
     void test_av_json_mapping() {
@@ -17,7 +17,7 @@ class BekreftTerminbekreftelseAksjonspunktDtoTest {
 
         var json = StandardJsonConfig.toJson(terminbekreftelseAksjonspunktDto);
 
-        var objektFraJson =  StandardJsonConfig.fromJson(json, BekreftTerminbekreftelseAksjonspunktDto.class);
+        var objektFraJson =  StandardJsonConfig.fromJson(json, SjekkTerminbekreftelseDto.class);
 
         assertThat(objektFraJson.getAntallBarn()).isEqualTo(terminbekreftelseAksjonspunktDto.getAntallBarn());
         assertThat(objektFraJson.getTermindato()).isEqualTo(terminbekreftelseAksjonspunktDto.getTermindato());
@@ -25,8 +25,8 @@ class BekreftTerminbekreftelseAksjonspunktDtoTest {
         assertThat(objektFraJson.getBegrunnelse()).isEqualTo(terminbekreftelseAksjonspunktDto.getBegrunnelse());
     }
 
-    private BekreftTerminbekreftelseAksjonspunktDto bekreftFødselAksjonspunktDto() {
-        return new BekreftTerminbekreftelseAksjonspunktDto("Test", LocalDate.now().plusDays(30), LocalDate.now().minusDays(10), 1);
+    private SjekkTerminbekreftelseDto bekreftFødselAksjonspunktDto() {
+        return new SjekkTerminbekreftelseDto("Test", LocalDate.now().plusDays(30), LocalDate.now().minusDays(10), 1);
     }
 
 }

--- a/domenetjenester/familie-hendelse/src/test/java/no/nav/foreldrepenger/familiehendelse/aksjonspunkt/SjekkTerminbekreftelseOppdatererTest.java
+++ b/domenetjenester/familie-hendelse/src/test/java/no/nav/foreldrepenger/familiehendelse/aksjonspunkt/SjekkTerminbekreftelseOppdatererTest.java
@@ -24,12 +24,12 @@ import no.nav.foreldrepenger.behandlingslager.testutilities.behandling.ScenarioF
 import no.nav.foreldrepenger.behandlingslager.testutilities.behandling.ScenarioMorSøkerEngangsstønad;
 import no.nav.foreldrepenger.dbstoette.EntityManagerAwareTest;
 import no.nav.foreldrepenger.familiehendelse.FamilieHendelseTjeneste;
-import no.nav.foreldrepenger.familiehendelse.aksjonspunkt.dto.BekreftTerminbekreftelseAksjonspunktDto;
+import no.nav.foreldrepenger.familiehendelse.aksjonspunkt.dto.SjekkTerminbekreftelseDto;
 import no.nav.foreldrepenger.skjæringstidspunkt.OpplysningsPeriodeTjeneste;
 
-class BekreftTerminbekreftelseOppdatererTest extends EntityManagerAwareTest {
+class SjekkTerminbekreftelseOppdatererTest extends EntityManagerAwareTest {
 
-    private static final AksjonspunktDefinisjon AKSJONSPUNKT_DEF = AksjonspunktDefinisjon.AVKLAR_TERMINBEKREFTELSE;
+    private static final AksjonspunktDefinisjon AKSJONSPUNKT_DEF = AksjonspunktDefinisjon.SJEKK_TERMINBEKREFTELSE;
 
     private final LocalDate now = LocalDate.now();
 
@@ -66,11 +66,11 @@ class BekreftTerminbekreftelseOppdatererTest extends EntityManagerAwareTest {
         scenario.leggTilAksjonspunkt(AKSJONSPUNKT_DEF, BehandlingStegType.SØKERS_RELASJON_TIL_BARN);
         var behandling = scenario.lagre(repositoryProvider);
         // Dto
-        var dto = new BekreftTerminbekreftelseAksjonspunktDto("begrunnelse",
+        var dto = new SjekkTerminbekreftelseDto("begrunnelse",
             avklartTermindato, avklartUtstedtDato, avklartAntallBarn);
         var aksjonspunkt = behandling.getAksjonspunktFor(dto.getAksjonspunktDefinisjon());
         // Act
-        var oppdaterer = new BekreftTerminbekreftelseOppdaterer(historikkRepository, mock(OpplysningsPeriodeTjeneste.class), familieHendelseTjeneste);
+        var oppdaterer = new SjekkTerminbekreftelseOppdaterer(historikkRepository, mock(OpplysningsPeriodeTjeneste.class), familieHendelseTjeneste);
 
         oppdaterer.oppdater(dto, new AksjonspunktOppdaterParameter(BehandlingReferanse.fra(behandling), dto, aksjonspunkt));
 
@@ -104,11 +104,11 @@ class BekreftTerminbekreftelseOppdatererTest extends EntityManagerAwareTest {
         scenario.leggTilAksjonspunkt(AKSJONSPUNKT_DEF, BehandlingStegType.SØKERS_RELASJON_TIL_BARN);
         var behandling = scenario.lagre(repositoryProvider);
         // Dto
-        var dto = new BekreftTerminbekreftelseAksjonspunktDto("begrunnelse",
+        var dto = new SjekkTerminbekreftelseDto("begrunnelse",
             opprinneligTermindato, opprinneligUtstedtDato, opprinneligAntallBarn);
         var aksjonspunkt = behandling.getAksjonspunktFor(dto.getAksjonspunktDefinisjon());
         // Act
-        var oppdaterer = new BekreftTerminbekreftelseOppdaterer(historikkRepository, mock(OpplysningsPeriodeTjeneste.class), familieHendelseTjeneste);
+        var oppdaterer = new SjekkTerminbekreftelseOppdaterer(historikkRepository, mock(OpplysningsPeriodeTjeneste.class), familieHendelseTjeneste);
 
         oppdaterer.oppdater(dto, new AksjonspunktOppdaterParameter(BehandlingReferanse.fra(behandling), dto, aksjonspunkt));
 
@@ -135,11 +135,11 @@ class BekreftTerminbekreftelseOppdatererTest extends EntityManagerAwareTest {
         scenario.leggTilAksjonspunkt(AKSJONSPUNKT_DEF, BehandlingStegType.SØKERS_RELASJON_TIL_BARN);
 
         var behandling = scenario.lagre(repositoryProvider);
-        var dto = new BekreftTerminbekreftelseAksjonspunktDto(
+        var dto = new SjekkTerminbekreftelseDto(
             "Begrunnelse", now.plusDays(30), now.minusDays(3), 1);
         var aksjonspunkt = behandling.getAksjonspunktFor(dto.getAksjonspunktDefinisjon());
         // Act
-        var oppdaterer = new BekreftTerminbekreftelseOppdaterer(historikkRepository, mock(OpplysningsPeriodeTjeneste.class), familieHendelseTjeneste);
+        var oppdaterer = new SjekkTerminbekreftelseOppdaterer(historikkRepository, mock(OpplysningsPeriodeTjeneste.class), familieHendelseTjeneste);
 
         oppdaterer.oppdater(dto, new AksjonspunktOppdaterParameter(BehandlingReferanse.fra(behandling), dto, aksjonspunkt));
 
@@ -168,10 +168,10 @@ class BekreftTerminbekreftelseOppdatererTest extends EntityManagerAwareTest {
         scenario.leggTilAksjonspunkt(AKSJONSPUNKT_DEF, BehandlingStegType.SØKERS_RELASJON_TIL_BARN);
 
         var behandling = scenario.lagre(repositoryProvider);
-        var dto = new BekreftTerminbekreftelseAksjonspunktDto("Begrunnelse", now.plusDays(30), now.minusDays(3), 2);
+        var dto = new SjekkTerminbekreftelseDto("Begrunnelse", now.plusDays(30), now.minusDays(3), 2);
         var aksjonspunkt = behandling.getAksjonspunktMedDefinisjonOptional(dto.getAksjonspunktDefinisjon()).get();
         // Act
-        var oppdaterer = new BekreftTerminbekreftelseOppdaterer(historikkRepository, mock(OpplysningsPeriodeTjeneste.class), familieHendelseTjeneste);
+        var oppdaterer = new SjekkTerminbekreftelseOppdaterer(historikkRepository, mock(OpplysningsPeriodeTjeneste.class), familieHendelseTjeneste);
 
         var resultat = oppdaterer.oppdater(dto, new AksjonspunktOppdaterParameter(BehandlingReferanse.fra(behandling), dto, aksjonspunkt));
 
@@ -182,7 +182,7 @@ class BekreftTerminbekreftelseOppdatererTest extends EntityManagerAwareTest {
         AksjonspunktTestSupport.fjernToTrinnsBehandlingKreves(aksjonspunkt);
 
         // Act
-        oppdaterer = new BekreftTerminbekreftelseOppdaterer(historikkRepository, mock(OpplysningsPeriodeTjeneste.class), familieHendelseTjeneste);
+        oppdaterer = new SjekkTerminbekreftelseOppdaterer(historikkRepository, mock(OpplysningsPeriodeTjeneste.class), familieHendelseTjeneste);
 
         var oppdateringResultat = oppdaterer.oppdater(dto, new AksjonspunktOppdaterParameter(BehandlingReferanse.fra(behandling), dto,
             aksjonspunkt));

--- a/domenetjenester/familie-hendelse/src/test/java/no/nav/foreldrepenger/familiehendelse/aksjonspunkt/SjekkTerminbekreftelseOppdatererTest.java
+++ b/domenetjenester/familie-hendelse/src/test/java/no/nav/foreldrepenger/familiehendelse/aksjonspunkt/SjekkTerminbekreftelseOppdatererTest.java
@@ -24,7 +24,7 @@ import no.nav.foreldrepenger.behandlingslager.testutilities.behandling.ScenarioF
 import no.nav.foreldrepenger.behandlingslager.testutilities.behandling.ScenarioMorSøkerEngangsstønad;
 import no.nav.foreldrepenger.dbstoette.EntityManagerAwareTest;
 import no.nav.foreldrepenger.familiehendelse.FamilieHendelseTjeneste;
-import no.nav.foreldrepenger.familiehendelse.aksjonspunkt.dto.SjekkTerminbekreftelseDto;
+import no.nav.foreldrepenger.familiehendelse.aksjonspunkt.dto.SjekkTerminbekreftelseAksjonspunktDto;
 import no.nav.foreldrepenger.skjæringstidspunkt.OpplysningsPeriodeTjeneste;
 
 class SjekkTerminbekreftelseOppdatererTest extends EntityManagerAwareTest {
@@ -66,7 +66,7 @@ class SjekkTerminbekreftelseOppdatererTest extends EntityManagerAwareTest {
         scenario.leggTilAksjonspunkt(AKSJONSPUNKT_DEF, BehandlingStegType.SØKERS_RELASJON_TIL_BARN);
         var behandling = scenario.lagre(repositoryProvider);
         // Dto
-        var dto = new SjekkTerminbekreftelseDto("begrunnelse",
+        var dto = new SjekkTerminbekreftelseAksjonspunktDto("begrunnelse",
             avklartTermindato, avklartUtstedtDato, avklartAntallBarn);
         var aksjonspunkt = behandling.getAksjonspunktFor(dto.getAksjonspunktDefinisjon());
         // Act
@@ -104,7 +104,7 @@ class SjekkTerminbekreftelseOppdatererTest extends EntityManagerAwareTest {
         scenario.leggTilAksjonspunkt(AKSJONSPUNKT_DEF, BehandlingStegType.SØKERS_RELASJON_TIL_BARN);
         var behandling = scenario.lagre(repositoryProvider);
         // Dto
-        var dto = new SjekkTerminbekreftelseDto("begrunnelse",
+        var dto = new SjekkTerminbekreftelseAksjonspunktDto("begrunnelse",
             opprinneligTermindato, opprinneligUtstedtDato, opprinneligAntallBarn);
         var aksjonspunkt = behandling.getAksjonspunktFor(dto.getAksjonspunktDefinisjon());
         // Act
@@ -135,7 +135,7 @@ class SjekkTerminbekreftelseOppdatererTest extends EntityManagerAwareTest {
         scenario.leggTilAksjonspunkt(AKSJONSPUNKT_DEF, BehandlingStegType.SØKERS_RELASJON_TIL_BARN);
 
         var behandling = scenario.lagre(repositoryProvider);
-        var dto = new SjekkTerminbekreftelseDto(
+        var dto = new SjekkTerminbekreftelseAksjonspunktDto(
             "Begrunnelse", now.plusDays(30), now.minusDays(3), 1);
         var aksjonspunkt = behandling.getAksjonspunktFor(dto.getAksjonspunktDefinisjon());
         // Act
@@ -168,7 +168,7 @@ class SjekkTerminbekreftelseOppdatererTest extends EntityManagerAwareTest {
         scenario.leggTilAksjonspunkt(AKSJONSPUNKT_DEF, BehandlingStegType.SØKERS_RELASJON_TIL_BARN);
 
         var behandling = scenario.lagre(repositoryProvider);
-        var dto = new SjekkTerminbekreftelseDto("Begrunnelse", now.plusDays(30), now.minusDays(3), 2);
+        var dto = new SjekkTerminbekreftelseAksjonspunktDto("Begrunnelse", now.plusDays(30), now.minusDays(3), 2);
         var aksjonspunkt = behandling.getAksjonspunktMedDefinisjonOptional(dto.getAksjonspunktDefinisjon()).get();
         // Act
         var oppdaterer = new SjekkTerminbekreftelseOppdaterer(historikkRepository, mock(OpplysningsPeriodeTjeneste.class), familieHendelseTjeneste);

--- a/domenetjenester/familie-hendelse/src/test/java/no/nav/foreldrepenger/familiehendelse/kontrollerfakta/fødsel/AksjonspunktUtlederForEngangsstønadFødselTest.java
+++ b/domenetjenester/familie-hendelse/src/test/java/no/nav/foreldrepenger/familiehendelse/kontrollerfakta/fødsel/AksjonspunktUtlederForEngangsstønadFødselTest.java
@@ -2,7 +2,7 @@ package no.nav.foreldrepenger.familiehendelse.kontrollerfakta.fødsel;
 
 import static no.nav.foreldrepenger.behandlingslager.behandling.BehandlingType.FØRSTEGANGSSØKNAD;
 import static no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.AksjonspunktDefinisjon.AUTO_VENT_PÅ_FØDSELREGISTRERING;
-import static no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.AksjonspunktDefinisjon.AVKLAR_TERMINBEKREFTELSE;
+import static no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.AksjonspunktDefinisjon.SJEKK_TERMINBEKREFTELSE;
 import static no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.AksjonspunktDefinisjon.SJEKK_MANGLENDE_FØDSEL;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -54,7 +54,7 @@ class AksjonspunktUtlederForEngangsstønadFødselTest extends EntityManagerAware
         //Act
         var utledeteAksjonspunkter = apUtleder.utledAksjonspunkterFor(lagInput(behandling));
         //Assert
-        assertThat(utledeteAksjonspunkter).containsExactly(AksjonspunktUtlederResultat.opprettForAksjonspunkt(AVKLAR_TERMINBEKREFTELSE));
+        assertThat(utledeteAksjonspunkter).containsExactly(AksjonspunktUtlederResultat.opprettForAksjonspunkt(SJEKK_TERMINBEKREFTELSE));
         verify(apUtleder).utledAksjonspunkterForTerminbekreftelse(any());
     }
 

--- a/domenetjenester/familie-hendelse/src/test/java/no/nav/foreldrepenger/familiehendelse/kontrollerfakta/fødsel/AksjonspunktUtlederForForeldrepengerFødselNårHovedsøkerErFarMedmorTest.java
+++ b/domenetjenester/familie-hendelse/src/test/java/no/nav/foreldrepenger/familiehendelse/kontrollerfakta/fødsel/AksjonspunktUtlederForForeldrepengerFødselNårHovedsøkerErFarMedmorTest.java
@@ -1,7 +1,7 @@
 package no.nav.foreldrepenger.familiehendelse.kontrollerfakta.fødsel;
 
 import static no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.AksjonspunktDefinisjon.AUTO_VENT_PÅ_FØDSELREGISTRERING;
-import static no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.AksjonspunktDefinisjon.AVKLAR_TERMINBEKREFTELSE;
+import static no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.AksjonspunktDefinisjon.SJEKK_TERMINBEKREFTELSE;
 import static no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.AksjonspunktDefinisjon.SJEKK_MANGLENDE_FØDSEL;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -99,7 +99,7 @@ class AksjonspunktUtlederForForeldrepengerFødselNårHovedsøkerErFarMedmorTest 
         var utledeteAksjonspunkter = apUtleder.utledAksjonspunkterFor(lagInput(behandling, LocalDate.now()));
 
         assertThat(utledeteAksjonspunkter).hasSize(1);
-        assertThat(utledeteAksjonspunkter.getFirst().aksjonspunktDefinisjon()).isEqualTo(AVKLAR_TERMINBEKREFTELSE);;
+        assertThat(utledeteAksjonspunkter.getFirst().aksjonspunktDefinisjon()).isEqualTo(SJEKK_TERMINBEKREFTELSE);;
     }
 
     @Test
@@ -110,7 +110,7 @@ class AksjonspunktUtlederForForeldrepengerFødselNårHovedsøkerErFarMedmorTest 
         var utledeteAksjonspunkter = apUtleder.utledAksjonspunkterFor(lagInputMedMinsterettFar(behandling, LocalDate.now()));
 
         assertThat(utledeteAksjonspunkter).hasSize(1);
-        assertThat(utledeteAksjonspunkter.getFirst().aksjonspunktDefinisjon()).isEqualTo(AVKLAR_TERMINBEKREFTELSE);
+        assertThat(utledeteAksjonspunkter.getFirst().aksjonspunktDefinisjon()).isEqualTo(SJEKK_TERMINBEKREFTELSE);
     }
 
     @Test
@@ -160,7 +160,7 @@ class AksjonspunktUtlederForForeldrepengerFødselNårHovedsøkerErFarMedmorTest 
         var apUtleder = Mockito.spy(new AksjonspunktUtlederForForeldrepengerFødsel(iayTjeneste, familieHendelseTjeneste,
             repositoryProvider.getYtelsesFordelingRepository()));
         var utledeteAksjonspunkter = apUtleder.utledAksjonspunkterFor(param);
-        assertThat(utledeteAksjonspunkter).containsExactly(AksjonspunktUtlederResultat.opprettForAksjonspunkt(AVKLAR_TERMINBEKREFTELSE));
+        assertThat(utledeteAksjonspunkter).containsExactly(AksjonspunktUtlederResultat.opprettForAksjonspunkt(SJEKK_TERMINBEKREFTELSE));
     }
 
     @Test
@@ -171,7 +171,7 @@ class AksjonspunktUtlederForForeldrepengerFødselNårHovedsøkerErFarMedmorTest 
         var apUtleder = Mockito.spy(new AksjonspunktUtlederForForeldrepengerFødsel(iayTjeneste, familieHendelseTjeneste,
             repositoryProvider.getYtelsesFordelingRepository()));
         var utledeteAksjonspunkter = apUtleder.utledAksjonspunkterFor(param);
-        assertThat(utledeteAksjonspunkter).containsExactly(AksjonspunktUtlederResultat.opprettForAksjonspunkt(AVKLAR_TERMINBEKREFTELSE));
+        assertThat(utledeteAksjonspunkter).containsExactly(AksjonspunktUtlederResultat.opprettForAksjonspunkt(SJEKK_TERMINBEKREFTELSE));
     }
 
     private Behandling opprettBehandlingFarSøkerFødselRegistrertIPDL(LocalDate fødseldato, int antallBarnSøknad, int antallBarnPDL) {

--- a/domenetjenester/familie-hendelse/src/test/java/no/nav/foreldrepenger/familiehendelse/kontrollerfakta/fødsel/AksjonspunktUtlederForForeldrepengerFødselNårHovedsøkerErMorTest.java
+++ b/domenetjenester/familie-hendelse/src/test/java/no/nav/foreldrepenger/familiehendelse/kontrollerfakta/fødsel/AksjonspunktUtlederForForeldrepengerFødselNårHovedsøkerErMorTest.java
@@ -1,7 +1,7 @@
 package no.nav.foreldrepenger.familiehendelse.kontrollerfakta.fødsel;
 
 import static no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.AksjonspunktDefinisjon.AUTO_VENT_PÅ_FØDSELREGISTRERING;
-import static no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.AksjonspunktDefinisjon.AVKLAR_TERMINBEKREFTELSE;
+import static no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.AksjonspunktDefinisjon.SJEKK_TERMINBEKREFTELSE;
 import static no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.AksjonspunktDefinisjon.SJEKK_MANGLENDE_FØDSEL;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -139,7 +139,7 @@ class AksjonspunktUtlederForForeldrepengerFødselNårHovedsøkerErMorTest extend
         var param = lagInput(behandling);
         var utledeteAksjonspunkter = apUtleder.utledAksjonspunkterFor(param);
         //Assert
-        assertThat(utledeteAksjonspunkter).containsExactly(AksjonspunktUtlederResultat.opprettForAksjonspunkt(AVKLAR_TERMINBEKREFTELSE));
+        assertThat(utledeteAksjonspunkter).containsExactly(AksjonspunktUtlederResultat.opprettForAksjonspunkt(SJEKK_TERMINBEKREFTELSE));
         verify(apUtleder).erSøkerRegistrertArbeidstakerMedLøpendeArbeidsforholdIAARegisteret(param);
     }
 
@@ -181,7 +181,7 @@ class AksjonspunktUtlederForForeldrepengerFødselNårHovedsøkerErMorTest extend
         var param = lagInput(behandling);
         var utledeteAksjonspunkter = apUtleder.utledAksjonspunkterFor(param);
         //Assert
-        assertThat(utledeteAksjonspunkter).containsExactly(AksjonspunktUtlederResultat.opprettForAksjonspunkt(AVKLAR_TERMINBEKREFTELSE));
+        assertThat(utledeteAksjonspunkter).containsExactly(AksjonspunktUtlederResultat.opprettForAksjonspunkt(SJEKK_TERMINBEKREFTELSE));
         verify(apUtleder).erSøkerRegistrertArbeidstakerMedLøpendeArbeidsforholdIAARegisteret(param);
     }
 

--- a/domenetjenester/registerinnhenting/src/test/java/no/nav/foreldrepenger/domene/registerinnhenting/impl/EndringskontrollerTest.java
+++ b/domenetjenester/registerinnhenting/src/test/java/no/nav/foreldrepenger/domene/registerinnhenting/impl/EndringskontrollerTest.java
@@ -241,7 +241,7 @@ class EndringskontrollerTest {
         var scenario = ScenarioFarSøkerForeldrepenger.forFødsel()
             .medFødselAdopsjonsdato(List.of(fdato))
             .medBehandlingType(BehandlingType.FØRSTEGANGSSØKNAD)
-            .leggTilAksjonspunkt(AksjonspunktDefinisjon.AVKLAR_TERMINBEKREFTELSE, BehandlingStegType.KONTROLLER_FAKTA);
+            .leggTilAksjonspunkt(AksjonspunktDefinisjon.SJEKK_TERMINBEKREFTELSE, BehandlingStegType.KONTROLLER_FAKTA);
         scenario.medSøknadHendelse().medAntallBarn(1).medTerminbekreftelse(scenario.medSøknadHendelse().getTerminbekreftelseBuilder()
             .medTermindato(LocalDate.now().minusDays(5))
             .medUtstedtDato(LocalDate.now().minusMonths(1))
@@ -257,13 +257,13 @@ class EndringskontrollerTest {
 
         forceOppdaterBehandlingSteg(behandling, BehandlingStegType.SØKERS_RELASJON_TIL_BARN, BehandlingStegStatus.INNGANG, BehandlingStegStatus.UTFØRT);
 
-        assertThat(behandling.getAksjonspunktFor(AksjonspunktDefinisjon.AVKLAR_TERMINBEKREFTELSE).erÅpentAksjonspunkt()).isTrue();
+        assertThat(behandling.getAksjonspunktFor(AksjonspunktDefinisjon.SJEKK_TERMINBEKREFTELSE).erÅpentAksjonspunkt()).isTrue();
 
         var startpunktSRB = StartpunktType.OPPTJENING;
         when(startpunktTjenesteMock.utledStartpunktForDiffBehandlingsgrunnlag(any(), any(), any(EndringsresultatDiff.class))).thenReturn(startpunktSRB);
         when(behandlingModellTjenesteMock.erStegAEtterStegB(any(), any(), any(), any())).thenReturn(false); // Opptjening er etter SRTB
         when(behandlingModellTjenesteMock.skalAksjonspunktLøsesIEllerEtterSteg(FagsakYtelseType.FORELDREPENGER, BehandlingType.FØRSTEGANGSSØKNAD,
-            BehandlingStegType.SØKERS_RELASJON_TIL_BARN, AksjonspunktDefinisjon.AVKLAR_TERMINBEKREFTELSE)).thenReturn(true);
+            BehandlingStegType.SØKERS_RELASJON_TIL_BARN, AksjonspunktDefinisjon.SJEKK_TERMINBEKREFTELSE)).thenReturn(true);
         when(behandlingskontrollTjenesteMock.initBehandlingskontroll(any(), any())).thenReturn(new BehandlingskontrollKontekst(behandling, lås));
 
         // Blir ikke reutledet
@@ -277,7 +277,7 @@ class EndringskontrollerTest {
         // Assert
         assertThat(behandling.getAktivtBehandlingSteg()).isEqualTo(BehandlingStegType.SØKERS_RELASJON_TIL_BARN);
         verify(aksjonspunktkontrollTjenesteMock).lagreAksjonspunkterAvbrutt(any(), any(), any());
-        assertThat(behandling.getAksjonspunktMedDefinisjonOptional(AksjonspunktDefinisjon.AVKLAR_TERMINBEKREFTELSE)).hasValueSatisfying(Aksjonspunkt::erAvbrutt);
+        assertThat(behandling.getAksjonspunktMedDefinisjonOptional(AksjonspunktDefinisjon.SJEKK_TERMINBEKREFTELSE)).hasValueSatisfying(Aksjonspunkt::erAvbrutt);
     }
 
     @Test
@@ -287,7 +287,7 @@ class EndringskontrollerTest {
         var scenario = ScenarioFarSøkerForeldrepenger.forFødsel()
             .medFødselAdopsjonsdato(List.of(fdato))
             .medBehandlingType(BehandlingType.FØRSTEGANGSSØKNAD)
-            .leggTilAksjonspunkt(AksjonspunktDefinisjon.AVKLAR_TERMINBEKREFTELSE, BehandlingStegType.KONTROLLER_FAKTA);
+            .leggTilAksjonspunkt(AksjonspunktDefinisjon.SJEKK_TERMINBEKREFTELSE, BehandlingStegType.KONTROLLER_FAKTA);
         scenario.medSøknadHendelse().medAntallBarn(1).medTerminbekreftelse(scenario.medSøknadHendelse().getTerminbekreftelseBuilder()
             .medTermindato(LocalDate.now().minusDays(5))
             .medUtstedtDato(LocalDate.now().minusMonths(1))
@@ -302,7 +302,7 @@ class EndringskontrollerTest {
 
         forceOppdaterBehandlingSteg(behandling, BehandlingStegType.SØKERS_RELASJON_TIL_BARN, BehandlingStegStatus.INNGANG, BehandlingStegStatus.UTFØRT);
 
-        assertThat(behandling.getAksjonspunktFor(AksjonspunktDefinisjon.AVKLAR_TERMINBEKREFTELSE).erÅpentAksjonspunkt()).isTrue();
+        assertThat(behandling.getAksjonspunktFor(AksjonspunktDefinisjon.SJEKK_TERMINBEKREFTELSE).erÅpentAksjonspunkt()).isTrue();
 
         var startpunktSRB = StartpunktType.OPPTJENING;
         when(startpunktTjenesteMock.utledStartpunktForDiffBehandlingsgrunnlag(any(), any(), any(EndringsresultatDiff.class))).thenReturn(startpunktSRB);
@@ -311,7 +311,7 @@ class EndringskontrollerTest {
         // Blir ikke reutledet
         when(kontrollerFaktaTjenesteMock.utledAksjonspunkterFomSteg(any(), any(), any())).thenReturn(Collections.emptyList());
         when(totrinnRepositoryMock.hentTotrinnaksjonspunktvurderinger(any()))
-            .thenReturn(List.of(new Totrinnsvurdering.Builder(behandling, AksjonspunktDefinisjon.AVKLAR_TERMINBEKREFTELSE).medGodkjent(false).build()));
+            .thenReturn(List.of(new Totrinnsvurdering.Builder(behandling, AksjonspunktDefinisjon.SJEKK_TERMINBEKREFTELSE).medGodkjent(false).build()));
 
         var endringskontroller = endringskontroller();
 
@@ -322,7 +322,7 @@ class EndringskontrollerTest {
         // Assert
         assertThat(behandling.getAktivtBehandlingSteg()).isEqualTo(BehandlingStegType.SØKERS_RELASJON_TIL_BARN);
         verify(aksjonspunktkontrollTjenesteMock, times(0)).lagreAksjonspunkterAvbrutt(any(), any(), any());
-        assertThat(behandling.getAksjonspunktMedDefinisjonOptional(AksjonspunktDefinisjon.AVKLAR_TERMINBEKREFTELSE)).hasValueSatisfying(Aksjonspunkt::erOpprettet);
+        assertThat(behandling.getAksjonspunktMedDefinisjonOptional(AksjonspunktDefinisjon.SJEKK_TERMINBEKREFTELSE)).hasValueSatisfying(Aksjonspunkt::erOpprettet);
     }
 
     @Test

--- a/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/aksjonspunkt/AksjonspunktRestTjenesteTest.java
+++ b/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/aksjonspunkt/AksjonspunktRestTjenesteTest.java
@@ -29,8 +29,8 @@ import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingsresultatRepo
 import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.AksjonspunktDefinisjon;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepository;
 import no.nav.foreldrepenger.domene.vedtak.TotrinnTjeneste;
-import no.nav.foreldrepenger.familiehendelse.aksjonspunkt.dto.SjekkTerminbekreftelseDto;
-import no.nav.foreldrepenger.familiehendelse.aksjonspunkt.dto.SjekkManglendeFodselDto;
+import no.nav.foreldrepenger.familiehendelse.aksjonspunkt.dto.SjekkTerminbekreftelseAksjonspunktDto;
+import no.nav.foreldrepenger.familiehendelse.aksjonspunkt.dto.SjekkManglendeFødselAksjonspunktDto;
 import no.nav.foreldrepenger.familiehendelse.aksjonspunkt.dto.DokumentertBarnDto;
 import no.nav.foreldrepenger.web.app.tjenester.behandling.uttak.dto.FastsetteUttakDto;
 import no.nav.foreldrepenger.web.app.tjenester.behandling.vedtak.aksjonspunkt.AksjonspunktGodkjenningDto;
@@ -69,7 +69,7 @@ class AksjonspunktRestTjenesteTest {
     @Test
     void skal_bekrefte_terminbekreftelse() throws Exception {
         Collection<BekreftetAksjonspunktDto> aksjonspunkt = new ArrayList<>();
-        aksjonspunkt.add(new SjekkTerminbekreftelseDto(BEGRUNNELSE, termindato, utstedtdato, 1));
+        aksjonspunkt.add(new SjekkTerminbekreftelseAksjonspunktDto(BEGRUNNELSE, termindato, utstedtdato, 1));
 
         aksjonspunktRestTjeneste.bekreft(mock(HttpServletRequest.class),
             BekreftedeAksjonspunkterDto.lagDto(behandlingUuid, BEHANDLING_VERSJON, aksjonspunkt));
@@ -81,7 +81,7 @@ class AksjonspunktRestTjenesteTest {
     void skal_bekrefte_fødsel() throws Exception {
         Collection<BekreftetAksjonspunktDto> aksjonspunkt = new ArrayList<>();
         var uidentifiserteBarn = new DokumentertBarnDto[]{new DokumentertBarnDto(fødselsdato, null)};
-        aksjonspunkt.add(new SjekkManglendeFodselDto(BEGRUNNELSE, true, List.of(uidentifiserteBarn)));
+        aksjonspunkt.add(new SjekkManglendeFødselAksjonspunktDto(BEGRUNNELSE, true, List.of(uidentifiserteBarn)));
 
         aksjonspunktRestTjeneste.bekreft(mock(HttpServletRequest.class),
             BekreftedeAksjonspunkterDto.lagDto(behandlingUuid, BEHANDLING_VERSJON, aksjonspunkt));
@@ -92,7 +92,7 @@ class AksjonspunktRestTjenesteTest {
     @Test
     void skal_bekrefte_antall_barn() throws Exception {
         Collection<BekreftetAksjonspunktDto> aksjonspunkt = new ArrayList<>();
-        aksjonspunkt.add(new SjekkManglendeFodselDto(BEGRUNNELSE, false, new ArrayList<>()));
+        aksjonspunkt.add(new SjekkManglendeFødselAksjonspunktDto(BEGRUNNELSE, false, new ArrayList<>()));
 
         aksjonspunktRestTjeneste.bekreft(mock(HttpServletRequest.class),
             BekreftedeAksjonspunkterDto.lagDto(behandlingUuid, BEHANDLING_VERSJON, aksjonspunkt));
@@ -120,7 +120,7 @@ class AksjonspunktRestTjenesteTest {
     void skal_ikke_kunne_bekrefte_andre_aksjonspunkt_ved_status_fatter_vedtak() {
         when(behandling.getStatus()).thenReturn(BehandlingStatus.FATTER_VEDTAK);
         Collection<BekreftetAksjonspunktDto> aksjonspunkt = new ArrayList<>();
-        aksjonspunkt.add(new SjekkManglendeFodselDto(BEGRUNNELSE, false, new ArrayList<>()));
+        aksjonspunkt.add(new SjekkManglendeFødselAksjonspunktDto(BEGRUNNELSE, false, new ArrayList<>()));
         var dto = BekreftedeAksjonspunkterDto.lagDto(behandlingUuid, BEHANDLING_VERSJON, aksjonspunkt);
         var request = mock(HttpServletRequest.class);
         assertThrows(FunksjonellException.class, () -> aksjonspunktRestTjeneste.bekreft(request, dto));

--- a/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/aksjonspunkt/AksjonspunktRestTjenesteTest.java
+++ b/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/aksjonspunkt/AksjonspunktRestTjenesteTest.java
@@ -29,7 +29,7 @@ import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingsresultatRepo
 import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.AksjonspunktDefinisjon;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepository;
 import no.nav.foreldrepenger.domene.vedtak.TotrinnTjeneste;
-import no.nav.foreldrepenger.familiehendelse.aksjonspunkt.dto.BekreftTerminbekreftelseAksjonspunktDto;
+import no.nav.foreldrepenger.familiehendelse.aksjonspunkt.dto.SjekkTerminbekreftelseDto;
 import no.nav.foreldrepenger.familiehendelse.aksjonspunkt.dto.SjekkManglendeFodselDto;
 import no.nav.foreldrepenger.familiehendelse.aksjonspunkt.dto.DokumentertBarnDto;
 import no.nav.foreldrepenger.web.app.tjenester.behandling.uttak.dto.FastsetteUttakDto;
@@ -69,7 +69,7 @@ class AksjonspunktRestTjenesteTest {
     @Test
     void skal_bekrefte_terminbekreftelse() throws Exception {
         Collection<BekreftetAksjonspunktDto> aksjonspunkt = new ArrayList<>();
-        aksjonspunkt.add(new BekreftTerminbekreftelseAksjonspunktDto(BEGRUNNELSE, termindato, utstedtdato, 1));
+        aksjonspunkt.add(new SjekkTerminbekreftelseDto(BEGRUNNELSE, termindato, utstedtdato, 1));
 
         aksjonspunktRestTjeneste.bekreft(mock(HttpServletRequest.class),
             BekreftedeAksjonspunkterDto.lagDto(behandlingUuid, BEHANDLING_VERSJON, aksjonspunkt));

--- a/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/aksjonspunkt/AksjonspunktTjenesteTest.java
+++ b/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/aksjonspunkt/AksjonspunktTjenesteTest.java
@@ -36,7 +36,7 @@ import no.nav.foreldrepenger.behandlingslager.testutilities.behandling.AbstractT
 import no.nav.foreldrepenger.behandlingslager.testutilities.behandling.ScenarioMorSøkerEngangsstønad;
 import no.nav.foreldrepenger.behandlingslager.testutilities.behandling.ScenarioMorSøkerForeldrepenger;
 import no.nav.foreldrepenger.dbstoette.CdiDbAwareTest;
-import no.nav.foreldrepenger.familiehendelse.aksjonspunkt.dto.SjekkTerminbekreftelseDto;
+import no.nav.foreldrepenger.familiehendelse.aksjonspunkt.dto.SjekkTerminbekreftelseAksjonspunktDto;
 import no.nav.foreldrepenger.familiehendelse.aksjonspunkt.dto.OmsorgsvilkårAksjonspunktDto;
 import no.nav.vedtak.sikkerhet.kontekst.IdentType;
 import no.nav.vedtak.sikkerhet.kontekst.KontekstHolder;
@@ -76,7 +76,7 @@ class AksjonspunktTjenesteTest {
         var behandling = scenario.lagre(repositoryProvider);
         var lås = new BehandlingLås(behandling.getId());
 
-        var dto = new SjekkTerminbekreftelseDto(BEGRUNNELSE, TERMINDATO, UTSTEDTDATO, 1);
+        var dto = new SjekkTerminbekreftelseAksjonspunktDto(BEGRUNNELSE, TERMINDATO, UTSTEDTDATO, 1);
 
         // Act
         aksjonspunktTjeneste.bekreftAksjonspunkter(singletonList(dto), behandling, lås);
@@ -115,7 +115,7 @@ class AksjonspunktTjenesteTest {
         var behandling = scenario.lagre(repositoryProvider);
         var behandlingSpy = spy(behandling);
 
-        var dto = new SjekkTerminbekreftelseDto(BEGRUNNELSE, TERMINDATO, UTSTEDTDATO, 1);
+        var dto = new SjekkTerminbekreftelseAksjonspunktDto(BEGRUNNELSE, TERMINDATO, UTSTEDTDATO, 1);
 
         KontekstHolder.setKontekst(RequestKontekst.forRequest("IDENT", "IDENT", IdentType.InternBruker, null, UUID.randomUUID(), Set.of()));
 
@@ -154,7 +154,7 @@ class AksjonspunktTjenesteTest {
         var revurdering = opprettRevurderingsbehandlingMedAksjonspunkt(førstegangsbehandling,
                 AksjonspunktDefinisjon.SJEKK_TERMINBEKREFTELSE);
         var lås = new BehandlingLås(revurdering.getId());
-        var dto = new SjekkTerminbekreftelseDto(BEGRUNNELSE, LocalDate.now(), LocalDate.now(), 2);
+        var dto = new SjekkTerminbekreftelseAksjonspunktDto(BEGRUNNELSE, LocalDate.now(), LocalDate.now(), 2);
 
         // Act
         aksjonspunktTjeneste.bekreftAksjonspunkter(singletonList(dto), revurdering, lås);

--- a/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/aksjonspunkt/AksjonspunktTjenesteTest.java
+++ b/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/aksjonspunkt/AksjonspunktTjenesteTest.java
@@ -36,7 +36,7 @@ import no.nav.foreldrepenger.behandlingslager.testutilities.behandling.AbstractT
 import no.nav.foreldrepenger.behandlingslager.testutilities.behandling.ScenarioMorSøkerEngangsstønad;
 import no.nav.foreldrepenger.behandlingslager.testutilities.behandling.ScenarioMorSøkerForeldrepenger;
 import no.nav.foreldrepenger.dbstoette.CdiDbAwareTest;
-import no.nav.foreldrepenger.familiehendelse.aksjonspunkt.dto.BekreftTerminbekreftelseAksjonspunktDto;
+import no.nav.foreldrepenger.familiehendelse.aksjonspunkt.dto.SjekkTerminbekreftelseDto;
 import no.nav.foreldrepenger.familiehendelse.aksjonspunkt.dto.OmsorgsvilkårAksjonspunktDto;
 import no.nav.vedtak.sikkerhet.kontekst.IdentType;
 import no.nav.vedtak.sikkerhet.kontekst.KontekstHolder;
@@ -72,11 +72,11 @@ class AksjonspunktTjenesteTest {
     void skal_sette_aksjonspunkt_til_utført_og_lagre_behandling() {
         // Arrange
         // Bruker BekreftTerminbekreftelseAksjonspunktDto som konkret case
-        var scenario = lagScenarioMedAksjonspunkt(AksjonspunktDefinisjon.AVKLAR_TERMINBEKREFTELSE);
+        var scenario = lagScenarioMedAksjonspunkt(AksjonspunktDefinisjon.SJEKK_TERMINBEKREFTELSE);
         var behandling = scenario.lagre(repositoryProvider);
         var lås = new BehandlingLås(behandling.getId());
 
-        var dto = new BekreftTerminbekreftelseAksjonspunktDto(BEGRUNNELSE, TERMINDATO, UTSTEDTDATO, 1);
+        var dto = new SjekkTerminbekreftelseDto(BEGRUNNELSE, TERMINDATO, UTSTEDTDATO, 1);
 
         // Act
         aksjonspunktTjeneste.bekreftAksjonspunkter(singletonList(dto), behandling, lås);
@@ -111,11 +111,11 @@ class AksjonspunktTjenesteTest {
         // Arrange
         // Bruker BekreftTerminbekreftelseAksjonspunktDto som konkret case
         var aksjonspunktTjenesteImpl = aksjonspunktTjeneste;
-        var scenario = lagScenarioMedAksjonspunkt(AksjonspunktDefinisjon.AVKLAR_TERMINBEKREFTELSE);
+        var scenario = lagScenarioMedAksjonspunkt(AksjonspunktDefinisjon.SJEKK_TERMINBEKREFTELSE);
         var behandling = scenario.lagre(repositoryProvider);
         var behandlingSpy = spy(behandling);
 
-        var dto = new BekreftTerminbekreftelseAksjonspunktDto(BEGRUNNELSE, TERMINDATO, UTSTEDTDATO, 1);
+        var dto = new SjekkTerminbekreftelseDto(BEGRUNNELSE, TERMINDATO, UTSTEDTDATO, 1);
 
         KontekstHolder.setKontekst(RequestKontekst.forRequest("IDENT", "IDENT", IdentType.InternBruker, null, UUID.randomUUID(), Set.of()));
 
@@ -133,7 +133,7 @@ class AksjonspunktTjenesteTest {
         // Arrange
         // Bruker BekreftTerminbekreftelseAksjonspunktDto som konkret case
         var aksjonspunktTjenesteImpl = aksjonspunktTjeneste;
-        var scenario = lagScenarioMedAksjonspunkt(AksjonspunktDefinisjon.AVKLAR_TERMINBEKREFTELSE);
+        var scenario = lagScenarioMedAksjonspunkt(AksjonspunktDefinisjon.SJEKK_TERMINBEKREFTELSE);
         var behandling = scenario.lagre(repositoryProvider);
         var behandlingSpy = spy(behandling);
 
@@ -149,12 +149,12 @@ class AksjonspunktTjenesteTest {
     @Test
     void skal_sette_totrinn_når_revurdering_ap_medfører_endring_i_grunnlag() {
         // Arrange
-        var førstegangsbehandling = opprettFørstegangsbehandlingMedAksjonspunkt(AksjonspunktDefinisjon.AVKLAR_TERMINBEKREFTELSE);
+        var førstegangsbehandling = opprettFørstegangsbehandlingMedAksjonspunkt(AksjonspunktDefinisjon.SJEKK_TERMINBEKREFTELSE);
         AksjonspunktTestSupport.setTilUtført(førstegangsbehandling.getAksjonspunkter().iterator().next(), BEGRUNNELSE);
         var revurdering = opprettRevurderingsbehandlingMedAksjonspunkt(førstegangsbehandling,
-                AksjonspunktDefinisjon.AVKLAR_TERMINBEKREFTELSE);
+                AksjonspunktDefinisjon.SJEKK_TERMINBEKREFTELSE);
         var lås = new BehandlingLås(revurdering.getId());
-        var dto = new BekreftTerminbekreftelseAksjonspunktDto(BEGRUNNELSE, LocalDate.now(), LocalDate.now(), 2);
+        var dto = new SjekkTerminbekreftelseDto(BEGRUNNELSE, LocalDate.now(), LocalDate.now(), 2);
 
         // Act
         aksjonspunktTjeneste.bekreftAksjonspunkter(singletonList(dto), revurdering, lås);


### PR DESCRIPTION
For å gjøre navngivingen av akjonspunktet for teminbekreftelse likt i:
* fpsak (`AvklarTerminbekreftelse`), 
* frontend (`SjekkTerminbekreftelse`) og i 
* autotest (`AvklarFaktaTerminBekreftelse`) 

ønsker jeg å omdøpe til SjekkTerminbekreftelse på tvers for da blir det likere SjekkManglendeFødsel 😄 