### PR TITLE
TFP-6340 ignorer henlagt omgjøringskrav

### DIFF
--- a/domenetjenester/behandling-klage/src/main/java/no/nav/foreldrepenger/behandling/kabal/KabalHendelse.java
+++ b/domenetjenester/behandling-klage/src/main/java/no/nav/foreldrepenger/behandling/kabal/KabalHendelse.java
@@ -35,7 +35,7 @@ public record KabalHendelse(UUID eventId,
     public record BehandlingFeilregistrertDetaljer(LocalDateTime feilregistrert, BehandlingType type, String navIdent, String reason) {}
 
     public enum BehandlingType {
-        KLAGE, ANKE, ANKE_I_TRYGDERETTEN
+        KLAGE, ANKE, ANKE_I_TRYGDERETTEN, BEHANDLING_ETTER_TRYGDERETTEN_OPPHEVET, OMGJOERINGSKRAV
     }
 }
 


### PR DESCRIPTION
Flytter ut litt kode for å redusere metode-kompleksitet (Sonar)
Vil ikke gjøre noe med henlagte (beh feilregistrert) omgjøringskrav ettersom de ikke har noen "skyggebehandling" hos oss. 
Omgjøringskrav opprettes i Kabal med ref til en avsluttet klage, men vi vet ikke om dem før de evt vedtas eller henlegges.

Lager ingen tester for dette tilfellet - er løpende oppfølging av ekstern integrasjon og oppførsel under utvikling.