### PR TITLE
TFP-6342 feil i oppholdfletting pga toList

### DIFF
--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/tilrettelegging/SvpAvklartOpphold.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/tilrettelegging/SvpAvklartOpphold.java
@@ -72,15 +72,14 @@ public class SvpAvklartOpphold extends BaseCreateableEntitet {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         var that = (SvpAvklartOpphold) o;
-        return Objects.equals(oppholdPeriode.getFomDato(), that.oppholdPeriode.getFomDato()) &&
-            Objects.equals(oppholdPeriode.getTomDato(), that.oppholdPeriode.getTomDato()) &&
+        return Objects.equals(oppholdPeriode, that.oppholdPeriode) &&
             Objects.equals(svpOppholdÅrsak, that.svpOppholdÅrsak) &&
             Objects.equals(svpOppholdKilde, that.svpOppholdKilde);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(oppholdPeriode.getFomDato(), oppholdPeriode.getTomDato(), svpOppholdÅrsak, svpOppholdKilde);
+        return Objects.hash(oppholdPeriode, svpOppholdÅrsak, svpOppholdKilde);
     }
 
     @Override

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/tilrettelegging/SvpTilretteleggingEntitet.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/tilrettelegging/SvpTilretteleggingEntitet.java
@@ -321,13 +321,17 @@ public class SvpTilretteleggingEntitet extends BaseEntitet {
             this.mal.skalBrukes = skalBrukes;
             return this;
         }
-        public Builder medAvklartOpphold(SvpAvklartOpphold avklarteOpphold) {
-            this.mal.avklarteOpphold.add(avklarteOpphold);
+        public Builder medAvklartOpphold(SvpAvklartOpphold opphold) {
+            if (this.mal.avklarteOpphold.isEmpty() || this.mal.avklarteOpphold.stream().noneMatch(ao -> Objects.equals(ao, opphold))) {
+                this.mal.avklarteOpphold.add(opphold);
+            }
             return this;
         }
 
+        // NB! fjerner evt eksisterende innslag og legger til de nye (med deduplisering)
         public Builder medAvklarteOpphold(List<SvpAvklartOpphold> avklarteOpphold) {
-            this.mal.avklarteOpphold = avklarteOpphold;
+            this.mal.avklarteOpphold.clear();
+            avklarteOpphold.forEach(this::medAvklartOpphold);
             return this;
         }
 


### PR DESCRIPTION
Feil i mottak av ny søknad (se TFP for detaljer) pg omlegging til toList() og at man gjorde tilordning framfor legg til.
Gjør nå clear + add (med duplikatsjekk) der man skal legge til en justert liste.

Ser du noe med som trengs å gjøres @AnjaAalerud ? 
Jeg var litt i stuss med filtreringen, men skjønner at man lar opphold fra før ny søknad bli liggende mens opphold etter ny søknad hentes kun fra den nye søknaden. Det legges da opp til at ny søknad må ha med alle framtidige opphold (med fom etter ny tilrettelegging-fom). Jeg tror dette blir ett av temaene for endringssøknad SVP til høsten.