### PR TITLE
TFP-6341 analyse av falsk identitet

### DIFF
--- a/domenetjenester/person/src/main/java/no/nav/foreldrepenger/domene/person/pdl/PersonBasisTjeneste.java
+++ b/domenetjenester/person/src/main/java/no/nav/foreldrepenger/domene/person/pdl/PersonBasisTjeneste.java
@@ -158,7 +158,7 @@ public class PersonBasisTjeneste {
     }
 
     private void sjekkFalskIdentitet(Person person, FagsakYtelseType ytelseType, AktørId aktørId) {
-        if (person.getFalskIdentitet().getErFalsk()) {
+        if (person.getFalskIdentitet() != null && person.getFalskIdentitet().getErFalsk()) {
             var query = new HentPersonQueryRequest();
             query.setIdent(aktørId.getId());
             var projection = new PersonResponseProjection()

--- a/domenetjenester/person/src/main/java/no/nav/foreldrepenger/domene/person/pdl/PersonBasisTjeneste.java
+++ b/domenetjenester/person/src/main/java/no/nav/foreldrepenger/domene/person/pdl/PersonBasisTjeneste.java
@@ -8,6 +8,9 @@ import java.util.Optional;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import no.nav.foreldrepenger.behandlingslager.aktør.NavBrukerKjønn;
 import no.nav.foreldrepenger.behandlingslager.aktør.PersoninfoArbeidsgiver;
 import no.nav.foreldrepenger.behandlingslager.aktør.PersoninfoBasis;
@@ -23,6 +26,8 @@ import no.nav.pdl.AdressebeskyttelseGradering;
 import no.nav.pdl.AdressebeskyttelseResponseProjection;
 import no.nav.pdl.Doedsfall;
 import no.nav.pdl.DoedsfallResponseProjection;
+import no.nav.pdl.FalskIdentitetIdentifiserendeInformasjonResponseProjection;
+import no.nav.pdl.FalskIdentitetResponseProjection;
 import no.nav.pdl.Foedselsdato;
 import no.nav.pdl.FoedselsdatoResponseProjection;
 import no.nav.pdl.HentPersonQueryRequest;
@@ -32,9 +37,7 @@ import no.nav.pdl.KjoennType;
 import no.nav.pdl.NavnResponseProjection;
 import no.nav.pdl.Person;
 import no.nav.pdl.PersonResponseProjection;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import no.nav.pdl.PersonnavnResponseProjection;
 
 @ApplicationScoped
 public class PersonBasisTjeneste {
@@ -57,10 +60,13 @@ public class PersonBasisTjeneste {
         var query = new HentPersonQueryRequest();
         query.setIdent(aktørId.getId());
         var projection = new PersonResponseProjection()
+            .falskIdentitet(new FalskIdentitetResponseProjection().erFalsk())
             .navn(new NavnResponseProjection().fornavn().mellomnavn().etternavn())
             .adressebeskyttelse(new AdressebeskyttelseResponseProjection().gradering());
 
         var person = pdlKlient.hentPerson(ytelseType, query, projection);
+
+        sjekkFalskIdentitet(person, ytelseType, aktørId);
 
         return new PersoninfoVisning(aktørId, personIdent, mapNavnVisning(person, aktørId), getDiskresjonskode(person));
     }
@@ -69,23 +75,26 @@ public class PersonBasisTjeneste {
         var query = new HentPersonQueryRequest();
         query.setIdent(aktørId.getId());
         var projection = new PersonResponseProjection()
-                .navn(new NavnResponseProjection().fornavn().mellomnavn().etternavn())
-                .foedselsdato(new FoedselsdatoResponseProjection().foedselsdato())
-                .doedsfall(new DoedsfallResponseProjection().doedsdato())
-                .kjoenn(new KjoennResponseProjection().kjoenn())
-                .adressebeskyttelse(new AdressebeskyttelseResponseProjection().gradering());
+            .falskIdentitet(new FalskIdentitetResponseProjection().erFalsk())
+            .navn(new NavnResponseProjection().fornavn().mellomnavn().etternavn())
+            .foedselsdato(new FoedselsdatoResponseProjection().foedselsdato())
+            .doedsfall(new DoedsfallResponseProjection().doedsdato())
+            .kjoenn(new KjoennResponseProjection().kjoenn())
+            .adressebeskyttelse(new AdressebeskyttelseResponseProjection().gradering());
 
         var person = pdlKlient.hentPerson(ytelseType, query, projection);
 
+        sjekkFalskIdentitet(person, ytelseType, aktørId);
+
         var fødselsdato = person.getFoedselsdato().stream()
-                .map(Foedselsdato::getFoedselsdato)
-                .filter(Objects::nonNull)
-                .findFirst().map(d -> LocalDate.parse(d, DateTimeFormatter.ISO_LOCAL_DATE))
-                .orElseGet(() -> IS_PROD ? null : LocalDate.now().minusDays(1));
+            .map(Foedselsdato::getFoedselsdato)
+            .filter(Objects::nonNull)
+            .findFirst().map(d -> LocalDate.parse(d, DateTimeFormatter.ISO_LOCAL_DATE))
+            .orElseGet(() -> IS_PROD ? null : LocalDate.now().minusDays(1));
         var dødsdato = person.getDoedsfall().stream()
-                .map(Doedsfall::getDoedsdato)
-                .filter(Objects::nonNull)
-                .findFirst().map(d -> LocalDate.parse(d, DateTimeFormatter.ISO_LOCAL_DATE)).orElse(null);
+            .map(Doedsfall::getDoedsdato)
+            .filter(Objects::nonNull)
+            .findFirst().map(d -> LocalDate.parse(d, DateTimeFormatter.ISO_LOCAL_DATE)).orElse(null);
         return new PersoninfoBasis(aktørId, personIdent, mapNavn(person, aktørId), fødselsdato, dødsdato,
             mapKjønn(person), getDiskresjonskode(person).getKode());
     }
@@ -94,20 +103,20 @@ public class PersonBasisTjeneste {
         var query = new HentPersonQueryRequest();
         query.setIdent(aktørId.getId());
         var projection = new PersonResponseProjection()
-                .navn(new NavnResponseProjection().fornavn().mellomnavn().etternavn())
-                .foedselsdato(new FoedselsdatoResponseProjection().foedselsdato());
+            .navn(new NavnResponseProjection().fornavn().mellomnavn().etternavn())
+            .foedselsdato(new FoedselsdatoResponseProjection().foedselsdato());
 
         var person = pdlKlient.hentPersonTilgangsnektSomInfo(ytelseType, query, projection);
 
         var fødselsdato = person.getFoedselsdato().stream()
-                .map(Foedselsdato::getFoedselsdato)
-                .filter(Objects::nonNull)
-                .findFirst().map(d -> LocalDate.parse(d, DateTimeFormatter.ISO_LOCAL_DATE)).orElse(null);
+            .map(Foedselsdato::getFoedselsdato)
+            .filter(Objects::nonNull)
+            .findFirst().map(d -> LocalDate.parse(d, DateTimeFormatter.ISO_LOCAL_DATE)).orElse(null);
 
         var arbeidsgiver = new PersoninfoArbeidsgiver.Builder().medAktørId(aktørId).medPersonIdent(personIdent)
-                .medNavn(person.getNavn().stream().map(PersoninfoTjeneste::mapNavn).filter(Objects::nonNull).findFirst().orElse(null))
-                .medFødselsdato(fødselsdato)
-                .build();
+            .medNavn(person.getNavn().stream().map(PersoninfoTjeneste::mapNavn).filter(Objects::nonNull).findFirst().orElse(null))
+            .medFødselsdato(fødselsdato)
+            .build();
 
         return person.getNavn().isEmpty() || person.getFoedselsdato().isEmpty() ? Optional.empty() : Optional.of(arbeidsgiver);
     }
@@ -138,14 +147,49 @@ public class PersonBasisTjeneste {
         var query = new HentPersonQueryRequest();
         query.setIdent(aktørId.getId());
         var projection = new PersonResponseProjection()
-                .kjoenn(new KjoennResponseProjection().kjoenn());
+            .kjoenn(new KjoennResponseProjection().kjoenn());
 
         var person = pdlKlient.hentPerson(ytelseType, query, projection);
 
         var kjønn = new PersoninfoKjønn.Builder().medAktørId(aktørId)
-                .medNavBrukerKjønn(mapKjønn(person))
-                .build();
+            .medNavBrukerKjønn(mapKjønn(person))
+            .build();
         return person.getKjoenn().isEmpty() ? Optional.empty() : Optional.of(kjønn);
+    }
+
+    private void sjekkFalskIdentitet(Person person, FagsakYtelseType ytelseType, AktørId aktørId) {
+        if (person.getFalskIdentitet().getErFalsk()) {
+            var query = new HentPersonQueryRequest();
+            query.setIdent(aktørId.getId());
+            var projection = new PersonResponseProjection()
+                .falskIdentitet(new FalskIdentitetResponseProjection().rettIdentitetErUkjent().rettIdentitetVedIdentifikasjonsnummer()
+                    .rettIdentitetVedOpplysninger(new FalskIdentitetIdentifiserendeInformasjonResponseProjection().kjoenn().foedselsdato()
+                        .personnavn(new PersonnavnResponseProjection().fornavn().mellomnavn().etternavn()).statsborgerskap()));
+            var falskIdentitetPerson = pdlKlient.hentPerson(ytelseType, query, projection);
+
+            if (Objects.equals(falskIdentitetPerson.getFalskIdentitet().getRettIdentitetErUkjent(), Boolean.TRUE)) {
+                LOG.info("Falsk identitet aktør {} har rettIdentitetErUkjent", aktørId);
+            } else if (falskIdentitetPerson.getFalskIdentitet().getRettIdentitetVedIdentifikasjonsnummer() != null) {
+                LOG.info("Falsk identitet aktør {} har rettIdentitetVedIdentifikasjonsnummer {}", aktørId, falskIdentitetPerson.getFalskIdentitet().getRettIdentitetVedIdentifikasjonsnummer());
+            } else if (falskIdentitetPerson.getFalskIdentitet().getRettIdentitetVedOpplysninger() != null) {
+                // .personnavn(new PersonnavnResponseProjection().fornavn().mellomnavn().etternavn()).statsborgerskap())
+                var kjønn = falskIdentitetPerson.getFalskIdentitet().getRettIdentitetVedOpplysninger().getKjoenn();
+                var statsborgerskap = falskIdentitetPerson.getFalskIdentitet().getRettIdentitetVedOpplysninger().getStatsborgerskap();
+                var fødselsdato = falskIdentitetPerson.getFalskIdentitet().getRettIdentitetVedOpplysninger().getFoedselsdato();
+                var navn = Optional.ofNullable(falskIdentitetPerson.getFalskIdentitet().getRettIdentitetVedOpplysninger().getPersonnavn())
+                    .map(p -> Optional.ofNullable(p.getFornavn()).orElse("UtenFN")
+                        + Optional.ofNullable(p.getMellomnavn()).map(m -> leftPad(m)).orElse(("UtenMN"))
+                        + Optional.ofNullable(p.getEtternavn()).map(e -> "ETTERN").orElse(("UtenEN")))
+                    .orElse("UtenNavn");
+                LOG.info("Falsk identitet aktør {} har rettIdentitetVedOpplysninger navn {} fdato {} kjønn {} statsborger {}", aktørId, navn, fødselsdato, kjønn, statsborgerskap);
+            } else {
+                LOG.info("Falsk identitet aktør {} mangler info om rett identitet", aktørId);
+            }
+        }
+    }
+
+    private static String leftPad(String navn) {
+        return Optional.ofNullable(navn).map(n -> " " + navn).orElse("");
     }
 
     private Diskresjonskode getDiskresjonskode(Person person) {
@@ -179,13 +223,16 @@ public class PersonBasisTjeneste {
     }
 
     private static NavBrukerKjønn mapKjønn(Person person) {
-        var kode = person.getKjoenn().stream()
-                .map(Kjoenn::getKjoenn)
-                .filter(Objects::nonNull)
-                .findFirst().orElse(KjoennType.UKJENT);
-        if (KjoennType.MANN.equals(kode))
-            return NavBrukerKjønn.MANN;
-        return KjoennType.KVINNE.equals(kode) ? NavBrukerKjønn.KVINNE : NavBrukerKjønn.UDEFINERT;
+        var kjønnType = person.getKjoenn().stream()
+            .map(Kjoenn::getKjoenn)
+            .filter(Objects::nonNull)
+            .findFirst().orElse(KjoennType.UKJENT);
+        return mapKjønn(kjønnType);
     }
 
+    private static NavBrukerKjønn mapKjønn(KjoennType kjønn) {
+        if (KjoennType.MANN.equals(kjønn))
+            return NavBrukerKjønn.MANN;
+        return KjoennType.KVINNE.equals(kjønn) ? NavBrukerKjønn.KVINNE : NavBrukerKjønn.UDEFINERT;
+    }
 }


### PR DESCRIPTION
Gjelder tilfelle (første av 500k+) som har stadfestet falsk identitet fra FREG.
Logger hva som finnes av informasjon (som kan brukes til å populere data).
Senere PR vil se på å bruke data fra denne datastrukturen - men det er mye annet som må justeres (rettigheter, ....)