### PR TITLE
TFP-6341 oppdager og logger tilfelle av falsk identitet

### DIFF
--- a/domenetjenester/person/src/main/java/no/nav/foreldrepenger/domene/person/pdl/PdlKlientLogCause.java
+++ b/domenetjenester/person/src/main/java/no/nav/foreldrepenger/domene/person/pdl/PdlKlientLogCause.java
@@ -83,14 +83,7 @@ public class PdlKlientLogCause {
     }
 
     // Man kan tenke seg å hente rett ident eller navn/statsborgerskap fra falskIdentitet-informasjonen. Se an frekvens og innhold
-    public void sjekkPersonFalskIdentitet(FagsakYtelseType ytelseType, AktørId aktørId, List<Folkeregisteridentifikator> folkeregisteridentifikatorer) {
-        var identer = Optional.ofNullable(folkeregisteridentifikatorer).orElseGet(List::of).stream()
-            .map(Folkeregisteridentifikator::getIdentifikasjonsnummer)
-            .filter(Objects::nonNull)
-            .toList();
-        if (!identer.isEmpty()) {
-            return;
-        }
+    public void sjekkPersonFalskIdentitet(FagsakYtelseType ytelseType, AktørId aktørId) {
         var query = new HentPersonQueryRequest();
         query.setIdent(aktørId.getId());
         var projection = new PersonResponseProjection()

--- a/domenetjenester/person/src/main/java/no/nav/foreldrepenger/domene/person/pdl/PdlKlientLogCause.java
+++ b/domenetjenester/person/src/main/java/no/nav/foreldrepenger/domene/person/pdl/PdlKlientLogCause.java
@@ -4,6 +4,9 @@ package no.nav.foreldrepenger.domene.person.pdl;
 import static java.net.HttpURLConnection.HTTP_NOT_FOUND;
 
 import java.net.SocketTimeoutException;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -12,10 +15,19 @@ import jakarta.ws.rs.ProcessingException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import no.nav.foreldrepenger.behandlingslager.aktør.PersonstatusType;
 import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakYtelseType;
+import no.nav.foreldrepenger.domene.typer.AktørId;
+import no.nav.pdl.FalskIdentitetIdentifiserendeInformasjonResponseProjection;
+import no.nav.pdl.FalskIdentitetResponseProjection;
+import no.nav.pdl.Folkeregisteridentifikator;
+import no.nav.pdl.FolkeregisteridentifikatorResponseProjection;
+import no.nav.pdl.Folkeregisterpersonstatus;
+import no.nav.pdl.FolkeregisterpersonstatusResponseProjection;
 import no.nav.pdl.HentPersonQueryRequest;
 import no.nav.pdl.Person;
 import no.nav.pdl.PersonResponseProjection;
+import no.nav.pdl.PersonnavnResponseProjection;
 import no.nav.vedtak.exception.IntegrasjonException;
 import no.nav.vedtak.felles.integrasjon.person.PdlException;
 import no.nav.vedtak.felles.integrasjon.person.Persondata;
@@ -68,6 +80,71 @@ public class PdlKlientLogCause {
         } catch (ProcessingException e) {
             throw e.getCause() instanceof SocketTimeoutException ? new IntegrasjonException(PDL_TIMEOUT_KODE, PDL_TIMEOUT_MSG) : e;
         }
+    }
+
+    // Man kan tenke seg å hente rett ident eller navn/statsborgerskap fra falskIdentitet-informasjonen. Se an frekvens og innhold
+    public void sjekkPersonFalskIdentitet(FagsakYtelseType ytelseType, AktørId aktørId, List<Folkeregisteridentifikator> folkeregisteridentifikatorer) {
+        var identer = Optional.ofNullable(folkeregisteridentifikatorer).orElseGet(List::of).stream()
+            .map(Folkeregisteridentifikator::getIdentifikasjonsnummer)
+            .filter(Objects::nonNull)
+            .toList();
+        if (!identer.isEmpty()) {
+            return;
+        }
+        var query = new HentPersonQueryRequest();
+        query.setIdent(aktørId.getId());
+        var projection = new PersonResponseProjection()
+            .folkeregisteridentifikator(new FolkeregisteridentifikatorResponseProjection().status().identifikasjonsnummer())
+            .folkeregisterpersonstatus(new FolkeregisterpersonstatusResponseProjection().status())
+            .falskIdentitet(new FalskIdentitetResponseProjection().erFalsk().rettIdentitetErUkjent().rettIdentitetVedIdentifikasjonsnummer()
+                .rettIdentitetVedOpplysninger(new FalskIdentitetIdentifiserendeInformasjonResponseProjection().kjoenn().foedselsdato()
+                    .personnavn(new PersonnavnResponseProjection().fornavn().mellomnavn().etternavn()).statsborgerskap()));
+
+        var falskIdentitetPerson = hentPerson(ytelseType, query, projection);
+
+        if (falskIdentitetPerson.getFalskIdentitet() != null && falskIdentitetPerson.getFalskIdentitet().getErFalsk()) {
+            // Skal mangler personidentifikator, ha opphørt personstatus og kanskje informasjon i falskIdentitet
+            if (falskIdentitetPerson.getFolkeregisteridentifikator() != null) {
+                var identifikatorer = falskIdentitetPerson.getFolkeregisteridentifikator().stream()
+                    .map(p -> p.getIdentifikasjonsnummer().substring(p.getIdentifikasjonsnummer().length() - 5) + " " + p.getStatus())
+                    .toList();
+                if (!identifikatorer.isEmpty()) {
+                    LOG.warn("Falsk identitet aktør {} har identer {}", aktørId, identifikatorer);
+                }
+            }
+            if (falskIdentitetPerson.getFolkeregisterpersonstatus() != null) {
+                var statuser = falskIdentitetPerson.getFolkeregisterpersonstatus().stream()
+                    .map(Folkeregisterpersonstatus::getStatus)
+                    .map(PersonstatusType::fraFregPersonstatus)
+                    .toList();
+                if (!statuser.contains(PersonstatusType.UTPE)) {
+                    LOG.warn("Falsk identitet aktør {} har ikke status opphørt {}", aktørId, statuser);
+                }
+            }
+            if (Objects.equals(falskIdentitetPerson.getFalskIdentitet().getRettIdentitetErUkjent(), Boolean.TRUE)) {
+                LOG.warn("Falsk identitet aktør {} har rettIdentitetErUkjent", aktørId);
+            } else if (falskIdentitetPerson.getFalskIdentitet().getRettIdentitetVedIdentifikasjonsnummer() != null) {
+                LOG.warn("Falsk identitet aktør {} har rettIdentitetVedIdentifikasjonsnummer {}", aktørId, falskIdentitetPerson.getFalskIdentitet().getRettIdentitetVedIdentifikasjonsnummer());
+            } else if (falskIdentitetPerson.getFalskIdentitet().getRettIdentitetVedOpplysninger() != null) {
+                var kjønn = falskIdentitetPerson.getFalskIdentitet().getRettIdentitetVedOpplysninger().getKjoenn();
+                var statsborgerskap = falskIdentitetPerson.getFalskIdentitet().getRettIdentitetVedOpplysninger().getStatsborgerskap();
+                var fødselsdato = falskIdentitetPerson.getFalskIdentitet().getRettIdentitetVedOpplysninger().getFoedselsdato();
+                var navn = Optional.ofNullable(falskIdentitetPerson.getFalskIdentitet().getRettIdentitetVedOpplysninger().getPersonnavn())
+                    .map(p -> Optional.ofNullable(p.getFornavn()).orElse("UtenFN")
+                        + leftPad(Optional.ofNullable(p.getMellomnavn()).orElse("UtenMN"))
+                        + leftPad(Optional.ofNullable(p.getEtternavn()).map(e -> "ETTERN").orElse("UtenEN")))
+                    .orElse("UtenNavn");
+                LOG.warn("Falsk identitet aktør {} har rettIdentitetVedOpplysninger navn {} fdato {} kjønn {} statsborger {}", aktørId, navn, fødselsdato, kjønn, statsborgerskap);
+            } else {
+                LOG.warn("Falsk identitet aktør {} mangler info om rett identitet", aktørId);
+            }
+        } else {
+            LOG.warn("Person uten folkeregisteridentifikator aktør {} - ikke falsk person", aktørId);
+        }
+    }
+
+    private static String leftPad(String navn) {
+        return Optional.ofNullable(navn).map(n -> " " + navn).orElse("");
     }
 
     public Person hentPerson(FagsakYtelseType ytelseType, HentPersonQueryRequest q, PersonResponseProjection p, boolean ignoreNotFound) {

--- a/domenetjenester/person/src/main/java/no/nav/foreldrepenger/domene/person/pdl/PersonBasisTjeneste.java
+++ b/domenetjenester/person/src/main/java/no/nav/foreldrepenger/domene/person/pdl/PersonBasisTjeneste.java
@@ -8,10 +8,6 @@ import java.util.Optional;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 
-import no.nav.pdl.FolkeregisteridentifikatorResponseProjection;
-
-import no.nav.pdl.FolkeregisterpersonstatusResponseProjection;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -30,10 +26,9 @@ import no.nav.pdl.AdressebeskyttelseGradering;
 import no.nav.pdl.AdressebeskyttelseResponseProjection;
 import no.nav.pdl.Doedsfall;
 import no.nav.pdl.DoedsfallResponseProjection;
-import no.nav.pdl.FalskIdentitetIdentifiserendeInformasjonResponseProjection;
-import no.nav.pdl.FalskIdentitetResponseProjection;
 import no.nav.pdl.Foedselsdato;
 import no.nav.pdl.FoedselsdatoResponseProjection;
+import no.nav.pdl.FolkeregisteridentifikatorResponseProjection;
 import no.nav.pdl.HentPersonQueryRequest;
 import no.nav.pdl.Kjoenn;
 import no.nav.pdl.KjoennResponseProjection;
@@ -41,7 +36,6 @@ import no.nav.pdl.KjoennType;
 import no.nav.pdl.NavnResponseProjection;
 import no.nav.pdl.Person;
 import no.nav.pdl.PersonResponseProjection;
-import no.nav.pdl.PersonnavnResponseProjection;
 
 @ApplicationScoped
 public class PersonBasisTjeneste {
@@ -64,13 +58,13 @@ public class PersonBasisTjeneste {
         var query = new HentPersonQueryRequest();
         query.setIdent(aktørId.getId());
         var projection = new PersonResponseProjection()
-            .falskIdentitet(new FalskIdentitetResponseProjection().erFalsk())
+            .folkeregisteridentifikator(new FolkeregisteridentifikatorResponseProjection().identifikasjonsnummer())
             .navn(new NavnResponseProjection().fornavn().mellomnavn().etternavn())
             .adressebeskyttelse(new AdressebeskyttelseResponseProjection().gradering());
 
         var person = pdlKlient.hentPerson(ytelseType, query, projection);
 
-        sjekkFalskIdentitet(person, ytelseType, aktørId);
+        pdlKlient.sjekkPersonFalskIdentitet(ytelseType, aktørId, person.getFolkeregisteridentifikator());
 
         return new PersoninfoVisning(aktørId, personIdent, mapNavnVisning(person, aktørId), getDiskresjonskode(person));
     }
@@ -79,7 +73,7 @@ public class PersonBasisTjeneste {
         var query = new HentPersonQueryRequest();
         query.setIdent(aktørId.getId());
         var projection = new PersonResponseProjection()
-            .falskIdentitet(new FalskIdentitetResponseProjection().erFalsk())
+            .folkeregisteridentifikator(new FolkeregisteridentifikatorResponseProjection().identifikasjonsnummer())
             .navn(new NavnResponseProjection().fornavn().mellomnavn().etternavn())
             .foedselsdato(new FoedselsdatoResponseProjection().foedselsdato())
             .doedsfall(new DoedsfallResponseProjection().doedsdato())
@@ -88,7 +82,7 @@ public class PersonBasisTjeneste {
 
         var person = pdlKlient.hentPerson(ytelseType, query, projection);
 
-        sjekkFalskIdentitet(person, ytelseType, aktørId);
+        pdlKlient.sjekkPersonFalskIdentitet(ytelseType, aktørId, person.getFolkeregisteridentifikator());
 
         var fødselsdato = person.getFoedselsdato().stream()
             .map(Foedselsdato::getFoedselsdato)
@@ -159,55 +153,6 @@ public class PersonBasisTjeneste {
             .medNavBrukerKjønn(mapKjønn(person))
             .build();
         return person.getKjoenn().isEmpty() ? Optional.empty() : Optional.of(kjønn);
-    }
-
-    private void sjekkFalskIdentitet(Person person, FagsakYtelseType ytelseType, AktørId aktørId) {
-        if (person.getFalskIdentitet() != null && person.getFalskIdentitet().getErFalsk()) {
-            var query = new HentPersonQueryRequest();
-            query.setIdent(aktørId.getId());
-            var projection = new PersonResponseProjection()
-                .folkeregisteridentifikator(new FolkeregisteridentifikatorResponseProjection().status().identifikasjonsnummer())
-                .folkeregisterpersonstatus(new FolkeregisterpersonstatusResponseProjection().status())
-                .falskIdentitet(new FalskIdentitetResponseProjection().rettIdentitetErUkjent().rettIdentitetVedIdentifikasjonsnummer()
-                    .rettIdentitetVedOpplysninger(new FalskIdentitetIdentifiserendeInformasjonResponseProjection().kjoenn().foedselsdato()
-                        .personnavn(new PersonnavnResponseProjection().fornavn().mellomnavn().etternavn()).statsborgerskap()));
-            var falskIdentitetPerson = pdlKlient.hentPerson(ytelseType, query, projection);
-
-            if (falskIdentitetPerson.getFolkeregisteridentifikator() != null) {
-                var identifikatorer = falskIdentitetPerson.getFolkeregisteridentifikator().stream()
-                    .map(p -> p.getIdentifikasjonsnummer().substring(p.getIdentifikasjonsnummer().length() - 5) + " " + p.getStatus())
-                    .toList();
-                LOG.info("Falsk identitet aktør {} har identer {}", aktørId, identifikatorer);
-            }
-            if (falskIdentitetPerson.getFolkeregisterpersonstatus() != null) {
-                var statuser = falskIdentitetPerson.getFolkeregisterpersonstatus().stream()
-                    .map(p -> p.getStatus())
-                    .toList();
-                LOG.info("Falsk identitet aktør {} har statuser {}", aktørId, statuser);
-            }
-            if (Objects.equals(falskIdentitetPerson.getFalskIdentitet().getRettIdentitetErUkjent(), Boolean.TRUE)) {
-                LOG.info("Falsk identitet aktør {} har rettIdentitetErUkjent", aktørId);
-            } else if (falskIdentitetPerson.getFalskIdentitet().getRettIdentitetVedIdentifikasjonsnummer() != null) {
-                LOG.info("Falsk identitet aktør {} har rettIdentitetVedIdentifikasjonsnummer {}", aktørId, falskIdentitetPerson.getFalskIdentitet().getRettIdentitetVedIdentifikasjonsnummer());
-            } else if (falskIdentitetPerson.getFalskIdentitet().getRettIdentitetVedOpplysninger() != null) {
-                // .personnavn(new PersonnavnResponseProjection().fornavn().mellomnavn().etternavn()).statsborgerskap())
-                var kjønn = falskIdentitetPerson.getFalskIdentitet().getRettIdentitetVedOpplysninger().getKjoenn();
-                var statsborgerskap = falskIdentitetPerson.getFalskIdentitet().getRettIdentitetVedOpplysninger().getStatsborgerskap();
-                var fødselsdato = falskIdentitetPerson.getFalskIdentitet().getRettIdentitetVedOpplysninger().getFoedselsdato();
-                var navn = Optional.ofNullable(falskIdentitetPerson.getFalskIdentitet().getRettIdentitetVedOpplysninger().getPersonnavn())
-                    .map(p -> Optional.ofNullable(p.getFornavn()).orElse("UtenFN")
-                        + leftPad(Optional.ofNullable(p.getMellomnavn()).orElse("UtenMN"))
-                        + leftPad(Optional.ofNullable(p.getEtternavn()).map(e -> "ETTERN").orElse("UtenEN")))
-                    .orElse("UtenNavn");
-                LOG.info("Falsk identitet aktør {} har rettIdentitetVedOpplysninger navn {} fdato {} kjønn {} statsborger {}", aktørId, navn, fødselsdato, kjønn, statsborgerskap);
-            } else {
-                LOG.info("Falsk identitet aktør {} mangler info om rett identitet", aktørId);
-            }
-        }
-    }
-
-    private static String leftPad(String navn) {
-        return Optional.ofNullable(navn).map(n -> " " + navn).orElse("");
     }
 
     private Diskresjonskode getDiskresjonskode(Person person) {

--- a/domenetjenester/person/src/main/java/no/nav/foreldrepenger/domene/person/pdl/PersonBasisTjeneste.java
+++ b/domenetjenester/person/src/main/java/no/nav/foreldrepenger/domene/person/pdl/PersonBasisTjeneste.java
@@ -64,7 +64,9 @@ public class PersonBasisTjeneste {
 
         var person = pdlKlient.hentPerson(ytelseType, query, projection);
 
-        pdlKlient.sjekkPersonFalskIdentitet(ytelseType, aktørId, person.getFolkeregisteridentifikator());
+        if (person.getFolkeregisteridentifikator() == null || person.getFolkeregisteridentifikator().isEmpty()) {
+            pdlKlient.sjekkPersonFalskIdentitet(ytelseType, aktørId);
+        }
 
         return new PersoninfoVisning(aktørId, personIdent, mapNavnVisning(person, aktørId), getDiskresjonskode(person));
     }
@@ -82,7 +84,9 @@ public class PersonBasisTjeneste {
 
         var person = pdlKlient.hentPerson(ytelseType, query, projection);
 
-        pdlKlient.sjekkPersonFalskIdentitet(ytelseType, aktørId, person.getFolkeregisteridentifikator());
+        if (person.getFolkeregisteridentifikator() == null || person.getFolkeregisteridentifikator().isEmpty()) {
+            pdlKlient.sjekkPersonFalskIdentitet(ytelseType, aktørId);
+        }
 
         var fødselsdato = person.getFoedselsdato().stream()
             .map(Foedselsdato::getFoedselsdato)

--- a/domenetjenester/person/src/main/java/no/nav/foreldrepenger/domene/person/pdl/PersonBasisTjeneste.java
+++ b/domenetjenester/person/src/main/java/no/nav/foreldrepenger/domene/person/pdl/PersonBasisTjeneste.java
@@ -65,7 +65,7 @@ public class PersonBasisTjeneste {
         var person = pdlKlient.hentPerson(ytelseType, query, projection);
 
         if (person.getFolkeregisteridentifikator() == null || person.getFolkeregisteridentifikator().isEmpty()) {
-            pdlKlient.sjekkPersonFalskIdentitet(ytelseType, aktørId);
+            pdlKlient.sjekkUtenIdentifikatorFalskIdentitet(ytelseType, aktørId);
         }
 
         return new PersoninfoVisning(aktørId, personIdent, mapNavnVisning(person, aktørId), getDiskresjonskode(person));
@@ -85,7 +85,7 @@ public class PersonBasisTjeneste {
         var person = pdlKlient.hentPerson(ytelseType, query, projection);
 
         if (person.getFolkeregisteridentifikator() == null || person.getFolkeregisteridentifikator().isEmpty()) {
-            pdlKlient.sjekkPersonFalskIdentitet(ytelseType, aktørId);
+            pdlKlient.sjekkUtenIdentifikatorFalskIdentitet(ytelseType, aktørId);
         }
 
         var fødselsdato = person.getFoedselsdato().stream()

--- a/domenetjenester/person/src/main/java/no/nav/foreldrepenger/domene/person/pdl/PersoninfoTjeneste.java
+++ b/domenetjenester/person/src/main/java/no/nav/foreldrepenger/domene/person/pdl/PersoninfoTjeneste.java
@@ -29,6 +29,7 @@ import no.nav.pdl.Doedsfall;
 import no.nav.pdl.DoedsfallResponseProjection;
 import no.nav.pdl.Foedselsdato;
 import no.nav.pdl.FoedselsdatoResponseProjection;
+import no.nav.pdl.FolkeregisteridentifikatorResponseProjection;
 import no.nav.pdl.ForelderBarnRelasjon;
 import no.nav.pdl.ForelderBarnRelasjonResponseProjection;
 import no.nav.pdl.ForelderBarnRelasjonRolle;
@@ -104,6 +105,7 @@ public class PersoninfoTjeneste {
         query.setIdent(personIdent.getIdent());
 
         var projection = new PersonResponseProjection()
+            .folkeregisteridentifikator(new FolkeregisteridentifikatorResponseProjection().identifikasjonsnummer())
             .navn(new NavnResponseProjection().fornavn().mellomnavn().etternavn())
             .foedselsdato(new FoedselsdatoResponseProjection().foedselsdato())
             .doedsfall(new DoedsfallResponseProjection().doedsdato())
@@ -118,6 +120,8 @@ public class PersoninfoTjeneste {
         }
 
         var person = pdlKlient.hentPerson(ytelseType, query, projection);
+
+        pdlKlient.sjekkPersonFalskIdentitet(ytelseType, aktørId, person.getFolkeregisteridentifikator());
 
         var fødselsdato = person.getFoedselsdato().stream()
             .map(Foedselsdato::getFoedselsdato)
@@ -182,6 +186,7 @@ public class PersoninfoTjeneste {
     private static String leftPad(String navn) {
         return Optional.ofNullable(navn).map(n -> " " + navn).orElse("");
     }
+
     private static NavBrukerKjønn mapKjønn(Person person) {
         var kode = person.getKjoenn().stream()
             .map(Kjoenn::getKjoenn)

--- a/domenetjenester/person/src/main/java/no/nav/foreldrepenger/domene/person/pdl/PersoninfoTjeneste.java
+++ b/domenetjenester/person/src/main/java/no/nav/foreldrepenger/domene/person/pdl/PersoninfoTjeneste.java
@@ -121,7 +121,9 @@ public class PersoninfoTjeneste {
 
         var person = pdlKlient.hentPerson(ytelseType, query, projection);
 
-        pdlKlient.sjekkPersonFalskIdentitet(ytelseType, aktørId, person.getFolkeregisteridentifikator());
+        if (person.getFolkeregisteridentifikator() == null || person.getFolkeregisteridentifikator().isEmpty()) {
+            pdlKlient.sjekkPersonFalskIdentitet(ytelseType, aktørId);
+        }
 
         var fødselsdato = person.getFoedselsdato().stream()
             .map(Foedselsdato::getFoedselsdato)

--- a/domenetjenester/person/src/main/java/no/nav/foreldrepenger/domene/person/pdl/PersoninfoTjeneste.java
+++ b/domenetjenester/person/src/main/java/no/nav/foreldrepenger/domene/person/pdl/PersoninfoTjeneste.java
@@ -122,7 +122,7 @@ public class PersoninfoTjeneste {
         var person = pdlKlient.hentPerson(ytelseType, query, projection);
 
         if (person.getFolkeregisteridentifikator() == null || person.getFolkeregisteridentifikator().isEmpty()) {
-            pdlKlient.sjekkPersonFalskIdentitet(ytelseType, aktørId);
+            pdlKlient.sjekkUtenIdentifikatorFalskIdentitet(ytelseType, aktørId);
         }
 
         var fødselsdato = person.getFoedselsdato().stream()
@@ -182,11 +182,7 @@ public class PersoninfoTjeneste {
     }
 
     static String mapNavn(Navn navn) {
-        return navn.getFornavn() + leftPad(navn.getMellomnavn()) + leftPad(navn.getEtternavn());
-    }
-
-    private static String leftPad(String navn) {
-        return Optional.ofNullable(navn).map(n -> " " + navn).orElse("");
+        return navn.getFornavn() + PdlKlientLogCause.leftPad(navn.getMellomnavn()) + PdlKlientLogCause.leftPad(navn.getEtternavn());
     }
 
     private static NavBrukerKjønn mapKjønn(Person person) {


### PR DESCRIPTION
Dette har oppstått i ett tilfelle av noen hundre tusen, men kan øke. Da var det oppgitt annenpart som var falsk.
Legger i denne omgangen opp til å logge tilfelle slik at de er mer direkte synlig enn ved at navn/fødselsdato er null.
Når vi vet mer om forekomst og datainnhold i falskIdentitet - så kan man bruke disse til å supplere riktig ident, eller navn / fødselsdato for visning. Men det kan fort ta et år eller fler før neste tilfelle kommer.