### PR TITLE
redaksjonell: Duplisert tekst i historikk

### DIFF
--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/Behandlingsoppretter.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/Behandlingsoppretter.java
@@ -149,7 +149,7 @@ public class Behandlingsoppretter {
 
     public void henleggBehandling(Behandling behandling) {
         var lås = behandlingRepository.taSkriveLås(behandling);
-        henleggBehandlingTjeneste.henleggBehandlingTeknisk(behandling, lås, BehandlingResultatType.MERGET_OG_HENLAGT, "Mottatt ny søknad");
+        henleggBehandlingTjeneste.henleggBehandlingTeknisk(behandling, lås, BehandlingResultatType.MERGET_OG_HENLAGT, null);
     }
 
     public void opprettInntektsmeldingerFraMottatteDokumentPåNyBehandling(Behandling nyBehandling) {


### PR DESCRIPTION
Unngå duplisert tekst "Mottatt ny søknad" - som kommer både fra behandlingsresultattype og oppgitt i koden.