### PR TITLE
TFP-1059 vise/lagre klage mottatt dato

### DIFF
--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/klage/KlageFormkravEntitet.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/klage/KlageFormkravEntitet.java
@@ -1,5 +1,6 @@
 package no.nav.foreldrepenger.behandlingslager.behandling.klage;
 
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -56,6 +57,9 @@ public class KlageFormkravEntitet extends BaseEntitet {
     @Column(name = "begrunnelse", nullable = false)
     private String begrunnelse;
 
+    @Column(name = "mottatt_dato")
+    private LocalDate mottattDato;
+
     public KlageFormkravEntitet() {
         // Hibernate
     }
@@ -69,6 +73,7 @@ public class KlageFormkravEntitet extends BaseEntitet {
         this.erKonkret = entitet.erKonkret;
         this.erSignert = entitet.erSignert;
         this.begrunnelse = entitet.begrunnelse;
+        this.mottattDato = entitet.mottattDato;
     }
 
     public void setKlageVurdertAv(KlageVurdertAv klageVurdertAv) {
@@ -97,6 +102,10 @@ public class KlageFormkravEntitet extends BaseEntitet {
 
     public void setBegrunnelse(String begrunnelse) {
         this.begrunnelse = begrunnelse;
+    }
+
+    public void setMottattDato(LocalDate mottattDato) {
+        this.mottattDato = mottattDato;
     }
 
     public Long hentId() {
@@ -133,6 +142,10 @@ public class KlageFormkravEntitet extends BaseEntitet {
 
     public String hentBegrunnelse() {
         return begrunnelse;
+    }
+
+    public LocalDate getMottattDato() {
+        return mottattDato;
     }
 
     public List<KlageAvvistÅrsak> hentAvvistÅrsaker() {
@@ -174,12 +187,13 @@ public class KlageFormkravEntitet extends BaseEntitet {
             erKonkret == that.erKonkret &&
             erSignert == that.erSignert &&
             klageVurdertAv == that.klageVurdertAv &&
-            Objects.equals(begrunnelse, that.begrunnelse);
+            Objects.equals(begrunnelse, that.begrunnelse) &&
+            Objects.equals(mottattDato, that.mottattDato);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(klageResultat, klageVurdertAv, gjelderVedtak, erKlagerPart, erFristOverholdt, erKonkret, erSignert, begrunnelse);
+        return Objects.hash(klageResultat, klageVurdertAv, gjelderVedtak, erKlagerPart, erFristOverholdt, erKonkret, erSignert, begrunnelse, mottattDato);
     }
 
     public static Builder builder() {
@@ -241,6 +255,11 @@ public class KlageFormkravEntitet extends BaseEntitet {
             return this;
         }
 
+        public Builder medMottattDato(LocalDate mottattDato) {
+            klageFormkravEntitetMal.mottattDato = mottattDato;
+            return this;
+        }
+
         public KlageFormkravEntitet build() {
             verifyStateForBuild();
             return klageFormkravEntitetMal;
@@ -269,6 +288,7 @@ public class KlageFormkravEntitet extends BaseEntitet {
             + "erKonkret=" + erKonkret() + ", "
             + "erSignert=" + erSignert() + ", "
             + "begrunnelse=" + hentBegrunnelse() + ", "
+            + "mottattDato=" + getMottattDato() + ", "
             + ">";
     }
 

--- a/behandlingslager/testutil/src/main/java/no/nav/foreldrepenger/behandlingslager/testutilities/behandling/ScenarioKlageEngangsstønad.java
+++ b/behandlingslager/testutil/src/main/java/no/nav/foreldrepenger/behandlingslager/testutilities/behandling/ScenarioKlageEngangsstønad.java
@@ -9,6 +9,7 @@ import static no.nav.foreldrepenger.behandlingslager.behandling.klage.KlageVurde
 import static no.nav.foreldrepenger.behandlingslager.behandling.klage.KlageVurdering.STADFESTE_YTELSESVEDTAK;
 import static org.mockito.Mockito.lenient;
 
+import java.time.LocalDate;
 import java.util.EnumMap;
 import java.util.Map;
 import java.util.Optional;
@@ -287,6 +288,7 @@ public class ScenarioKlageEngangsstønad {
                 .medErSignert(true)
                 .medGjelderVedtak(true)
                 .medBegrunnelse("Begrunnelse")
+                .medMottattDato(LocalDate.now())
                 .medKlageResultat(klageResultat)
                 .medKlageVurdertAv(klageVurdertAv);
     }

--- a/behandlingslager/testutil/src/test/java/no/nav/foreldrepenger/behandlingslager/behandling/KlageRepositoryTest.java
+++ b/behandlingslager/testutil/src/test/java/no/nav/foreldrepenger/behandlingslager/behandling/KlageRepositoryTest.java
@@ -17,6 +17,8 @@ import no.nav.foreldrepenger.behandlingslager.testutilities.behandling.ScenarioF
 import no.nav.foreldrepenger.behandlingslager.testutilities.behandling.ScenarioKlageEngangsstønad;
 import no.nav.foreldrepenger.dbstoette.EntityManagerAwareTest;
 
+import java.time.LocalDate;
+
 class KlageRepositoryTest extends EntityManagerAwareTest {
 
     private BehandlingRepositoryProvider repositoryProvider;
@@ -159,6 +161,7 @@ class KlageRepositoryTest extends EntityManagerAwareTest {
             .medErKonkret(true)
             .medErSignert(true)
             .medGjelderVedtak(true)
+            .medMottattDato(LocalDate.now())
             .medBegrunnelse("Begrunnelse")
             .medKlageResultat(klageResultat)
             .medKlageVurdertAv(klageVurdertAv);

--- a/domenetjenester/behandling-klage/src/main/java/no/nav/foreldrepenger/behandling/kabal/KabalDokumenter.java
+++ b/domenetjenester/behandling-klage/src/main/java/no/nav/foreldrepenger/behandling/kabal/KabalDokumenter.java
@@ -1,8 +1,6 @@
 package no.nav.foreldrepenger.behandling.kabal;
 
-import java.time.LocalDate;
 import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -52,13 +50,6 @@ public class KabalDokumenter {
         this.mottatteDokumentRepository = mottatteDokumentRepository;
         this.behandlingDokumentRepository = behandlingDokumentRepository;
         this.historikkRepository = historikkRepository;
-    }
-
-    LocalDate utledDokumentMottattDato(Behandling behandling) {
-        return finnMottattDokumentFor(behandling.getId(), erKlageEllerAnkeDokument())
-            .map(MottattDokument::getMottattDato)
-            .min(Comparator.naturalOrder())
-            .orElseGet(() -> behandling.getOpprettetDato().toLocalDate());
     }
 
     List<TilKabalDto.DokumentReferanse> finnDokumentReferanserForKlage(long behandlingId, Saksnummer saksnummer, KlageResultatEntitet resultat, KlageHjemmel hjemmel) {

--- a/domenetjenester/behandling-klage/src/main/java/no/nav/foreldrepenger/behandling/kabal/KabalTjeneste.java
+++ b/domenetjenester/behandling-klage/src/main/java/no/nav/foreldrepenger/behandling/kabal/KabalTjeneste.java
@@ -85,7 +85,8 @@ public class KabalTjeneste {
             .or(() -> Optional.ofNullable(resultat.getKlageHjemmel()))
             .orElseGet(() -> KlageHjemmel.standardHjemmelForYtelse(klageBehandling.getFagsakYtelseType()));
         var enhet = utledEnhet(klageBehandling.getFagsak());
-        var klageMottattDato  = kabalDokumenter.utledDokumentMottattDato(klageBehandling);
+        var klageMottattDato  = klageVurderingTjeneste.getKlageMottattDato(klageBehandling)
+            .orElseGet(() -> klageBehandling.getOpprettetTidspunkt().toLocalDate());
         var sakenGjelder = utledSakenGjelder(klageBehandling);
         var fullmektig = utledFullmektig(klageBehandling, Optional.of(resultat.getKlageResultat()));
         var dokumentReferanser = kabalDokumenter.finnDokumentReferanserForKlage(klageBehandling.getId(),

--- a/domenetjenester/behandling-klage/src/main/java/no/nav/foreldrepenger/behandling/klage/KlageVurderingTjeneste.java
+++ b/domenetjenester/behandling-klage/src/main/java/no/nav/foreldrepenger/behandling/klage/KlageVurderingTjeneste.java
@@ -1,6 +1,7 @@
 package no.nav.foreldrepenger.behandling.klage;
 
 import java.time.LocalDate;
+import java.util.Comparator;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -12,6 +13,8 @@ import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingStegType;
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandlingsresultat;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingsresultatRepository;
+import no.nav.foreldrepenger.behandlingslager.behandling.DokumentTypeId;
+import no.nav.foreldrepenger.behandlingslager.behandling.MottattDokument;
 import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.AksjonspunktDefinisjon;
 import no.nav.foreldrepenger.behandlingslager.behandling.events.BehandlingRelasjonEvent;
 import no.nav.foreldrepenger.behandlingslager.behandling.klage.KlageFormkravEntitet;
@@ -24,6 +27,7 @@ import no.nav.foreldrepenger.behandlingslager.behandling.klage.KlageVurderingRes
 import no.nav.foreldrepenger.behandlingslager.behandling.klage.KlageVurdertAv;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingLås;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepository;
+import no.nav.foreldrepenger.behandlingslager.behandling.repository.MottatteDokumentRepository;
 import no.nav.foreldrepenger.behandlingsprosess.prosessering.BehandlingProsesseringTjeneste;
 import no.nav.foreldrepenger.dokumentbestiller.DokumentBehandlingTjeneste;
 import no.nav.foreldrepenger.dokumentbestiller.DokumentBestillerTjeneste;
@@ -40,6 +44,7 @@ public class KlageVurderingTjeneste {
     private BehandlingProsesseringTjeneste behandlingProsesseringTjeneste;
     private BehandlingsresultatRepository behandlingsresultatRepository;
     private BehandlingEventPubliserer behandlingEventPubliserer;
+    private MottatteDokumentRepository mottatteDokumentRepository;
 
     @Inject
     public KlageVurderingTjeneste(DokumentBestillerTjeneste dokumentBestillerTjeneste,
@@ -48,7 +53,8 @@ public class KlageVurderingTjeneste {
                                   KlageRepository klageRepository,
                                   BehandlingProsesseringTjeneste behandlingProsesseringTjeneste,
                                   BehandlingsresultatRepository behandlingsresultatRepository,
-                                  BehandlingEventPubliserer behandlingEventPubliserer) {
+                                  BehandlingEventPubliserer behandlingEventPubliserer,
+                                  MottatteDokumentRepository mottatteDokumentRepository) {
         this.dokumentBestillerTjeneste = dokumentBestillerTjeneste;
         this.dokumentBehandlingTjeneste = dokumentBehandlingTjeneste;
         this.klageRepository = klageRepository;
@@ -56,6 +62,7 @@ public class KlageVurderingTjeneste {
         this.behandlingRepository = behandlingRepository;
         this.behandlingsresultatRepository = behandlingsresultatRepository;
         this.behandlingEventPubliserer = behandlingEventPubliserer;
+        this.mottatteDokumentRepository = mottatteDokumentRepository;
     }
 
     KlageVurderingTjeneste() {
@@ -216,5 +223,17 @@ public class KlageVurderingTjeneste {
             return "Vedtaket er stadfestet";
         }
         return null;
+    }
+
+    public Optional<LocalDate> getKlageMottattDato(Behandling behandling, KlageFormkravEntitet formkrav) {
+        return Optional.ofNullable(formkrav.getMottattDato())
+            .or(() -> getKlageDokumentMottattDato(behandling));
+    }
+
+    private Optional<LocalDate> getKlageDokumentMottattDato(Behandling behandling) {
+        return mottatteDokumentRepository.hentMottatteDokument(behandling.getId()).stream()
+            .filter(dok -> DokumentTypeId.KLAGE_DOKUMENT.equals(dok.getDokumentType()))
+            .min(Comparator.comparing(MottattDokument::getMottattDato))
+            .map(MottattDokument::getMottattDato);
     }
 }

--- a/domenetjenester/behandling-klage/src/main/java/no/nav/foreldrepenger/behandling/klage/KlageVurderingTjeneste.java
+++ b/domenetjenester/behandling-klage/src/main/java/no/nav/foreldrepenger/behandling/klage/KlageVurderingTjeneste.java
@@ -225,15 +225,15 @@ public class KlageVurderingTjeneste {
         return null;
     }
 
-    public Optional<LocalDate> getKlageMottattDato(Behandling behandling, KlageFormkravEntitet formkrav) {
-        return Optional.ofNullable(formkrav.getMottattDato())
+    public Optional<LocalDate> getKlageMottattDato(Behandling behandling) {
+        return hentKlageFormkrav(behandling, KlageVurdertAv.NFP).map(KlageFormkravEntitet::getMottattDato)
             .or(() -> getKlageDokumentMottattDato(behandling));
     }
 
     private Optional<LocalDate> getKlageDokumentMottattDato(Behandling behandling) {
         return mottatteDokumentRepository.hentMottatteDokument(behandling.getId()).stream()
             .filter(dok -> DokumentTypeId.KLAGE_DOKUMENT.equals(dok.getDokumentType()))
-            .min(Comparator.comparing(MottattDokument::getMottattDato))
-            .map(MottattDokument::getMottattDato);
+            .map(MottattDokument::getMottattDato)
+            .min(Comparator.naturalOrder());
     }
 }

--- a/migreringer/src/main/resources/db/migration/defaultDS/4.1/V4.1_44__TFP-1059-klage-mottattdato.sql
+++ b/migreringer/src/main/resources/db/migration/defaultDS/4.1/V4.1_44__TFP-1059-klage-mottattdato.sql
@@ -1,0 +1,2 @@
+alter table KLAGE_FORMKRAV ADD MOTTATT_DATO DATE;
+COMMENT ON COLUMN KLAGE_FORMKRAV.MOTTATT_DATO IS 'Registrert verdi dersom annen enn i mottatt dokument';

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/klage/KlageFormkravResultatDto.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/klage/KlageFormkravResultatDto.java
@@ -1,5 +1,6 @@
 package no.nav.foreldrepenger.web.app.tjenester.behandling.klage;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.UUID;
 
@@ -7,12 +8,13 @@ import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingType;
 import no.nav.foreldrepenger.behandlingslager.behandling.klage.KlageAvvistÅrsak;
 
 public record KlageFormkravResultatDto(Long paKlagdBehandlingId,
-                                      UUID paKlagdBehandlingUuid,
-                                      BehandlingType paklagdBehandlingType,
-                                      String begrunnelse,
-                                      boolean erKlagerPart,
-                                      boolean erKlageKonkret,
-                                      boolean erKlagefirstOverholdt,
-                                      boolean erSignert,
-                                      List<KlageAvvistÅrsak> avvistArsaker) {
+                                       UUID paKlagdBehandlingUuid,
+                                       BehandlingType paklagdBehandlingType,
+                                       String begrunnelse,
+                                       boolean erKlagerPart,
+                                       boolean erKlageKonkret,
+                                       boolean erKlagefirstOverholdt,
+                                       boolean erSignert,
+                                       List<KlageAvvistÅrsak> avvistArsaker,
+                                       LocalDate mottattDato) {
 }

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/klage/KlageFormkravResultatDto.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/klage/KlageFormkravResultatDto.java
@@ -1,6 +1,5 @@
 package no.nav.foreldrepenger.web.app.tjenester.behandling.klage;
 
-import java.time.LocalDate;
 import java.util.List;
 import java.util.UUID;
 
@@ -15,6 +14,5 @@ public record KlageFormkravResultatDto(Long paKlagdBehandlingId,
                                        boolean erKlageKonkret,
                                        boolean erKlagefirstOverholdt,
                                        boolean erSignert,
-                                       List<KlageAvvistÅrsak> avvistArsaker,
-                                       LocalDate mottattDato) {
+                                       List<KlageAvvistÅrsak> avvistArsaker) {
 }

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/klage/KlagebehandlingDto.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/klage/KlagebehandlingDto.java
@@ -1,5 +1,6 @@
 package no.nav.foreldrepenger.web.app.tjenester.behandling.klage;
 
+import java.time.LocalDate;
 import java.util.List;
 
 import no.nav.foreldrepenger.behandlingslager.behandling.klage.KlageHjemmel;
@@ -10,5 +11,6 @@ public record KlagebehandlingDto(KlageFormkravResultatDto klageFormkravResultatN
                                  KlageVurderingResultatDto klageVurderingResultatNK,
                                  List<KlageHjemmel> aktuelleHjemler,
                                  boolean underBehandlingKabal,
-                                 boolean behandletAvKabal) {
+                                 boolean behandletAvKabal,
+                                 LocalDate mottattDato) {
 }

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/klage/aksjonspunkt/KlageFormKravAksjonspunktMellomlagringDto.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/klage/aksjonspunkt/KlageFormKravAksjonspunktMellomlagringDto.java
@@ -1,5 +1,6 @@
 package no.nav.foreldrepenger.web.app.tjenester.behandling.klage.aksjonspunkt;
 
+import java.time.LocalDate;
 import java.util.UUID;
 
 import jakarta.validation.Valid;
@@ -25,6 +26,7 @@ public class KlageFormKravAksjonspunktMellomlagringDto implements KlageFormKravL
     private boolean erTilbakekreving;
     @Valid
     private KlageTilbakekrevingDto klageTilbakekreving;
+    private LocalDate mottattDato;
     @JsonProperty("paKlagdBehandlingUuid")
     private UUID paKlagdBehandlingUuid;
     @Size(max = 2000)
@@ -49,7 +51,8 @@ public class KlageFormKravAksjonspunktMellomlagringDto implements KlageFormKravL
                                                      boolean erTilbakekreving,
                                                      KlageTilbakekrevingDto klageTilbakekreving,
                                                      String begrunnelse,
-                                                     String fritekstTilBrev) {
+                                                     String fritekstTilBrev,
+                                                     LocalDate mottattDato) {
         this.kode = kode;
         this.behandlingUuid = behandlingUuid;
         this.erKlagerPart = erKlagerPart;
@@ -61,7 +64,7 @@ public class KlageFormKravAksjonspunktMellomlagringDto implements KlageFormKravL
         this.klageTilbakekreving = klageTilbakekreving;
         this.begrunnelse = begrunnelse;
         this.fritekstTilBrev = fritekstTilBrev;
-
+        this.mottattDato = mottattDato;
     }
 
     public String getKode() {
@@ -104,6 +107,10 @@ public class KlageFormKravAksjonspunktMellomlagringDto implements KlageFormKravL
     @Override
     public KlageTilbakekrevingDto klageTilbakekreving() {
         return klageTilbakekreving;
+    }
+    @Override
+    public LocalDate mottattDato() {
+        return mottattDato;
     }
 
     public String fritekstTilBrev() {

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/klage/aksjonspunkt/KlageFormKravLagreDto.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/klage/aksjonspunkt/KlageFormKravLagreDto.java
@@ -1,5 +1,6 @@
 package no.nav.foreldrepenger.web.app.tjenester.behandling.klage.aksjonspunkt;
 
+import java.time.LocalDate;
 import java.util.UUID;
 
 public interface KlageFormKravLagreDto {
@@ -20,4 +21,6 @@ public interface KlageFormKravLagreDto {
     default UUID hentpåKlagdEksternBehandlingUuId() {
         return erTilbakekreving() && klageTilbakekreving() != null ? klageTilbakekreving().tilbakekrevingUuid() : null;
     }
+
+    LocalDate mottattDato();
 }

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/klage/aksjonspunkt/KlageFormkravAksjonspunktDto.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/klage/aksjonspunkt/KlageFormkravAksjonspunktDto.java
@@ -1,6 +1,7 @@
 package no.nav.foreldrepenger.web.app.tjenester.behandling.klage.aksjonspunkt;
 
 
+import java.time.LocalDate;
 import java.util.UUID;
 
 import jakarta.validation.Valid;
@@ -37,6 +38,8 @@ public final class KlageFormkravAksjonspunktDto extends BekreftetAksjonspunktDto
     @Pattern(regexp = InputValideringRegex.FRITEKST)
     private String fritekstTilBrev;
 
+    private LocalDate mottattDato;
+
 
     KlageFormkravAksjonspunktDto() {
         // For Jackson
@@ -50,7 +53,8 @@ public final class KlageFormkravAksjonspunktDto extends BekreftetAksjonspunktDto
                                         String begrunnelse,
                                         boolean erTilbakekreving,
                                         KlageTilbakekrevingDto klageTilbakekreving,
-                                        String fritekstTilBrev) {
+                                        String fritekstTilBrev,
+                                        LocalDate mottattDato) {
         super(begrunnelse);
         this.erKlagerPart = erKlagerPart;
         this.erFristOverholdt = erFristOverholdt;
@@ -60,6 +64,7 @@ public final class KlageFormkravAksjonspunktDto extends BekreftetAksjonspunktDto
         this.erTilbakekreving = erTilbakekreving;
         this.klageTilbakekreving = klageTilbakekreving;
         this.fritekstTilBrev = fritekstTilBrev;
+        this.mottattDato = mottattDato;
     }
 
     @Override
@@ -86,6 +91,11 @@ public final class KlageFormkravAksjonspunktDto extends BekreftetAksjonspunktDto
     @Override
     public boolean erTilbakekreving() {
         return erTilbakekreving;
+    }
+
+    @Override
+    public LocalDate mottattDato() {
+        return mottattDato;
     }
 
 

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/klage/aksjonspunkt/KlageFormkravOppdaterer.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/klage/aksjonspunkt/KlageFormkravOppdaterer.java
@@ -70,9 +70,7 @@ public class KlageFormkravOppdaterer implements AksjonspunktOppdaterer<KlageForm
         }
 
         var klageFormkrav = klageVurderingTjeneste.hentKlageFormkrav(klageBehandling, klageVurdertAv);
-        var klageMottattDato = klageFormkrav
-            .flatMap(formkrav -> klageVurderingTjeneste.getKlageMottattDato(klageBehandling, formkrav))
-            .orElse(null);
+        var klageMottattDato = klageVurderingTjeneste.getKlageMottattDato(klageBehandling).orElse(null);
 
         klageFormkravHistorikk.opprettHistorikkinnslagFormkrav(klageBehandling, apDefFormkrav, dto, klageFormkrav, klageResultat, klageMottattDato, dto.getBegrunnelse());
         var optionalAvvistÅrsak = vurderOgLagreFormkrav(dto, klageBehandling, klageResultat, klageVurdertAv);

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/klage/aksjonspunkt/KlageFormkravOppdaterer.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/klage/aksjonspunkt/KlageFormkravOppdaterer.java
@@ -70,8 +70,11 @@ public class KlageFormkravOppdaterer implements AksjonspunktOppdaterer<KlageForm
         }
 
         var klageFormkrav = klageVurderingTjeneste.hentKlageFormkrav(klageBehandling, klageVurdertAv);
+        var klageMottattDato = klageFormkrav
+            .flatMap(formkrav -> klageVurderingTjeneste.getKlageMottattDato(klageBehandling, formkrav))
+            .orElse(null);
 
-        klageFormkravHistorikk.opprettHistorikkinnslagFormkrav(klageBehandling, apDefFormkrav, dto, klageFormkrav, klageResultat, dto.getBegrunnelse());
+        klageFormkravHistorikk.opprettHistorikkinnslagFormkrav(klageBehandling, apDefFormkrav, dto, klageFormkrav, klageResultat, klageMottattDato, dto.getBegrunnelse());
         var optionalAvvistÅrsak = vurderOgLagreFormkrav(dto, klageBehandling, klageResultat, klageVurdertAv);
         if (optionalAvvistÅrsak.isPresent()) {
             lagreKlageVurderingResultatMedAvvistKlage(klageBehandling, skriveLås, klageVurdertAv, dto.fritekstTilBrev() != null ? dto.fritekstTilBrev() : null);
@@ -120,6 +123,7 @@ public class KlageFormkravOppdaterer implements AksjonspunktOppdaterer<KlageForm
             .medErKonkret(dto.erKonkret())
             .medErSignert(dto.erSignert())
             .medErFristOverholdt(dto.erFristOverholdt())
+            .medMottattDato(dto.mottattDato())
             .medBegrunnelse(dto.getBegrunnelse())
             .medGjelderVedtak(dto.påKlagdBehandlingUuid() != null)
             .medKlageResultat(klageResultat);

--- a/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/klage/KlageFormkravOppdatererTest.java
+++ b/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/klage/KlageFormkravOppdatererTest.java
@@ -2,12 +2,15 @@ package no.nav.foreldrepenger.web.app.tjenester.behandling.klage;
 
 import static no.nav.foreldrepenger.behandlingslager.behandling.historikk.HistorikkinnslagLinjeBuilder.format;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.time.LocalDate;
 import java.util.Comparator;
 import java.util.Optional;
 import java.util.UUID;
+
+import no.nav.foreldrepenger.behandlingslager.behandling.repository.MottatteDokumentRepository;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -68,7 +71,7 @@ class KlageFormkravOppdatererTest extends EntityManagerAwareTest {
         BehandlingRepository behandlingRepository = repositoryProvider.getBehandlingRepository();
         klageRepository = new KlageRepository(getEntityManager());
         KlageVurderingTjeneste klageVurderingTjeneste = new KlageVurderingTjeneste(null, null, behandlingRepository, klageRepository, null,
-            repositoryProvider.getBehandlingsresultatRepository(), eventPubliserer);
+            repositoryProvider.getBehandlingsresultatRepository(), eventPubliserer, mock(MottatteDokumentRepository.class));
         var formHistorikk = new KlageHistorikkinnslag(repositoryProvider.getHistorikkinnslagRepository(), behandlingRepository,
             repositoryProvider.getBehandlingVedtakRepository(), mockFptilbakeRestKlient);
         klageFormkravOppdaterer = new KlageFormkravOppdaterer(klageVurderingTjeneste, behandlingRepository, aksjonspunktkontrollTjeneste,
@@ -129,7 +132,7 @@ class KlageFormkravOppdatererTest extends EntityManagerAwareTest {
         assertThat(historikk).hasSize(2);
         var historikkinnslag = historikk.getFirst();
         assertThat(historikkinnslag.getSkjermlenke()).isEqualByComparingTo(SkjermlenkeType.FORMKRAV_KLAGE_NFP);
-        assertThat(historikkinnslag.getLinjer()).hasSize(6);
+        assertThat(historikkinnslag.getLinjer()).hasSize(7);
         var linjer = historikkinnslag.getLinjer();
 
 
@@ -181,7 +184,7 @@ class KlageFormkravOppdatererTest extends EntityManagerAwareTest {
         assertThat(historikk).hasSize(2);
         var historikkinnslag = historikk.get(0);
         assertThat(historikkinnslag.getSkjermlenke()).isEqualByComparingTo(SkjermlenkeType.FORMKRAV_KLAGE_NFP);
-        assertThat(historikkinnslag.getLinjer()).hasSize(6);
+        assertThat(historikkinnslag.getLinjer()).hasSize(7);
         var linjer = historikkinnslag.getLinjer();
         assertThat(linjer.stream()
             .anyMatch(tekstlinje -> tekstlinje.getTekst().contains(KlageHistorikkinnslag.PÅKLAGD_BEHANDLING) && tekstlinje.getTekst()
@@ -213,7 +216,7 @@ class KlageFormkravOppdatererTest extends EntityManagerAwareTest {
         when(mockFptilbakeRestKlient.hentTilbakekrevingsVedtakInfo(TILBAKEKREVING_BEHANDLING_UUID)).thenReturn(
             new TilbakekrevingVedtakDto(1L, klageTilbakekrevingDto.tilbakekrevingVedtakDato(),
                 klageTilbakekrevingDto.tilbakekrevingBehandlingType()));
-        klageFormkravAksjonspunktDto = new KlageFormkravAksjonspunktDto(true, true, true, true, null, "test", false, null, null);
+        klageFormkravAksjonspunktDto = new KlageFormkravAksjonspunktDto(true, true, true, true, null, "test", false, null, null, LocalDate.now());
         klageFormkravOppdaterer.oppdater(klageFormkravAksjonspunktDto, aksjonspunktOppdaterParameter);
 
         var historikk = historikkinnslagRepository.hent(behandling.getSaksnummer())
@@ -223,7 +226,7 @@ class KlageFormkravOppdatererTest extends EntityManagerAwareTest {
         assertThat(historikk).hasSize(2);
         var historikkinnslag = historikk.get(0);
         assertThat(historikkinnslag.getSkjermlenke()).isEqualByComparingTo(SkjermlenkeType.FORMKRAV_KLAGE_NFP);
-        assertThat(historikkinnslag.getLinjer()).hasSize(6);
+        assertThat(historikkinnslag.getLinjer()).hasSize(7);
         var linjer = historikkinnslag.getLinjer();
         assertThat(linjer.stream()
             .anyMatch(tekstlinje -> tekstlinje.getTekst().contains(KlageHistorikkinnslag.PÅKLAGD_BEHANDLING) && tekstlinje.getTekst()
@@ -255,7 +258,7 @@ class KlageFormkravOppdatererTest extends EntityManagerAwareTest {
         when(mockFptilbakeRestKlient.hentTilbakekrevingsVedtakInfo(TILBAKEKREVING_BEHANDLING_UUID)).thenReturn(
             new TilbakekrevingVedtakDto(1L, klageTilbakekrevingDto.tilbakekrevingVedtakDato(),
                 klageTilbakekrevingDto.tilbakekrevingBehandlingType()));
-        klageFormkravAksjonspunktDto = new KlageFormkravAksjonspunktDto(true, true, true, true, behandling.getUuid(), "test", false, null, null);
+        klageFormkravAksjonspunktDto = new KlageFormkravAksjonspunktDto(true, true, true, true, behandling.getUuid(), "test", false, null, null, LocalDate.now());
         klageFormkravOppdaterer.oppdater(klageFormkravAksjonspunktDto, aksjonspunktOppdaterParameter);
 
         var historikk = historikkinnslagRepository.hent(behandling.getSaksnummer())
@@ -265,7 +268,7 @@ class KlageFormkravOppdatererTest extends EntityManagerAwareTest {
         assertThat(historikk).hasSize(2);
         var historikkinnslag = historikk.get(0);
         assertThat(historikkinnslag.getSkjermlenke()).isEqualByComparingTo(SkjermlenkeType.FORMKRAV_KLAGE_NFP);
-        assertThat(historikkinnslag.getLinjer()).hasSize(6);
+        assertThat(historikkinnslag.getLinjer()).hasSize(7);
         var linjer = historikkinnslag.getLinjer();
         assertThat(linjer.stream()
             .anyMatch(tekstlinje -> tekstlinje.getTekst().contains(KlageHistorikkinnslag.PÅKLAGD_BEHANDLING) && tekstlinje.getTekst()
@@ -285,7 +288,7 @@ class KlageFormkravOppdatererTest extends EntityManagerAwareTest {
         final String fritekstTilBrev = "Tester at fritekst lagres på vurderingsresulatet";
 
         var klageAvvistMedFritekst = new KlageFormkravAksjonspunktDto(true, true, false, true, behandling.getUuid(), "test", false, null,
-            fritekstTilBrev);
+            fritekstTilBrev, LocalDate.now());
         var aksjonspunktOppdaterParameter = new AksjonspunktOppdaterParameter(BehandlingReferanse.fra(behandling), klageAvvistMedFritekst,
             behandling.getAksjonspunktFor(AksjonspunktDefinisjon.MANUELL_VURDERING_AV_KLAGE_NFP));
 
@@ -303,7 +306,7 @@ class KlageFormkravOppdatererTest extends EntityManagerAwareTest {
         var vurderingResBuilder = KlageVurderingResultat.builder().medFritekstTilBrev(fritekstTilBrev).medKlageVurdertAv(KlageVurdertAv.NFP);
         klageRepository.lagreVurderingsResultat(behandling, vurderingResBuilder);
 
-        var klageAvvistUtenFritekst = new KlageFormkravAksjonspunktDto(true, true, true, true, behandling.getUuid(), "test", false, null, null);
+        var klageAvvistUtenFritekst = new KlageFormkravAksjonspunktDto(true, true, true, true, behandling.getUuid(), "test", false, null, null, LocalDate.now());
         var aksjonspunktOppdaterParameter = new AksjonspunktOppdaterParameter(BehandlingReferanse.fra(behandling), klageAvvistUtenFritekst,
             behandling.getAksjonspunktFor(AksjonspunktDefinisjon.MANUELL_VURDERING_AV_KLAGE_NFP));
 
@@ -332,7 +335,7 @@ class KlageFormkravOppdatererTest extends EntityManagerAwareTest {
     }
 
     private KlageFormkravAksjonspunktDto lagKlageAksjonspunktDto(boolean erTilbakekreving, KlageTilbakekrevingDto klageTilbakekrevingDto) {
-        return new KlageFormkravAksjonspunktDto(true, true, true, true, behandling.getUuid(), "test", erTilbakekreving, klageTilbakekrevingDto, null);
+        return new KlageFormkravAksjonspunktDto(true, true, true, true, behandling.getUuid(), "test", erTilbakekreving, klageTilbakekrevingDto, null, LocalDate.now());
     }
 
 }

--- a/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/klage/KlagevurderingOppdatererTest.java
+++ b/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/klage/KlagevurderingOppdatererTest.java
@@ -10,6 +10,8 @@ import java.util.Optional;
 
 import jakarta.inject.Inject;
 
+import no.nav.foreldrepenger.behandlingslager.behandling.repository.MottatteDokumentRepository;
+
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
@@ -117,7 +119,7 @@ class KlagevurderingOppdatererTest {
         var behandlingRepository = repositoryProvider.getBehandlingRepository();
         var klageVurderingTjeneste = new KlageVurderingTjeneste(dokumentBestillerTjeneste, Mockito.mock(DokumentBehandlingTjeneste.class),
             behandlingRepository, klageRepository, behandlingProsesseringTjeneste,
-            repositoryProvider.getBehandlingsresultatRepository(), eventPubliserer);
+            repositoryProvider.getBehandlingsresultatRepository(), eventPubliserer, mock(MottatteDokumentRepository.class));
         var klageHistorikk = new KlageHistorikkinnslag(repositoryProvider.getHistorikkinnslagRepository(),
             behandlingRepository, repositoryProvider.getBehandlingVedtakRepository(), mock(FptilbakeRestKlient.class));
         return new KlagevurderingOppdaterer(klageHistorikk, behandlendeEnhetTjeneste, eventPubliserer, aksjonspunktkontrollTjeneste, klageVurderingTjeneste,


### PR DESCRIPTION
Det er ønskelig å kunne redigere klage mottatt dato (som brukes i brev), dersom den er tidligere enn registrert i mottatt dokument.

Frontend: dato mottattDato kommer opp fra backend i KlageFormkavResultatNfp og må sendes ned ved mellomlagring+Ap
* KlageVurdering, KlageFormkravAp (og FormkravMellomlagretDataType): får nytt felt "mottattDato?: string"
* tempSaveklageButton må initvalues/tranformere/populereAptilBackend
* FormkravKlageFormNfp: Vise "Klage mottatt dato" rett under "Vedtaket som er påklagd" med datepicker. Hente verdi fra backendDto og sende ned ved mellomlagring eller løsing av AP