### PR TITLE
Fjerner bruk av JsonFormat.Shape.OBJECT

### DIFF
--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/beregning/AktivitetStatus.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/beregning/AktivitetStatus.java
@@ -13,14 +13,12 @@ import jakarta.persistence.Converter;
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
 import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
 
 
-@JsonFormat(shape = JsonFormat.Shape.OBJECT)
 @JsonAutoDetect(getterVisibility = Visibility.NONE, setterVisibility = Visibility.NONE, fieldVisibility = Visibility.ANY)
 public enum AktivitetStatus implements Kodeverdi {
     ARBEIDSAVKLARINGSPENGER("AAP", "Arbeidsavklaringspenger", Inntektskategori.ARBEIDSAVKLARINGSPENGER),

--- a/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/iay/modell/kodeverk/SkatteOgAvgiftsregelType.java
+++ b/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/iay/modell/kodeverk/SkatteOgAvgiftsregelType.java
@@ -7,14 +7,11 @@ import java.util.Map;
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
 import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonFormat;
-import com.fasterxml.jackson.annotation.JsonFormat.Shape;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
 
-@JsonFormat(shape = Shape.OBJECT)
 @JsonAutoDetect(getterVisibility = Visibility.NONE, setterVisibility = Visibility.NONE, fieldVisibility = Visibility.ANY)
 public enum SkatteOgAvgiftsregelType implements Kodeverdi {
 

--- a/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/iay/modell/kodeverk/VirksomhetType.java
+++ b/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/iay/modell/kodeverk/VirksomhetType.java
@@ -7,14 +7,12 @@ import java.util.Map;
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
 import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import no.nav.foreldrepenger.behandlingslager.behandling.beregning.Inntektskategori;
 import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
 
-@JsonFormat(shape = JsonFormat.Shape.OBJECT)
 @JsonAutoDetect(getterVisibility = Visibility.NONE, setterVisibility = Visibility.NONE, fieldVisibility = Visibility.ANY)
 public enum VirksomhetType implements Kodeverdi {
 

--- a/domenetjenester/familie-hendelse/src/main/java/no/nav/foreldrepenger/familiehendelse/rest/SøknadType.java
+++ b/domenetjenester/familie-hendelse/src/main/java/no/nav/foreldrepenger/familiehendelse/rest/SøknadType.java
@@ -1,11 +1,9 @@
 package no.nav.foreldrepenger.familiehendelse.rest;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonValue;
 
 import no.nav.foreldrepenger.behandlingslager.behandling.familiehendelse.FamilieHendelseEntitet;
 
-@JsonFormat(shape = JsonFormat.Shape.OBJECT)
 public enum SøknadType {
     FØDSEL("ST-001"),
     ADOPSJON("ST-002"),


### PR DESCRIPTION
Johannes kom over disse.
Jeg er litt usikker på hva de gjør på en enum, testene og autotestene kjører fint etter jeg har fjernet disse.
Noen som kjenner historikken? Kanskje noe som bare ligger igjen etter kodeverk oppryddingen for en del år siden?

EndringsresultatSnapshot har denne også, så det blir det litt forskjell fra enumbruk. Kanskje den burde beholdes