### PR TITLE
TFP-6385 ny struktur for enkø/dekø

### DIFF
--- a/domenetjenester/behandling-prosessering/src/main/java/no/nav/foreldrepenger/behandlingsprosess/prosessering/BehandlingProsesseringTjeneste.java
+++ b/domenetjenester/behandling-prosessering/src/main/java/no/nav/foreldrepenger/behandlingsprosess/prosessering/BehandlingProsesseringTjeneste.java
@@ -68,9 +68,6 @@ public interface BehandlingProsesseringTjeneste {
     // Til bruk for å kjøre behandlingsprosessen videre. Lagrer tasks. Returnerer gruppe-handle
     String opprettTasksForFortsettBehandling(Behandling behandling);
 
-    // Til bruk for å kjøre behandlingsprosessen videre. Lagrer tasks. Setter autopunkt til utført. Returnerer gruppe-handle
-    String opprettTasksForFortsettBehandlingSettUtført(Behandling behandling, Optional<AksjonspunktDefinisjon> autoPunktUtført);
-
     // Brukes kun der et steg har suspendet seg selv. Lagrer tasks. Returnerer gruppe-handle
     String opprettTasksForFortsettBehandlingResumeStegNesteKjøring(Behandling behandling, BehandlingStegType stegType,
                                                                    LocalDateTime nesteKjøringEtter);
@@ -84,4 +81,8 @@ public interface BehandlingProsesseringTjeneste {
     String opprettTasksForInitiellRegisterInnhenting(Behandling behandling);
 
     Set<Long> behandlingerMedFeiletProsessTask();
+
+    void enkøBehandling(Behandling behandling);
+
+    String dekøBehandling(Behandling behandling);
 }

--- a/domenetjenester/behandling-prosessering/src/main/java/no/nav/foreldrepenger/behandlingsprosess/prosessering/task/DekøBehandlingTask.java
+++ b/domenetjenester/behandling-prosessering/src/main/java/no/nav/foreldrepenger/behandlingsprosess/prosessering/task/DekøBehandlingTask.java
@@ -1,0 +1,82 @@
+package no.nav.foreldrepenger.behandlingsprosess.prosessering.task;
+
+import java.time.LocalDateTime;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import no.nav.foreldrepenger.behandlingskontroll.BehandlingskontrollTjeneste;
+import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
+import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingStegType;
+import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.AksjonspunktDefinisjon;
+import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.AksjonspunktType;
+import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingLåsRepository;
+import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepository;
+import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakProsesstaskRekkefølge;
+import no.nav.foreldrepenger.behandlingslager.task.BehandlingProsessTask;
+import no.nav.foreldrepenger.behandlingsprosess.prosessering.BehandlingProsesseringTjeneste;
+import no.nav.vedtak.felles.prosesstask.api.ProsessTask;
+import no.nav.vedtak.felles.prosesstask.api.ProsessTaskData;
+
+/**
+ * Tar en behandling av kø. Gjenopptar dersom den ikke er på vent av andre årsaker (kompletthet, mm)
+ */
+@ApplicationScoped
+@ProsessTask("behandlingskontroll.dekøBehandling")
+@FagsakProsesstaskRekkefølge(gruppeSekvens = true)
+public class DekøBehandlingTask extends BehandlingProsessTask {
+
+    private BehandlingRepository behandlingRepository;
+    private BehandlingskontrollTjeneste behandlingskontrollTjeneste;
+    private BehandlingProsesseringTjeneste behandlingProsesseringTjeneste;
+
+    DekøBehandlingTask() {
+        // for CDI proxy
+    }
+
+    @Inject
+    public DekøBehandlingTask(BehandlingRepository behandlingRepository, BehandlingLåsRepository låsRepository,
+                              BehandlingskontrollTjeneste behandlingskontrollTjeneste,
+                              BehandlingProsesseringTjeneste behandlingProsesseringTjeneste) {
+        super(låsRepository);
+        this.behandlingRepository = behandlingRepository;
+        this.behandlingskontrollTjeneste = behandlingskontrollTjeneste;
+        this.behandlingProsesseringTjeneste = behandlingProsesseringTjeneste;
+    }
+
+    @Override
+    protected void prosesser(ProsessTaskData prosessTaskData, Long behandlingId) {
+
+        var lås = behandlingRepository.taSkriveLås(behandlingId);
+        var behandling = behandlingRepository.hentBehandling(behandlingId);
+        var kontekst = behandlingskontrollTjeneste.initBehandlingskontroll(behandling, lås);
+
+        if (behandling.erKøet()) {
+            var køAksjonspunkt = behandling.getÅpentAksjonspunktMedDefinisjonOptional(AksjonspunktDefinisjon.AUTO_KØET_BEHANDLING).orElseThrow();
+            behandlingskontrollTjeneste.settAutopunktTilUtført(kontekst, behandling, køAksjonspunkt);
+        }
+
+        var nå = LocalDateTime.now();
+        if (behandling.isBehandlingPåVent()) {
+            var skalVentePåGjenopptak = behandling.getÅpneAksjonspunkter(AksjonspunktType.AUTOPUNKT).stream()
+                .anyMatch(a -> a.getFristTid() != null && a.getFristTid().isAfter(nå));
+            if (skalVentePåGjenopptak) {
+                return;
+            } else {
+                behandlingskontrollTjeneste.taBehandlingAvVentSetAlleAutopunktUtført(kontekst, behandling);
+            }
+        }
+
+        if (erRegisterinnhentingPassert(behandling)) {
+            behandlingProsesseringTjeneste.opprettTasksForGjenopptaOppdaterFortsett(behandling, nå);
+        } else {
+            behandlingProsesseringTjeneste.opprettTasksForFortsettBehandling(behandling);
+        }
+
+    }
+
+    private boolean erRegisterinnhentingPassert(Behandling behandling) {
+        return behandlingProsesseringTjeneste.erBehandlingEtterSteg(behandling, BehandlingStegType.INNHENT_REGISTEROPP);
+    }
+
+}

--- a/domenetjenester/behandling-prosessering/src/main/java/no/nav/foreldrepenger/behandlingsprosess/prosessering/task/FortsettBehandlingTask.java
+++ b/domenetjenester/behandling-prosessering/src/main/java/no/nav/foreldrepenger/behandlingsprosess/prosessering/task/FortsettBehandlingTask.java
@@ -64,7 +64,7 @@ public class FortsettBehandlingTask implements ProsessTaskHandler {
                 if (behandling.isBehandlingPåVent()) { // Autopunkt
                     behandlingskontrollTjeneste.taBehandlingAvVentSetAlleAutopunktUtført(kontekst, behandling);
                 }
-            } else {
+            } else { // TODO: Slett denne etter omlegging
                 Optional.ofNullable(data.getPropertyValue(UTFORT_AUTOPUNKT))
                     .map(AksjonspunktDefinisjon::fraKode)
                     .flatMap(behandling::getÅpentAksjonspunktMedDefinisjonOptional)

--- a/domenetjenester/behandling-revurdering/src/main/java/no/nav/foreldrepenger/behandling/revurdering/etterkontroll/tjeneste/fp/EtterkontrollTjenesteImpl.java
+++ b/domenetjenester/behandling-revurdering/src/main/java/no/nav/foreldrepenger/behandling/revurdering/etterkontroll/tjeneste/fp/EtterkontrollTjenesteImpl.java
@@ -19,8 +19,6 @@ import no.nav.foreldrepenger.behandlingslager.aktør.FødtBarnInfo;
 import no.nav.foreldrepenger.behandlingslager.aktør.OrganisasjonsEnhet;
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingÅrsakType;
-import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.AksjonspunktDefinisjon;
-import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.Venteårsak;
 import no.nav.foreldrepenger.behandlingslager.behandling.familiehendelse.FamilieHendelseEntitet;
 import no.nav.foreldrepenger.behandlingslager.behandling.familiehendelse.FamilieHendelseGrunnlagEntitet;
 import no.nav.foreldrepenger.behandlingslager.behandling.familiehendelse.FamilieHendelseType;
@@ -142,7 +140,7 @@ public class EtterkontrollTjenesteImpl implements EtterkontrollTjeneste {
     }
 
     public void enkøBehandling(Behandling behandling) {
-        behandlingProsesseringTjeneste.settBehandlingPåVentUtenSteg(behandling, AksjonspunktDefinisjon.AUTO_KØET_BEHANDLING,  null, Venteårsak.VENT_ÅPEN_BEHANDLING);
+        behandlingProsesseringTjeneste.enkøBehandling(behandling);
     }
 
 }

--- a/domenetjenester/behandling-revurdering/src/main/java/no/nav/foreldrepenger/behandling/revurdering/flytkontroll/BehandlingFlytkontroll.java
+++ b/domenetjenester/behandling-revurdering/src/main/java/no/nav/foreldrepenger/behandling/revurdering/flytkontroll/BehandlingFlytkontroll.java
@@ -1,7 +1,5 @@
 package no.nav.foreldrepenger.behandling.revurdering.flytkontroll;
 
-import java.util.Optional;
-
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 
@@ -13,7 +11,6 @@ import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingStegType;
 import no.nav.foreldrepenger.behandlingslager.behandling.SpesialBehandling;
 import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.AksjonspunktDefinisjon;
-import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.Venteårsak;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepository;
 import no.nav.foreldrepenger.behandlingslager.fagsak.Fagsak;
 import no.nav.foreldrepenger.behandlingslager.hendelser.StartpunktType;
@@ -69,7 +66,7 @@ public class BehandlingFlytkontroll {
             var køetAnnenpartBerørt = annenpartÅpneBehandlinger.stream().filter(b -> SpesialBehandling.skalIkkeKøes(b) && venterVedUttakSynk(b)).findFirst();
             køetAnnenpartBerørt.ifPresent(b -> {
                 LOG.warn("Berørt behandling: Annenpart har en berørt på vent ved uttak. Fortsetter annenpart og går selv på vent.");
-                behandlingProsesseringTjeneste.opprettTasksForFortsettBehandlingSettUtført(b, Optional.of(AksjonspunktDefinisjon.AUTO_KØET_BEHANDLING));
+                behandlingProsesseringTjeneste.dekøBehandling(b);
             });
             return annenpartÅpneBehandlinger.stream().anyMatch(b -> SpesialBehandling.skalIkkeKøes(b) && (passertUttakSynk(b) || venterVedUttakSynk(b)));
         }
@@ -93,7 +90,7 @@ public class BehandlingFlytkontroll {
     }
 
     public void settNyRevurderingPåVent(Behandling behandling) {
-        behandlingProsesseringTjeneste.settBehandlingPåVentUtenSteg(behandling, AksjonspunktDefinisjon.AUTO_KØET_BEHANDLING, null, Venteårsak.VENT_ÅPEN_BEHANDLING);
+        behandlingProsesseringTjeneste.enkøBehandling(behandling);
     }
 
     public boolean finnesÅpenBerørtForFagsak(Long fagsakId, Long behandlingId) {

--- a/domenetjenester/behandling-revurdering/src/test/java/no/nav/foreldrepenger/behandling/revurdering/flytkontroll/BehandlingFlytkontrollTest.java
+++ b/domenetjenester/behandling-revurdering/src/test/java/no/nav/foreldrepenger/behandling/revurdering/flytkontroll/BehandlingFlytkontrollTest.java
@@ -2,7 +2,6 @@ package no.nav.foreldrepenger.behandling.revurdering.flytkontroll;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -140,7 +139,7 @@ class BehandlingFlytkontrollTest {
         when(behandlingBerørt.harÅpentAksjonspunktMedType(AksjonspunktDefinisjon.AUTO_KØET_BEHANDLING)).thenReturn(true);
         when(behandlingBerørt.getAktivtBehandlingSteg()).thenReturn(StartpunktType.UTTAKSVILKÅR.getBehandlingSteg());
         assertThat(flytkontroll.uttaksProsessenSkalVente(EGEN_BERØRT_ID)).isTrue();
-        verify(behandlingProsesseringTjeneste, times(1)).opprettTasksForFortsettBehandlingSettUtført(any(), eq(Optional.of(AksjonspunktDefinisjon.AUTO_KØET_BEHANDLING)));
+        verify(behandlingProsesseringTjeneste, times(1)).dekøBehandling(any());
     }
 
 

--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/Behandlingsoppretter.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/Behandlingsoppretter.java
@@ -20,7 +20,6 @@ import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingÅrsakType;
 import no.nav.foreldrepenger.behandlingslager.behandling.DokumentTypeId;
 import no.nav.foreldrepenger.behandlingslager.behandling.MottattDokument;
 import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.AksjonspunktDefinisjon;
-import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.Venteårsak;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepositoryProvider;
 import no.nav.foreldrepenger.behandlingslager.behandling.søknad.SøknadRepository;
@@ -207,7 +206,7 @@ public class Behandlingsoppretter {
 
 
     public void settSomKøet(Behandling nyKøetBehandling) {
-        behandlingProsesseringTjeneste.settBehandlingPåVentUtenSteg(nyKøetBehandling, AksjonspunktDefinisjon.AUTO_KØET_BEHANDLING, null, Venteårsak.VENT_ÅPEN_BEHANDLING);
+        behandlingProsesseringTjeneste.enkøBehandling(nyKøetBehandling);
     }
 
     public boolean erOpphørtBehandling(Behandling behandling) {

--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/sakskompleks/KøKontroller.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/sakskompleks/KøKontroller.java
@@ -12,7 +12,6 @@ import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingType;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingÅrsakType;
 import no.nav.foreldrepenger.behandlingslager.behandling.SpesialBehandling;
 import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.AksjonspunktDefinisjon;
-import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.Venteårsak;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepositoryProvider;
 import no.nav.foreldrepenger.behandlingslager.behandling.søknad.SøknadEntitet;
@@ -83,12 +82,12 @@ public class KøKontroller {
     }
 
     public void enkøBehandling(Behandling behandling) {
-        behandlingProsesseringTjeneste.settBehandlingPåVentUtenSteg(behandling, AksjonspunktDefinisjon.AUTO_KØET_BEHANDLING, null, Venteårsak.VENT_ÅPEN_BEHANDLING);
+        behandlingProsesseringTjeneste.enkøBehandling(behandling);
     }
 
     public void submitBerørtBehandling(Behandling behandling, Optional<Behandling> åpenBehandling) {
         if (!behandling.harNoenBehandlingÅrsaker(BehandlingÅrsakType.alleTekniskeÅrsaker())) throw new IllegalArgumentException("Behandling er ikke berørt");
-        åpenBehandling.ifPresent(b -> behandlingProsesseringTjeneste.settBehandlingPåVentUtenSteg(b, AksjonspunktDefinisjon.AUTO_KØET_BEHANDLING, null, Venteårsak.VENT_ÅPEN_BEHANDLING));
+        åpenBehandling.ifPresent(b -> behandlingProsesseringTjeneste.enkøBehandling(b));
         behandlingProsesseringTjeneste.opprettTasksForStartBehandling(behandling);
     }
 
@@ -104,7 +103,7 @@ public class KøKontroller {
         var køetBehandlingMedforelder = behandlingRevurderingTjeneste.finnKøetBehandlingMedforelder(fagsak);
         var køetBerørt = sjekkKøetBerørt(køetBehandling, køetBehandlingMedforelder);
         if (køetBerørt.isPresent()) {
-            behandlingProsesseringTjeneste.opprettTasksForFortsettBehandlingSettUtført(køetBerørt.get(), Optional.of(AksjonspunktDefinisjon.AUTO_KØET_BEHANDLING));
+            behandlingProsesseringTjeneste.dekøBehandling(køetBerørt.get());
             return;
         }
         var nesteBehandling = finnTidligsteSøknad(køetBehandling, køetBehandlingMedforelder)
@@ -113,7 +112,7 @@ public class KøKontroller {
             if (skalOppdatereKøetBehandling(b)) {
                 lagreOppdaterKøetProsesstask(b);
             } else {
-                behandlingProsesseringTjeneste.opprettTasksForFortsettBehandlingSettUtført(b, Optional.of(AksjonspunktDefinisjon.AUTO_KØET_BEHANDLING));
+                behandlingProsesseringTjeneste.dekøBehandling(b);
             }
         });
     }
@@ -154,7 +153,7 @@ public class KøKontroller {
 
     private void opprettTaskForÅStarteBehandling(Behandling behandling) {
         if (behandling.harÅpentAksjonspunktMedType(AksjonspunktDefinisjon.AUTO_KØET_BEHANDLING)) {
-            behandlingProsesseringTjeneste.opprettTasksForFortsettBehandlingSettUtført(behandling, Optional.of(AksjonspunktDefinisjon.AUTO_KØET_BEHANDLING));
+            behandlingProsesseringTjeneste.dekøBehandling(behandling);
         } else {
             behandlingProsesseringTjeneste.opprettTasksForStartBehandling(behandling);
         }
@@ -178,7 +177,7 @@ public class KøKontroller {
             }
             behandlingProsesseringTjeneste.opprettTasksForStartBehandling(oppdatertBehandling);
         } else {
-            behandlingProsesseringTjeneste.opprettTasksForFortsettBehandlingSettUtført(behandling, Optional.of(AksjonspunktDefinisjon.AUTO_KØET_BEHANDLING));
+            behandlingProsesseringTjeneste.dekøBehandling(behandling);
         }
     }
 

--- a/domenetjenester/mottak/src/test/java/no/nav/foreldrepenger/mottak/sakskompleks/BerørtBehandlingKontrollerTest.java
+++ b/domenetjenester/mottak/src/test/java/no/nav/foreldrepenger/mottak/sakskompleks/BerørtBehandlingKontrollerTest.java
@@ -32,7 +32,6 @@ import no.nav.foreldrepenger.behandlingslager.behandling.Behandlingsresultat;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingsresultatRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingÅrsakType;
 import no.nav.foreldrepenger.behandlingslager.behandling.KonsekvensForYtelsen;
-import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.AksjonspunktDefinisjon;
 import no.nav.foreldrepenger.behandlingslager.behandling.historikk.HistorikkinnslagRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepositoryProvider;
@@ -154,8 +153,7 @@ class BerørtBehandlingKontrollerTest {
         berørtBehandlingKontroller.vurderNesteOppgaveIBehandlingskø(fBehandling.getId());
 
         // Assert
-        verify(behandlingProsesseringTjeneste).opprettTasksForFortsettBehandlingSettUtført(køetBehandling,
-            Optional.of(AksjonspunktDefinisjon.AUTO_KØET_BEHANDLING));
+        verify(behandlingProsesseringTjeneste).dekøBehandling(køetBehandling);
     }
 
     @Test
@@ -177,7 +175,7 @@ class BerørtBehandlingKontrollerTest {
         berørtBehandlingKontroller.vurderNesteOppgaveIBehandlingskø(fBehandling.getId());
 
         // Assert
-        verify(behandlingProsesseringTjeneste).opprettTasksForFortsettBehandlingSettUtført(any(), any());
+        verify(behandlingProsesseringTjeneste).dekøBehandling(any());
     }
 
     @Test
@@ -190,8 +188,7 @@ class BerørtBehandlingKontrollerTest {
         berørtBehandlingKontroller.vurderNesteOppgaveIBehandlingskø(fBehandling.getId());
 
         // Assert
-        verify(behandlingProsesseringTjeneste).opprettTasksForFortsettBehandlingSettUtført(køetBehandlingMedforelder,
-            Optional.of(AksjonspunktDefinisjon.AUTO_KØET_BEHANDLING));
+        verify(behandlingProsesseringTjeneste).dekøBehandling(køetBehandlingMedforelder);
     }
 
     @Test
@@ -208,8 +205,7 @@ class BerørtBehandlingKontrollerTest {
 
         // Assert
         verifyNoMoreInteractions(behandlingsoppretter);
-        verify(behandlingProsesseringTjeneste).opprettTasksForFortsettBehandlingSettUtført(køetBehandlingMedforelder,
-            Optional.of(AksjonspunktDefinisjon.AUTO_KØET_BEHANDLING));
+        verify(behandlingProsesseringTjeneste).dekøBehandling(køetBehandlingMedforelder);
     }
 
     private void settOppAvsluttetBehandlingBruker() {
@@ -287,8 +283,7 @@ class BerørtBehandlingKontrollerTest {
         berørtBehandlingKontroller.vurderNesteOppgaveIBehandlingskø(fBehandling.getId());
         // Assert
         verifyNoMoreInteractions(behandlingsoppretter);
-        verify(behandlingProsesseringTjeneste).opprettTasksForFortsettBehandlingSettUtført(køetBehandlingMedforelder,
-            Optional.of(AksjonspunktDefinisjon.AUTO_KØET_BEHANDLING));
+        verify(behandlingProsesseringTjeneste).dekøBehandling(køetBehandlingMedforelder);
     }
 
     @Test
@@ -319,8 +314,7 @@ class BerørtBehandlingKontrollerTest {
         berørtBehandlingKontroller.vurderNesteOppgaveIBehandlingskø(fBehandling.getId());
         // Assert
         verifyNoMoreInteractions(behandlingsoppretter);
-        verify(behandlingProsesseringTjeneste).opprettTasksForFortsettBehandlingSettUtført(køetBehandling,
-            Optional.of(AksjonspunktDefinisjon.AUTO_KØET_BEHANDLING));
+        verify(behandlingProsesseringTjeneste).dekøBehandling(køetBehandling);
     }
 
     @Test
@@ -399,8 +393,7 @@ class BerørtBehandlingKontrollerTest {
         berørtBehandlingKontroller.vurderNesteOppgaveIBehandlingskø(fBehandling.getId());
         // Assert - dekø fra medforelders kø
         verifyNoMoreInteractions(behandlingsoppretter);
-        verify(behandlingProsesseringTjeneste).opprettTasksForFortsettBehandlingSettUtført(køetBehandling,
-            Optional.of(AksjonspunktDefinisjon.AUTO_KØET_BEHANDLING));
+        verify(behandlingProsesseringTjeneste).dekøBehandling(køetBehandling);
     }
 
     @Test
@@ -415,8 +408,7 @@ class BerørtBehandlingKontrollerTest {
         berørtBehandlingKontroller.vurderNesteOppgaveIBehandlingskø(fBehandling.getId());
         // Assert  - dekø fra medforelders kø
         verifyNoMoreInteractions(behandlingsoppretter);
-        verify(behandlingProsesseringTjeneste).opprettTasksForFortsettBehandlingSettUtført(køetBehandlingMedforelder,
-            Optional.of(AksjonspunktDefinisjon.AUTO_KØET_BEHANDLING));
+        verify(behandlingProsesseringTjeneste).dekøBehandling(køetBehandlingMedforelder);
     }
 
     @Test
@@ -430,8 +422,7 @@ class BerørtBehandlingKontrollerTest {
         berørtBehandlingKontroller.vurderNesteOppgaveIBehandlingskø(fBehandling.getId());
         // Assert dekø fra egen kø
         verifyNoMoreInteractions(behandlingsoppretter);
-        verify(behandlingProsesseringTjeneste).opprettTasksForFortsettBehandlingSettUtført(køetBehandling,
-            Optional.of(AksjonspunktDefinisjon.AUTO_KØET_BEHANDLING));
+        verify(behandlingProsesseringTjeneste).dekøBehandling(køetBehandling);
     }
 
     @Test

--- a/domenetjenester/mottak/src/test/java/no/nav/foreldrepenger/mottak/sakskompleks/KøKontrollerTest.java
+++ b/domenetjenester/mottak/src/test/java/no/nav/foreldrepenger/mottak/sakskompleks/KøKontrollerTest.java
@@ -79,7 +79,7 @@ class KøKontrollerTest {
         // Assert
         Mockito.verify(behandlingsoppretter, times(0)).oppdaterBehandlingViaHenleggelse(any(), any());
         Mockito.verify(ytelsesFordelingRepository, times(0)).kopierGrunnlagFraEksisterendeBehandling(any(), any());
-        Mockito.verify(behandlingProsesseringTjeneste).opprettTasksForFortsettBehandlingSettUtført(eq(morKøetBehandling), any());
+        Mockito.verify(behandlingProsesseringTjeneste).dekøBehandling(eq(morKøetBehandling));
     }
 
     @Test

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/forvaltning/ForvaltningTekniskRestTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/forvaltning/ForvaltningTekniskRestTjeneste.java
@@ -27,8 +27,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import no.nav.foreldrepenger.behandlingskontroll.AksjonspunktkontrollTjeneste;
 import no.nav.foreldrepenger.behandlingskontroll.BehandlingskontrollTjeneste;
 import no.nav.foreldrepenger.behandlingslager.behandling.SpesialBehandling;
-import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.AksjonspunktDefinisjon;
-import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.Venteårsak;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepositoryProvider;
 import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakProsessTaskRepository;
@@ -167,7 +165,7 @@ public class ForvaltningTekniskRestTjeneste {
         if (behandling == null || behandling.erKøet() || SpesialBehandling.erSpesialBehandling(behandling)) {
             return Response.status(Response.Status.BAD_REQUEST).build();
         }
-        behandlingProsesseringTjeneste.settBehandlingPåVentUtenSteg(behandling, AksjonspunktDefinisjon.AUTO_KØET_BEHANDLING, null, Venteårsak.VENT_ÅPEN_BEHANDLING);
+        behandlingProsesseringTjeneste.enkøBehandling(behandling);
         behandlingRepository.lagre(behandling, lås);
         return Response.ok().build();
     }


### PR DESCRIPTION
Oppdaget gjennom dekøing av behandlinger på vent og feilmelding derfra. Noen har utløpt frist, andre ikke.
Ser behov for å oppdatere behandlinger etter dekøing. GjenopptaOppdaterFortsett vil oppdatere ved behov (24t)
Lager et mer eksplisitt grensesnitt for køing og kall mot behandlingskontroll