### PR TITLE
TFP-6071: tilrettelegg for medTerminType

### DIFF
--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/familiehendelse/FamilieHendelseBuilder.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/familiehendelse/FamilieHendelseBuilder.java
@@ -119,13 +119,16 @@ public class FamilieHendelseBuilder {
      *
      * @return builder
      */
-    public FamilieHendelseBuilder erFødsel() {
-        if (hendelse.getType().equals(FamilieHendelseType.UDEFINERT)
-                || hendelse.getType().equals(FamilieHendelseType.FØDSEL)
-                || hendelse.getType().equals(FamilieHendelseType.TERMIN)) {
-            hendelse.setType(FamilieHendelseType.FØDSEL);
+    public FamilieHendelseBuilder medFødselType() {
+        return medType(FamilieHendelseType.FØDSEL);
+    }
+
+    private FamilieHendelseBuilder medType(FamilieHendelseType type) {
+        if (hendelse.getType().equals(FamilieHendelseType.UDEFINERT) || hendelse.getType().equals(FamilieHendelseType.FØDSEL) || hendelse.getType()
+            .equals(FamilieHendelseType.TERMIN)) {
+            hendelse.setType(type);
         } else {
-            throw FamilieHendelseFeil.kanIkkeEndreTypePåHendelseFraTil(hendelse.getType(), FamilieHendelseType.FØDSEL);
+            throw FamilieHendelseFeil.kanIkkeEndreTypePåHendelseFraTil(hendelse.getType(), type);
         }
         return this;
     }
@@ -154,13 +157,12 @@ public class FamilieHendelseBuilder {
         }
         if (hendelse.getAdopsjon().isPresent()) {
             if (hendelse.getAdopsjon().get().getOmsorgovertakelseVilkår().equals(OmsorgsovertakelseVilkårType.UDEFINERT)
-                    && !erSøknadEllerBekreftetVersjonOgSattTilOmsorg()) {
+                && !erSøknadEllerBekreftetVersjonOgSattTilOmsorg()) {
                 hendelse.setType(FamilieHendelseType.ADOPSJON);
             } else {
                 hendelse.setType(FamilieHendelseType.OMSORG);
             }
-        } else if (!hendelse.getBarna().isEmpty()
-                || erHendelsenSattTil(FamilieHendelseType.FØDSEL)) {
+        } else if (!hendelse.getBarna().isEmpty() || erHendelsenSattTil(FamilieHendelseType.FØDSEL)) {
             hendelse.setType(FamilieHendelseType.FØDSEL);
         } else if (hendelse.getTerminbekreftelse().isPresent()) {
             hendelse.setType(FamilieHendelseType.TERMIN);
@@ -175,14 +177,12 @@ public class FamilieHendelseBuilder {
     }
 
     private boolean erSøknadEllerBekreftetVersjonOgSattTilOmsorg() {
-        return (type.equals(HendelseVersjonType.SØKNAD) || type.equals(HendelseVersjonType.BEKREFTET))
-                && hendelse.getType() != null
-                && hendelse.getType().equals(FamilieHendelseType.OMSORG);
+        return (type.equals(HendelseVersjonType.SØKNAD) || type.equals(HendelseVersjonType.BEKREFTET)) && hendelse.getType() != null
+            && hendelse.getType().equals(FamilieHendelseType.OMSORG);
     }
 
     private boolean erHendelsenSattTil(FamilieHendelseType type) {
-        return hendelse.getType() != null
-                && hendelse.getType().equals(type);
+        return hendelse.getType() != null && hendelse.getType().equals(type);
     }
 
     HendelseVersjonType getType() {

--- a/domenetjenester/behandling-revurdering/src/test/java/no/nav/foreldrepenger/behandling/revurdering/etterkontroll/es/AutomatiskEtterkontrollTaskTest.java
+++ b/domenetjenester/behandling-revurdering/src/test/java/no/nav/foreldrepenger/behandling/revurdering/etterkontroll/es/AutomatiskEtterkontrollTaskTest.java
@@ -239,7 +239,7 @@ class AutomatiskEtterkontrollTaskTest {
         if (medBekreftet) {
             scenario.medBekreftetHendelse()
                     .medFødselsDato(terminDato)
-                    .erFødsel()
+                    .medFødselType()
                     .medAntallBarn(antallBarn);
         }
 

--- a/domenetjenester/behandling-revurdering/src/test/java/no/nav/foreldrepenger/behandling/revurdering/etterkontroll/fp/AutomatiskEtterkontrollTaskTest.java
+++ b/domenetjenester/behandling-revurdering/src/test/java/no/nav/foreldrepenger/behandling/revurdering/etterkontroll/fp/AutomatiskEtterkontrollTaskTest.java
@@ -551,11 +551,11 @@ class AutomatiskEtterkontrollTaskTest {
             .medAntallBarn(1);
 
         if (medBekreftet) {
-            scenario.medBekreftetHendelse().tilbakestillBarn().medFødselsDato(terminDato, antallBarn).erFødsel().medAntallBarn(antallBarn);
+            scenario.medBekreftetHendelse().tilbakestillBarn().medFødselsDato(terminDato, antallBarn).medFødselType().medAntallBarn(antallBarn);
         }
 
         if (medOverstyrtFødsel) {
-            scenario.medOverstyrtHendelse().tilbakestillBarn().medFødselsDato(terminDato, antallBarn).erFødsel().medAntallBarn(antallBarn);
+            scenario.medOverstyrtHendelse().tilbakestillBarn().medFødselsDato(terminDato, antallBarn).medFødselType().medAntallBarn(antallBarn);
         }
 
         if (medOverstyrtTermin) {

--- a/domenetjenester/behandling-revurdering/src/test/java/no/nav/foreldrepenger/behandling/revurdering/ytelse/fp/UttakGrunnlagTjenesteTest.java
+++ b/domenetjenester/behandling-revurdering/src/test/java/no/nav/foreldrepenger/behandling/revurdering/ytelse/fp/UttakGrunnlagTjenesteTest.java
@@ -48,13 +48,13 @@ class UttakGrunnlagTjenesteTest {
     void skal_ignorere_overstyrt_familiehendelse_hvis_saksbehandler_har_valgt_at_fødsel_ikke_er_dokumentert() {
         var førstegangsScenario = ScenarioMorSøkerEngangsstønad.forFødsel();
         var fødselsDato = LocalDate.of(2019, 10, 10);
-        førstegangsScenario.medBekreftetHendelse().medFødselsDato(fødselsDato).medAntallBarn(1).erFødsel();
-        førstegangsScenario.medOverstyrtHendelse().medAntallBarn(0).erFødsel();
+        førstegangsScenario.medBekreftetHendelse().medFødselsDato(fødselsDato).medAntallBarn(1).medFødselType();
+        førstegangsScenario.medOverstyrtHendelse().medAntallBarn(0).medFødselType();
         var behandling = førstegangsScenario.lagre(repositoryProvider);
 
         var revurderingScenario = ScenarioMorSøkerEngangsstønad.forFødsel()
             .medOriginalBehandling(behandling, BehandlingÅrsakType.RE_ENDRING_FRA_BRUKER);
-        revurderingScenario.medBekreftetHendelse().medAntallBarn(1).medFødselsDato(fødselsDato).erFødsel();
+        revurderingScenario.medBekreftetHendelse().medAntallBarn(1).medFødselsDato(fødselsDato).medFødselType();
         var revurdering = revurderingScenario.lagre(repositoryProvider);
 
         var grunnlagRevurdering = tjeneste.grunnlag(BehandlingReferanse.fra(revurdering));

--- a/domenetjenester/familie-hendelse/src/main/java/no/nav/foreldrepenger/familiehendelse/aksjonspunkt/SjekkManglendeFødselOppdaterer.java
+++ b/domenetjenester/familie-hendelse/src/main/java/no/nav/foreldrepenger/familiehendelse/aksjonspunkt/SjekkManglendeFødselOppdaterer.java
@@ -71,7 +71,7 @@ public class SjekkManglendeFødselOppdaterer implements AksjonspunktOppdaterer<S
             var oppdatertOverstyrtHendelse = familieHendelseTjeneste.opprettBuilderForOverstyring(behandlingId)
                 .tilbakestillBarn()
                 .medAntallBarn(utledetResultat.size())
-                .erFødsel() // Settes til fødsel for å sikre at typen blir fødsel selv om det ikke er født barn.
+                .medFødselType() // Settes til fødsel for å sikre at typen blir fødsel selv om det ikke er født barn.
                 .medErMorForSykVedFødsel(null);
             utledetResultat.forEach(it -> oppdatertOverstyrtHendelse.leggTilBarn(it.getFødselsdato(), it.getDødsdato().orElse(null)));
 

--- a/domenetjenester/inngangsvilkar/src/test/java/no/nav/foreldrepenger/inngangsvilkaar/fødsel/FødselsvilkårMorTest.java
+++ b/domenetjenester/inngangsvilkar/src/test/java/no/nav/foreldrepenger/inngangsvilkaar/fødsel/FødselsvilkårMorTest.java
@@ -259,7 +259,7 @@ class FødselsvilkårMorTest extends EntityManagerAwareTest {
         var fødselsdato = LocalDate.now();
         var scenario = ScenarioFarSøkerEngangsstønad.forFødsel();
         scenario.medSøknadHendelse().medFødselsDato(fødselsdato).medAntallBarn(1);
-        scenario.medBekreftetHendelse().tilbakestillBarn().medAntallBarn(0).erFødsel();
+        scenario.medBekreftetHendelse().tilbakestillBarn().medAntallBarn(0).medFødselType();
         scenario.medBrukerKjønn(NavBrukerKjønn.KVINNE);
         leggTilSøker(scenario, NavBrukerKjønn.KVINNE);
         var behandling = scenario.lagre(repositoryProvider);

--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/dokumentpersiterer/impl/søknad/v3/FamilieHendelseOversetter.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/dokumentpersiterer/impl/søknad/v3/FamilieHendelseOversetter.java
@@ -65,7 +65,7 @@ public class FamilieHendelseOversetter  {
         hendelseBuilder.medTerminbekreftelse(hendelseBuilder.getTerminbekreftelseBuilder().medTermindato(termindato));
         var fødselsdato = omYtelse.getFødselsdato();
         if (fødselsdato != null) {
-            hendelseBuilder.erFødsel().medFødselsDato(fødselsdato).medAntallBarn(1);
+            hendelseBuilder.medFødselType().medFødselsDato(fødselsdato).medAntallBarn(1);
         }
     }
 

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/forvaltning/ForvaltningSøknadRestTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/forvaltning/ForvaltningSøknadRestTjeneste.java
@@ -123,7 +123,7 @@ public class ForvaltningSøknadRestTjeneste {
         }
         var hendelsebuilder = familieHendelseRepository.opprettBuilderForOverstyring(behandlingId)
             .medAntallBarn(1)
-            .erFødsel() // Settes til fødsel for å sikre at typen blir fødsel selv om det ikke er født barn.
+            .medFødselType() // Settes til fødsel for å sikre at typen blir fødsel selv om det ikke er født barn.
             .medErMorForSykVedFødsel(null)
             .leggTilBarn(dto.getFødselsdato(), dto.getDødsdato());
         familieHendelseTjeneste.lagreOverstyrtHendelse(behandlingId, hendelsebuilder);

--- a/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/dto/behandling/BehandlingDtoLenkeTestUtils.java
+++ b/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/dto/behandling/BehandlingDtoLenkeTestUtils.java
@@ -66,7 +66,7 @@ public class BehandlingDtoLenkeTestUtils {
 
     static ScenarioMorSøkerEngangsstønad lagESBehandling() {
         var scenario = ScenarioMorSøkerEngangsstønad.forFødsel();
-        scenario.medSøknadHendelse().erFødsel().build();
+        scenario.medSøknadHendelse().medFødselType().build();
         return scenario;
     }
 


### PR DESCRIPTION
relatert til https://github.com/navikt/fp-sak/pull/7438/files
splitter omdøpingen av medFødselType ut for å reduserte berørte filer som ikke er direkte knyttet til featuren om overstyring av fødsel

