### PR TITLE
TFP-6246 bedre logging rollesamsvar

### DIFF
--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/aktør/FødtBarnInfo.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/aktør/FødtBarnInfo.java
@@ -1,14 +1,27 @@
 package no.nav.foreldrepenger.behandlingslager.aktør;
 
 import java.time.LocalDate;
+import java.util.Objects;
 import java.util.Optional;
 
+import no.nav.foreldrepenger.behandlingslager.behandling.personopplysning.RelasjonsRolleType;
 import no.nav.foreldrepenger.domene.typer.PersonIdent;
 
-public record FødtBarnInfo(PersonIdent ident, LocalDate fødselsdato, LocalDate dødsdato) {
+public record FødtBarnInfo(PersonIdent ident, LocalDate fødselsdato, LocalDate dødsdato, RelasjonsRolleType forelderRolle) {
 
     public Optional<LocalDate> getDødsdato() {
         return Optional.ofNullable(dødsdato);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        return o instanceof FødtBarnInfo that && Objects.equals(ident, that.ident)
+            && Objects.equals(dødsdato, that.dødsdato) && Objects.equals(fødselsdato, that.fødselsdato);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(ident, fødselsdato, dødsdato);
     }
 
     @Override
@@ -23,6 +36,7 @@ public record FødtBarnInfo(PersonIdent ident, LocalDate fødselsdato, LocalDate
         private PersonIdent ident;
         private LocalDate fødselsdato;
         private LocalDate dødsdato;
+        private RelasjonsRolleType forelderRolle = RelasjonsRolleType.UDEFINERT;
 
         public Builder medIdent(PersonIdent ident) {
             this.ident = ident;
@@ -39,9 +53,14 @@ public record FødtBarnInfo(PersonIdent ident, LocalDate fødselsdato, LocalDate
             return this;
         }
 
+        public Builder medForelderRolle(RelasjonsRolleType forelderRolle) {
+            this.forelderRolle = forelderRolle;
+            return this;
+        }
+
         public FødtBarnInfo build() {
             // Vurder sjekking ident != null || dødsdato != null
-            return new FødtBarnInfo(ident, fødselsdato, dødsdato);
+            return new FødtBarnInfo(ident, fødselsdato, dødsdato, forelderRolle);
         }
     }
 }

--- a/domenetjenester/registerinnhenting/src/main/java/no/nav/foreldrepenger/domene/registerinnhenting/RegisterdataInnhenter.java
+++ b/domenetjenester/registerinnhenting/src/main/java/no/nav/foreldrepenger/domene/registerinnhenting/RegisterdataInnhenter.java
@@ -124,8 +124,9 @@ public class RegisterdataInnhenter {
         var rolleFiltrertFødselFREG = personopplysningInnhenter.innhentAlleFødteForIntervaller(behandling.getFagsakYtelseType(), behandling.getRelasjonsRolleType(), behandling.getAktørId(), fødselsIntervall);
         var filtrertFødselFREG = personopplysningInnhenter.innhentAlleFødteForIntervaller(behandling.getFagsakYtelseType(), behandling.getAktørId(), fødselsIntervall);
         if (rolleFiltrertFødselFREG.size() != filtrertFødselFREG.size()) {
-            LOG.info("Innhent FamilieHendelse ulike antall barn - sak {} rolle {} barn/rolle {} barn/alle {}", behandling.getSaksnummer().getVerdi(),
-                behandling.getRelasjonsRolleType(), rolleFiltrertFødselFREG, filtrertFødselFREG);
+            var funnetRoller = filtrertFødselFREG.stream().map(FødtBarnInfo::forelderRolle).collect(Collectors.toSet());
+            LOG.info("Brukerrolle sak {} Innhent FamilieHendelse  saksrolle {} registerRolle {} barn/saksrolle {} barn/alle {} ",
+                behandling.getSaksnummer().getVerdi(), behandling.getRelasjonsRolleType(), funnetRoller, rolleFiltrertFødselFREG, filtrertFødselFREG);
         }
         innhentPersoninformasjon(behandling, filtrertFødselFREG);
         innhentFamiliehendelse(behandling.getId(), rolleFiltrertFødselFREG.isEmpty() ? filtrertFødselFREG : rolleFiltrertFødselFREG);


### PR DESCRIPTION
Går på logging av
* Korrigering av rolle i søknadoversetter - tar hensyn til mulige språkutfordringer, ikke juridisk kjønn.
* Avvik mellom rollefiltrerte barn innenfor fødselsintervall og registerdata. 

På sikt: Mulig aksjonspunkt for å avklare saksrolle - må være veldig tidlig i prosessen pga STP-vurdering.
Antagelig er en exception mer relevant rett etter RegistrerSøknadSteg mest best. (Sammen med swagger-metode)