### PR TITLE
Forslag til hvordan kutte ned på lengde på DTO i OpenApi

### DIFF
--- a/web/src/main/java/no/nav/foreldrepenger/web/app/konfig/ApiConfig.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/konfig/ApiConfig.java
@@ -82,8 +82,7 @@ public class ApiConfig extends Application {
 
             // Her ber vi den om å inkludere pakkenavn i typenavnet. Da risikerer vi ikke kollisjon ved like typenavn. fqn = fully-qualified-name.
             // Ved kollisjon vil den som er sist prosessert overskrive alle tidligere.
-            var typeNameResolver =new PrefixStrippingFQNTypeNameResolver("no.nav.foreldrepenger.web.app.", "no.nav.");
-            typeNameResolver.setUseFqn(true);
+            var typeNameResolver = new EgenPrefix();
 
             ModelConverters.getInstance().addConverter(new ModelResolver(lagObjectMapperUtenJsonSubTypeAnnotasjoner(),  typeNameResolver));
 

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/konfig/EgenPrefix.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/konfig/EgenPrefix.java
@@ -1,0 +1,66 @@
+package no.nav.foreldrepenger.web.app.konfig;
+
+
+import io.swagger.v3.core.jackson.TypeNameResolver;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+public class EgenPrefix extends TypeNameResolver {
+    private final Map<String, Class<?>> previouslyResolvedTo;
+
+    public EgenPrefix() {
+        this.previouslyResolvedTo = new HashMap<>();
+        this.setUseFqn(true);
+    }
+
+    private boolean hasPreviouslyResolvedToOtherClass(String name, Class<?> cls) {
+        Class<?> prevCls = (Class)this.previouslyResolvedTo.get(name);
+        if (cls != null && prevCls != null) {
+            return !prevCls.equals(cls);
+        } else {
+            return false;
+        }
+    }
+
+    private String strippedName(String fqn, Class<?> cls) {
+        String dtoNavn = fqn.replaceAll("^.*\\.", "");
+
+        if (!this.hasPreviouslyResolvedToOtherClass(dtoNavn, cls)) {
+            return dtoNavn;
+        }
+
+        return fqn;
+    }
+
+    protected String getNameOfClass(Class<?> cls) {
+        String name = this.strippedName(super.getNameOfClass(cls), cls);
+        if (this.hasPreviouslyResolvedToOtherClass(name, cls)) {
+            Class<?> otherClass = (Class)this.previouslyResolvedTo.get(name);
+            if (otherClass != null) {
+                throw new IllegalArgumentException("Type name \"" + name + "\", (for class" + cls.getName() + ") has previously resolved to another class (" + otherClass.getName() + ")");
+            } else {
+                throw new IllegalArgumentException("Type name \"" + name + "\", (for class" + cls.getName() + ") has previously resolved to another class");
+            }
+        }
+
+        var dtoNavnErTatt = this.previouslyResolvedTo.get(name) != null;
+
+        if (dtoNavnErTatt) {
+            var fqn = super.getNameOfClass(cls);
+            var navnDeler = fqn.split("\\.");
+
+            // Prefix på 3 ledd er nok for å sikre unikhet
+            String nyttNavnMed3PrefixLedd = String.join(".", Arrays.copyOfRange(navnDeler, navnDeler.length-3, navnDeler.length));
+            this.previouslyResolvedTo.put(nyttNavnMed3PrefixLedd, cls);
+            return nyttNavnMed3PrefixLedd;
+        }
+
+        this.previouslyResolvedTo.put(name, cls);
+//        var antallDtoMedDot = this.previouslyResolvedTo.keySet().stream().filter(k -> k.contains(".")).count();
+//        System.out.println(antallDtoMedDot);
+        return name;
+
+    }
+}

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/konfig/EgenPrefix.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/konfig/EgenPrefix.java
@@ -15,35 +15,12 @@ public class EgenPrefix extends TypeNameResolver {
         this.setUseFqn(true);
     }
 
-    private boolean hasPreviouslyResolvedToOtherClass(String name, Class<?> cls) {
-        Class<?> prevCls = (Class)this.previouslyResolvedTo.get(name);
-        if (cls != null && prevCls != null) {
-            return !prevCls.equals(cls);
-        } else {
-            return false;
-        }
-    }
-
-    private String strippedName(String fqn, Class<?> cls) {
-        String dtoNavn = fqn.replaceAll("^.*\\.", "");
-
-        if (!this.hasPreviouslyResolvedToOtherClass(dtoNavn, cls)) {
-            return dtoNavn;
-        }
-
-        return fqn;
+    private String strippedName(String fqn) {
+        return fqn.replaceAll("^.*\\.", "");
     }
 
     protected String getNameOfClass(Class<?> cls) {
-        String name = this.strippedName(super.getNameOfClass(cls), cls);
-        if (this.hasPreviouslyResolvedToOtherClass(name, cls)) {
-            Class<?> otherClass = (Class)this.previouslyResolvedTo.get(name);
-            if (otherClass != null) {
-                throw new IllegalArgumentException("Type name \"" + name + "\", (for class" + cls.getName() + ") has previously resolved to another class (" + otherClass.getName() + ")");
-            } else {
-                throw new IllegalArgumentException("Type name \"" + name + "\", (for class" + cls.getName() + ") has previously resolved to another class");
-            }
-        }
+        String name = this.strippedName(super.getNameOfClass(cls));
 
         var dtoNavnErTatt = this.previouslyResolvedTo.get(name) != null;
 
@@ -58,9 +35,6 @@ public class EgenPrefix extends TypeNameResolver {
         }
 
         this.previouslyResolvedTo.put(name, cls);
-//        var antallDtoMedDot = this.previouslyResolvedTo.keySet().stream().filter(k -> k.contains(".")).count();
-//        System.out.println(antallDtoMedDot);
         return name;
-
     }
 }


### PR DESCRIPTION
For å unngå DTO navnekonflikter har vi til nå brukt fully qualified name for å sikre unikhet. Men det gir veldig kronglete typenavn å forholde seg til i frontend.

Eksempler:
* foreldrepenger_behandlingslager_behandling_aksjonspunkt_AksjonspunktType
* foreldrepenger_domene_arbeidInntektsmelding_dto_InntektsmeldingDto
* foreldrepenger_domene_arbeidsforhold_dto_InntektsmeldingDto

Denne forsøker å kunne legge på prefixer der det er kollisjoner. Hvis det er en kollisjon vil DTOen som kollider få prefix i 3 ledd bakover. Det sikrer unikhet.

Da går vi til disse istedenfor
* AksjonspunktType
* InntektsmeldingDto
* arbeidsforhold_dto_InntektsmeldingDto

Dette er bare et forslag og åpner for andre ideer til hvordan dette best kan løses!

