### PR TITLE
TFP-6401 sortere barn mer konsekvent

### DIFF
--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/familiehendelse/UidentifisertBarn.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/familiehendelse/UidentifisertBarn.java
@@ -1,6 +1,7 @@
 package no.nav.foreldrepenger.behandlingslager.behandling.familiehendelse;
 
 import java.time.LocalDate;
+import java.util.Comparator;
 import java.util.Optional;
 
 /**
@@ -9,9 +10,16 @@ import java.util.Optional;
  */
 public interface UidentifisertBarn {
 
+    Comparator<UidentifisertBarn> FØDSEL_COMPARATOR = Comparator.comparing(UidentifisertBarn::getFødselsdato, Comparator.naturalOrder())
+            .thenComparing(UidentifisertBarn::getDødsdatoNullable, Comparator.nullsFirst(Comparator.naturalOrder()));
+
     LocalDate getFødselsdato();
 
     Optional<LocalDate> getDødsdato();
+
+    default LocalDate getDødsdatoNullable() {
+        return getDødsdato().orElse(null);
+    }
 
     Integer getBarnNummer();
 

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/familiehendelse/UidentifisertBarnEntitet.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/familiehendelse/UidentifisertBarnEntitet.java
@@ -46,9 +46,8 @@ public class UidentifisertBarnEntitet extends BaseEntitet implements Uidentifise
 
     /**
      * Bruker ikke builder pattern siden få felter.
-     * Denne constructor får være public.
      */
-    public UidentifisertBarnEntitet(LocalDate fødselsdato) {
+    private UidentifisertBarnEntitet(LocalDate fødselsdato) {
         this.fødselsdato = fødselsdato;
     }
 

--- a/domenetjenester/familie-hendelse/src/main/java/no/nav/foreldrepenger/familiehendelse/aksjonspunkt/fødsel/FaktaFødselTjeneste.java
+++ b/domenetjenester/familie-hendelse/src/main/java/no/nav/foreldrepenger/familiehendelse/aksjonspunkt/fødsel/FaktaFødselTjeneste.java
@@ -134,7 +134,7 @@ public class FaktaFødselTjeneste {
 
             addLinjeForAntallBarn(fh, oppdatertFødselStatus, historikkinnslag);
 
-            if (oppdatertFødselStatus.size() != gjeldendeFødselStatus.size() || !oppdatertFødselStatus.containsAll(gjeldendeFødselStatus)) {
+            if (!oppdatertFødselStatus.equals(gjeldendeFødselStatus)) {
                 addLinjerForBarn(oppdatertFødselStatus, gjeldendeFødselStatus, historikkinnslag);
             }
         }

--- a/domenetjenester/familie-hendelse/src/main/java/no/nav/foreldrepenger/familiehendelse/aksjonspunkt/fødsel/FaktaFødselTjeneste.java
+++ b/domenetjenester/familie-hendelse/src/main/java/no/nav/foreldrepenger/familiehendelse/aksjonspunkt/fødsel/FaktaFødselTjeneste.java
@@ -18,6 +18,7 @@ import no.nav.foreldrepenger.behandling.aksjonspunkt.OppdateringResultat;
 import no.nav.foreldrepenger.behandlingslager.behandling.familiehendelse.FamilieHendelseBuilder;
 import no.nav.foreldrepenger.behandlingslager.behandling.familiehendelse.FamilieHendelseGrunnlagEntitet;
 import no.nav.foreldrepenger.behandlingslager.behandling.familiehendelse.TerminbekreftelseEntitet;
+import no.nav.foreldrepenger.behandlingslager.behandling.familiehendelse.UidentifisertBarn;
 import no.nav.foreldrepenger.behandlingslager.behandling.historikk.HistorikkAktør;
 import no.nav.foreldrepenger.behandlingslager.behandling.historikk.Historikkinnslag;
 import no.nav.foreldrepenger.behandlingslager.behandling.historikk.HistorikkinnslagLinjeBuilder;
@@ -31,6 +32,10 @@ import no.nav.vedtak.exception.FunksjonellException;
 
 @ApplicationScoped
 public class FaktaFødselTjeneste {
+
+    private static final Comparator<DokumentertBarnDto> DOKBARN_COMPARATOR = Comparator.comparing(DokumentertBarnDto::fødselsdato, Comparator.naturalOrder())
+        .thenComparing(DokumentertBarnDto::dødsdato, Comparator.nullsFirst(Comparator.naturalOrder()));
+
     private FamilieHendelseTjeneste familieHendelseTjeneste;
     private OpplysningsPeriodeTjeneste opplysningsPeriodeTjeneste;
     private HistorikkinnslagRepository historikkinnslagRepository;
@@ -84,7 +89,7 @@ public class FaktaFødselTjeneste {
 
         if (barna.isPresent()) {
             oppdatere.medFødselType().tilbakestillBarn().medAntallBarn(barna.get().size());
-            barna.get().forEach(b -> oppdatere.leggTilBarn(b.fødselsdato(), b.dødsdato()));
+            barna.get().stream().sorted(DOKBARN_COMPARATOR).forEach(b -> oppdatere.leggTilBarn(b.fødselsdato(), b.dødsdato()));
         } else {
             resetBarna(familieHendelse, oppdatere);
         }
@@ -124,12 +129,12 @@ public class FaktaFødselTjeneste {
         historikkinnslag.addLinje(new HistorikkinnslagLinjeBuilder().bold("Er barnet født?").tekst(format(barna.isPresent())));
 
         if (barna.isPresent()) {
-            var oppdatertFødselStatus = barna.get().stream().map(FødselStatus::new).toList();
-            var gjeldendeFødselStatus = fh.getGjeldendeBarna().stream().map(FødselStatus::new).toList();
+            var oppdatertFødselStatus = barna.get().stream().map(FødselStatus::new).sorted(UidentifisertBarn.FØDSEL_COMPARATOR).toList();
+            var gjeldendeFødselStatus = fh.getGjeldendeBarna().stream().map(FødselStatus::new).sorted(UidentifisertBarn.FØDSEL_COMPARATOR).toList();
 
             addLinjeForAntallBarn(fh, oppdatertFødselStatus, historikkinnslag);
 
-            if (!oppdatertFødselStatus.equals(gjeldendeFødselStatus)) {
+            if (oppdatertFødselStatus.size() != gjeldendeFødselStatus.size() || !oppdatertFødselStatus.containsAll(gjeldendeFødselStatus)) {
                 addLinjerForBarn(oppdatertFødselStatus, gjeldendeFødselStatus, historikkinnslag);
             }
         }

--- a/domenetjenester/familie-hendelse/src/main/java/no/nav/foreldrepenger/familiehendelse/aksjonspunkt/fødsel/modell/FødselStatus.java
+++ b/domenetjenester/familie-hendelse/src/main/java/no/nav/foreldrepenger/familiehendelse/aksjonspunkt/fødsel/modell/FødselStatus.java
@@ -74,8 +74,6 @@ public class FødselStatus implements UidentifisertBarn, Comparable<FødselStatu
 
     @Override
     public int compareTo(FødselStatus other) {
-        return Comparator.comparing((FødselStatus p) -> p.fødselsdato)
-            .thenComparing(p -> p.dødsdato, Comparator.nullsLast(Comparator.naturalOrder()))
-            .compare(this, other);
+        return UidentifisertBarn.FØDSEL_COMPARATOR.compare(this, other);
     }
 }

--- a/domenetjenester/familie-hendelse/src/test/java/no/nav/foreldrepenger/familiehendelse/aksjonspunkt/adopsjon/BekreftDokumentasjonOppdatererTest.java
+++ b/domenetjenester/familie-hendelse/src/test/java/no/nav/foreldrepenger/familiehendelse/aksjonspunkt/adopsjon/BekreftDokumentasjonOppdatererTest.java
@@ -15,7 +15,6 @@ import no.nav.foreldrepenger.behandling.BehandlingReferanse;
 import no.nav.foreldrepenger.behandling.aksjonspunkt.AksjonspunktOppdaterParameter;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingStegType;
 import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.AksjonspunktDefinisjon;
-import no.nav.foreldrepenger.behandlingslager.behandling.familiehendelse.UidentifisertBarnEntitet;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepositoryProvider;
 import no.nav.foreldrepenger.behandlingslager.behandling.søknad.FarSøkerType;
 import no.nav.foreldrepenger.behandlingslager.testutilities.behandling.ScenarioFarSøkerEngangsstønad;
@@ -48,7 +47,7 @@ class BekreftDokumentasjonOppdatererTest extends EntityManagerAwareTest {
         scenario.medSøknad().medFarSøkerType(FarSøkerType.ADOPTERER_ALENE);
         scenario.medSøknadHendelse()
             .medAdopsjon(scenario.medSøknadHendelse().getAdopsjonBuilder().medOmsorgsovertakelseDato(opprinneligOvertakelsesdato))
-            .leggTilBarn(new UidentifisertBarnEntitet(opprinneligFødselsdato));
+            .leggTilBarn(opprinneligFødselsdato);
         scenario.medBekreftetHendelse()
             .medAdopsjon(scenario.medBekreftetHendelse().getAdopsjonBuilder().medOmsorgsovertakelseDato(opprinneligOvertakelsesdato))
             .leggTilBarn(opprinneligFødselsdato);

--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/dokumentpersiterer/impl/søknad/v3/FamilieHendelseOversetter.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/dokumentpersiterer/impl/søknad/v3/FamilieHendelseOversetter.java
@@ -1,5 +1,6 @@
 package no.nav.foreldrepenger.mottak.dokumentpersiterer.impl.søknad.v3;
 
+import java.util.Comparator;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -101,7 +102,7 @@ public class FamilieHendelseOversetter  {
     private void byggOmsorgsovertakelsesrelaterteFelter(Omsorgsovertakelse omsorgsovertakelse,
                                                         FamilieHendelseBuilder hendelseBuilder,
                                                         SøknadEntitet.Builder søknadBuilder) {
-        var fødselsdatoene = omsorgsovertakelse.getFoedselsdato();
+        var fødselsdatoene = omsorgsovertakelse.getFoedselsdato().stream().sorted(Comparator.naturalOrder()).toList();
 
         hendelseBuilder.tilbakestillBarn().medAntallBarn(omsorgsovertakelse.getAntallBarn());
         var familieHendelseAdopsjon = hendelseBuilder.getAdopsjonBuilder().medOmsorgsovertakelseDato(omsorgsovertakelse.getOmsorgsovertakelsesdato());
@@ -121,7 +122,7 @@ public class FamilieHendelseOversetter  {
 
 
     private void byggAdopsjonsrelaterteFelter(Adopsjon adopsjon, FamilieHendelseBuilder hendelseBuilder) {
-        var fødselsdatoene = adopsjon.getFoedselsdato();
+        var fødselsdatoene = adopsjon.getFoedselsdato().stream().sorted(Comparator.naturalOrder()).toList();
 
         hendelseBuilder.tilbakestillBarn().medAntallBarn(adopsjon.getAntallBarn());
         var familieHendelseAdopsjon = hendelseBuilder.getAdopsjonBuilder()

--- a/domenetjenester/person/src/main/java/no/nav/foreldrepenger/domene/person/pdl/FødselTjeneste.java
+++ b/domenetjenester/person/src/main/java/no/nav/foreldrepenger/domene/person/pdl/FødselTjeneste.java
@@ -3,6 +3,7 @@ package no.nav.foreldrepenger.domene.person.pdl;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
 
@@ -34,6 +35,9 @@ import no.nav.vedtak.felles.integrasjon.person.PersonMappers;
 
 @ApplicationScoped
 public class FødselTjeneste {
+
+    private static final Comparator<FødtBarnInfo> FØDTBARNINFO_COMPARATOR = Comparator.comparing(FødtBarnInfo::fødselsdato, Comparator.naturalOrder())
+        .thenComparing(FødtBarnInfo::dødsdato, Comparator.nullsFirst(Comparator.naturalOrder()));
 
     private static final Logger LOG = LoggerFactory.getLogger(FødselTjeneste.class);
 
@@ -74,6 +78,7 @@ public class FødselTjeneste {
 
         return alleBarn.stream()
                 .filter(fBI -> intervaller.stream().anyMatch(i -> i.encloses(fBI.fødselsdato())))
+                .sorted(FØDTBARNINFO_COMPARATOR)
                 .toList();
     }
 

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/fødsel/OmsorgsovertakelseTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/fødsel/OmsorgsovertakelseTjeneste.java
@@ -16,6 +16,7 @@ import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingsresultatRepo
 import no.nav.foreldrepenger.behandlingslager.behandling.familiehendelse.AdopsjonEntitet;
 import no.nav.foreldrepenger.behandlingslager.behandling.familiehendelse.FamilieHendelseEntitet;
 import no.nav.foreldrepenger.behandlingslager.behandling.familiehendelse.OmsorgsovertakelseVilkårType;
+import no.nav.foreldrepenger.behandlingslager.behandling.familiehendelse.UidentifisertBarn;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.vilkår.VilkårResultat;
 import no.nav.foreldrepenger.behandlingslager.behandling.vilkår.VilkårType;
@@ -94,14 +95,11 @@ public class OmsorgsovertakelseTjeneste {
             familieHendelse.getAdopsjon().map(AdopsjonEntitet::getAnkomstNorgeDato).orElse(null));
     }
 
-    private static <T> int getBarnNummer(T barn, List<T> barnListe) {
-        return barnListe.indexOf(barn) + 1;
-    }
-
     private List<OmsorgsovertakelseDto.BarnHendelseData> getBarn(FamilieHendelseEntitet familieHendelse) {
         return Optional.ofNullable(familieHendelse).map(FamilieHendelseEntitet::getBarna).orElseGet(List::of).stream()
+            .sorted(UidentifisertBarn.FØDSEL_COMPARATOR)
             .map(barn -> new OmsorgsovertakelseDto.BarnHendelseData(barn.getFødselsdato(), barn.getDødsdato().orElse(null),
-                getBarnNummer(barn, familieHendelse.getBarna())))
+                barn.getBarnNummer()))
             .toList();
     }
 

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/fødsel/dto/OmsorgsovertakelseDto.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/fødsel/dto/OmsorgsovertakelseDto.java
@@ -21,7 +21,7 @@ public record OmsorgsovertakelseDto(@NotNull Omsorgsovertakelse søknad,
     public record SaksbehandlerVurdering(@NotNull VilkårUtfallType vilkårUtfallType, Avslagsårsak avslagsårsak) {
     }
 
-    public record BarnHendelseData(@NotNull LocalDate fødselsdato, LocalDate dødsdato, Integer barnNummer) {
+    public record BarnHendelseData(@NotNull LocalDate fødselsdato, LocalDate dødsdato, @NotNull Integer barnNummer) {
     }
 
     public record Omsorgsovertakelse(@NotNull List<BarnHendelseData> barn, LocalDate omsorgsovertakelseDato, @NotNull int antallBarn,


### PR DESCRIPTION
Legger på mer konsekvent sortering av barn basert på fødselsdato + dødsdatoNullsFirst - innhenting, fødsel-AP, omsorg.

Jeg har nå lagt inn obligatorisk barnNummer opp til frontend og antatt at samme nummerering sendes ned. Kunne like godt fjerne barnNummer opp/ned frontend. Kommentarer ? 

Beholder Register-barn som egen nummerserie som ikke er korrelert med Søknadsbarn/Overstyrtbarn - det fordi man ikke bør matche på presise datoer - det innhentes i et vindu rundt oppgitt fødselsdato.

Hvis vi skal åpne for å endre fødselsdatoer eller legge til barn i omsorgsovertagelse, så må vi ta stilling til behov for ny registerinnhenting basert på tidsvinduer rundt nye datoer. Det er litt mer meta enn gjort i en håndvending.