### PR TITLE
FAGSYSTEM-401297: Forslag til strengere nullstilling av utfyllende test i vedtaksbrev

### DIFF
--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/Behandling.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/Behandling.java
@@ -563,16 +563,6 @@ public class Behandling extends BaseEntitet {
             .anyMatch(Aksjonspunkt::erAvbrutt);
     }
 
-    public boolean harAvbruttAlleAksjonspunktAvTyper(Set<AksjonspunktDefinisjon> aksjonspunktTyper) {
-        var relevanteAksjonspunkter = getAksjonspunkter().stream()
-            .filter(ap -> aksjonspunktTyper.contains(ap.getAksjonspunktDefinisjon()))
-            .toList();
-        if (relevanteAksjonspunkter.isEmpty()) {
-            return false;
-        }
-        return relevanteAksjonspunkter.stream().allMatch(Aksjonspunkt::erAvbrutt);
-    }
-
     public boolean harUtførtAksjonspunktMedType(AksjonspunktDefinisjon aksjonspunktDefinisjon) {
         return getAksjonspunktMedDefinisjonOptional(aksjonspunktDefinisjon)
             .map(ap -> ap.getStatus().equals(AksjonspunktStatus.UTFØRT)).orElse(false);

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/Behandlingsresultat.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/Behandlingsresultat.java
@@ -270,6 +270,10 @@ public class Behandlingsresultat extends BaseEntitet {
         }
     }
 
+    public boolean isBehandlingInnvilget() {
+        return BehandlingResultatType.getAlleInnvilgetKoder().contains(behandlingResultatType);
+    }
+
     public boolean isBehandlingHenlagt() {
         return BehandlingResultatType.getAlleHenleggelseskoder().contains(behandlingResultatType);
     }

--- a/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/foreslåvedtak/ForeslåVedtakTjenesteTest.java
+++ b/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/foreslåvedtak/ForeslåVedtakTjenesteTest.java
@@ -46,6 +46,7 @@ import no.nav.foreldrepenger.behandlingslager.testutilities.behandling.ScenarioM
 import no.nav.foreldrepenger.behandlingslager.testutilities.behandling.ScenarioMorSøkerForeldrepenger;
 import no.nav.foreldrepenger.dbstoette.CdiDbAwareTest;
 import no.nav.foreldrepenger.dokumentbestiller.DokumentBehandlingTjeneste;
+import no.nav.foreldrepenger.domene.prosess.BeregningTjeneste;
 import no.nav.foreldrepenger.domene.typer.AktørId;
 import no.nav.foreldrepenger.domene.vedtak.impl.KlageAnkeVedtakTjeneste;
 import no.nav.foreldrepenger.produksjonsstyring.oppgavebehandling.OppgaveTjeneste;
@@ -94,7 +95,7 @@ class ForeslåVedtakTjenesteTest {
         var sjekkMotEksisterendeOppgaverTjeneste = new SjekkMotEksisterendeOppgaverTjeneste(oppgaveTjeneste);
         var klageAnke = new KlageAnkeVedtakTjeneste(klageRepository, ankeRepository);
         tjeneste = new ForeslåVedtakTjeneste(fagsakRepository, behandlingRepository, behandlingsresultatRepository, klageAnke,
-            sjekkMotEksisterendeOppgaverTjeneste, dokumentBehandlingTjeneste, mock(FagsakEgenskapRepository.class));
+            sjekkMotEksisterendeOppgaverTjeneste, dokumentBehandlingTjeneste, mock(FagsakEgenskapRepository.class), mock(BeregningTjeneste.class));
     }
 
     @Test
@@ -216,7 +217,10 @@ class ForeslåVedtakTjenesteTest {
 
     @Test
     void nullstillerFritekstfeltetDersomIkkeLengerRelevant() {
-        behandling = ScenarioMorSøkerForeldrepenger.forFødsel().medBehandlingType(BehandlingType.FØRSTEGANGSSØKNAD).lagre(repositoryProvider);
+        behandling = ScenarioMorSøkerForeldrepenger.forFødsel()
+            .medBehandlingType(BehandlingType.FØRSTEGANGSSØKNAD)
+            .medBehandlingsresultat(Behandlingsresultat.builder().medBehandlingResultatType(BehandlingResultatType.INNVILGET))
+            .lagre(repositoryProvider);
         leggTilAksjonspunkt(AksjonspunktDefinisjon.VURDER_MEDLEMSKAPSVILKÅRET, true, false);
         leggTilAksjonspunkt(AksjonspunktDefinisjon.FASTSETT_BEREGNINGSGRUNNLAG_ARBEIDSTAKER_FRILANS, true, true);
         // Act

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/vedtak/aksjonspunkt/VedtaksbrevOverstyringDto.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/vedtak/aksjonspunkt/VedtaksbrevOverstyringDto.java
@@ -5,6 +5,7 @@ import no.nav.foreldrepenger.behandling.aksjonspunkt.BekreftetAksjonspunktDto;
 public abstract class VedtaksbrevOverstyringDto extends BekreftetAksjonspunktDto {
 
     private boolean skalBrukeOverstyrendeFritekstBrev;
+    private String utfyllendeBrevtekst;
 
     protected VedtaksbrevOverstyringDto() {
         // For Jackson


### PR DESCRIPTION
Fra tidligere har vi bare fjernet utfyllende frittekst vanlig automatiske vedtaksbrev:
1. Hvis det foreligger aksjonspunkt avvik i beregning, og alle disse er avbrutt => fjern
2. Hvis det ikke er totrinn => fjern
3. Ellers behold

Endring
1. Hvis det foreligger aksjonspunkt avvik i beregning, og alle disse er avbrutt 
OG Hvis manuelt fastsatte andeler på stp => fjern
2. Hvis det er entrinn => fjern
3. Hvis manuelt fastsatte andeler på stp => fjern

