### PR TITLE
bugfix: viderefør manuell revurder og ansvarlig saksbehandler

### DIFF
--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/Behandlingsoppretter.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/Behandlingsoppretter.java
@@ -121,7 +121,11 @@ public class Behandlingsoppretter {
         if (BehandlingType.FØRSTEGANGSSØKNAD.equals(sisteYtelseBehandling.getType())) {
             return opprettNyFørstegangsbehandlingMedImOgVedleggFraForrige(sisteYtelseBehandling.getFagsak(), revurderingsÅrsak, sisteYtelseBehandling,false);
         }
-        var revurdering = opprettRevurdering(sisteYtelseBehandling.getFagsak(), revurderingsÅrsak);
+        var manuell = sisteYtelseBehandling.erManueltOpprettet();
+        var revurdering = manuell ? opprettManuellRevurdering(sisteYtelseBehandling.getFagsak(), revurderingsÅrsak) : opprettRevurdering(sisteYtelseBehandling.getFagsak(), revurderingsÅrsak);
+        if (manuell) {
+            Optional.ofNullable(sisteYtelseBehandling.getAnsvarligSaksbehandler()).ifPresent(revurdering::setAnsvarligSaksbehandler);
+        }
 
         if (uregistrertPapirSøknadFP) {
             kopierPapirsøknadVedBehov(sisteYtelseBehandling, revurdering);


### PR DESCRIPTION
For tilfelle der en åpen manuell revurdering blir lagt i kø pga en berørt og så må reopprettes med den berørte som original.
Her har vi ikke tatt var på om revurderingen var manuelt opprettet (derfor fikk den startpunkt uttak).
Tar vare på om reopprettet revurdering var manuelt opprettet + evt ansvarlig saksbehandler (slik oppgaven blir reservert)