### PR TITLE
bugfix: Må scanne minst 1 aksjonspunkt-dto fra modul

### DIFF
--- a/web/src/main/java/no/nav/foreldrepenger/web/app/jackson/JacksonJsonConfig.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/jackson/JacksonJsonConfig.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import no.nav.foreldrepenger.domene.opptjening.dto.AvklarAktivitetsPerioderDto;
 import no.nav.foreldrepenger.domene.person.verge.dto.AvklarVergeDto;
 import no.nav.foreldrepenger.domene.rest.dto.VurderFaktaOmBeregningDto;
+import no.nav.foreldrepenger.familiehendelse.aksjonspunkt.omsorgsovertakelse.dto.VurderOmsorgsovertakelseVilkårAksjonspunktDto;
 import no.nav.foreldrepenger.web.app.IndexClasses;
 import no.nav.foreldrepenger.web.app.tjenester.RestImplementationClasses;
 
@@ -61,6 +62,7 @@ public class JacksonJsonConfig implements ContextResolver<ObjectMapper> {
         // andre dtoer
         scanClasses.add(AvklarAktivitetsPerioderDto.class);
         scanClasses.add(VurderFaktaOmBeregningDto.class);
+        scanClasses.add(VurderOmsorgsovertakelseVilkårAksjonspunktDto.class);
         scanClasses.add(AvklarVergeDto.class);
 
         // avled code location fra klassene


### PR DESCRIPTION
Dette er litt skrøpelig - jeg fjernet scanning av 1 klasse i domene/fam-hendelse, slik at ingen ble scannet - finner ingen av Dtos i modulen.

Peker på at vi bør flytte alle Dtos ut i en kontraksmodul slik at de er tilgjengelig bredere.