### PR TITLE
TFP-6443 første del av opprydding i søknaddto

### DIFF
--- a/domenetjenester/inngangsvilkar/src/main/java/no/nav/foreldrepenger/inngangsvilkaar/søknad/InngangsvilkårEngangsstønadSøknadsfrist.java
+++ b/domenetjenester/inngangsvilkar/src/main/java/no/nav/foreldrepenger/inngangsvilkaar/søknad/InngangsvilkårEngangsstønadSøknadsfrist.java
@@ -41,7 +41,7 @@ public class InngangsvilkårEngangsstønadSøknadsfrist implements Inngangsvilk�
     }
 
     private VilkårData vurderSøknadsfristOppfyltAutomatisk(BehandlingReferanse ref) {
-        var fristdata = fristTjeneste.finnSøknadsfrist(ref.behandlingId()).orElseThrow();
+        var fristdata = fristTjeneste.finnSøknadsfrist(ref.behandlingId());
 
         var søknadMottattDato = fristdata.getSøknadMottattDato();
         var fristdato = fristdata.getUtledetSøknadsfrist();

--- a/domenetjenester/skjaeringstidspunkt/src/main/java/no/nav/foreldrepenger/skjæringstidspunkt/SøknadsperiodeFristTjeneste.java
+++ b/domenetjenester/skjaeringstidspunkt/src/main/java/no/nav/foreldrepenger/skjæringstidspunkt/SøknadsperiodeFristTjeneste.java
@@ -1,11 +1,9 @@
 package no.nav.foreldrepenger.skjæringstidspunkt;
 
-import java.util.Optional;
-
 import no.nav.foreldrepenger.behandling.Søknadsfristdatoer;
 
 public interface SøknadsperiodeFristTjeneste {
 
-    Optional<Søknadsfristdatoer> finnSøknadsfrist(Long behandlingId);
+    Søknadsfristdatoer finnSøknadsfrist(Long behandlingId);
 
 }

--- a/domenetjenester/skjaeringstidspunkt/src/main/java/no/nav/foreldrepenger/skjæringstidspunkt/SøknadsperiodeFristTjenesteImpl.java
+++ b/domenetjenester/skjaeringstidspunkt/src/main/java/no/nav/foreldrepenger/skjæringstidspunkt/SøknadsperiodeFristTjenesteImpl.java
@@ -1,7 +1,5 @@
 package no.nav.foreldrepenger.skjæringstidspunkt;
 
-import java.util.Optional;
-
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 
@@ -34,7 +32,7 @@ public class SøknadsperiodeFristTjenesteImpl implements SøknadsperiodeFristTje
     }
 
     @Override
-    public Optional<Søknadsfristdatoer> finnSøknadsfrist(Long behandlingId) {
+    public Søknadsfristdatoer finnSøknadsfrist(Long behandlingId) {
         var behandling = behandlingRepository.hentBehandling(behandlingId);
         if (behandling.erYtelseBehandling()) {
             if (FagsakYtelseType.ENGANGSTØNAD.equals(behandling.getFagsakYtelseType())) {
@@ -50,7 +48,7 @@ public class SøknadsperiodeFristTjenesteImpl implements SøknadsperiodeFristTje
         }
         // returner tom container for andre behandlingtyper
         // (så ser vi om det evt. er noen call paths som kaller på noen form for skjæringstidspunkt)
-        return Optional.of(Søknadsfristdatoer.builder().build());
+        return Søknadsfristdatoer.builder().build();
     }
 
 }

--- a/domenetjenester/skjaeringstidspunkt/src/main/java/no/nav/foreldrepenger/skjæringstidspunkt/es/SøknadsperiodeFristTjenesteImpl.java
+++ b/domenetjenester/skjaeringstidspunkt/src/main/java/no/nav/foreldrepenger/skjæringstidspunkt/es/SøknadsperiodeFristTjenesteImpl.java
@@ -6,7 +6,6 @@ import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.Period;
 import java.util.EnumSet;
-import java.util.Optional;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -44,14 +43,14 @@ public class SøknadsperiodeFristTjenesteImpl implements SøknadsperiodeFristTje
     }
 
     @Override
-    public Optional<Søknadsfristdatoer> finnSøknadsfrist(Long behandlingId) {
+    public Søknadsfristdatoer finnSøknadsfrist(Long behandlingId) {
         var intervall = familieGrunnlagRepository.hentAggregatHvisEksisterer(behandlingId)
             .map(FamilieHendelseGrunnlagEntitet::getGjeldendeVersjon)
             .map(FamilieHendelseEntitet::getSkjæringstidspunkt)
             .map(fhdato -> new LocalDateInterval(fhdato, fhdato))
             .orElse(null);
 
-        return Optional.of(finnSøknadsfrist(behandlingId, intervall));
+        return finnSøknadsfrist(behandlingId, intervall);
     }
 
     private Søknadsfristdatoer finnSøknadsfrist(Long behandlingId, LocalDateInterval søknadsperiode) {

--- a/domenetjenester/skjaeringstidspunkt/src/main/java/no/nav/foreldrepenger/skjæringstidspunkt/fp/SøknadsperiodeFristTjenesteImpl.java
+++ b/domenetjenester/skjaeringstidspunkt/src/main/java/no/nav/foreldrepenger/skjæringstidspunkt/fp/SøknadsperiodeFristTjenesteImpl.java
@@ -5,7 +5,6 @@ import static java.time.temporal.ChronoUnit.DAYS;
 import java.time.LocalDate;
 import java.util.Comparator;
 import java.util.List;
-import java.util.Optional;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -43,7 +42,7 @@ public class SøknadsperiodeFristTjenesteImpl implements SøknadsperiodeFristTje
     }
 
     @Override
-    public Optional<Søknadsfristdatoer> finnSøknadsfrist(Long behandlingId) {
+    public Søknadsfristdatoer finnSøknadsfrist(Long behandlingId) {
         var søknadMottattDato = søknadRepository.hentSøknadHvisEksisterer(behandlingId)
             .map(SøknadEntitet::getMottattDato).orElse(null);
         var perioder = ytelsesFordelingRepository.hentAggregatHvisEksisterer(behandlingId)
@@ -55,7 +54,7 @@ public class SøknadsperiodeFristTjenesteImpl implements SøknadsperiodeFristTje
         var max = perioder.stream().map(OppgittPeriodeEntitet::getTom).max(Comparator.naturalOrder());
         var periode = min.map(m -> new LocalDateInterval(m, max.orElseThrow())).orElse(null);
 
-        return Optional.of(finnSøknadsfrist(behandlingId, periode));
+        return finnSøknadsfrist(behandlingId, periode);
     }
 
     private Søknadsfristdatoer finnSøknadsfrist(Long behandlingId, LocalDateInterval søknadsperiode) {

--- a/domenetjenester/skjaeringstidspunkt/src/main/java/no/nav/foreldrepenger/skjæringstidspunkt/svp/SøknadsperiodeFristTjenesteImpl.java
+++ b/domenetjenester/skjaeringstidspunkt/src/main/java/no/nav/foreldrepenger/skjæringstidspunkt/svp/SøknadsperiodeFristTjenesteImpl.java
@@ -54,14 +54,14 @@ public class SøknadsperiodeFristTjenesteImpl implements SøknadsperiodeFristTje
     }
 
     @Override
-    public Optional<Søknadsfristdatoer> finnSøknadsfrist(Long behandlingId) {
+    public Søknadsfristdatoer finnSøknadsfrist(Long behandlingId) {
         var familieHendelseEntitet = familieHendelseRepository.hentAggregatHvisEksisterer(behandlingId)
             .map(FamilieHendelseGrunnlagEntitet::getGjeldendeVersjon);
         var tilretteleggingFom = svangerskapspengerRepository.hentGrunnlag(behandlingId)
             .flatMap(SøknadsperiodeFristTjenesteImpl::utledNettoSøknadsperiodeFomFraGrunnlag);
 
         if (fødselFørTilrettelegging(familieHendelseEntitet, tilretteleggingFom)) {
-            return Optional.of(finnSøknadsfrist(behandlingId, null));
+            return finnSøknadsfrist(behandlingId, null);
         }
 
         var tomFraTermin = familieHendelseEntitet
@@ -69,7 +69,7 @@ public class SøknadsperiodeFristTjenesteImpl implements SøknadsperiodeFristTje
 
         var periode = tilretteleggingFom.map(fom -> new LocalDateInterval(fom, tomFraTermin.orElse(fom))).orElse(null);
 
-        return Optional.of(finnSøknadsfrist(behandlingId, periode));
+        return finnSøknadsfrist(behandlingId, periode);
     }
 
     private boolean fødselFørTilrettelegging(Optional<FamilieHendelseEntitet> familieHendelseEntitet, Optional<LocalDate> tilretteleggingFom) {

--- a/domenetjenester/skjaeringstidspunkt/src/test/java/no/nav/foreldrepenger/skjæringstidspunkt/fp/SøknadsperiodeFristTjenesteImplTest.java
+++ b/domenetjenester/skjaeringstidspunkt/src/test/java/no/nav/foreldrepenger/skjæringstidspunkt/fp/SøknadsperiodeFristTjenesteImplTest.java
@@ -53,9 +53,8 @@ class SøknadsperiodeFristTjenesteImplTest extends EntityManagerAwareTest {
 
         var tjeneste = tjeneste(repositoryProvider);
 
-        assertThat(tjeneste.finnSøknadsfrist(behandling.getId())).isPresent();
-        assertThat(tjeneste.finnSøknadsfrist(behandling.getId()).orElseThrow().getSøknadGjelderPeriode().getFomDato()).isEqualTo(fedrekvoteFom);
-        assertThat(tjeneste.finnSøknadsfrist(behandling.getId()).orElseThrow().getSøknadGjelderPeriode().getTomDato()).isEqualTo(fedrekvoteTom);
+        assertThat(tjeneste.finnSøknadsfrist(behandling.getId()).getSøknadGjelderPeriode().getFomDato()).isEqualTo(fedrekvoteFom);
+        assertThat(tjeneste.finnSøknadsfrist(behandling.getId()).getSøknadGjelderPeriode().getTomDato()).isEqualTo(fedrekvoteTom);
     }
 
     @Test
@@ -72,10 +71,7 @@ class SøknadsperiodeFristTjenesteImplTest extends EntityManagerAwareTest {
 
         var tjeneste = tjeneste(repositoryProvider);
         var resultat = tjeneste.finnSøknadsfrist(behandling.getId());
-        System.out.println(resultat);
-        assertThat(resultat)
-            .isPresent()
-            .hasValueSatisfying(r -> assertThat(r.getSøknadGjelderPeriode()).isNull());
+        assertThat(resultat.getSøknadGjelderPeriode()).isNull();
     }
 
     private SøknadsperiodeFristTjeneste tjeneste(BehandlingRepositoryProvider repositoryProvider) {

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/dto/behandling/BehandlingDtoTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/dto/behandling/BehandlingDtoTjeneste.java
@@ -56,7 +56,6 @@ import no.nav.foreldrepenger.domene.uttak.UttakTjeneste;
 import no.nav.foreldrepenger.domene.uttak.beregnkontoer.UtregnetStønadskontoTjeneste;
 import no.nav.foreldrepenger.domene.vedtak.TotrinnTjeneste;
 import no.nav.foreldrepenger.domene.vedtak.intern.VedtaksbrevStatusUtleder;
-import no.nav.foreldrepenger.konfig.Environment;
 import no.nav.foreldrepenger.skjæringstidspunkt.SkjæringstidspunktTjeneste;
 import no.nav.foreldrepenger.web.app.rest.ResourceLink;
 import no.nav.foreldrepenger.web.app.tjenester.behandling.BehandlingRestTjeneste;
@@ -354,7 +353,8 @@ public class BehandlingDtoTjeneste {
         var harSakenSøknad = søknadRepository.hentSøknadHvisEksisterer(behandling.getId()).isPresent();
         dto.setHarRegisterdata(harInnhentetRegisterData);
         dto.setHarSøknad(harSakenSøknad);
-        dto.leggTil(get(SøknadRestTjeneste.SOKNAD_PATH, "soknad", uuidDto));
+        dto.leggTil(get(SøknadRestTjeneste.SOKNAD_PATH, "soknad", uuidDto)); //TODO TFP-6443 slett
+        dto.leggTil(get(SøknadRestTjeneste.SØKNAD_PATH, "søknad", uuidDto));
 
         if (dto.isErAktivPapirsoknad()) {
             return dto;

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/medlem/MedlemskapDto.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/medlem/MedlemskapDto.java
@@ -3,11 +3,12 @@ package no.nav.foreldrepenger.web.app.tjenester.behandling.medlem;
 import static com.fasterxml.jackson.annotation.JsonInclude.Include;
 
 import java.time.LocalDate;
+import java.util.List;
 import java.util.Set;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-
 import jakarta.validation.constraints.NotNull;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
 
 import no.nav.foreldrepenger.behandlingslager.aktør.OppholdstillatelseType;
 import no.nav.foreldrepenger.behandlingslager.aktør.PersonstatusType;
@@ -27,12 +28,12 @@ public record MedlemskapDto(ManuellBehandlingResultat manuellBehandlingResultat,
                             LegacyManuellBehandling legacyManuellBehandling,
                             @NotNull Set<Region> regioner,
                             @NotNull Set<Personstatus> personstatuser,
-                            @NotNull Set<Utenlandsopphold> utenlandsopphold,
+                            @NotNull MedlemskapDto.OppgittUtlandsopphold oppgittUtlandsopphold,
+                            @NotNull Set<Utlandsopphold> utenlandsopphold, //TODO TFP-6443 slett
                             @NotNull Set<PersonadresseDto> adresser,
                             @NotNull Set<Oppholdstillatelse> oppholdstillatelser,
                             @NotNull Set<MedlemskapPeriode> medlemskapsperioder,
-                            @NotNull Set<MedlemskapAvvik> avvik,
-                            Annenpart annenpart) {
+                            @NotNull Set<MedlemskapAvvik> avvik, Annenpart annenpart) {
 
     private static final LocalDate OPPHOLD_CUTOFF = LocalDate.of(2018, 7, 1);
 
@@ -49,13 +50,8 @@ public record MedlemskapDto(ManuellBehandlingResultat manuellBehandlingResultat,
     record LegacyManuellBehandling(@NotNull Set<MedlemPeriode> perioder) {
 
         @JsonInclude(Include.NON_NULL)
-        record MedlemPeriode(@NotNull LocalDate vurderingsdato,
-                             Boolean oppholdsrettVurdering,
-                             Boolean erEosBorger,
-                             Boolean lovligOppholdVurdering,
-                             Boolean bosattVurdering,
-                             MedlemskapManuellVurderingType medlemskapManuellVurderingType,
-                             String begrunnelse) {
+        record MedlemPeriode(@NotNull LocalDate vurderingsdato, Boolean oppholdsrettVurdering, Boolean erEosBorger, Boolean lovligOppholdVurdering,
+                             Boolean bosattVurdering, MedlemskapManuellVurderingType medlemskapManuellVurderingType, String begrunnelse) {
         }
     }
 
@@ -68,9 +64,9 @@ public record MedlemskapDto(ManuellBehandlingResultat manuellBehandlingResultat,
         }
     }
 
-    record Utenlandsopphold(@NotNull LocalDate fom, LocalDate tom, @NotNull Landkoder landkode) {
-        public static Utenlandsopphold map(MedlemskapOppgittLandOppholdEntitet moloe) {
-            return new Utenlandsopphold(moloe.getPeriodeFom(), moloe.getPeriodeTom(), moloe.getLand());
+    record Utlandsopphold(@NotNull LocalDate fom, LocalDate tom, @NotNull Landkoder landkode, @NotNull String landNavn) {
+        public static Utlandsopphold map(MedlemskapOppgittLandOppholdEntitet moloe) {
+            return new Utlandsopphold(moloe.getPeriodeFom(), moloe.getPeriodeTom(), moloe.getLand(), Landkoder.navnLesbart(moloe.getLand()));
         }
     }
 
@@ -90,6 +86,11 @@ public record MedlemskapDto(ManuellBehandlingResultat manuellBehandlingResultat,
     }
 
     record Annenpart(@NotNull Set<PersonadresseDto> adresser, @NotNull Set<Region> regioner, @NotNull Set<Personstatus> personstatuser) {
+    }
+
+    record OppgittUtlandsopphold(@NotNull boolean oppholdSistePeriode, @NotNull boolean oppholdNestePeriode,
+                                 @NotNull List<Utlandsopphold> utlandsoppholdFør, @NotNull List<Utlandsopphold> utlandsoppholdEtter) {
+
     }
 }
 

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/søknad/SøknadDto.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/søknad/SøknadDto.java
@@ -1,0 +1,15 @@
+package no.nav.foreldrepenger.web.app.tjenester.behandling.søknad;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import jakarta.validation.constraints.NotNull;
+
+public record SøknadDto(@NotNull LocalDate mottattDato, String begrunnelseForSenInnsending, @NotNull List<ManglendeVedleggDto> manglendeVedlegg,
+                        @NotNull Søknadsfrist søknadsfrist) {
+
+    public record Søknadsfrist(LocalDate gjeldendeMottattDato, LocalDate utledetSøknadsfrist,
+                               LocalDate søknadsperiodeStart, LocalDate søknadsperiodeSlutt, @NotNull long dagerOversittetFrist) {
+
+    }
+}

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/søknad/SøknadDtoTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/søknad/SøknadDtoTjeneste.java
@@ -1,154 +1,71 @@
 package no.nav.foreldrepenger.web.app.tjenester.behandling.søknad;
 
-import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 
 import no.nav.foreldrepenger.behandling.BehandlingReferanse;
-import no.nav.foreldrepenger.behandling.FagsakRelasjonTjeneste;
-import no.nav.foreldrepenger.behandling.Søknadsfristdatoer;
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
 import no.nav.foreldrepenger.behandlingslager.behandling.DokumentTypeId;
-import no.nav.foreldrepenger.behandlingslager.behandling.familiehendelse.AdopsjonEntitet;
-import no.nav.foreldrepenger.behandlingslager.behandling.familiehendelse.FamilieHendelseEntitet;
-import no.nav.foreldrepenger.behandlingslager.behandling.familiehendelse.FamilieHendelseRepository;
-import no.nav.foreldrepenger.behandlingslager.behandling.familiehendelse.TerminbekreftelseEntitet;
-import no.nav.foreldrepenger.behandlingslager.behandling.familiehendelse.UidentifisertBarn;
-import no.nav.foreldrepenger.behandlingslager.behandling.personopplysning.RelasjonsRolleType;
-import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepositoryProvider;
 import no.nav.foreldrepenger.behandlingslager.behandling.søknad.SøknadEntitet;
 import no.nav.foreldrepenger.behandlingslager.behandling.søknad.SøknadRepository;
-import no.nav.foreldrepenger.behandlingslager.fagsak.Dekningsgrad;
 import no.nav.foreldrepenger.behandlingslager.uttak.Uttaksperiodegrense;
 import no.nav.foreldrepenger.behandlingslager.uttak.UttaksperiodegrenseRepository;
-import no.nav.foreldrepenger.domene.medlem.MedlemTjeneste;
-import no.nav.foreldrepenger.domene.tid.VirkedagUtil;
-import no.nav.foreldrepenger.domene.ytelsefordeling.YtelseFordelingTjeneste;
 import no.nav.foreldrepenger.kompletthet.Kompletthetsjekker;
 import no.nav.foreldrepenger.kompletthet.ManglendeVedlegg;
-import no.nav.foreldrepenger.skjæringstidspunkt.SkjæringstidspunktTjeneste;
 import no.nav.foreldrepenger.skjæringstidspunkt.SøknadsperiodeFristTjeneste;
 import no.nav.fpsak.tidsserie.LocalDateInterval;
 
 @ApplicationScoped
 public class SøknadDtoTjeneste {
 
-    private SkjæringstidspunktTjeneste skjæringstidspunktTjeneste;
     private SøknadsperiodeFristTjeneste fristTjeneste;
     private Kompletthetsjekker kompletthetsjekker;
-    private FamilieHendelseRepository familieHendelseRepository;
-    private YtelseFordelingTjeneste ytelseFordelingTjeneste;
     private UttaksperiodegrenseRepository uttaksperiodegrenseRepository;
     private SøknadRepository søknadRepository;
-    private MedlemTjeneste medlemTjeneste;
-    private FagsakRelasjonTjeneste fagsakRelasjonTjeneste;
-    private BehandlingRepository behandlingRepository;
-
-    protected SøknadDtoTjeneste() {
-        // for CDI proxy
-    }
 
     @Inject
     public SøknadDtoTjeneste(BehandlingRepositoryProvider repositoryProvider,
-                             SkjæringstidspunktTjeneste skjæringstidspunktTjeneste,
                              SøknadsperiodeFristTjeneste fristTjeneste,
-                             Kompletthetsjekker kompletthetsjekker,
-                             YtelseFordelingTjeneste ytelseFordelingTjeneste,
-                             MedlemTjeneste medlemTjeneste,
-                             FagsakRelasjonTjeneste fagsakRelasjonTjeneste) {
-        this.skjæringstidspunktTjeneste = skjæringstidspunktTjeneste;
+                             Kompletthetsjekker kompletthetsjekker) {
         this.fristTjeneste = fristTjeneste;
         this.kompletthetsjekker = kompletthetsjekker;
-        this.ytelseFordelingTjeneste = ytelseFordelingTjeneste;
-        this.medlemTjeneste = medlemTjeneste;
-        this.familieHendelseRepository = repositoryProvider.getFamilieHendelseRepository();
         this.søknadRepository = repositoryProvider.getSøknadRepository();
         this.uttaksperiodegrenseRepository = repositoryProvider.getUttaksperiodegrenseRepository();
-        this.fagsakRelasjonTjeneste = fagsakRelasjonTjeneste;
-        this.behandlingRepository = repositoryProvider.getBehandlingRepository();
     }
 
-    public Optional<SoknadDto> mapFra(Behandling behandling) {
-        return søknadRepository.hentSøknadHvisEksisterer(behandling.getId())
-            .map(s -> getSøknadDto(behandling, s));
+    SøknadDtoTjeneste() {
+        // for CDI proxy
     }
 
-    private SoknadDto getSøknadDto(Behandling behandling, SøknadEntitet søknad) {
+    public Optional<SøknadDto> lagDto(Behandling behandling) {
+        return søknadRepository.hentSøknadHvisEksisterer(behandling.getId()).map(s -> lagSøknadDto(behandling, s));
+    }
+
+    private SøknadDto lagSøknadDto(Behandling behandling, SøknadEntitet søknad) {
         var ref = BehandlingReferanse.fra(behandling);
-        var fhGrunnlag = familieHendelseRepository.hentAggregat(behandling.getId());
-        if (fhGrunnlag.getSøknadVersjon().getGjelderFødsel()) {
-            return lagSoknadFodselDto(søknad, fhGrunnlag.getSøknadVersjon(), ref);
-        } else {
-            return lagSoknadAdopsjonDto(søknad, fhGrunnlag.getSøknadVersjon(), ref);
-        }
-    }
-
-    private SoknadDto lagSoknadFodselDto(SøknadEntitet søknad, FamilieHendelseEntitet familieHendelse, BehandlingReferanse ref) {
         var behandlingId = ref.behandlingId();
 
-        var soknadFodselDto = new SoknadFodselDto();
-        var fødselsdatoer = familieHendelse.getBarna().stream()
-            .collect(Collectors.toMap(UidentifisertBarn::getBarnNummer, UidentifisertBarn::getFødselsdato));
-        mapFellesSoknadDtoFelter(ref, søknad, soknadFodselDto);
-        soknadFodselDto.setSoknadType(SøknadType.FØDSEL);
-        soknadFodselDto.setUtstedtdato(familieHendelse.getTerminbekreftelse().map(TerminbekreftelseEntitet::getUtstedtdato).orElse(null));
-        soknadFodselDto.setTermindato(familieHendelse.getTerminbekreftelse().map(TerminbekreftelseEntitet::getTermindato).orElse(null));
-        soknadFodselDto.setAntallBarn(familieHendelse.getAntallBarn());
-        soknadFodselDto.setBegrunnelseForSenInnsending(søknad.getBegrunnelseForSenInnsending());
-        soknadFodselDto.setFarSokerType(søknad.getFarSøkerType());
-
-        medlemTjeneste.hentMedlemskap(behandlingId)
-            .ifPresent(ma -> soknadFodselDto.setOppgittTilknytning(OppgittTilknytningDto.mapFra(ma.getOppgittTilknytning().orElse(null))));
-
-        soknadFodselDto.setManglendeVedlegg(genererManglendeVedlegg(ref));
-        soknadFodselDto.setFodselsdatoer(fødselsdatoer);
-
-        return soknadFodselDto;
-    }
-
-    private Optional<OppgittFordelingDto.OppgittDekningsgradDto> finnAnnenPartsOppgittDekningsgrad(BehandlingReferanse ref) {
-        return fagsakRelasjonTjeneste.finnRelasjonForHvisEksisterer(ref.fagsakId())
-            .flatMap(fr -> fr.getRelatertFagsakFraId(ref.fagsakId()))
-            .flatMap(annenPartsFagsak -> behandlingRepository.hentSisteYtelsesBehandlingForFagsakIdReadOnly(annenPartsFagsak.getId())
-                .flatMap(b -> ytelseFordelingTjeneste.hentAggregatHvisEksisterer(b.getId()).map(yfa -> {
-                    var søknadEntitet = søknadRepository.hentSøknadHvisEksisterer(b.getId());
-                    var søknadDato = søknadEntitet.map(SøknadEntitet::getSøknadsdato).orElse(null);
-                    var søktDekningsgrad = yfa.getOppgittDekningsgrad().getVerdi();
-                    return new OppgittFordelingDto.OppgittDekningsgradDto(søknadDato, søktDekningsgrad);
-                })));
-    }
-
-    private void mapFellesSoknadDtoFelter(BehandlingReferanse ref, SøknadEntitet søknad, SoknadDto soknadDto) {
-        soknadDto.setMottattDato(søknad.getMottattDato());
+        var frist = fristTjeneste.finnSøknadsfrist(behandlingId);
         var gjeldendeMottattDato = uttaksperiodegrenseRepository.hentHvisEksisterer(ref.behandlingId())
             .map(Uttaksperiodegrense::getMottattDato)
             .orElseGet(søknad::getMottattDato);
-        var frister = fristTjeneste.finnSøknadsfrist(ref.behandlingId());
-        var fristDto = new SøknadsfristDto();
-        fristDto.setMottattDato(gjeldendeMottattDato);
-        frister.map(Søknadsfristdatoer::getUtledetSøknadsfrist).ifPresent(fristDto::setUtledetSøknadsfrist);
-        frister.map(Søknadsfristdatoer::getSøknadGjelderPeriode).map(LocalDateInterval::getFomDato).ifPresent(fristDto::setSøknadsperiodeStart);
-        frister.map(Søknadsfristdatoer::getSøknadGjelderPeriode).map(LocalDateInterval::getTomDato).ifPresent(fristDto::setSøknadsperiodeSlutt);
-        frister.map(Søknadsfristdatoer::getDagerOversittetFrist).ifPresent(fristDto::setDagerOversittetFrist);
-        soknadDto.setSøknadsfrist(fristDto);
 
-        ytelseFordelingTjeneste.hentAggregatHvisEksisterer(ref.behandlingId()).ifPresent(yfa -> {
-            var startdato = hentOppgittStartdatoForPermisjon(ref.behandlingId(), søknad.getRelasjonsRolleType());
-            var søkerOppgitt = new OppgittFordelingDto.OppgittDekningsgradDto(søknad.getSøknadsdato(), yfa.getOppgittDekningsgrad().getVerdi());
-            var annenPartOppgitt = finnAnnenPartsOppgittDekningsgrad(ref);
-            var avklartDekningsgrad = Optional.ofNullable(yfa.getSakskompleksDekningsgrad()).map(Dekningsgrad::getVerdi).orElse(null);
-            var dekningsgrader = new OppgittFordelingDto.DekningsgradInfoDto(avklartDekningsgrad, søkerOppgitt, annenPartOppgitt.orElse(null));
-            soknadDto.setOppgittFordeling(new OppgittFordelingDto(startdato.orElse(null), dekningsgrader));
-        });
+        var utledetSøknadsfrist = frist.getUtledetSøknadsfrist();
+        var søknadsperiodeStart = Optional.ofNullable(frist.getSøknadGjelderPeriode()).map(LocalDateInterval::getFomDato).orElse(null);
+        var søknadsperiodeSlutt = Optional.ofNullable(frist.getSøknadGjelderPeriode()).map(LocalDateInterval::getTomDato).orElse(null);
+        var dagerOversittetFrist = Optional.ofNullable(frist.getDagerOversittetFrist()).orElse(0L);
+        var søknadsfrist = new SøknadDto.Søknadsfrist(gjeldendeMottattDato, utledetSøknadsfrist, søknadsperiodeStart, søknadsperiodeSlutt,
+            dagerOversittetFrist);
+
+        return new SøknadDto(søknad.getMottattDato(), søknad.getBegrunnelseForSenInnsending(), lagManglendeVedleggDto(ref), søknadsfrist);
     }
 
-    private List<ManglendeVedleggDto> genererManglendeVedlegg(BehandlingReferanse ref) {
+    private List<ManglendeVedleggDto> lagManglendeVedleggDto(BehandlingReferanse ref) {
         var alleManglendeVedlegg = new ArrayList<>(kompletthetsjekker.utledAlleManglendeVedleggForForsendelse(ref));
         var vedleggSomIkkeKommer = kompletthetsjekker.utledAlleManglendeInntektsmeldingerSomIkkeKommer(ref);
 
@@ -166,43 +83,4 @@ public class SøknadDtoTjeneste {
             return new ManglendeVedleggDto(mv.dokumentType());
         }
     }
-
-    private SoknadDto lagSoknadAdopsjonDto(SøknadEntitet søknad, FamilieHendelseEntitet familieHendelse, BehandlingReferanse ref) {
-        var behandlingId = ref.behandlingId();
-        var fødselsdatoer = familieHendelse.getBarna().stream()
-            .collect(Collectors.toMap(UidentifisertBarn::getBarnNummer, UidentifisertBarn::getFødselsdato));
-        var soknadAdopsjonDto = new SoknadAdopsjonDto();
-        mapFellesSoknadDtoFelter(ref, søknad, soknadAdopsjonDto);
-        soknadAdopsjonDto.setSoknadType(SøknadType.ADOPSJON);
-        soknadAdopsjonDto.setOmsorgsovertakelseDato(familieHendelse.getAdopsjon().map(AdopsjonEntitet::getOmsorgsovertakelseDato).orElse(null));
-        soknadAdopsjonDto.setBarnetsAnkomstTilNorgeDato(familieHendelse.getAdopsjon().map(AdopsjonEntitet::getAnkomstNorgeDato).orElse(null));
-        soknadAdopsjonDto.setFarSokerType(søknad.getFarSøkerType());
-        soknadAdopsjonDto.setAdopsjonFodelsedatoer(fødselsdatoer);
-        soknadAdopsjonDto.setAntallBarn(familieHendelse.getAntallBarn());
-        soknadAdopsjonDto.setBegrunnelseForSenInnsending(søknad.getBegrunnelseForSenInnsending());
-
-        medlemTjeneste.hentMedlemskap(behandlingId).ifPresent(ma -> soknadAdopsjonDto.setOppgittTilknytning(OppgittTilknytningDto.mapFra(ma.getOppgittTilknytning().orElse(null))));
-
-        soknadAdopsjonDto.setManglendeVedlegg(genererManglendeVedlegg(ref));
-        return soknadAdopsjonDto;
-    }
-
-    private Optional<LocalDate> hentOppgittStartdatoForPermisjon(Long behandlingId, RelasjonsRolleType rolleType) {
-        try {
-            var skjæringstidspunkter = skjæringstidspunktTjeneste.getSkjæringstidspunkter(behandlingId);
-
-            var oppgittStartdato = skjæringstidspunkter.getFørsteUttaksdatoHvisFinnes()
-                .or(skjæringstidspunkter::getSkjæringstidspunktHvisUtledet);
-            if (RelasjonsRolleType.MORA.equals(rolleType) && skjæringstidspunkter.gjelderFødsel()) {
-                var evFødselFørOppgittStartdato = familieHendelseRepository.hentAggregat(behandlingId)
-                    .getGjeldendeBekreftetVersjon().flatMap(FamilieHendelseEntitet::getFødselsdato).map(VirkedagUtil::fomVirkedag)
-                    .filter(fødselsdatoUkedag -> fødselsdatoUkedag.isBefore(oppgittStartdato.orElse(LocalDate.MAX)));
-                return evFødselFørOppgittStartdato.or(() -> oppgittStartdato);
-            }
-            return oppgittStartdato;
-        } catch (Exception e) {
-            return Optional.empty();
-        }
-    }
-
 }

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/søknad/SøknadDtoTjenesteOld.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/søknad/SøknadDtoTjenesteOld.java
@@ -1,0 +1,207 @@
+package no.nav.foreldrepenger.web.app.tjenester.behandling.søknad;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+import no.nav.foreldrepenger.behandling.BehandlingReferanse;
+import no.nav.foreldrepenger.behandling.FagsakRelasjonTjeneste;
+import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
+import no.nav.foreldrepenger.behandlingslager.behandling.DokumentTypeId;
+import no.nav.foreldrepenger.behandlingslager.behandling.familiehendelse.AdopsjonEntitet;
+import no.nav.foreldrepenger.behandlingslager.behandling.familiehendelse.FamilieHendelseEntitet;
+import no.nav.foreldrepenger.behandlingslager.behandling.familiehendelse.FamilieHendelseRepository;
+import no.nav.foreldrepenger.behandlingslager.behandling.familiehendelse.TerminbekreftelseEntitet;
+import no.nav.foreldrepenger.behandlingslager.behandling.familiehendelse.UidentifisertBarn;
+import no.nav.foreldrepenger.behandlingslager.behandling.personopplysning.RelasjonsRolleType;
+import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepository;
+import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepositoryProvider;
+import no.nav.foreldrepenger.behandlingslager.behandling.søknad.SøknadEntitet;
+import no.nav.foreldrepenger.behandlingslager.behandling.søknad.SøknadRepository;
+import no.nav.foreldrepenger.behandlingslager.fagsak.Dekningsgrad;
+import no.nav.foreldrepenger.behandlingslager.uttak.Uttaksperiodegrense;
+import no.nav.foreldrepenger.behandlingslager.uttak.UttaksperiodegrenseRepository;
+import no.nav.foreldrepenger.domene.medlem.MedlemTjeneste;
+import no.nav.foreldrepenger.domene.tid.VirkedagUtil;
+import no.nav.foreldrepenger.domene.ytelsefordeling.YtelseFordelingTjeneste;
+import no.nav.foreldrepenger.kompletthet.Kompletthetsjekker;
+import no.nav.foreldrepenger.kompletthet.ManglendeVedlegg;
+import no.nav.foreldrepenger.skjæringstidspunkt.SkjæringstidspunktTjeneste;
+import no.nav.foreldrepenger.skjæringstidspunkt.SøknadsperiodeFristTjeneste;
+import no.nav.fpsak.tidsserie.LocalDateInterval;
+
+@ApplicationScoped
+public class SøknadDtoTjenesteOld {
+
+    private SkjæringstidspunktTjeneste skjæringstidspunktTjeneste;
+    private SøknadsperiodeFristTjeneste fristTjeneste;
+    private Kompletthetsjekker kompletthetsjekker;
+    private FamilieHendelseRepository familieHendelseRepository;
+    private YtelseFordelingTjeneste ytelseFordelingTjeneste;
+    private UttaksperiodegrenseRepository uttaksperiodegrenseRepository;
+    private SøknadRepository søknadRepository;
+    private MedlemTjeneste medlemTjeneste;
+    private FagsakRelasjonTjeneste fagsakRelasjonTjeneste;
+    private BehandlingRepository behandlingRepository;
+
+    protected SøknadDtoTjenesteOld() {
+        // for CDI proxy
+    }
+
+    @Inject
+    public SøknadDtoTjenesteOld(BehandlingRepositoryProvider repositoryProvider,
+                                SkjæringstidspunktTjeneste skjæringstidspunktTjeneste,
+                                SøknadsperiodeFristTjeneste fristTjeneste,
+                                Kompletthetsjekker kompletthetsjekker,
+                                YtelseFordelingTjeneste ytelseFordelingTjeneste,
+                                MedlemTjeneste medlemTjeneste,
+                                FagsakRelasjonTjeneste fagsakRelasjonTjeneste) {
+        this.skjæringstidspunktTjeneste = skjæringstidspunktTjeneste;
+        this.fristTjeneste = fristTjeneste;
+        this.kompletthetsjekker = kompletthetsjekker;
+        this.ytelseFordelingTjeneste = ytelseFordelingTjeneste;
+        this.medlemTjeneste = medlemTjeneste;
+        this.familieHendelseRepository = repositoryProvider.getFamilieHendelseRepository();
+        this.søknadRepository = repositoryProvider.getSøknadRepository();
+        this.uttaksperiodegrenseRepository = repositoryProvider.getUttaksperiodegrenseRepository();
+        this.fagsakRelasjonTjeneste = fagsakRelasjonTjeneste;
+        this.behandlingRepository = repositoryProvider.getBehandlingRepository();
+    }
+
+    public Optional<SoknadDto> mapFra(Behandling behandling) {
+        return søknadRepository.hentSøknadHvisEksisterer(behandling.getId())
+            .map(s -> getSøknadDto(behandling, s));
+    }
+
+    private SoknadDto getSøknadDto(Behandling behandling, SøknadEntitet søknad) {
+        var ref = BehandlingReferanse.fra(behandling);
+        var fhGrunnlag = familieHendelseRepository.hentAggregat(behandling.getId());
+        if (fhGrunnlag.getSøknadVersjon().getGjelderFødsel()) {
+            return lagSoknadFodselDto(søknad, fhGrunnlag.getSøknadVersjon(), ref);
+        } else {
+            return lagSoknadAdopsjonDto(søknad, fhGrunnlag.getSøknadVersjon(), ref);
+        }
+    }
+
+    private SoknadDto lagSoknadFodselDto(SøknadEntitet søknad, FamilieHendelseEntitet familieHendelse, BehandlingReferanse ref) {
+        var behandlingId = ref.behandlingId();
+
+        var soknadFodselDto = new SoknadFodselDto();
+        var fødselsdatoer = familieHendelse.getBarna().stream()
+            .collect(Collectors.toMap(UidentifisertBarn::getBarnNummer, UidentifisertBarn::getFødselsdato));
+        mapFellesSoknadDtoFelter(ref, søknad, soknadFodselDto);
+        soknadFodselDto.setSoknadType(SøknadType.FØDSEL);
+        soknadFodselDto.setUtstedtdato(familieHendelse.getTerminbekreftelse().map(TerminbekreftelseEntitet::getUtstedtdato).orElse(null));
+        soknadFodselDto.setTermindato(familieHendelse.getTerminbekreftelse().map(TerminbekreftelseEntitet::getTermindato).orElse(null));
+        soknadFodselDto.setAntallBarn(familieHendelse.getAntallBarn());
+        soknadFodselDto.setBegrunnelseForSenInnsending(søknad.getBegrunnelseForSenInnsending());
+        soknadFodselDto.setFarSokerType(søknad.getFarSøkerType());
+
+        medlemTjeneste.hentMedlemskap(behandlingId)
+            .ifPresent(ma -> soknadFodselDto.setOppgittTilknytning(OppgittTilknytningDto.mapFra(ma.getOppgittTilknytning().orElse(null))));
+
+        soknadFodselDto.setManglendeVedlegg(genererManglendeVedlegg(ref));
+        soknadFodselDto.setFodselsdatoer(fødselsdatoer);
+
+        return soknadFodselDto;
+    }
+
+    private Optional<OppgittFordelingDto.OppgittDekningsgradDto> finnAnnenPartsOppgittDekningsgrad(BehandlingReferanse ref) {
+        return fagsakRelasjonTjeneste.finnRelasjonForHvisEksisterer(ref.fagsakId())
+            .flatMap(fr -> fr.getRelatertFagsakFraId(ref.fagsakId()))
+            .flatMap(annenPartsFagsak -> behandlingRepository.hentSisteYtelsesBehandlingForFagsakIdReadOnly(annenPartsFagsak.getId())
+                .flatMap(b -> ytelseFordelingTjeneste.hentAggregatHvisEksisterer(b.getId()).map(yfa -> {
+                    var søknadEntitet = søknadRepository.hentSøknadHvisEksisterer(b.getId());
+                    var søknadDato = søknadEntitet.map(SøknadEntitet::getSøknadsdato).orElse(null);
+                    var søktDekningsgrad = yfa.getOppgittDekningsgrad().getVerdi();
+                    return new OppgittFordelingDto.OppgittDekningsgradDto(søknadDato, søktDekningsgrad);
+                })));
+    }
+
+    private void mapFellesSoknadDtoFelter(BehandlingReferanse ref, SøknadEntitet søknad, SoknadDto soknadDto) {
+        soknadDto.setMottattDato(søknad.getMottattDato());
+        var gjeldendeMottattDato = uttaksperiodegrenseRepository.hentHvisEksisterer(ref.behandlingId())
+            .map(Uttaksperiodegrense::getMottattDato)
+            .orElseGet(søknad::getMottattDato);
+        var frister = fristTjeneste.finnSøknadsfrist(ref.behandlingId());
+        var fristDto = new SøknadsfristDto();
+        fristDto.setMottattDato(gjeldendeMottattDato);
+        fristDto.setUtledetSøknadsfrist(frister.getUtledetSøknadsfrist());
+        Optional.ofNullable(frister.getSøknadGjelderPeriode()).map(LocalDateInterval::getFomDato).ifPresent(fristDto::setSøknadsperiodeStart);
+        Optional.ofNullable(frister.getSøknadGjelderPeriode()).map(LocalDateInterval::getTomDato).ifPresent(fristDto::setSøknadsperiodeSlutt);
+        Optional.ofNullable(frister.getDagerOversittetFrist()).ifPresent(fristDto::setDagerOversittetFrist);
+        soknadDto.setSøknadsfrist(fristDto);
+
+        ytelseFordelingTjeneste.hentAggregatHvisEksisterer(ref.behandlingId()).ifPresent(yfa -> {
+            var startdato = hentOppgittStartdatoForPermisjon(ref.behandlingId(), søknad.getRelasjonsRolleType());
+            var søkerOppgitt = new OppgittFordelingDto.OppgittDekningsgradDto(søknad.getSøknadsdato(), yfa.getOppgittDekningsgrad().getVerdi());
+            var annenPartOppgitt = finnAnnenPartsOppgittDekningsgrad(ref);
+            var avklartDekningsgrad = Optional.ofNullable(yfa.getSakskompleksDekningsgrad()).map(Dekningsgrad::getVerdi).orElse(null);
+            var dekningsgrader = new OppgittFordelingDto.DekningsgradInfoDto(avklartDekningsgrad, søkerOppgitt, annenPartOppgitt.orElse(null));
+            soknadDto.setOppgittFordeling(new OppgittFordelingDto(startdato.orElse(null), dekningsgrader));
+        });
+    }
+
+    private List<ManglendeVedleggDto> genererManglendeVedlegg(BehandlingReferanse ref) {
+        var alleManglendeVedlegg = new ArrayList<>(kompletthetsjekker.utledAlleManglendeVedleggForForsendelse(ref));
+        var vedleggSomIkkeKommer = kompletthetsjekker.utledAlleManglendeInntektsmeldingerSomIkkeKommer(ref);
+
+        // Fjerner slik at det ikke blir dobbelt opp, og for å markere korrekt hvilke som ikke vil komme
+        alleManglendeVedlegg.removeIf(e -> vedleggSomIkkeKommer.stream().anyMatch(it -> it.arbeidsgiver().equals(e.arbeidsgiver())));
+        alleManglendeVedlegg.addAll(vedleggSomIkkeKommer);
+
+        return alleManglendeVedlegg.stream().map(this::mapTilManglendeVedleggDto).toList();
+    }
+
+    private ManglendeVedleggDto mapTilManglendeVedleggDto(ManglendeVedlegg mv) {
+        if (mv.dokumentType().equals(DokumentTypeId.INNTEKTSMELDING)) {
+            return new ManglendeVedleggDto(mv.dokumentType(), mv.arbeidsgiver(), mv.brukerHarSagtAtIkkeKommer());
+        } else {
+            return new ManglendeVedleggDto(mv.dokumentType());
+        }
+    }
+
+    private SoknadDto lagSoknadAdopsjonDto(SøknadEntitet søknad, FamilieHendelseEntitet familieHendelse, BehandlingReferanse ref) {
+        var behandlingId = ref.behandlingId();
+        var fødselsdatoer = familieHendelse.getBarna().stream()
+            .collect(Collectors.toMap(UidentifisertBarn::getBarnNummer, UidentifisertBarn::getFødselsdato));
+        var soknadAdopsjonDto = new SoknadAdopsjonDto();
+        mapFellesSoknadDtoFelter(ref, søknad, soknadAdopsjonDto);
+        soknadAdopsjonDto.setSoknadType(SøknadType.ADOPSJON);
+        soknadAdopsjonDto.setOmsorgsovertakelseDato(familieHendelse.getAdopsjon().map(AdopsjonEntitet::getOmsorgsovertakelseDato).orElse(null));
+        soknadAdopsjonDto.setBarnetsAnkomstTilNorgeDato(familieHendelse.getAdopsjon().map(AdopsjonEntitet::getAnkomstNorgeDato).orElse(null));
+        soknadAdopsjonDto.setFarSokerType(søknad.getFarSøkerType());
+        soknadAdopsjonDto.setAdopsjonFodelsedatoer(fødselsdatoer);
+        soknadAdopsjonDto.setAntallBarn(familieHendelse.getAntallBarn());
+        soknadAdopsjonDto.setBegrunnelseForSenInnsending(søknad.getBegrunnelseForSenInnsending());
+
+        medlemTjeneste.hentMedlemskap(behandlingId).ifPresent(ma -> soknadAdopsjonDto.setOppgittTilknytning(OppgittTilknytningDto.mapFra(ma.getOppgittTilknytning().orElse(null))));
+
+        soknadAdopsjonDto.setManglendeVedlegg(genererManglendeVedlegg(ref));
+        return soknadAdopsjonDto;
+    }
+
+    private Optional<LocalDate> hentOppgittStartdatoForPermisjon(Long behandlingId, RelasjonsRolleType rolleType) {
+        try {
+            var skjæringstidspunkter = skjæringstidspunktTjeneste.getSkjæringstidspunkter(behandlingId);
+
+            var oppgittStartdato = skjæringstidspunkter.getFørsteUttaksdatoHvisFinnes()
+                .or(skjæringstidspunkter::getSkjæringstidspunktHvisUtledet);
+            if (RelasjonsRolleType.MORA.equals(rolleType) && skjæringstidspunkter.gjelderFødsel()) {
+                var evFødselFørOppgittStartdato = familieHendelseRepository.hentAggregat(behandlingId)
+                    .getGjeldendeBekreftetVersjon().flatMap(FamilieHendelseEntitet::getFødselsdato).map(VirkedagUtil::fomVirkedag)
+                    .filter(fødselsdatoUkedag -> fødselsdatoUkedag.isBefore(oppgittStartdato.orElse(LocalDate.MAX)));
+                return evFødselFørOppgittStartdato.or(() -> oppgittStartdato);
+            }
+            return oppgittStartdato;
+        } catch (Exception e) {
+            return Optional.empty();
+        }
+    }
+
+}

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/søknad/SøknadRestTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/søknad/SøknadRestTjeneste.java
@@ -34,30 +34,46 @@ public class SøknadRestTjeneste {
     static final String BASE_PATH = "/behandling";
     private static final String SOKNAD_PART_PATH = "/soknad";
     public static final String SOKNAD_PATH = BASE_PATH + SOKNAD_PART_PATH;
+    private static final String SØKNAD_PART_PATH = "/søknad";
+    public static final String SØKNAD_PATH = BASE_PATH + SØKNAD_PART_PATH;
 
     private BehandlingRepository behandlingRepository;
-    private SøknadDtoTjeneste dtoMapper;
+    private SøknadDtoTjenesteOld dtoMapper;
+    private SøknadDtoTjeneste dtoTjeneste;
 
     public SøknadRestTjeneste() {
         // for CDI proxy
     }
 
     @Inject
-    public SøknadRestTjeneste(BehandlingRepositoryProvider behandlingRepositoryProvider, SøknadDtoTjeneste dtoMapper) {
+    public SøknadRestTjeneste(BehandlingRepositoryProvider behandlingRepositoryProvider, SøknadDtoTjenesteOld dtoMapper, SøknadDtoTjeneste dtoTjeneste) {
         this.dtoMapper = dtoMapper;
         this.behandlingRepository = behandlingRepositoryProvider.getBehandlingRepository();
-
+        this.dtoTjeneste = dtoTjeneste;
     }
 
+    //TODO TFP-6443 slett
     @GET
     @Path(SOKNAD_PART_PATH)
     @Operation(description = "Hent informasjon om søknad", tags = "søknad", responses = {
             @ApiResponse(responseCode = "200", description = "Returnerer Søknad, null hvis ikke eksisterer (GUI støtter ikke NOT_FOUND p.t.)", content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = SoknadDto.class)))
     })
     @BeskyttetRessurs(actionType = ActionType.READ, resourceType = ResourceType.FAGSAK, sporingslogg = false)
-    public SoknadDto getSøknad(@TilpassetAbacAttributt(supplierClass = BehandlingAbacSuppliers.UuidAbacDataSupplier.class)
+    public SoknadDto getSoknad(@TilpassetAbacAttributt(supplierClass = BehandlingAbacSuppliers.UuidAbacDataSupplier.class)
         @NotNull @QueryParam(UuidDto.NAME) @Parameter(description = UuidDto.DESC) @Valid UuidDto uuidDto) {
         var behandling = behandlingRepository.hentBehandling(uuidDto.getBehandlingUuid());
         return dtoMapper.mapFra(behandling).orElse(null);
+    }
+
+    @GET
+    @Path(SØKNAD_PART_PATH)
+    @Operation(description = "Hent informasjon om søknad", tags = "søknad", responses = {
+        @ApiResponse(responseCode = "200", description = "Returnerer søknad", content = @Content(mediaType = MediaType.APPLICATION_JSON, schema = @Schema(implementation = SoknadDto.class)))
+    })
+    @BeskyttetRessurs(actionType = ActionType.READ, resourceType = ResourceType.FAGSAK, sporingslogg = false)
+    public SøknadDto getSøknad(@TilpassetAbacAttributt(supplierClass = BehandlingAbacSuppliers.UuidAbacDataSupplier.class)
+                               @NotNull @QueryParam(UuidDto.NAME) @Parameter(description = UuidDto.DESC) @Valid UuidDto uuidDto) {
+        var behandling = behandlingRepository.hentBehandling(uuidDto.getBehandlingUuid());
+        return dtoTjeneste.lagDto(behandling).orElse(null);
     }
 }

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/uttak/fakta/FaktaUttakFellesTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/uttak/fakta/FaktaUttakFellesTjeneste.java
@@ -13,6 +13,7 @@ import jakarta.inject.Inject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import no.nav.foreldrepenger.behandling.BehandlingReferanse;
 import no.nav.foreldrepenger.behandling.aksjonspunkt.OppdateringResultat;
 import no.nav.foreldrepenger.behandling.revurdering.ytelse.UttakInputTjeneste;
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
@@ -94,7 +95,7 @@ class FaktaUttakFellesTjeneste {
             .toList();
 
         var behandling = behandlingRepository.hentBehandling(behandlingId);
-        validerFørsteUttaksdag(overstyrtePerioder, behandling);
+        validerFørsteUttaksdag(overstyrtePerioder, BehandlingReferanse.fra(behandling));
         var overstyrtePerioderMedMottattDato = oppdaterMedMottattdato(behandling, overstyrtePerioder);
         ytelseFordelingTjeneste.overstyrSøknadsperioder(behandlingId, overstyrtePerioderMedMottattDato);
         oppdaterEndringsdato(overstyrtePerioderMedMottattDato, behandlingId);
@@ -146,11 +147,11 @@ class FaktaUttakFellesTjeneste {
         }
     }
 
-    private void validerFørsteUttaksdag(List<OppgittPeriodeEntitet> overstyrtePerioder, Behandling behandling) {
+    private void validerFørsteUttaksdag(List<OppgittPeriodeEntitet> overstyrtePerioder, BehandlingReferanse ref) {
         //Burde overstyre første uttaksdag i Fakta om saken
         var førsteOverstyrt = overstyrtePerioder.stream().filter(p -> !p.isUtsettelse()).map(OppgittPeriodeEntitet::getFom).min(Comparator.naturalOrder());
         if (førsteOverstyrt.isPresent()) {
-            var førsteUttaksdato = ytelseFordelingDtoTjeneste.finnFørsteUttaksdato(behandling);
+            var førsteUttaksdato = ytelseFordelingDtoTjeneste.finnFørsteUttaksdato(ref);
             if (førsteOverstyrt.get().isBefore(førsteUttaksdato)) {
                 throw new IllegalArgumentException(
                     "første dag i overstyrte perioder kan ikke ligge før gyldig første uttaksdato " + førsteOverstyrt + " - " + førsteUttaksdato);

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/ytelsefordeling/YtelseFordelingDto.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/ytelsefordeling/YtelseFordelingDto.java
@@ -1,50 +1,16 @@
 package no.nav.foreldrepenger.web.app.tjenester.behandling.ytelsefordeling;
 
-import jakarta.validation.constraints.NotNull;
-
 import java.time.LocalDate;
 
-public class YtelseFordelingDto {
-    private Boolean overstyrtOmsorg;
-    @NotNull private LocalDate førsteUttaksdato;
-    private boolean ønskerJustertVedFødsel;
+import jakarta.validation.constraints.NotNull;
 
-    private YtelseFordelingDto() {
+public record YtelseFordelingDto(Boolean overstyrtOmsorg, @NotNull LocalDate førsteUttaksdato, @NotNull LocalDate startDatoForPermisjon,
+                                 @NotNull DekningsgradInfoDto dekningsgrader) {
+
+    public record DekningsgradInfoDto(Integer avklartDekningsgrad, @NotNull OppgittDekningsgradDto søker, OppgittDekningsgradDto annenPart) {
     }
 
-    public Boolean getOverstyrtOmsorg() {
-        return overstyrtOmsorg;
+    public record OppgittDekningsgradDto(@NotNull LocalDate søknadsdato, Integer dekningsgrad) {
     }
 
-    public LocalDate getFørsteUttaksdato() {
-        return førsteUttaksdato;
-    }
-
-    public boolean isØnskerJustertVedFødsel() {
-        return ønskerJustertVedFødsel;
-    }
-
-    public static class Builder {
-
-        private final YtelseFordelingDto kladd = new YtelseFordelingDto();
-
-        public Builder medOverstyrtOmsorg(Boolean overstyrtOmsorg) {
-            kladd.overstyrtOmsorg = overstyrtOmsorg;
-            return this;
-        }
-
-        public Builder medFørsteUttaksdato(LocalDate førsteUttaksdato) {
-            kladd.førsteUttaksdato = førsteUttaksdato;
-            return this;
-        }
-
-        public Builder medØnskerJustertVedFødsel(boolean ønskerJustertVedFødsel) {
-            kladd.ønskerJustertVedFødsel = ønskerJustertVedFødsel;
-            return this;
-        }
-
-        public YtelseFordelingDto build() {
-            return kladd;
-        }
-    }
 }

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/ytelsefordeling/YtelseFordelingDtoTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/ytelsefordeling/YtelseFordelingDtoTjeneste.java
@@ -3,6 +3,8 @@ package no.nav.foreldrepenger.web.app.tjenester.behandling.ytelsefordeling;
 import static no.nav.foreldrepenger.web.app.tjenester.behandling.ytelsefordeling.OmsorgOgRettDto.Verdi.IKKE_RELEVANT;
 import static no.nav.foreldrepenger.web.app.tjenester.behandling.ytelsefordeling.OmsorgOgRettDto.Verdi.JA;
 import static no.nav.foreldrepenger.web.app.tjenester.behandling.ytelsefordeling.OmsorgOgRettDto.Verdi.fra;
+import static no.nav.foreldrepenger.web.app.tjenester.behandling.ytelsefordeling.YtelseFordelingDto.DekningsgradInfoDto;
+import static no.nav.foreldrepenger.web.app.tjenester.behandling.ytelsefordeling.YtelseFordelingDto.OppgittDekningsgradDto;
 
 import java.time.LocalDate;
 import java.util.Objects;
@@ -13,24 +15,32 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 
 import no.nav.foreldrepenger.behandling.BehandlingReferanse;
+import no.nav.foreldrepenger.behandling.FagsakRelasjonTjeneste;
 import no.nav.foreldrepenger.behandling.revurdering.ytelse.UttakInputTjeneste;
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
+import no.nav.foreldrepenger.behandlingslager.behandling.familiehendelse.FamilieHendelseEntitet;
+import no.nav.foreldrepenger.behandlingslager.behandling.familiehendelse.FamilieHendelseRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.personopplysning.OppgittAnnenPartEntitet;
 import no.nav.foreldrepenger.behandlingslager.behandling.personopplysning.RelasjonsRolleType;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepository;
+import no.nav.foreldrepenger.behandlingslager.behandling.søknad.SøknadEntitet;
+import no.nav.foreldrepenger.behandlingslager.behandling.søknad.SøknadRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.ufore.UføretrygdGrunnlagEntitet;
 import no.nav.foreldrepenger.behandlingslager.behandling.ufore.UføretrygdRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.AvklarteUttakDatoerEntitet;
 import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.OppgittRettighetEntitet;
 import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.Rettighetstype;
 import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.YtelseFordelingAggregat;
+import no.nav.foreldrepenger.behandlingslager.fagsak.Dekningsgrad;
 import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakYtelseType;
 import no.nav.foreldrepenger.domene.personopplysning.PersonopplysningTjeneste;
+import no.nav.foreldrepenger.domene.tid.VirkedagUtil;
 import no.nav.foreldrepenger.domene.uttak.ForeldrepengerUttak;
 import no.nav.foreldrepenger.domene.uttak.ForeldrepengerUttakTjeneste;
 import no.nav.foreldrepenger.domene.uttak.input.Annenpart;
 import no.nav.foreldrepenger.domene.uttak.input.ForeldrepengerGrunnlag;
 import no.nav.foreldrepenger.domene.ytelsefordeling.YtelseFordelingTjeneste;
+import no.nav.foreldrepenger.skjæringstidspunkt.SkjæringstidspunktTjeneste;
 import no.nav.vedtak.konfig.Tid;
 
 @ApplicationScoped
@@ -42,6 +52,10 @@ public class YtelseFordelingDtoTjeneste {
     private PersonopplysningTjeneste personopplysningTjeneste;
     private BehandlingRepository behandlingRepository;
     private UttakInputTjeneste uttakInputTjeneste;
+    private SkjæringstidspunktTjeneste skjæringstidspunktTjeneste;
+    private FamilieHendelseRepository familieHendelseRepository;
+    private SøknadRepository søknadRepository;
+    private FagsakRelasjonTjeneste fagsakRelasjonTjeneste;
 
     YtelseFordelingDtoTjeneste() {
         //CDI
@@ -53,45 +67,54 @@ public class YtelseFordelingDtoTjeneste {
                                       ForeldrepengerUttakTjeneste uttakTjeneste,
                                       PersonopplysningTjeneste personopplysningTjeneste,
                                       BehandlingRepository behandlingRepository,
-                                      UttakInputTjeneste uttakInputTjeneste) {
+                                      UttakInputTjeneste uttakInputTjeneste,
+                                      SkjæringstidspunktTjeneste skjæringstidspunktTjeneste,
+                                      FamilieHendelseRepository familieHendelseRepository,
+                                      SøknadRepository søknadRepository,
+                                      FagsakRelasjonTjeneste fagsakRelasjonTjeneste) {
         this.ytelseFordelingTjeneste = ytelseFordelingTjeneste;
         this.uføretrygdRepository = uføretrygdRepository;
         this.uttakTjeneste = uttakTjeneste;
         this.personopplysningTjeneste = personopplysningTjeneste;
         this.behandlingRepository = behandlingRepository;
         this.uttakInputTjeneste = uttakInputTjeneste;
+        this.skjæringstidspunktTjeneste = skjæringstidspunktTjeneste;
+        this.familieHendelseRepository = familieHendelseRepository;
+        this.søknadRepository = søknadRepository;
+        this.fagsakRelasjonTjeneste = fagsakRelasjonTjeneste;
     }
 
-    public Optional<YtelseFordelingDto> mapFra(Behandling behandling) {
-        var ytelseFordelingAggregat = ytelseFordelingTjeneste.hentAggregatHvisEksisterer(behandling.getId());
-        var dtoBuilder = new YtelseFordelingDto.Builder();
-        ytelseFordelingAggregat.ifPresent(yfa -> {
-            dtoBuilder.medOverstyrtOmsorg(yfa.getOverstyrtOmsorg());
-            dtoBuilder.medFørsteUttaksdato(finnFørsteUttaksdato(behandling));
-            dtoBuilder.medØnskerJustertVedFødsel(yfa.getGjeldendeFordeling().ønskerJustertVedFødsel());
+    public Optional<YtelseFordelingDto> mapFra(BehandlingReferanse ref) {
+        return ytelseFordelingTjeneste.hentAggregatHvisEksisterer(ref.behandlingId()).map(yfa -> {
+            var startdatoForPermisjon = hentStartdatoForPermisjon(ref.behandlingId(), ref.relasjonRolle()).orElse(null);
+            var søknad = søknadRepository.hentSøknad(ref.behandlingId());
+            var søkerOppgitt = new OppgittDekningsgradDto(søknad.getSøknadsdato(), yfa.getOppgittDekningsgrad().getVerdi());
+            var annenPartOppgitt = finnAnnenPartsOppgittDekningsgrad(ref);
+            var avklartDekningsgrad = Optional.ofNullable(yfa.getSakskompleksDekningsgrad()).map(Dekningsgrad::getVerdi).orElse(null);
+            var dekningsgrader = new DekningsgradInfoDto(avklartDekningsgrad, søkerOppgitt, annenPartOppgitt.orElse(null));
+            return new YtelseFordelingDto(yfa.getOverstyrtOmsorg(), finnFørsteUttaksdato(ref), startdatoForPermisjon, dekningsgrader);
         });
-        return Optional.of(dtoBuilder.build());
     }
 
-    public LocalDate finnFørsteUttaksdato(Behandling behandling) {
-        var ytelseFordelingAggregat = ytelseFordelingTjeneste.hentAggregat(behandling.getId());
+    public LocalDate finnFørsteUttaksdato(BehandlingReferanse ref) {
+        var ytelseFordelingAggregat = ytelseFordelingTjeneste.hentAggregat(ref.behandlingId());
         var førsteUttaksdato = ytelseFordelingAggregat.getAvklarteDatoer().map(AvklarteUttakDatoerEntitet::getFørsteUttaksdato);
         return førsteUttaksdato.orElseGet(
-            () -> behandling.erRevurdering() ? finnFørsteUttaksdatoRevurdering(behandling) : finnFørsteUttaksdatoFørstegangsbehandling(behandling));
+            () -> ref.erRevurdering() ? finnFørsteUttaksdatoRevurdering(ref) : finnFørsteUttaksdatoFørstegangsbehandling(ref));
     }
 
-    private LocalDate finnFørsteUttaksdatoFørstegangsbehandling(Behandling behandling) {
-        return ytelseFordelingTjeneste.hentAggregat(behandling.getId()).getGjeldendeFordeling().finnFørsteUttaksdato().orElseThrow();
+    private LocalDate finnFørsteUttaksdatoFørstegangsbehandling(BehandlingReferanse behandling) {
+        return ytelseFordelingTjeneste.hentAggregat(behandling.behandlingId()).getGjeldendeFordeling().finnFørsteUttaksdato().orElseThrow();
     }
 
-    private LocalDate finnFørsteUttaksdatoRevurdering(Behandling behandling) {
-        var originalBehandling = behandling.getOriginalBehandlingId()
+    private LocalDate finnFørsteUttaksdatoRevurdering(BehandlingReferanse ref) {
+        var originalBehandling = ref.getOriginalBehandlingId()
             .orElseThrow(() -> new IllegalStateException("Utviklerfeil: Original behandling mangler på revurdering - skal ikke skje"));
         var uttakOriginal = uttakTjeneste.hentHvisEksisterer(originalBehandling);
         var førsteUttakOriginal = uttakOriginal.flatMap(ForeldrepengerUttak::finnFørsteUttaksdatoHvisFinnes);
         var førsteUttaksdatoTidligereBehandling = førsteUttakOriginal.orElse(Tid.TIDENES_ENDE);
 
-        var førsteUttaksdatoSøkt = ytelseFordelingTjeneste.hentAggregat(behandling.getId()).getOppgittFordeling().finnFørsteUttaksdato();
+        var førsteUttaksdatoSøkt = ytelseFordelingTjeneste.hentAggregat(ref.behandlingId()).getOppgittFordeling().finnFørsteUttaksdato();
 
         return førsteUttaksdatoSøkt.filter(søktFom -> søktFom.isBefore(førsteUttaksdatoTidligereBehandling))
             .orElse(førsteUttaksdatoTidligereBehandling);
@@ -125,16 +148,16 @@ public class YtelseFordelingDtoTjeneste {
 
         var søknad = mapSøknad(oppgittAnnenpart.orElse(null), oppgittRettighet, behandling.getRelasjonsRolleType());
         return Optional.of(
-            new OmsorgOgRettDto(søknad, registerdata.orElse(null), manuellBehandlingResultat.orElse(null),
-                utledRettighetstype(behandling), behandling.getRelasjonsRolleType()));
+            new OmsorgOgRettDto(søknad, registerdata.orElse(null), manuellBehandlingResultat.orElse(null), utledRettighetstype(behandling),
+                behandling.getRelasjonsRolleType()));
     }
 
     private Rettighetstype utledRettighetstype(Behandling behandling) {
         var uttakInput = uttakInputTjeneste.lagInput(behandling);
         var harAnnenForelderForeldrepenger = harAnnenForelderForeldrepenger(uttakInput.getYtelsespesifiktGrunnlag());
         var ytelseFordelingAggregat = ytelseFordelingTjeneste.hentAggregat(behandling.getId());
-        return ytelseFordelingAggregat.getGjeldendeRettighetstype(harAnnenForelderForeldrepenger,
-            behandling.getRelasjonsRolleType(), uføretrygdRepository.hentGrunnlag(behandling.getId()).orElse(null));
+        return ytelseFordelingAggregat.getGjeldendeRettighetstype(harAnnenForelderForeldrepenger, behandling.getRelasjonsRolleType(),
+            uføretrygdRepository.hentGrunnlag(behandling.getId()).orElse(null));
     }
 
     private Optional<OmsorgOgRettDto.RegisterData> opprettRegisterdata(Long behandlingId, boolean oppgittAleneomsorg) {
@@ -202,5 +225,36 @@ public class YtelseFordelingDtoTjeneste {
 
     private static Optional<String> utledAnnenpartIdent(OppgittAnnenPartEntitet ap) {
         return Optional.ofNullable(ap).map(OppgittAnnenPartEntitet::getUtenlandskPersonident);
+    }
+
+    private Optional<LocalDate> hentStartdatoForPermisjon(Long behandlingId, RelasjonsRolleType rolleType) {
+        try {
+            var skjæringstidspunkter = skjæringstidspunktTjeneste.getSkjæringstidspunkter(behandlingId);
+
+            var oppgittStartdato = skjæringstidspunkter.getFørsteUttaksdatoHvisFinnes().or(skjæringstidspunkter::getSkjæringstidspunktHvisUtledet);
+            if (RelasjonsRolleType.MORA.equals(rolleType) && skjæringstidspunkter.gjelderFødsel()) {
+                var evFødselFørOppgittStartdato = familieHendelseRepository.hentAggregat(behandlingId)
+                    .getGjeldendeBekreftetVersjon()
+                    .flatMap(FamilieHendelseEntitet::getFødselsdato)
+                    .map(VirkedagUtil::fomVirkedag)
+                    .filter(fødselsdatoUkedag -> fødselsdatoUkedag.isBefore(oppgittStartdato.orElse(LocalDate.MAX)));
+                return evFødselFørOppgittStartdato.or(() -> oppgittStartdato);
+            }
+            return oppgittStartdato;
+        } catch (Exception e) {
+            return Optional.empty();
+        }
+    }
+
+    private Optional<OppgittDekningsgradDto> finnAnnenPartsOppgittDekningsgrad(BehandlingReferanse ref) {
+        return fagsakRelasjonTjeneste.finnRelasjonForHvisEksisterer(ref.fagsakId())
+            .flatMap(fr -> fr.getRelatertFagsakFraId(ref.fagsakId()))
+            .flatMap(annenPartsFagsak -> behandlingRepository.hentSisteYtelsesBehandlingForFagsakIdReadOnly(annenPartsFagsak.getId())
+                .flatMap(b -> ytelseFordelingTjeneste.hentAggregatHvisEksisterer(b.getId()).map(yfa -> {
+                    var søknadEntitet = søknadRepository.hentSøknadHvisEksisterer(b.getId());
+                    var søknadDato = søknadEntitet.map(SøknadEntitet::getSøknadsdato).orElse(null);
+                    var søktDekningsgrad = yfa.getOppgittDekningsgrad().getVerdi();
+                    return new OppgittDekningsgradDto(søknadDato, søktDekningsgrad);
+                })));
     }
 }

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/ytelsefordeling/YtelsefordelingRestTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/ytelsefordeling/YtelsefordelingRestTjeneste.java
@@ -16,6 +16,7 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import no.nav.foreldrepenger.behandling.BehandlingReferanse;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepositoryProvider;
 import no.nav.foreldrepenger.web.app.tjenester.behandling.dto.BehandlingAbacSuppliers;
@@ -59,7 +60,7 @@ public class YtelsefordelingRestTjeneste {
     public YtelseFordelingDto getYtelsefordeling(@TilpassetAbacAttributt(supplierClass = BehandlingAbacSuppliers.UuidAbacDataSupplier.class)
         @NotNull @QueryParam(UuidDto.NAME) @Parameter(description = UuidDto.DESC) @Valid UuidDto uuidDto) {
         var behandling = behandlingRepository.hentBehandling(uuidDto.getBehandlingUuid());
-        return dtoMapper.mapFra(behandling).orElse(null);
+        return dtoMapper.mapFra(BehandlingReferanse.fra(behandling)).orElse(null);
     }
 
     @GET


### PR DESCRIPTION
Ny v2 tjeneste
Flyttet oppgitt tilknytning til medlemdto
Flyttet felter rundt startdato/dekningsgrad for fakta om saken til ytelsefordelingdto. Kanskje et naturlig hjem, men også åpen ny tjeneste/dto. Fakta om saken trenger blanding av YF og søknad (mottatt dato for søker og annen part)