### PR TITLE
TFP-6445 etabler egen forvaltning-jaxrs-app med autorisering = drift

### DIFF
--- a/web/src/main/java/no/nav/foreldrepenger/web/app/konfig/ApiConfig.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/konfig/ApiConfig.java
@@ -29,6 +29,7 @@ import io.swagger.v3.core.jackson.ModelResolver;
 import io.swagger.v3.core.util.ObjectMapperFactory;
 import io.swagger.v3.jaxrs2.integration.JaxrsAnnotationScanner;
 import io.swagger.v3.jaxrs2.integration.JaxrsOpenApiContextBuilder;
+import io.swagger.v3.jaxrs2.integration.resources.OpenApiResource;
 import io.swagger.v3.oas.integration.OpenApiConfigurationException;
 import io.swagger.v3.oas.integration.SwaggerConfiguration;
 import io.swagger.v3.oas.models.OpenAPI;
@@ -147,7 +148,8 @@ public class ApiConfig extends Application {
         classes.addAll(RestImplementationClasses.getServiceClasses());
         // forvaltning/swagger
         classes.addAll(RestImplementationClasses.getForvaltningClasses());
-
+        // swagger
+        classes.add(OpenApiResource.class);
         // Applikasjonsoppsett
         classes.addAll(FellesConfigClasses.getFellesConfigClasses());
 

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/konfig/ApiConfig.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/konfig/ApiConfig.java
@@ -64,6 +64,7 @@ public class ApiConfig extends Application {
 
             oas.info(info).addServersItem(server);
             var oasConfig = new SwaggerConfiguration()
+                .id("openapi.context.id.servlet." + ApiConfig.class.getName())
                 .openAPI(oas)
                 .prettyPrint(true)
                 .scannerClass(JaxrsAnnotationScanner.class.getName())

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/konfig/FellesConfigClasses.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/konfig/FellesConfigClasses.java
@@ -4,7 +4,6 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
-import io.swagger.v3.jaxrs2.integration.resources.OpenApiResource;
 import no.nav.foreldrepenger.web.app.exceptions.ConstraintViolationMapper;
 import no.nav.foreldrepenger.web.app.exceptions.GeneralRestExceptionMapper;
 import no.nav.foreldrepenger.web.app.exceptions.JsonMappingExceptionMapper;
@@ -19,8 +18,6 @@ public class FellesConfigClasses {
         Set<Class<?>> classes = new HashSet<>();
         // Autentisering
         classes.add(AuthenticationFilter.class);
-        // swagger
-        classes.add(OpenApiResource.class);
 
         // (De)Serialisering
         classes.add(JacksonJsonConfig.class);

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/konfig/ForvaltningApiConfig.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/konfig/ForvaltningApiConfig.java
@@ -15,6 +15,7 @@ import org.glassfish.jersey.server.ServerProperties;
 
 import io.swagger.v3.jaxrs2.integration.JaxrsAnnotationScanner;
 import io.swagger.v3.jaxrs2.integration.JaxrsOpenApiContextBuilder;
+import io.swagger.v3.jaxrs2.integration.resources.OpenApiResource;
 import io.swagger.v3.oas.integration.OpenApiConfigurationException;
 import io.swagger.v3.oas.integration.SwaggerConfiguration;
 import io.swagger.v3.oas.models.OpenAPI;
@@ -29,7 +30,7 @@ public class ForvaltningApiConfig extends Application {
 
     private static final Environment ENV = Environment.current();
 
-    public static final String FORVALTNING_URI = "/forvaltning";
+    public static final String FORVALTNING_URI = "/forvaltning/api";
 
     public ForvaltningApiConfig() {
         var info = new Info()
@@ -49,10 +50,9 @@ public class ForvaltningApiConfig extends Application {
                 .scannerClass(JaxrsAnnotationScanner.class.getName())
                 .resourceClasses(RestImplementationClasses.getForvaltningClasses().stream().map(Class::getName).collect(Collectors.toSet()));
 
-            var context = new JaxrsOpenApiContextBuilder<>()
+            new JaxrsOpenApiContextBuilder<>()
                 .openApiConfiguration(oasConfig)
                 .buildContext(true);
-            context.read();
 
         } catch (OpenApiConfigurationException e) {
             throw new TekniskException("OPEN-API", e.getMessage(), e);
@@ -66,6 +66,8 @@ public class ForvaltningApiConfig extends Application {
         classes.add(ForvaltningAuthorizationFilter.class);
         // forvaltning/swagger
         classes.addAll(RestImplementationClasses.getForvaltningClasses());
+        // swagger
+        classes.add(OpenApiResource.class);
 
         // Applikasjonsoppsett
         classes.addAll(FellesConfigClasses.getFellesConfigClasses());

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/konfig/ForvaltningApiConfig.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/konfig/ForvaltningApiConfig.java
@@ -43,6 +43,7 @@ public class ForvaltningApiConfig extends Application {
 
             oas.info(info).addServersItem(server);
             var oasConfig = new SwaggerConfiguration()
+                .id("openapi.context.id.servlet." + ForvaltningApiConfig.class.getName())
                 .openAPI(oas)
                 .prettyPrint(true)
                 .scannerClass(JaxrsAnnotationScanner.class.getName())

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/konfig/ForvaltningApiConfig.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/konfig/ForvaltningApiConfig.java
@@ -1,0 +1,84 @@
+package no.nav.foreldrepenger.web.app.konfig;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import jakarta.ws.rs.ApplicationPath;
+import jakarta.ws.rs.core.Application;
+
+import org.glassfish.jersey.server.ServerProperties;
+
+import io.swagger.v3.jaxrs2.integration.JaxrsAnnotationScanner;
+import io.swagger.v3.jaxrs2.integration.JaxrsOpenApiContextBuilder;
+import io.swagger.v3.oas.integration.OpenApiConfigurationException;
+import io.swagger.v3.oas.integration.SwaggerConfiguration;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.servers.Server;
+import no.nav.foreldrepenger.konfig.Environment;
+import no.nav.foreldrepenger.web.app.tjenester.RestImplementationClasses;
+import no.nav.vedtak.exception.TekniskException;
+
+@ApplicationPath(ForvaltningApiConfig.FORVALTNING_URI)
+public class ForvaltningApiConfig extends Application {
+
+    private static final Environment ENV = Environment.current();
+
+    public static final String FORVALTNING_URI = "/forvaltning";
+
+    public ForvaltningApiConfig() {
+        var info = new Info()
+            .title("FPSAK - Foreldrepenger, engangsstønad og svangerskapspenger")
+            .version(Optional.ofNullable(ENV.imageName()).orElse("1.0"))
+            .description("REST grensesnitt for FPSAK.");
+        var server = new Server().url(ENV.getProperty("context.path", "/fpsak"));
+
+        try {
+            var oas = new OpenAPI().openapi("3.1.1");
+
+            oas.info(info).addServersItem(server);
+            var oasConfig = new SwaggerConfiguration()
+                .openAPI(oas)
+                .prettyPrint(true)
+                .scannerClass(JaxrsAnnotationScanner.class.getName())
+                .resourceClasses(RestImplementationClasses.getForvaltningClasses().stream().map(Class::getName).collect(Collectors.toSet()));
+
+            var context = new JaxrsOpenApiContextBuilder<>()
+                .openApiConfiguration(oasConfig)
+                .buildContext(true);
+            context.read();
+
+        } catch (OpenApiConfigurationException e) {
+            throw new TekniskException("OPEN-API", e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public Set<Class<?>> getClasses() {
+        Set<Class<?>> classes = new HashSet<>();
+        // Krever autentisert og medlem av DRIFT
+        classes.add(ForvaltningAuthorizationFilter.class);
+        // forvaltning/swagger
+        classes.addAll(RestImplementationClasses.getForvaltningClasses());
+
+        // Applikasjonsoppsett
+        classes.addAll(FellesConfigClasses.getFellesConfigClasses());
+
+        return Collections.unmodifiableSet(classes);
+    }
+
+    @Override
+    public Map<String, Object> getProperties() {
+        Map<String, Object> properties = new HashMap<>();
+        // Ref Jersey doc
+        properties.put(ServerProperties.BV_SEND_ERROR_IN_RESPONSE, true);
+        properties.put(ServerProperties.PROCESSING_RESPONSE_ERRORS_ENABLED, true);
+        return properties;
+    }
+
+}

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/konfig/ForvaltningAuthorizationFilter.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/konfig/ForvaltningAuthorizationFilter.java
@@ -1,0 +1,39 @@
+package no.nav.foreldrepenger.web.app.konfig;
+
+import jakarta.annotation.Priority;
+import jakarta.ws.rs.Priorities;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.container.ContainerRequestFilter;
+import jakarta.ws.rs.container.ResourceInfo;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.ext.Provider;
+
+import no.nav.vedtak.sikkerhet.kontekst.AnsattGruppe;
+import no.nav.vedtak.sikkerhet.kontekst.KontekstHolder;
+import no.nav.vedtak.sikkerhet.kontekst.RequestKontekst;
+
+@Provider
+@Priority(Priorities.AUTHORIZATION)
+public class ForvaltningAuthorizationFilter implements ContainerRequestFilter {
+
+    @Context
+    private ResourceInfo resourceinfo;
+
+    public ForvaltningAuthorizationFilter() {
+        // Ingenting
+    }
+
+    @Override
+    public void filter(ContainerRequestContext req) {
+        if (!KontekstHolder.harKontekst() || !KontekstHolder.getKontekst().erAutentisert() || !(KontekstHolder.getKontekst() instanceof RequestKontekst kontekst)) {
+            throw new WebApplicationException(Response.Status.FORBIDDEN);
+        }
+        if (!kontekst.harGruppe(AnsattGruppe.DRIFT)) {
+            throw new WebApplicationException(Response.Status.FORBIDDEN);
+        }
+
+    }
+
+}

--- a/web/src/main/java/no/nav/foreldrepenger/web/server/jetty/JettyServer.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/server/jetty/JettyServer.java
@@ -35,6 +35,7 @@ import org.slf4j.bridge.SLF4JBridgeHandler;
 import no.nav.foreldrepenger.konfig.Environment;
 import no.nav.foreldrepenger.web.app.konfig.ApiConfig;
 import no.nav.foreldrepenger.web.app.konfig.EksternApiConfig;
+import no.nav.foreldrepenger.web.app.konfig.ForvaltningApiConfig;
 import no.nav.foreldrepenger.web.app.konfig.InternalApiConfig;
 
 public class JettyServer {
@@ -169,6 +170,8 @@ public class JettyServer {
         handler.addConstraintMapping(pathConstraint(Constraint.ALLOWED, InternalApiConfig.INTERNAL_URI + "/*"));
         // Slipp gjennom til autentisering i JaxRs / auth-filter
         handler.addConstraintMapping(pathConstraint(Constraint.ALLOWED, ApiConfig.API_URI + "/*"));
+        // Slipp gjennom til autentisering i JaxRs / auth-filter
+        handler.addConstraintMapping(pathConstraint(Constraint.ALLOWED, ForvaltningApiConfig.FORVALTNING_URI + "/*"));
         // Slipp gjennom til autentisering i JaxRs / auth-filter
         handler.addConstraintMapping(pathConstraint(Constraint.ALLOWED, EksternApiConfig.EKSTERN_API_URI + "/*"));
         // Alt annet av paths og metoder forbudt - 403

--- a/web/src/test/java/no/nav/foreldrepenger/web/app/konfig/RestApiTester.java
+++ b/web/src/test/java/no/nav/foreldrepenger/web/app/konfig/RestApiTester.java
@@ -28,11 +28,14 @@ public class RestApiTester {
         return liste;
     }
 
-    static Collection<Class<?>> finnAlleRestTjenester() {
-        return new ArrayList<>(finnAlleRestTjenester(new ApiConfig()));
+    private static Collection<Class<?>> finnAlleRestTjenester() {
+        var resultat = new ArrayList<>(finnAlleRestTjenester(new ApiConfig()));
+        resultat.addAll(finnAlleRestTjenester(new EksternApiConfig()));
+        resultat.addAll(finnAlleRestTjenester(new ForvaltningApiConfig()));
+        return resultat;
     }
 
-    static Collection<Class<?>> finnAlleRestTjenester(Application config) {
+    private static Collection<Class<?>> finnAlleRestTjenester(Application config) {
         return config.getClasses().stream().filter(c -> c.getAnnotation(Path.class) != null).filter(c -> !UNNTATT.contains(c)).toList();
     }
 }


### PR DESCRIPTION
Egen Jaxrs-app med forvaltningsklasser. Med autorisering som krever medlemskap i drift.
Neste steg: legge om fp-swagger til å bruke ny path + sanere forvaltning i ApiConfig