### PR TITLE
chore: Standardiser kode for kodeverdi udefinert

### DIFF
--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/aktør/NavBrukerKjønn.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/aktør/NavBrukerKjønn.java
@@ -15,7 +15,7 @@ public enum NavBrukerKjønn implements Kodeverdi {
 
     KVINNE("K", "Kvinne"),
     MANN("M", "Mann"),
-    UDEFINERT("-", "Ikke definert"),
+    UDEFINERT(STANDARDKODE_UDEFINERT, "Ikke definert"),
     ;
 
     public static final String KODEVERK = "BRUKER_KJOENN";

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/aktør/OppholdstillatelseType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/aktør/OppholdstillatelseType.java
@@ -17,7 +17,7 @@ public enum OppholdstillatelseType implements Kodeverdi {
 
     MIDLERTIDIG("MIDLERTIDIG", "Midlertidig oppholdstillatelse"),
     PERMANENT("PERMANENT", "Permanent oppholdstillatelse"),
-    UDEFINERT("-", "Ikke definert"),
+    UDEFINERT(STANDARDKODE_UDEFINERT, "Ikke definert"),
     ;
 
     private static final Map<String, OppholdstillatelseType> KODER = Arrays.stream(values())

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/aktør/PersonstatusType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/aktør/PersonstatusType.java
@@ -21,7 +21,7 @@ public enum PersonstatusType implements Kodeverdi {
     UREG("UREG", "Ikke bosatt (f.reg)"),
     UTPE("UTPE", "Opphørt"),
     UTVA("UTVA", "Utflyttet"),
-    UDEFINERT("-", "Ikke definert"),
+    UDEFINERT(STANDARDKODE_UDEFINERT, "Ikke definert"),
     ;
 
     private static final Map<String, PersonstatusType> FRA_FREG = Map.ofEntries(

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/BehandlingStegStatus.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/BehandlingStegStatus.java
@@ -33,7 +33,7 @@ public enum BehandlingStegStatus implements Kodeverdi {
     UTFØRT("UTFØRT", "Utført"),
     FREMOVERFØRT("FREMOVERFØRT", "Fremoverført"),
     TILBAKEFØRT("TILBAKEFØRT", "Tilbakeført"),
-    UDEFINERT("-", "Ikke definert"),
+    UDEFINERT(STANDARDKODE_UDEFINERT, "Ikke definert"),
 
     ;
     private static final Set<BehandlingStegStatus> KAN_UTFØRE_STEG = new HashSet<>(Arrays.asList(STARTET, VENTER));

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/BehandlingTema.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/BehandlingTema.java
@@ -21,7 +21,7 @@ public enum BehandlingTema implements Kodeverdi, MedOffisiellKode {
     FORELDREPENGER_ADOPSJON("FORP_ADOP", "Foreldrepenger ved adopsjon", "ab0072"),
     FORELDREPENGER_FØDSEL("FORP_FODS", "Foreldrepenger ved fødsel", "ab0047"),
     SVANGERSKAPSPENGER("SVP", "Svangerskapspenger", "ab0126"),
-    UDEFINERT("-", "Ikke definert", null),
+    UDEFINERT(STANDARDKODE_UDEFINERT, "Ikke definert", null),
 
     ;
 

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/BehandlingType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/BehandlingType.java
@@ -29,7 +29,7 @@ public enum BehandlingType implements Kodeverdi, MedOffisiellKode {
     TILBAKEKREVING_ORDINÆR("BT-007", "Tilbakekreving", "ae0054", 6),
     TILBAKEKREVING_REVURDERING("BT-009", "Revurdering tilbakekreving", "ae0043", 6),
 
-    UDEFINERT("-", "Ikke definert", null, 0),
+    UDEFINERT(STANDARDKODE_UDEFINERT, "Ikke definert", null, 0),
     ;
 
     private static final Set<BehandlingType> YTELSE_BEHANDLING_TYPER = Set.of(FØRSTEGANGSSØKNAD, REVURDERING);

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/BehandlingÅrsakType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/BehandlingÅrsakType.java
@@ -96,7 +96,7 @@ public enum BehandlingÅrsakType implements Kodeverdi {
     RE_TILSTØTENDE_YTELSE_OPPHØRT("RE-TILST-YT-OPPH", "Annen ytelse opphørt"),
 
     // La stå
-    UDEFINERT("-", "Ikke definert"),
+    UDEFINERT(STANDARDKODE_UDEFINERT, "Ikke definert"),
 
     ;
 

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/DokumentKategori.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/DokumentKategori.java
@@ -16,7 +16,7 @@ import no.nav.foreldrepenger.behandlingslager.kodeverk.MedOffisiellKode;
 
 public enum DokumentKategori implements Kodeverdi, MedOffisiellKode {
 
-    UDEFINERT("-", "Ikke definert", null),
+    UDEFINERT(STANDARDKODE_UDEFINERT, "Ikke definert", null),
     KLAGE_ELLER_ANKE("KLGA", "Klage eller anke", "KA"),
     IKKE_TOLKBART_SKJEMA("ITSKJ", "Ikke tolkbart skjema", "IS"),
     SØKNAD("SOKN", "Søknad", "SOK"),

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/DokumentTypeId.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/DokumentTypeId.java
@@ -149,7 +149,7 @@ public enum DokumentTypeId implements Kodeverdi, MedOffisiellKode {
     ANNET_SKJEMA_IKKE_NAV("ANNET_SKJEMA_IKKE_NAV", "I000049", "Annet skjema (ikke NAV-skjema)"),
     ANNET("ANNET", "I000060", "Annet"),
 
-    UDEFINERT("-", "", "Ikke definert"),
+    UDEFINERT(STANDARDKODE_UDEFINERT, "", "Ikke definert"),
     ;
 
     public static final String KODEVERK = "DOKUMENT_TYPE_ID";

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/RettenTil.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/RettenTil.java
@@ -15,7 +15,7 @@ public enum RettenTil implements Kodeverdi {
 
     HAR_RETT_TIL_FP("HAR_RETT_TIL_FP", "Bruker har rett til foreldrepenger"),
     HAR_IKKE_RETT_TIL_FP("HAR_IKKE_RETT_TIL_FP", "Bruker har ikke rett til foreldrepenger"),
-    UDEFINERT("-", "Udefinert"),
+    UDEFINERT(STANDARDKODE_UDEFINERT, "Udefinert"),
     ;
 
     public static final String KODEVERK = "RETTEN_TIL";

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/Tema.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/Tema.java
@@ -12,7 +12,7 @@ public enum Tema implements Kodeverdi, MedOffisiellKode {
 
     FOR("FOR", "Foreldre- og Svangerskapspenger", "FOR"),
 
-    UDEFINERT("-", "Ikke definert", null)
+    UDEFINERT(STANDARDKODE_UDEFINERT, "Ikke definert", null)
     ;
 
     public static final String KODEVERK = "TEMA";

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/Temagrupper.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/Temagrupper.java
@@ -8,7 +8,7 @@ import no.nav.foreldrepenger.behandlingslager.kodeverk.MedOffisiellKode;
 public enum Temagrupper implements Kodeverdi, MedOffisiellKode {
 
     FAMILIEYTELSER("FMLI", "Familie", "FMLI"),
-    UDEFINERT("-", "Udefinert", null),
+    UDEFINERT(STANDARDKODE_UDEFINERT, "Udefinert", null),
     ;
 
     public static final String KODEVERK = "TEMAGRUPPER";

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/VariantFormat.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/VariantFormat.java
@@ -18,7 +18,7 @@ public enum VariantFormat implements Kodeverdi, MedOffisiellKode {
     FULLVERSJON("FULL", "Versjon med infotekster", "FULLVERSJON"),
     BREVBESTILLING("BREVB", "Brevbestilling data", "BREVBESTILLING"),
     ARKIV("ARKIV", "Arkivformat", "ARKIV"),
-    UDEFINERT("-", "Ikke definert", null),
+    UDEFINERT(STANDARDKODE_UDEFINERT, "Ikke definert", null),
 
     ;
     private static final String KODEVERK = "VARIANT_FORMAT";

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/aksjonspunkt/AksjonspunktType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/aksjonspunkt/AksjonspunktType.java
@@ -15,7 +15,7 @@ public enum AksjonspunktType implements Kodeverdi {
     MANUELL("MANU", "Manuell"),
     OVERSTYRING("OVST", "Overstyring"),
     SAKSBEHANDLEROVERSTYRING("SAOV", "Saksbehandleroverstyring"),
-    UDEFINERT("-", "Ikke definert"),
+    UDEFINERT(STANDARDKODE_UDEFINERT, "Ikke definert"),
     ;
 
     private static final Map<String, AksjonspunktType> KODER = new LinkedHashMap<>();

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/aksjonspunkt/Venteårsak.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/aksjonspunkt/Venteårsak.java
@@ -13,7 +13,7 @@ import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
 
 public enum Venteårsak implements Kodeverdi {
 
-    UDEFINERT("-", "Ikke definert"),
+    UDEFINERT(STANDARDKODE_UDEFINERT, "Ikke definert"),
 
     /*
      * Disse er i bruk i koden i fpsak, frontend, eller kalkulus.

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/aksjonspunkt/VurderÅrsak.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/aksjonspunkt/VurderÅrsak.java
@@ -17,7 +17,7 @@ public enum VurderÅrsak implements Kodeverdi {
     UTREDNING("UTREDNING", "Utredning"),
     SAKSFLYT("SAKSFLYT", "Saksflyt"),
     BEGRUNNELSE("BEGRUNNELSE", "Begrunnelse"),
-    UDEFINERT("-", "Ikke definert"),
+    UDEFINERT(STANDARDKODE_UDEFINERT, "Ikke definert"),
 
     @Deprecated
     ANNET("ANNET", "Annet"), // UTGÅTT, beholdes pga historikk

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/aktivitetskrav/AktivitetskravPermisjonType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/aktivitetskrav/AktivitetskravPermisjonType.java
@@ -13,7 +13,7 @@ import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
 
 public enum AktivitetskravPermisjonType implements Kodeverdi {
 
-    UDEFINERT("-", "Ikke definert"),
+    UDEFINERT(STANDARDKODE_UDEFINERT, "Ikke definert"),
     UTDANNING("UTDANNING", "Utdanning"),
     FORELDREPENGER("FORELDREPENGER", "Foreldrepenger"),
     PERMITTERING("PERMITTERING", "Permittering"),

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/anke/AnkeAvvistÅrsak.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/anke/AnkeAvvistÅrsak.java
@@ -12,7 +12,7 @@ public enum AnkeAvvistÅrsak implements Kodeverdi {
     ANKE_IKKE_PART("ANKE_IKKE_PART", "Anke er ikke part"),
     ANKE_IKKE_KONKRET("ANKE_IKKE_KONKRET", "Anke er ikke konkret"),
     ANKE_IKKE_SIGNERT("ANKE_IKKE_SIGNERT", "Anke er ikke signert"),
-    UDEFINERT("-", "Udefinert"),
+    UDEFINERT(STANDARDKODE_UDEFINERT, "Udefinert"),
     ;
 
     public static final String KODEVERK = "ANKE_AVVIST_AARSAK";

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/anke/AnkeOmgjørÅrsak.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/anke/AnkeOmgjørÅrsak.java
@@ -17,7 +17,7 @@ public enum AnkeOmgjørÅrsak implements Kodeverdi {
     ULIK_REGELVERKSTOLKNING("ULIK_REGELVERKSTOLKNING", "Ulik regelverkstolkning"),
     ULIK_VURDERING("ULIK_VURDERING", "Ulik skjønnsvurdering"),
     PROSESSUELL_FEIL("PROSESSUELL_FEIL", "Saksbehandlingsfeil"),
-    UDEFINERT("-", "Udefinert"),
+    UDEFINERT(STANDARDKODE_UDEFINERT, "Udefinert"),
     ;
 
     private static final Map<String, AnkeOmgjørÅrsak> KODER = new LinkedHashMap<>();

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/anke/AnkeVurdering.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/anke/AnkeVurdering.java
@@ -19,7 +19,7 @@ public enum AnkeVurdering implements Kodeverdi {
     ANKE_OPPHEVE_OG_HJEMSENDE("ANKE_OPPHEVE_OG_HJEMSENDE", "Ytelsesvedtaket oppheves og hjemsendes"),
     ANKE_OMGJOER("ANKE_OMGJOER", "Anken omgjøres"),
     ANKE_AVVIS("ANKE_AVVIS", "Anken avvises"),
-    UDEFINERT("-", "Udefinert"),
+    UDEFINERT(STANDARDKODE_UDEFINERT, "Udefinert"),
     ;
 
     private static final Map<String, AnkeVurdering> KODER = new LinkedHashMap<>();

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/anke/AnkeVurderingOmgjør.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/anke/AnkeVurderingOmgjør.java
@@ -17,7 +17,7 @@ public enum AnkeVurderingOmgjør implements Kodeverdi {
     ANKE_TIL_GUNST("ANKE_TIL_GUNST", "Gunst omgjør i anke"),
     ANKE_DELVIS_OMGJOERING_TIL_GUNST("ANKE_DELVIS_OMGJOERING_TIL_GUNST", "Delvis omgjøring, til gunst i anke"),
     ANKE_TIL_UGUNST("ANKE_TIL_UGUNST", "Ugunst omgjør i anke"),
-    UDEFINERT("-", "Udefinert"),
+    UDEFINERT(STANDARDKODE_UDEFINERT, "Udefinert"),
     ;
     private static final Map<String, AnkeVurderingOmgjør> KODER = new LinkedHashMap<>();
 

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/arbeidsforhold/ArbeidsforholdKomplettVurderingType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/arbeidsforhold/ArbeidsforholdKomplettVurderingType.java
@@ -38,7 +38,7 @@ public enum ArbeidsforholdKomplettVurderingType implements Kodeverdi {
     @Deprecated
     NYTT_ARBEIDSFORHOLD("NYTT_ARBEIDSFORHOLD", "Arbeidsforholdet er ansett som nytt"),
 
-    UDEFINERT("-", "Ikke definert"),
+    UDEFINERT(STANDARDKODE_UDEFINERT, "Ikke definert"),
     ;
     public static final String KODEVERK = "ARBEIDSFORHOLD_KOMPLETT_VURDERING_TYPE";
 

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/beregning/AktivitetStatus.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/beregning/AktivitetStatus.java
@@ -39,7 +39,7 @@ public enum AktivitetStatus implements Kodeverdi {
     TTLSTØTENDE_YTELSE("TY", "Tilstøtende ytelse", Inntektskategori.UDEFINERT),
     VENTELØNN_VARTPENGER("VENTELØNN_VARTPENGER", "Ventelønn/Vartpenger", Inntektskategori.UDEFINERT),
 
-    UDEFINERT("-", "Ikke definert", Inntektskategori.UDEFINERT);
+    UDEFINERT(STANDARDKODE_UDEFINERT, "Ikke definert", Inntektskategori.UDEFINERT);
 
     public static final String KODEVERK = "AKTIVITET_STATUS";
 

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/beregning/BeregningSatsType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/beregning/BeregningSatsType.java
@@ -15,7 +15,7 @@ public enum BeregningSatsType implements Kodeverdi {
     ENGANG("ENGANG", "Engangsstønad"),
     GRUNNBELØP("GRUNNBELØP", "Grunnbeløp"),
     GSNITT("GSNITT", "Grunnbeløp årsgjennomsnitt"),
-    UDEFINERT("-", "Ikke definert"),
+    UDEFINERT(STANDARDKODE_UDEFINERT, "Ikke definert"),
     ;
     public static final String KODEVERK = "SATS_TYPE";
 

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/beregning/Inntektskategori.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/beregning/Inntektskategori.java
@@ -25,7 +25,7 @@ public enum Inntektskategori implements Kodeverdi {
     JORDBRUKER("JORDBRUKER", "Selvstendig næringsdrivende - jordbruker"),
     FISKER("FISKER", "Selvstendig næringsdrivende - fisker"),
     ARBEIDSTAKER_UTEN_FERIEPENGER("ARBEIDSTAKER_UTEN_FERIEPENGER", "Arbeidstaker uten feriepenger"),
-    UDEFINERT("-", "Ingen inntektskategori (default)"),
+    UDEFINERT(STANDARDKODE_UDEFINERT, "Ingen inntektskategori (default)"),
     ;
     private static final Map<String, Inntektskategori> KODER = new LinkedHashMap<>();
     private static final Set<Inntektskategori> GIR_FERIEPENGER = Set.of(ARBEIDSTAKER, SJØMANN);

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/familiehendelse/FamilieHendelseType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/familiehendelse/FamilieHendelseType.java
@@ -17,7 +17,7 @@ public enum FamilieHendelseType implements Kodeverdi {
     OMSORG("OMSRGO", "Omsorgoverdragelse"),
     FØDSEL("FODSL", "Fødsel"),
     TERMIN("TERM", "Termin"),
-    UDEFINERT("-", "Ikke satt eller valgt kode"),
+    UDEFINERT(STANDARDKODE_UDEFINERT, "Ikke satt eller valgt kode"),
 
     ;
 

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/familiehendelse/OmsorgsovertakelseVilkårType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/familiehendelse/OmsorgsovertakelseVilkårType.java
@@ -41,7 +41,7 @@ public enum OmsorgsovertakelseVilkårType implements Kodeverdi {
         Avslagsårsak.STEBARNSADOPSJON_IKKE_FLERE_DAGER_IGJEN),
 
     /* Legger inn udefinert kode. Må gjerne erstattes av noe annet dersom starttilstand er kjent. */
-    UDEFINERT("-", "Ikke definert"),
+    UDEFINERT(STANDARDKODE_UDEFINERT, "Ikke definert"),
 
     ;
 

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/historikk/HistorikkAktør.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/historikk/HistorikkAktør.java
@@ -18,7 +18,7 @@ public enum HistorikkAktør implements Kodeverdi {
     SØKER("SOKER", "Søker"),
     ARBEIDSGIVER("ARBEIDSGIVER", "Arbeidsgiver"),
     VEDTAKSLØSNINGEN("VL", "Vedtaksløsningen"),
-    UDEFINERT("-", "Ikke definert"),
+    UDEFINERT(STANDARDKODE_UDEFINERT, "Ikke definert"),
     ;
 
     private static final Map<String, HistorikkAktør> KODER = new LinkedHashMap<>();

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/innsyn/InnsynResultatType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/innsyn/InnsynResultatType.java
@@ -16,7 +16,7 @@ public enum InnsynResultatType implements Kodeverdi {
     INNVILGET("INNV", "Innvilget innsyn"),
     DELVIS_INNVILGET("DELV", "Delvis innvilget innsyn"),
     AVVIST("AVVIST", "Avslått innsyn"),
-    UDEFINERT("-", "Ikke definert"),
+    UDEFINERT(STANDARDKODE_UDEFINERT, "Ikke definert"),
     ;
 
     private static final Map<String, InnsynResultatType> KODER = new LinkedHashMap<>();

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/klage/KlageAvvistÅrsak.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/klage/KlageAvvistÅrsak.java
@@ -16,7 +16,7 @@ public enum KlageAvvistÅrsak implements Kodeverdi {
     KLAGER_IKKE_PART("KLAGER_IKKE_PART", "Klager er ikke part"),
     IKKE_KONKRET("IKKE_KONKRET", "Klagen er ikke konkret"),
     IKKE_SIGNERT("IKKE_SIGNERT", "Klagen er ikke signert"),
-    UDEFINERT("-", "Ikke definert"),
+    UDEFINERT(STANDARDKODE_UDEFINERT, "Ikke definert"),
     ;
 
     private static final Map<String, KlageAvvistÅrsak> KODER = new LinkedHashMap<>();

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/klage/KlageHjemmel.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/klage/KlageHjemmel.java
@@ -42,7 +42,7 @@ public enum KlageHjemmel implements Kodeverdi {
     EØS_YTELSE("883-5", "EØS 883/2004 artikkel 5", "EOES_883_2004_5", Set.of(FP)),
     EØS_OPPTJEN("883-6", "EØS 883/2004 artikkel 6", "EOES_883_2004_6", Set.of(FP, SVP)),
 
-    UDEFINERT("-", "Ikke definert", "", Set.of()),
+    UDEFINERT(STANDARDKODE_UDEFINERT, "Ikke definert", "", Set.of()),
     ;
 
     private static final Map<String, KlageHjemmel> KODER = new LinkedHashMap<>();

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/klage/KlageMedholdÅrsak.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/klage/KlageMedholdÅrsak.java
@@ -17,7 +17,7 @@ public enum KlageMedholdÅrsak implements Kodeverdi {
     ULIK_REGELVERKSTOLKNING("ULIK_REGELVERKSTOLKNING", "Feil lovanvendelse"),
     ULIK_VURDERING("ULIK_VURDERING", "Ulik skjønnsvurdering"),
     PROSESSUELL_FEIL("PROSESSUELL_FEIL", "Saksbehandlingsfeil"),
-    UDEFINERT("-", "Ikke definert"),
+    UDEFINERT(STANDARDKODE_UDEFINERT, "Ikke definert"),
     ;
 
     private static final Map<String, KlageMedholdÅrsak> KODER = new LinkedHashMap<>();

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/klage/KlageVurdering.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/klage/KlageVurdering.java
@@ -18,7 +18,7 @@ public enum KlageVurdering implements Kodeverdi {
     MEDHOLD_I_KLAGE("MEDHOLD_I_KLAGE", "Medhold"),
     AVVIS_KLAGE("AVVIS_KLAGE", "Klagen avvises"),
     HJEMSENDE_UTEN_Å_OPPHEVE("HJEMSENDE_UTEN_Å_OPPHEVE", "Hjemsende uten å oppheve"),
-    UDEFINERT("-", "Udefinert"),
+    UDEFINERT(STANDARDKODE_UDEFINERT, "Udefinert"),
     ;
 
     private static final Map<String, KlageVurdering> KODER = new LinkedHashMap<>();

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/klage/KlageVurderingOmgjør.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/klage/KlageVurderingOmgjør.java
@@ -16,7 +16,7 @@ public enum KlageVurderingOmgjør implements Kodeverdi {
     GUNST_MEDHOLD_I_KLAGE("GUNST_MEDHOLD_I_KLAGE", "Gunst medhold i klage"),
     DELVIS_MEDHOLD_I_KLAGE("DELVIS_MEDHOLD_I_KLAGE", "Delvis medhold i klage"),
     UGUNST_MEDHOLD_I_KLAGE("UGUNST_MEDHOLD_I_KLAGE", "Ugunst medhold i klage"),
-    UDEFINERT("-", "Udefinert"),
+    UDEFINERT(STANDARDKODE_UDEFINERT, "Udefinert"),
     ;
 
     private static final Map<String, KlageVurderingOmgjør> KODER = new LinkedHashMap<>();

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/medlemskap/MedlemskapDekningType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/medlemskap/MedlemskapDekningType.java
@@ -30,7 +30,7 @@ public enum MedlemskapDekningType implements Kodeverdi {
     OPPHOR("OPPHOR", "Opphør"),
     UNNTATT("UNNTATT", "Unntatt"),
 
-    UDEFINERT("-", "Ikke definert"),
+    UDEFINERT(STANDARDKODE_UDEFINERT, "Ikke definert"),
     ;
 
 

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/medlemskap/MedlemskapKildeType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/medlemskap/MedlemskapKildeType.java
@@ -26,7 +26,7 @@ public enum MedlemskapKildeType implements Kodeverdi {
     TP("TP", "TP"),
     LAANEKASSEN("LAANEKASSEN", "Laanekassen"),
     ANNEN("ANNEN", "Annen"),
-    UDEFINERT("-", "Ikke definert"),
+    UDEFINERT(STANDARDKODE_UDEFINERT, "Ikke definert"),
     ;
 
     private static final Map<String, MedlemskapKildeType> KODER = new LinkedHashMap<>();

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/medlemskap/MedlemskapManuellVurderingType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/medlemskap/MedlemskapManuellVurderingType.java
@@ -13,7 +13,7 @@ import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
 
 public enum MedlemskapManuellVurderingType implements Kodeverdi {
 
-    UDEFINERT("-", "Ikke definert", false),
+    UDEFINERT(STANDARDKODE_UDEFINERT, "Ikke definert", false),
     MEDLEM("MEDLEM", "Periode med medlemskap", true),
     UNNTAK("UNNTAK", "Periode med unntak fra medlemskap", true),
     IKKE_RELEVANT("IKKE_RELEVANT", "Ikke relevant periode", true),

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/medlemskap/MedlemskapType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/medlemskap/MedlemskapType.java
@@ -16,7 +16,7 @@ public enum MedlemskapType implements Kodeverdi {
     ENDELIG("ENDELIG", "Endelig"),
     FORELOPIG("FORELOPIG", "Foreløpig"),
     UNDER_AVKLARING("AVKLARES", "Under avklaring"),
-    UDEFINERT("-", "Ikke definert"),
+    UDEFINERT(STANDARDKODE_UDEFINERT, "Ikke definert"),
     ;
 
     private static final Map<String, MedlemskapType> KODER = new LinkedHashMap<>();

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/opptjening/OpptjeningAktivitetKlassifisering.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/opptjening/OpptjeningAktivitetKlassifisering.java
@@ -17,7 +17,7 @@ public enum OpptjeningAktivitetKlassifisering implements Kodeverdi {
     BEKREFTET_AVVIST("BEKREFTET_AVVIST", "Bekreftet avvist"),
     ANTATT_GODKJENT("ANTATT_GODKJENT", "Antatt godkjent"),
     MELLOMLIGGENDE_PERIODE("MELLOMLIGGENDE_PERIODE", "Mellomliggende periode"),
-    UDEFINERT("-", "UDEFINERT"),
+    UDEFINERT(STANDARDKODE_UDEFINERT, "UDEFINERT"),
     ;
 
     private static final Map<String, OpptjeningAktivitetKlassifisering> KODER = new LinkedHashMap<>();

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/opptjening/OpptjeningAktivitetType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/opptjening/OpptjeningAktivitetType.java
@@ -83,7 +83,7 @@ public enum OpptjeningAktivitetType implements Kodeverdi {
 
     UTDANNINGSPERMISJON("UTDANNINGSPERMISJON", "Utdanningspermisjon",
             Set.of(), Set.of()),
-    UDEFINERT("-", "UDEFINERT",
+    UDEFINERT(STANDARDKODE_UDEFINERT, "UDEFINERT",
             Set.of(),
             Set.of()),
             ;

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/opptjening/ReferanseType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/opptjening/ReferanseType.java
@@ -15,7 +15,7 @@ public enum ReferanseType implements Kodeverdi {
 
     ORG_NR("ORG_NR", "Orgnr"),
     AKTØR_ID("AKTØR_ID", "Aktør Id"),
-    UDEFINERT("-", "Udefinert"),
+    UDEFINERT(STANDARDKODE_UDEFINERT, "Udefinert"),
     ;
 
     private static final Map<String, ReferanseType> KODER = new LinkedHashMap<>();

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/personopplysning/RelasjonsRolleType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/personopplysning/RelasjonsRolleType.java
@@ -25,7 +25,7 @@ public enum RelasjonsRolleType implements Kodeverdi {
     // Mulig verdi i PO_RELASJON
     ANNEN_PART_FRA_SØKNAD("ANPA", "Annen part fra søknad"),
 
-    UDEFINERT("-", "Ikke definert"),
+    UDEFINERT(STANDARDKODE_UDEFINERT, "Ikke definert"),
     ;
 
     private static final Map<String, RelasjonsRolleType> KODER = new LinkedHashMap<>();

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/skjermlenke/SkjermlenkeType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/skjermlenke/SkjermlenkeType.java
@@ -53,7 +53,7 @@ public enum SkjermlenkeType implements Kodeverdi {
     PUNKT_FOR_SVP_INNGANG("PUNKT_FOR_SVP_INNGANG", "Fakta om fødsel og tilrettelegging"),
     SOEKNADSFRIST("SOEKNADSFRIST", "Søknadsfrist"),
     TILKJENT_YTELSE("TILKJENT_YTELSE", "Tilkjent ytelse"),
-    UDEFINERT("-", "Ikke definert"),
+    UDEFINERT(STANDARDKODE_UDEFINERT, "Ikke definert"),
     UTLAND("UTLAND", "Endret utland"),
     UTTAK("UTTAK", "Uttak"),
     VEDTAK("VEDTAK", "Vedtak"),

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/søknad/FarSøkerType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/søknad/FarSøkerType.java
@@ -17,7 +17,7 @@ public enum FarSøkerType implements Kodeverdi {
     OVERTATT_OMSORG("OVERTATT_OMSORG", "Overtatt omsorg < 56 uker"),
     OVERTATT_OMSORG_F("OVERTATT_OMSORG_F", "Overtatt omsorg fødsel"),
     ANDRE_FORELD_DØD_F("ANDRE_FORELD_DØD_F", "Overtatt omsorg ifm. død ved fødsel"),
-    UDEFINERT("-", "Ikke definert"),
+    UDEFINERT(STANDARDKODE_UDEFINERT, "Ikke definert"),
     ;
 
     public static final String KODEVERK = "FAR_SOEKER_TYPE";

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/søknad/ForeldreType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/søknad/ForeldreType.java
@@ -16,7 +16,7 @@ public enum ForeldreType implements Kodeverdi {
     FAR("FAR", "Far"),
     MEDMOR("MEDMOR", "Medmor"),
     ANDRE("ANDRE", "Andre"),
-    UDEFINERT("-", "Ikke definert"),
+    UDEFINERT(STANDARDKODE_UDEFINERT, "Ikke definert"),
     ;
 
     private static final Map<String, ForeldreType> KODER = new LinkedHashMap<>();

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/søknad/SøknadAnnenPartType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/søknad/SøknadAnnenPartType.java
@@ -18,7 +18,7 @@ public enum SøknadAnnenPartType implements Kodeverdi {
     MEDMOR("MEDMOR", "Medmor"),
     FAR("FAR", "Far"),
     MEDFAR("MEDFAR", "Medfar"),
-    UDEFINERT("-", "Ikke definert"),
+    UDEFINERT(STANDARDKODE_UDEFINERT, "Ikke definert"),
     ;
 
     private static final Map<String, SøknadAnnenPartType> KODER = new LinkedHashMap<>();

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/tilbakekreving/TilbakekrevingVidereBehandling.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/tilbakekreving/TilbakekrevingVidereBehandling.java
@@ -13,7 +13,7 @@ import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
 
 public enum TilbakekrevingVidereBehandling implements Kodeverdi {
 
-    UDEFINIERT("-", "Udefinert."),
+    UDEFINIERT(STANDARDKODE_UDEFINERT, "Udefinert."),
     OPPRETT_TILBAKEKREVING("TILBAKEKR_OPPRETT", "Feilutbetaling med tilbakekreving"),
     IGNORER_TILBAKEKREVING("TILBAKEKR_IGNORER", "Feilutbetaling, avvent samordning"),
     INNTREKK("TILBAKEKR_INNTREKK", "Feilutbetalingen er trukket inn i annen utbetaling"),

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/vedtak/IverksettingStatus.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/vedtak/IverksettingStatus.java
@@ -16,7 +16,7 @@ public enum IverksettingStatus implements Kodeverdi {
     IKKE_IVERKSATT("IKKE_IVERKSATT", "Ikke iverksatt"),
     IVERKSATT("IVERKSATT", "Iverksatt"),
 
-    UDEFINERT("-", "Ikke definert"),
+    UDEFINERT(STANDARDKODE_UDEFINERT, "Ikke definert"),
 
     ;
 

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/vedtak/VedtakResultatType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/vedtak/VedtakResultatType.java
@@ -19,7 +19,7 @@ public enum VedtakResultatType implements Kodeverdi {
     VEDTAK_I_KLAGEBEHANDLING("VEDTAK_I_KLAGEBEHANDLING", "vedtak i klagebehandling"),
     VEDTAK_I_ANKEBEHANDLING("VEDTAK_I_ANKEBEHANDLING", "vedtak i ankebehandling"),
     VEDTAK_I_INNSYNBEHANDLING("VEDTAK_I_INNSYNBEHANDLING", "vedtak i innsynbehandling"),
-    UDEFINERT("-", "Ikke definert"),
+    UDEFINERT(STANDARDKODE_UDEFINERT, "Ikke definert"),
 
     ;
 

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/vedtak/Vedtaksbrev.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/vedtak/Vedtaksbrev.java
@@ -16,7 +16,7 @@ public enum Vedtaksbrev implements Kodeverdi {
     AUTOMATISK("AUTOMATISK", "Automatisk generert vedtaksbrev"),
     FRITEKST("FRITEKST", "Fritekstbrev"),
     INGEN("INGEN", "Ingen vedtaksbrev"),
-    UDEFINERT("-", "Udefinert"),
+    UDEFINERT(STANDARDKODE_UDEFINERT, "Udefinert"),
     ;
 
     private static final Map<String, Vedtaksbrev> KODER = new LinkedHashMap<>();

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/vilkår/Avslagsårsak.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/vilkår/Avslagsårsak.java
@@ -58,7 +58,7 @@ public enum Avslagsårsak implements Kodeverdi {
     SN_FL_HAR_IKKE_DOKUMENTERT_RISIKOFAKTORER("1065", "§14-4 andre ledd: Næringsdrivende/frilanser har ikke dokumentert risikofaktorer"),
     SN_FL_HAR_MULIGHET_TIL_Å_TILRETTELEGGE_SITT_VIRKE("1066", "§14-4 andre ledd: Næringsdrivende/frilanser har mulighet til å tilrettelegge sitt virke"),
     INGEN_BEREGNINGSREGLER_TILGJENGELIG_I_LØSNINGEN("1099", "Ingen beregningsregler tilgjengelig i løsningen"),
-    UDEFINERT("-", "Ikke definert"),
+    UDEFINERT(STANDARDKODE_UDEFINERT, "Ikke definert"),
     ;
 
     private static final Map<String, Avslagsårsak> KODER = new LinkedHashMap<>();

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/vilkår/VilkårType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/vilkår/VilkårType.java
@@ -111,7 +111,7 @@ public enum VilkårType implements Kodeverdi {
     /**
      * Brukes i stedet for null der det er optional.
      */
-    UDEFINERT("-", "Ikke definert", Map.of()),
+    UDEFINERT(STANDARDKODE_UDEFINERT, "Ikke definert", Map.of()),
 
     ;
 

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/vilkår/VilkårUtfallMerknad.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/vilkår/VilkårUtfallMerknad.java
@@ -45,7 +45,7 @@ public enum VilkårUtfallMerknad implements Kodeverdi {
     @Deprecated
     VM_7006("7006", "Venter på opptjeningsopplysninger"), // UTGÅTT, finnes i DB
 
-    UDEFINERT("-", "Ikke definert"),
+    UDEFINERT(STANDARDKODE_UDEFINERT, "Ikke definert"),
 
     ;
 

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/vilkår/VilkårUtfallType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/vilkår/VilkårUtfallType.java
@@ -16,7 +16,7 @@ public enum VilkårUtfallType implements Kodeverdi {
     IKKE_OPPFYLT("IKKE_OPPFYLT", "Ikke oppfylt"),
     IKKE_VURDERT("IKKE_VURDERT", "Ikke vurdert"),
 
-    UDEFINERT("-", "Ikke definert"),
+    UDEFINERT(STANDARDKODE_UDEFINERT, "Ikke definert"),
 
     ;
 

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/ytelsefordeling/MorsAktivitet.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/ytelsefordeling/MorsAktivitet.java
@@ -15,7 +15,7 @@ import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
 
 public enum MorsAktivitet implements Kodeverdi {
 
-    UDEFINERT("-", "Ikke satt eller valgt kode"),
+    UDEFINERT(STANDARDKODE_UDEFINERT, "Ikke satt eller valgt kode"),
     ARBEID("ARBEID", "Er i arbeid"),
     UTDANNING("UTDANNING", "Tar utdanning på heltid"),
     KVALPROG("KVALPROG", "Deltar i kvalifiseringsprogrammet"),

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/ytelsefordeling/periode/UttakPeriodeType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/ytelsefordeling/periode/UttakPeriodeType.java
@@ -20,7 +20,7 @@ public enum UttakPeriodeType implements Kodeverdi {
     FEDREKVOTE("FEDREKVOTE", "Fedrekvoten"),
     FORELDREPENGER("FORELDREPENGER", "Foreldrepenger"),
     FORELDREPENGER_FØR_FØDSEL("FORELDREPENGER_FØR_FØDSEL", "Foreldrepenger før fødsel"),
-    UDEFINERT("-", "Ikke satt eller valgt kode"),
+    UDEFINERT(STANDARDKODE_UDEFINERT, "Ikke satt eller valgt kode"),
     ;
     private static final Map<String, UttakPeriodeType> KODER = new LinkedHashMap<>();
 

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/ytelsefordeling/årsak/OppholdÅrsak.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/ytelsefordeling/årsak/OppholdÅrsak.java
@@ -12,7 +12,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
 
 public enum OppholdÅrsak implements Årsak {
 
-    UDEFINERT("-", "Ikke satt eller valgt kode"),
+    UDEFINERT(STANDARDKODE_UDEFINERT, "Ikke satt eller valgt kode"),
     MØDREKVOTE_ANNEN_FORELDER("UTTAK_MØDREKVOTE_ANNEN_FORELDER", "Annen forelder har uttak av Mødrekvote"),
     FEDREKVOTE_ANNEN_FORELDER("UTTAK_FEDREKVOTE_ANNEN_FORELDER", "Annen forelder har uttak av Fedrekvote"),
     KVOTE_FELLESPERIODE_ANNEN_FORELDER("UTTAK_FELLESP_ANNEN_FORELDER", "Annen forelder har uttak av Fellesperiode"),

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/ytelsefordeling/årsak/OverføringÅrsak.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/ytelsefordeling/årsak/OverføringÅrsak.java
@@ -15,7 +15,7 @@ public enum OverføringÅrsak implements Årsak {
     SYKDOM_ANNEN_FORELDER("SYKDOM_ANNEN_FORELDER", "Den andre foreldren er pga sykdom avhengig av hjelp for å ta seg av barnet/barna"),
     IKKE_RETT_ANNEN_FORELDER("IKKE_RETT_ANNEN_FORELDER", "Den andre foreldren har ikke rett på foreldrepenger"),
     ALENEOMSORG("ALENEOMSORG", "Aleneomsorg for barnet/barna"),
-    UDEFINERT("-", "Ikke satt eller valgt kode"),
+    UDEFINERT(STANDARDKODE_UDEFINERT, "Ikke satt eller valgt kode"),
     ;
     private static final Map<String, OverføringÅrsak> KODER = new LinkedHashMap<>();
 

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/ytelsefordeling/årsak/UtsettelseÅrsak.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/ytelsefordeling/årsak/UtsettelseÅrsak.java
@@ -17,7 +17,7 @@ public enum UtsettelseÅrsak implements Årsak {
     HV_OVELSE("HV_OVELSE", "Heimevernet"),
     NAV_TILTAK("NAV_TILTAK", "Tiltak i regi av Nav"),
     FRI("FRI", "Fri utsettelse fom høst 2021"),
-    UDEFINERT("-", "Ikke satt eller valgt kode"),
+    UDEFINERT(STANDARDKODE_UDEFINERT, "Ikke satt eller valgt kode"),
     ;
     private static final Map<String, UtsettelseÅrsak> KODER = new LinkedHashMap<>();
 

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/ytelsefordeling/årsak/Årsak.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/ytelsefordeling/årsak/Årsak.java
@@ -18,7 +18,7 @@ public interface Årsak extends Kodeverdi {
 
         @Override
         public String getKode() {
-            return "-";
+            return Kodeverdi.STANDARDKODE_UDEFINERT;
         }
 
     };

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/fagsak/FagsakYtelseType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/fagsak/FagsakYtelseType.java
@@ -16,7 +16,7 @@ public enum FagsakYtelseType implements Kodeverdi {
     ENGANGSTØNAD("ES", "Engangsstønad"),
     FORELDREPENGER("FP", "Foreldrepenger"),
     SVANGERSKAPSPENGER("SVP", "Svangerskapspenger"),
-    UDEFINERT("-", "Ikke definert"),
+    UDEFINERT(STANDARDKODE_UDEFINERT, "Ikke definert"),
     ;
 
     public static final String KODEVERK = "FAGSAK_YTELSE";

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/geografisk/Landkoder.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/geografisk/Landkoder.java
@@ -274,7 +274,7 @@ public enum Landkoder implements Kodeverdi {
     ZMB("ZMB", "ZAMBIA"),
     ZWE("ZWE", "ZIMBABWE"),
 
-    UDEFINERT("-", "Ikke definert"),
+    UDEFINERT(STANDARDKODE_UDEFINERT, "Ikke definert"),
     ;
 
     public static final String KODEVERK = "LANDKODER";

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/geografisk/Region.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/geografisk/Region.java
@@ -17,7 +17,7 @@ public enum Region implements Kodeverdi {
     NORDEN("NORDEN", "Nordisk", 1),
     EOS("EOS", "EU/EØS", 2),
     TREDJELANDS_BORGER("ANNET", "3.landsborger", 3),
-    UDEFINERT("-", "3.landsborger", 9),
+    UDEFINERT(STANDARDKODE_UDEFINERT, "3.landsborger", 9),
     ;
 
     public static final Comparator<Region> COMPARATOR = Comparator.comparing(Region::getRank);

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/geografisk/Språkkode.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/geografisk/Språkkode.java
@@ -23,7 +23,7 @@ public enum Språkkode implements Kodeverdi, MedOffisiellKode {
     NN("NN", "Nynorsk", "NN"),
     EN("EN", "Engelsk", "EN"),
 
-    UDEFINERT("-", "Ikke definert", null),
+    UDEFINERT(STANDARDKODE_UDEFINERT, "Ikke definert", null),
     ;
 
     public static final String KODEVERK = "SPRAAK_KODE";

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/hendelser/ForretningshendelseType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/hendelser/ForretningshendelseType.java
@@ -16,7 +16,7 @@ public enum ForretningshendelseType implements Kodeverdi {
     DØDFØDSEL("DØDFØDSEL", "Dødfødsel"),
     UTFLYTTING("UTFLYTTING", "Utflytting"),
 
-    UDEFINERT("-", "Ikke definert"),
+    UDEFINERT(STANDARDKODE_UDEFINERT, "Ikke definert"),
     ;
 
     private static final Map<String, ForretningshendelseType> KODER = new LinkedHashMap<>();

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/hendelser/StartpunktType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/hendelser/StartpunktType.java
@@ -36,7 +36,7 @@ public enum StartpunktType implements Kodeverdi {
     UTTAKSVILKÅR("UTTAKSVILKÅR", "Uttaksvilkår", 10, BehandlingStegType.INNGANG_UTTAK, Set.of(FagsakYtelseType.ENGANGSTØNAD)), // OBS: Endrer du startsteg må du flytte køhåndtering ....
     TILKJENT_YTELSE("TILKJENT_YTELSE", "Tilkjent ytelse", 11, BehandlingStegType.BEREGN_YTELSE, Set.of()), // OBS: Ikke testet for Engangsstønad
 
-    UDEFINERT("-", "Ikke definert", 99, BehandlingStegType.KONTROLLERER_SØKERS_OPPLYSNINGSPLIKT, Set.of()),
+    UDEFINERT(STANDARDKODE_UDEFINERT, "Ikke definert", 99, BehandlingStegType.KONTROLLERER_SØKERS_OPPLYSNINGSPLIKT, Set.of()),
     ;
 
     public static final String KODEVERK = "STARTPUNKT_TYPE";

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/kodeverk/Fagsystem.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/kodeverk/Fagsystem.java
@@ -27,7 +27,7 @@ public enum Fagsystem implements Kodeverdi, MedOffisiellKode {
     /**
      * Alle kodeverk må ha en verdi, det kan ikke være null i databasen. Denne koden gjør samme nytten.
      */
-    UDEFINERT("-", "Ikke definert", null),
+    UDEFINERT(STANDARDKODE_UDEFINERT, "Ikke definert", null),
     ;
 
     public static final String KODEVERK = "FAGSYSTEM";

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/kodeverk/Kodeverdi.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/kodeverk/Kodeverdi.java
@@ -5,6 +5,9 @@ import no.nav.foreldrepenger.behandlingslager.diff.IndexKey;
 /** Kodeverk som er portet til java. */
 public interface Kodeverdi extends IndexKey {
 
+    // La stå inntil videre! Er ofte lagret i database som "-" i non-null kolonner.
+    String STANDARDKODE_UDEFINERT = "-";
+
     String getKode();
 
     String getKodeverk();

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/risikoklassifisering/FaresignalVurdering.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/risikoklassifisering/FaresignalVurdering.java
@@ -16,7 +16,7 @@ public enum FaresignalVurdering implements Kodeverdi {
     AVSLAG_FARESIGNAL("AVSLAG_FARESIGNAL", "Saken er avslått på grunn av faresignalene"),
     AVSLAG_ANNET("AVSLAG_ANNET", "Saken er avslått av andre årsaker"),
     INGEN_INNVIRKNING("INGEN_INNVIRKNING", "Faresignalene vurderes ikke som reelle"),
-    UDEFINERT("-", "Udefinert"),
+    UDEFINERT(STANDARDKODE_UDEFINERT, "Udefinert"),
     ;
 
     private static final Map<String, FaresignalVurdering> KODER = new LinkedHashMap<>();

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/risikoklassifisering/Kontrollresultat.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/risikoklassifisering/Kontrollresultat.java
@@ -13,7 +13,7 @@ public enum Kontrollresultat implements Kodeverdi {
     HØY("HOY", "Kontrollresultatet er HØY"),
     IKKE_HØY("IKKE_HOY", "Kontrollresultatet er IKKE_HØY"),
     IKKE_KLASSIFISERT("IKKE_KLASSIFISERT", "Behandlingen er ikke blitt klassifisert"),
-    UDEFINERT("-", "Udefinert"),
+    UDEFINERT(STANDARDKODE_UDEFINERT, "Udefinert"),
     ;
 
     private static final Map<String, Kontrollresultat> KODER = new LinkedHashMap<>();

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/uttak/fp/GraderingAvslagÅrsak.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/uttak/fp/GraderingAvslagÅrsak.java
@@ -15,7 +15,7 @@ public enum GraderingAvslagÅrsak implements Kodeverdi {
 
     //MERK: Lovhjemler til brev hentes fra navn, se pattern i UttakHjemmelUtleder
 
-    UKJENT("-", "Ikke definert"),
+    UKJENT(STANDARDKODE_UDEFINERT, "Ikke definert"),
     GRADERING_FØR_UKE_7("4504", "§14-16 andre ledd: Avslag gradering - gradering før uke 7"),
     FOR_SEN_SØKNAD("4501", "§14-16: Ikke gradering pga. for sen søknad"),
     MANGLENDE_GRADERINGSAVTALE("4502", "§14-16 femte ledd, jf §21-3: Avslag graderingsavtale mangler - ikke dokumentert"),

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/uttak/fp/ManuellBehandlingÅrsak.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/uttak/fp/ManuellBehandlingÅrsak.java
@@ -14,7 +14,7 @@ import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
 
 public enum ManuellBehandlingÅrsak implements Kodeverdi {
 
-    UKJENT("-", "Ikke definert"),
+    UKJENT(STANDARDKODE_UDEFINERT, "Ikke definert"),
     STØNADSKONTO_TOM("5001", "Stønadskonto tom for stønadsdager. Vurder bruk av annen stønadskonto eller avslå perioden."),
     UGYLDIG_STØNADSKONTO("5002", "Ikke gyldig grunn for uttak av denne stønadskontoen. Vurder bruk av annen stønadskonto eller avslå perioden."),
     BEGRUNNELSE_IKKE_GYLDIG("5003", "Ikke gyldig grunn for overføring av kvote. Vurder bruk av annen stønadskonto eller avslå perioden."),

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/uttak/fp/PeriodeResultatÅrsak.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/uttak/fp/PeriodeResultatÅrsak.java
@@ -31,7 +31,7 @@ public enum PeriodeResultatÅrsak implements Kodeverdi {
 
     //MERK: Lovhjemler til brev hentes fra navn, se pattern i UttakHjemmelUtleder
 
-    UKJENT("-", "NN", "Ikke definert", null),
+    UKJENT(STANDARDKODE_UDEFINERT, "NN", "Ikke definert", null),
 
     // Regel oppfylt, resultat = innvilget
     FELLESPERIODE_ELLER_FORELDREPENGER("2002", "14-09", "§14-9: Innvilget fellesperiode/foreldrepenger", of(UTTAK),
@@ -262,7 +262,6 @@ public enum PeriodeResultatÅrsak implements Kodeverdi {
     ;
 
     private static final Map<String, PeriodeResultatÅrsak> KODER = new LinkedHashMap<>();
-    private static final String UDEFINERT_KODE = "-";
 
     public static final String KODEVERK = "PERIODE_RESULTAT_AARSAK";
 
@@ -302,7 +301,7 @@ public enum PeriodeResultatÅrsak implements Kodeverdi {
         this.kode = kode;
         this.sortering = sortering;
         this.navn = navn;
-        this.utfallType = UDEFINERT_KODE.equals(kode) ? null : Long.parseLong(kode) < 4000L ? UtfallType.INNVILGET : UtfallType.AVSLÅTT;
+        this.utfallType = Kodeverdi.STANDARDKODE_UDEFINERT.equals(kode) ? null : Long.parseLong(kode) < 4000L ? UtfallType.INNVILGET : UtfallType.AVSLÅTT;
         this.uttakTyper = uttakTyper == null ? of(UTTAK) : uttakTyper;
         this.valgbarForKonto =
             valgbarForKonto == null ? of(FELLESPERIODE, MØDREKVOTE, FEDREKVOTE, FORELDREPENGER, FORELDREPENGER_FØR_FØDSEL) : valgbarForKonto;

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/uttak/fp/StønadskontoType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/uttak/fp/StønadskontoType.java
@@ -45,7 +45,7 @@ public enum StønadskontoType implements Kodeverdi {
     // Annet, bla dager med fullt (200%) samtidig uttak (se også flerbarnsdager)
     FAR_RUNDT_FØDSEL("FAR_RUNDT_FØDSEL", "Fars uttak ifm fødsel", KontoKategori.ANNET),
 
-    UDEFINERT("-", "Ikke valgt stønadskonto", KontoKategori.ANNET),
+    UDEFINERT(STANDARDKODE_UDEFINERT, "Ikke valgt stønadskonto", KontoKategori.ANNET),
     ;
 
     public enum KontoKategori { STØNADSDAGER, UTVIDELSE, AKTIVITETSKRAV, MINSTERETT, ANNET }

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/uttak/fp/UttakUtsettelseType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/uttak/fp/UttakUtsettelseType.java
@@ -22,7 +22,7 @@ public enum UttakUtsettelseType implements Kodeverdi {
     HV_OVELSE("HV_OVELSE", "Heimevernet"),
     NAV_TILTAK("NAV_TILTAK", "Tiltak i regi av Nav"),
     FRI("FRI", "Fri utsettelse fom høst 2021"),
-    UDEFINERT("-", "Ikke satt eller valgt kode"),
+    UDEFINERT(STANDARDKODE_UDEFINERT, "Ikke satt eller valgt kode"),
     ;
     private static final Map<String, UttakUtsettelseType> KODER = new LinkedHashMap<>();
 

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/uttak/svp/ArbeidsforholdIkkeOppfyltÅrsak.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/uttak/svp/ArbeidsforholdIkkeOppfyltÅrsak.java
@@ -14,7 +14,7 @@ import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
 public enum ArbeidsforholdIkkeOppfyltÅrsak implements Kodeverdi {
 
     // Se også Periode ikke oppfylt - der brukes 8304-83011 + 8313+8314
-    INGEN("-", "Ikke definert"),
+    INGEN(STANDARDKODE_UDEFINERT, "Ikke definert"),
     HELE_UTTAKET_ER_ETTER_3_UKER_FØR_TERMINDATO("8301", "Hele uttaket er etter 3 uker før termindato"),
     UTTAK_KUN_PÅ_HELG("8302", "Uttak kun på helg"),
     ARBEIDSGIVER_KAN_TILRETTELEGGE("8303", "Arbeidsgiver kan tilrettelegge"),

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/uttak/svp/PeriodeIkkeOppfyltÅrsak.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/uttak/svp/PeriodeIkkeOppfyltÅrsak.java
@@ -14,7 +14,7 @@ import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
 
 public enum PeriodeIkkeOppfyltÅrsak implements Kodeverdi {
 
-    INGEN("-", "Ikke definert"),
+    INGEN(STANDARDKODE_UDEFINERT, "Ikke definert"),
 
     // Se også Arbeidsforhold ikke oppfylt - der brukes 8301-8303 + 8312
     _8304("8304", "Bruker er død"),

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/virksomhet/ArbeidType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/virksomhet/ArbeidType.java
@@ -45,7 +45,7 @@ public enum ArbeidType implements Kodeverdi, MedOffisiellKode {
     UTENLANDSK_ARBEIDSFORHOLD("UTENLANDSK_ARBEIDSFORHOLD", "Arbeid i utlandet", null, true),
     VENTELØNN_VARTPENGER("VENTELØNN_VARTPENGER", "Ventelønn eller vartpenger", null, true),
     VANLIG("VANLIG", "Vanlig", "VANLIG", false),
-    UDEFINERT("-", "Ikke definert", null, false),
+    UDEFINERT(STANDARDKODE_UDEFINERT, "Ikke definert", null, false),
     ;
 
     @Converter(autoApply = true)

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/virksomhet/Organisasjonstype.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/virksomhet/Organisasjonstype.java
@@ -10,7 +10,7 @@ public enum Organisasjonstype implements Kodeverdi {
     VIRKSOMHET("VIRKSOMHET", "Virksomhet"),
     ORGLEDD("ORGANISASJONSLEDD", "Organisasjonsledd"),
     KUNSTIG("KUNSTIG", "Kunstig arbeidsforhold lagt til av saksbehandler"),
-    UDEFINERT("-", "Udefinert"),
+    UDEFINERT(STANDARDKODE_UDEFINERT, "Udefinert"),
     ;
 
     public static final String KODEVERK = "ORGANISASJONSTYPE";

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/ytelse/RelatertYtelseType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/ytelse/RelatertYtelseType.java
@@ -24,7 +24,7 @@ public enum RelatertYtelseType implements Kodeverdi {
     OPPLÆRINGSPENGER("OLP", "Opplæringspenger"),
     ARBEIDSAVKLARINGSPENGER("AAP", "Arbeidsavklaringspenger"),
     DAGPENGER("DAG", "Dagpenger"),
-    UDEFINERT("-", "Ikke definert"),
+    UDEFINERT(STANDARDKODE_UDEFINERT, "Ikke definert"),
     ;
 
     public static final Set<RelatertYtelseType> PLEIEPENGER = Set.of(PLEIEPENGER_SYKT_BARN, PLEIEPENGER_NÆRSTÅENDE, OPPLÆRINGSPENGER);

--- a/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/iay/modell/kodeverk/ArbeidsforholdHandlingType.java
+++ b/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/iay/modell/kodeverk/ArbeidsforholdHandlingType.java
@@ -17,7 +17,7 @@ import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
 
 public enum ArbeidsforholdHandlingType implements Kodeverdi {
 
-    UDEFINERT("-", "Udefinert"),
+    UDEFINERT(STANDARDKODE_UDEFINERT, "Udefinert"),
     BRUK("BRUK", "Bruk"),
     NYTT_ARBEIDSFORHOLD("NYTT_ARBEIDSFORHOLD", "Arbeidsforholdet er ansett som nytt"),
     BRUK_UTEN_INNTEKTSMELDING("BRUK_UTEN_INNTEKTSMELDING", "Bruk, men ikke benytt inntektsmelding"),

--- a/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/iay/modell/kodeverk/Arbeidskategori.java
+++ b/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/iay/modell/kodeverk/Arbeidskategori.java
@@ -25,7 +25,7 @@ public enum Arbeidskategori implements Kodeverdi {
     KOMBINASJON_ARBEIDSTAKER_OG_DAGPENGER("KOMBINASJON_ARBEIDSTAKER_OG_DAGPENGER", "Kombinasjon arbeidstaker og dagpenger"),
     DAGMAMMA("DAGMAMMA", "Selvstendig næringsdrivende - Dagmamma"),
     UGYLDIG("UGYLDIG", "Ugyldig"),
-    UDEFINERT("-", "Ingen inntektskategori (default)"),
+    UDEFINERT(STANDARDKODE_UDEFINERT, "Ingen inntektskategori (default)"),
     ;
 
     private static final Map<String, Arbeidskategori> KODER = new LinkedHashMap<>();

--- a/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/iay/modell/kodeverk/BekreftetPermisjonStatus.java
+++ b/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/iay/modell/kodeverk/BekreftetPermisjonStatus.java
@@ -16,7 +16,7 @@ import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
 
 public enum BekreftetPermisjonStatus implements Kodeverdi {
 
-    UDEFINERT("-", "UDEFINERT"),
+    UDEFINERT(STANDARDKODE_UDEFINERT, "UDEFINERT"),
     BRUK_PERMISJON("BRUK_PERMISJON", "Bruk permisjonen til arbeidsforholdet"),
     IKKE_BRUK_PERMISJON("IKKE_BRUK_PERMISJON", "Ikke bruk permisjonen til arbeidsforholdet"),
     UGYLDIGE_PERIODER("UGYLDIGE_PERIODER", "Arbeidsforholdet inneholder permisjoner med ugyldige perioder"),

--- a/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/iay/modell/kodeverk/InntektPeriodeType.java
+++ b/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/iay/modell/kodeverk/InntektPeriodeType.java
@@ -18,7 +18,7 @@ public enum InntektPeriodeType implements Kodeverdi {
     ÅRLIG("AARLG", "Årlig", Period.ofYears(1)),
     FASTSATT25PAVVIK("INNFS", "Fastsatt etter 25 prosent avvik", Period.ofYears(1)),
     PREMIEGRUNNLAG("PREMGR", "Premiegrunnlag", Period.ofYears(1)),
-    UDEFINERT("-", "Ikke definert", null),
+    UDEFINERT(STANDARDKODE_UDEFINERT, "Ikke definert", null),
     ;
 
     private static final Map<String, InntektPeriodeType> KODER = new LinkedHashMap<>();

--- a/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/iay/modell/kodeverk/InntektsKilde.java
+++ b/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/iay/modell/kodeverk/InntektsKilde.java
@@ -10,7 +10,7 @@ import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
 
 public enum InntektsKilde implements Kodeverdi {
 
-    UDEFINERT("-", "Ikke definert"),
+    UDEFINERT(STANDARDKODE_UDEFINERT, "Ikke definert"),
     INNTEKT_OPPTJENING("INNTEKT_OPPTJENING", "INNTEKT_OPPTJENING"),
     INNTEKT_BEREGNING("INNTEKT_BEREGNING", "INNTEKT_BEREGNING"),
     INNTEKT_SAMMENLIGNING("INNTEKT_SAMMENLIGNING", "INNTEKT_SAMMENLIGNING"),

--- a/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/iay/modell/kodeverk/InntektsmeldingInnsendingsårsak.java
+++ b/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/iay/modell/kodeverk/InntektsmeldingInnsendingsårsak.java
@@ -12,7 +12,7 @@ public enum InntektsmeldingInnsendingsårsak implements Kodeverdi {
 
     NY("NY", "NY"),
     ENDRING("ENDRING", "ENDRING"),
-    UDEFINERT("-", "UDEFINERT"),
+    UDEFINERT(STANDARDKODE_UDEFINERT, "UDEFINERT"),
     ;
 
     private static final Map<String, InntektsmeldingInnsendingsårsak> KODER = new LinkedHashMap<>();

--- a/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/iay/modell/kodeverk/InntektspostType.java
+++ b/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/iay/modell/kodeverk/InntektspostType.java
@@ -10,7 +10,7 @@ import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
 
 public enum InntektspostType implements Kodeverdi {
 
-    UDEFINERT("-", "Ikke definert"),
+    UDEFINERT(STANDARDKODE_UDEFINERT, "Ikke definert"),
     LØNN("LØNN", "Lønn"),
     YTELSE("YTELSE", "Ytelse"),
     VANLIG("VANLIG", "Vanlig"),

--- a/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/iay/modell/kodeverk/NaturalYtelseType.java
+++ b/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/iay/modell/kodeverk/NaturalYtelseType.java
@@ -32,7 +32,7 @@ public enum NaturalYtelseType implements Kodeverdi, MedOffisiellKode {
     YRKEBIL_TJENESTLIGBEHOV_KILOMETER("YRKESBIL_KILOMETER", "Yrkesbil tjenesteligbehov kilometer", "yrkebilTjenestligbehovKilometer"),
     YRKEBIL_TJENESTLIGBEHOV_LISTEPRIS("YRKESBIL_LISTEPRIS", "Yrkesbil tjenesteligbehov listepris", "yrkebilTjenestligbehovListepris"),
     INNBETALING_TIL_UTENLANDSK_PENSJONSORDNING("UTENLANDSK_PENSJONSORDNING", "Innbetaling utenlandsk pensjonsordning", "innbetalingTilUtenlandskPensjonsordning"),
-    UDEFINERT("-", "Ikke definert", null),
+    UDEFINERT(STANDARDKODE_UDEFINERT, "Ikke definert", null),
     ;
 
     private static final Map<String, NaturalYtelseType> KODER = new LinkedHashMap<>();

--- a/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/iay/modell/kodeverk/PermisjonsbeskrivelseType.java
+++ b/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/iay/modell/kodeverk/PermisjonsbeskrivelseType.java
@@ -11,7 +11,7 @@ import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
 
 public enum PermisjonsbeskrivelseType implements Kodeverdi {
 
-    UDEFINERT("-", "Ikke definert"),
+    UDEFINERT(STANDARDKODE_UDEFINERT, "Ikke definert"),
     PERMISJON("PERMISJON", "Permisjon"),
     UTDANNINGSPERMISJON("UTDANNINGSPERMISJON", "Utdanningspermisjon"), // Utgår 31/12-2022
     UTDANNINGSPERMISJON_IKKE_LOVFESTET("UTDANNINGSPERMISJON_IKKE_LOVFESTET", "Utdanningspermisjon (Ikke lovfestet)"),

--- a/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/iay/modell/kodeverk/SkatteOgAvgiftsregelType.java
+++ b/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/iay/modell/kodeverk/SkatteOgAvgiftsregelType.java
@@ -26,7 +26,7 @@ public enum SkatteOgAvgiftsregelType implements Kodeverdi {
     KILDESKATT_PÅ_PENSJONER("KILDESKATT_PÅ_PENSJONER", "Kildeskatt på pensjoner"),
     JAN_MAYEN_OG_BILANDENE("JAN_MAYEN_OG_BILANDENE", "Inntekt på Jan Mayen og i norske biland i Antarktis"),
 
-    UDEFINERT("-", "Udefinert"),
+    UDEFINERT(STANDARDKODE_UDEFINERT, "Udefinert"),
     ;
 
     private static final Map<String, SkatteOgAvgiftsregelType> KODER = new LinkedHashMap<>();

--- a/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/iay/modell/kodeverk/VirksomhetType.java
+++ b/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/iay/modell/kodeverk/VirksomhetType.java
@@ -23,7 +23,7 @@ public enum VirksomhetType implements Kodeverdi {
     FRILANSER("FRILANSER", "Frilanser", Inntektskategori.FRILANSER),
     JORDBRUK_SKOGBRUK("JORDBRUK_SKOGBRUK", "Jordbruk", Inntektskategori.JORDBRUKER),
     ANNEN("ANNEN", "Annen næringsvirksomhet", Inntektskategori.UDEFINERT),
-    UDEFINERT("-", "Ikke definert", Inntektskategori.UDEFINERT),
+    UDEFINERT(STANDARDKODE_UDEFINERT, "Ikke definert", Inntektskategori.UDEFINERT),
     ;
 
     private static final Map<String, VirksomhetType> KODER = new LinkedHashMap<>();

--- a/domenetjenester/beregningsgrunnlag/src/main/java/no/nav/foreldrepenger/domene/modell/kodeverk/BeregningAktivitetHandlingType.java
+++ b/domenetjenester/beregningsgrunnlag/src/main/java/no/nav/foreldrepenger/domene/modell/kodeverk/BeregningAktivitetHandlingType.java
@@ -13,7 +13,7 @@ public enum BeregningAktivitetHandlingType implements Kodeverdi {
 
     BENYTT("BENYTT", "Benytt beregningaktivitet"),
     IKKE_BENYTT("IKKE_BENYTT", "Ikke benytt beregningaktivitet"),
-    UDEFINERT("-", "Ikke definert"),
+    UDEFINERT(STANDARDKODE_UDEFINERT, "Ikke definert"),
     ;
     public static final String KODEVERK = "BEREGNING_AKTIVITET_HANDLING_TYPE";
 

--- a/domenetjenester/beregningsgrunnlag/src/main/java/no/nav/foreldrepenger/domene/modell/kodeverk/BeregningsgrunnlagPeriodeRegelType.java
+++ b/domenetjenester/beregningsgrunnlag/src/main/java/no/nav/foreldrepenger/domene/modell/kodeverk/BeregningsgrunnlagPeriodeRegelType.java
@@ -18,7 +18,7 @@ public enum BeregningsgrunnlagPeriodeRegelType implements Kodeverdi {
     OPPDATER_GRUNNLAG_SVP("OPPDATER_GRUNNLAG_SVP", "Oppdater grunnlag for SVP"),
     FASTSETT2("FASTSETT2", "Fastsette/fullføre beregningsgrunnlag for andre gangs kjøring for SVP"),
     FINN_GRENSEVERDI("FINN_GRENSEVERDI", "Finne grenseverdi til kjøring av fastsett beregningsgrunnlag for SVP"),
-    UDEFINERT("-", "Ikke definert"),
+    UDEFINERT(STANDARDKODE_UDEFINERT, "Ikke definert"),
     ;
     public static final String KODEVERK = "BG_PERIODE_REGEL_TYPE";
 

--- a/domenetjenester/beregningsgrunnlag/src/main/java/no/nav/foreldrepenger/domene/modell/kodeverk/BeregningsgrunnlagRegelType.java
+++ b/domenetjenester/beregningsgrunnlag/src/main/java/no/nav/foreldrepenger/domene/modell/kodeverk/BeregningsgrunnlagRegelType.java
@@ -19,7 +19,7 @@ public enum BeregningsgrunnlagRegelType implements Kodeverdi {
     PERIODISERING_NATURALYTELSE("PERIODISERING_NATURALYTELSE", "Periodiser beregningsgrunnlag pga naturalytelse"),
     PERIODISERING_REFUSJON("PERIODISERING_REFUSJON", "Periodiser beregningsgrunnlag pga refusjon"),
     PERIODISERING_GRADERING("PERIODISERING_GRADERING", "Periodiser beregningsgrunnlag pga gradering og endring i utbetalingsgrad"),
-    UDEFINERT("-", "Ikke definert"),
+    UDEFINERT(STANDARDKODE_UDEFINERT, "Ikke definert"),
     ;
     public static final String KODEVERK = "BG_REGEL_TYPE";
 

--- a/domenetjenester/beregningsgrunnlag/src/main/java/no/nav/foreldrepenger/domene/modell/kodeverk/BeregningsgrunnlagTilstand.java
+++ b/domenetjenester/beregningsgrunnlag/src/main/java/no/nav/foreldrepenger/domene/modell/kodeverk/BeregningsgrunnlagTilstand.java
@@ -27,7 +27,7 @@ public enum BeregningsgrunnlagTilstand implements Kodeverdi {
     OPPDATERT_MED_REFUSJON_OG_GRADERING("OPPDATERT_MED_REFUSJON_OG_GRADERING", "Tilstand for splittet periode med refusjon og gradering", true),
     FASTSATT_INN("FASTSATT_INN", "Fastsatt - Inn", false),
     FASTSATT("FASTSATT", "Fastsatt", true),
-    UDEFINERT("-", "Ikke definert", false),
+    UDEFINERT(STANDARDKODE_UDEFINERT, "Ikke definert", false),
     ;
     public static final String KODEVERK = "BEREGNINGSGRUNNLAG_TILSTAND";
 

--- a/domenetjenester/beregningsgrunnlag/src/main/java/no/nav/foreldrepenger/domene/modell/kodeverk/FaktaOmBeregningTilfelle.java
+++ b/domenetjenester/beregningsgrunnlag/src/main/java/no/nav/foreldrepenger/domene/modell/kodeverk/FaktaOmBeregningTilfelle.java
@@ -28,7 +28,7 @@ public enum FaktaOmBeregningTilfelle implements Kodeverdi {
     FASTSETT_BG_KUN_YTELSE("FASTSETT_BG_KUN_YTELSE", "Fastsett beregningsgrunnlag for kun ytelse uten arbeidsforhold"),
     TILSTØTENDE_YTELSE("TILSTØTENDE_YTELSE", "Avklar beregningsgrunnlag og inntektskategori for tilstøtende ytelse"),
     FASTSETT_ENDRET_BEREGNINGSGRUNNLAG("FASTSETT_ENDRET_BEREGNINGSGRUNNLAG", "Fastsette endring i beregningsgrunnlag"),
-    UDEFINERT("-", "Ikke definert"),
+    UDEFINERT(STANDARDKODE_UDEFINERT, "Ikke definert"),
     ;
     public static final String KODEVERK = "FAKTA_OM_BEREGNING_TILFELLE";
 

--- a/domenetjenester/beregningsgrunnlag/src/main/java/no/nav/foreldrepenger/domene/modell/kodeverk/FaktaVurderingKilde.java
+++ b/domenetjenester/beregningsgrunnlag/src/main/java/no/nav/foreldrepenger/domene/modell/kodeverk/FaktaVurderingKilde.java
@@ -12,7 +12,7 @@ public enum FaktaVurderingKilde implements Kodeverdi {
 
     SAKSBEHANDLER("SAKSBEHANDLER", "Saksbehandler"),
     KALKULATOR("KALKULATOR", "Kalkulator"),
-    UDEFINERT("-", "Uspesifisert"),
+    UDEFINERT(STANDARDKODE_UDEFINERT, "Uspesifisert"),
     ;
 
     private static final Map<String, FaktaVurderingKilde> KODER = new LinkedHashMap<>();

--- a/domenetjenester/beregningsgrunnlag/src/main/java/no/nav/foreldrepenger/domene/modell/kodeverk/Hjemmel.java
+++ b/domenetjenester/beregningsgrunnlag/src/main/java/no/nav/foreldrepenger/domene/modell/kodeverk/Hjemmel.java
@@ -21,7 +21,7 @@ public enum Hjemmel implements Kodeverdi {
     F_14_7_8_43("F_14_7_8_43", "folketrygdloven §§ 14-7 og 8-43"),
     F_14_7_8_47("F_14_7_8_47", "folketrygdloven §§ 14-7 og 8-47"),
     F_14_7_8_49("F_14_7_8_49", "folketrygdloven §§ 14-7 og 8-49"),
-    UDEFINERT("-", "Ikke definert"),
+    UDEFINERT(STANDARDKODE_UDEFINERT, "Ikke definert"),
     ;
 
     private static final Map<String, Hjemmel> KODER = new LinkedHashMap<>();

--- a/domenetjenester/beregningsgrunnlag/src/main/java/no/nav/foreldrepenger/domene/modell/kodeverk/PeriodeÅrsak.java
+++ b/domenetjenester/beregningsgrunnlag/src/main/java/no/nav/foreldrepenger/domene/modell/kodeverk/PeriodeÅrsak.java
@@ -20,7 +20,7 @@ public enum PeriodeÅrsak implements Kodeverdi {
     ENDRING_I_AKTIVITETER_SØKT_FOR("ENDRING_I_AKTIVITETER_SØKT_FOR", "Endring i aktiviteter søkt for"),
     REFUSJON_AVSLÅTT("REFUSJON_AVSLÅTT", "Refusjon avslått"),
 
-    UDEFINERT("-", "Ikke definert"),
+    UDEFINERT(STANDARDKODE_UDEFINERT, "Ikke definert"),
     ;
 
     private static final Map<String, PeriodeÅrsak> KODER = new LinkedHashMap<>();

--- a/domenetjenester/dokumentarkiv/src/main/java/no/nav/foreldrepenger/dokumentarkiv/NAVSkjema.java
+++ b/domenetjenester/dokumentarkiv/src/main/java/no/nav/foreldrepenger/dokumentarkiv/NAVSkjema.java
@@ -1,5 +1,7 @@
 package no.nav.foreldrepenger.dokumentarkiv;
 
+import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
+
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -32,7 +34,7 @@ public enum NAVSkjema {
     // ANNET
     FORSIDE_SVP_GAMMEL("SSVPG", "AT-474B", "Tilrettelegging/omplassering pga graviditet / Søknad om svangerskapspenger til arbeidstaker"),
 
-    UDEFINERT("-", null, "Ukjent type dokument");
+    UDEFINERT(Kodeverdi.STANDARDKODE_UDEFINERT, null, "Ukjent type dokument");
 
     private static final Map<String, NAVSkjema> KODER = new LinkedHashMap<>();
     private static final Map<String, NAVSkjema> OFFISIELLE_KODER = new LinkedHashMap<>();

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/kodeverk/app/HentKodeverkTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/kodeverk/app/HentKodeverkTjeneste.java
@@ -142,7 +142,7 @@ public class HentKodeverkTjeneste {
         Map<String, Collection<? extends Kodeverdi>> mapFiltered = new LinkedHashMap<>();
 
         map.forEach((key, value) -> mapFiltered.put(key,
-            value.stream().filter(f -> !"-".equals(f.getKode())).collect(Collectors.toSet())));
+            value.stream().filter(f -> !Kodeverdi.STANDARDKODE_UDEFINERT.equals(f.getKode())).collect(Collectors.toSet())));
 
         KODEVERDIER_SOM_BRUKES_PÅ_KLIENT = Collections.unmodifiableMap(mapFiltered);
 


### PR DESCRIPTION
Neste steg:
* Sanere ubrukte tilfelle av fraKode
* Innføre DatabaseKode-grensesnitt og legge på aktuelle Enums
* Innføre FrontendKode-grensesnitt og legge på aktuelle Enums
* Innføre en Kodeverk-annotering + global enum av verdier fra eksisterende STRING Kodeverk
* Innføre LagretVedtakKode-grensesnitt og legge på aktuelle Enums
* Vurdere om navn beholdes på topp, eller flyttes ned til aktuelle steder (Frontend, LagretVedtak)