### PR TITLE
bugfix: oppdaget valideringsfeil ved annen serialisering

### DIFF
--- a/domenetjenester/beregningsgrunnlag/src/main/java/no/nav/foreldrepenger/domene/mappers/til_kalkulus/MapKalkulusYtelsegrunnlagFP.java
+++ b/domenetjenester/beregningsgrunnlag/src/main/java/no/nav/foreldrepenger/domene/mappers/til_kalkulus/MapKalkulusYtelsegrunnlagFP.java
@@ -60,7 +60,7 @@ public class MapKalkulusYtelsegrunnlagFP implements MapKalkulusYtelsegrunnlag {
 
     public AktivitetGraderingDto finnAktivitetGraderingerKalkulus(BehandlingReferanse ref) {
         var periodeMedGradering = beregningGraderingTjeneste.finnPerioderMedGradering(ref);
-        return new AktivitetGraderingDto(mapTilDto(periodeMedGradering));
+        return periodeMedGradering.isEmpty() ? null : new AktivitetGraderingDto(mapTilDto(periodeMedGradering));
     }
 
     private List<AndelGraderingDto> mapTilDto(List<PeriodeMedGradering> perioderMedGradering) {


### PR DESCRIPTION
AktivitetGraderingDto har en @Size(min = 1) List<AndelGraderingDto> andelGraderingDto
Dermed vil kall til kalkulus feile når vi bytter JsonInclude.Include fra NON_EMPTY til NON_NULL/NON_ABSENT - i dag blir tomme lister til null, mens med NON_NULL så sendes det en tom liste til kalkulus