### PR TITLE
TFP-6465 traverser alle typer

### DIFF
--- a/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/arbeidInntektsmelding/AvklarPermisjonUtenSluttdatoDto.java
+++ b/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/arbeidInntektsmelding/AvklarPermisjonUtenSluttdatoDto.java
@@ -1,7 +1,16 @@
 package no.nav.foreldrepenger.domene.arbeidInntektsmelding;
 
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 
-import no.nav.foreldrepenger.domene.iay.modell.kodeverk.BekreftetPermisjonStatus;
+import jakarta.validation.constraints.Pattern;
 
-public record AvklarPermisjonUtenSluttdatoDto(@NotNull String arbeidsgiverIdent, String internArbeidsforholdId, @NotNull BekreftetPermisjonStatus permisjonStatus) {}
+import no.nav.foreldrepenger.domene.iay.modell.kodeverk.BekreftetPermisjonStatus;
+import no.nav.foreldrepenger.validering.ValidKodeverk;
+import no.nav.vedtak.util.InputValideringRegex;
+
+import java.util.UUID;
+
+public record AvklarPermisjonUtenSluttdatoDto(@NotNull @Pattern(regexp = InputValideringRegex.ARBEIDSGIVER) String arbeidsgiverIdent,
+                                              UUID internArbeidsforholdId,
+                                              @NotNull @ValidKodeverk BekreftetPermisjonStatus permisjonStatus) {}

--- a/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/arbeidInntektsmelding/ManueltArbeidsforholdDto.java
+++ b/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/arbeidInntektsmelding/ManueltArbeidsforholdDto.java
@@ -13,6 +13,7 @@ import jakarta.validation.constraints.Size;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import no.nav.foreldrepenger.behandlingslager.behandling.arbeidsforhold.ArbeidsforholdKomplettVurderingType;
+import no.nav.foreldrepenger.validering.ValidKodeverk;
 import no.nav.vedtak.util.InputValideringRegex;
 
 public class ManueltArbeidsforholdDto {
@@ -50,7 +51,7 @@ public class ManueltArbeidsforholdDto {
     @NotNull
     private Integer stillingsprosent;
     @JsonProperty("vurdering")
-    @Valid
+    @ValidKodeverk
     @NotNull
     private ArbeidsforholdKomplettVurderingType vurdering;
     @JsonProperty("behandlingVersjon")

--- a/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/opptjening/dto/MerkOpptjeningUtlandDto.java
+++ b/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/opptjening/dto/MerkOpptjeningUtlandDto.java
@@ -2,6 +2,8 @@ package no.nav.foreldrepenger.domene.opptjening.dto;
 
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
+import jakarta.validation.Valid;
+
 import no.nav.foreldrepenger.behandling.aksjonspunkt.BekreftetAksjonspunktDto;
 import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.AksjonspunktKodeDefinisjon;
 import no.nav.foreldrepenger.behandlingslager.fagsak.egenskaper.UtlandDokumentasjonStatus;
@@ -9,6 +11,7 @@ import no.nav.foreldrepenger.behandlingslager.fagsak.egenskaper.UtlandDokumentas
 @JsonTypeName(AksjonspunktKodeDefinisjon.AUTOMATISK_MARKERING_AV_UTENLANDSSAK_KODE)
 public class MerkOpptjeningUtlandDto extends BekreftetAksjonspunktDto {
 
+    @Valid
     private UtlandDokumentasjonStatus dokStatus;
 
     public UtlandDokumentasjonStatus getDokStatus() {

--- a/domenetjenester/arbeidsforhold/src/test/java/no/nav/foreldrepenger/domene/arbeidInntektsmelding/AvklarArbeidPermisjonUtenSluttdatoOppdatererTest.java
+++ b/domenetjenester/arbeidsforhold/src/test/java/no/nav/foreldrepenger/domene/arbeidInntektsmelding/AvklarArbeidPermisjonUtenSluttdatoOppdatererTest.java
@@ -7,6 +7,7 @@ import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 
 import jakarta.inject.Inject;
 import jakarta.persistence.EntityManager;
@@ -103,8 +104,8 @@ class AvklarArbeidPermisjonUtenSluttdatoOppdatererTest {
             AksjonspunktDefinisjon.VURDER_PERMISJON_UTEN_SLUTTDATO);
 
         var bekreftetArbeidMedPermisjonUtenSluttdato = new BekreftArbeidMedPermisjonUtenSluttdatoDto("Har tatt stilling til dette",
-            List.of(new AvklarPermisjonUtenSluttdatoDto(NAV_ORGNR, INTERN_ARBEIDSFORHOLD_ID, BekreftetPermisjonStatus.BRUK_PERMISJON),
-                new AvklarPermisjonUtenSluttdatoDto(KUNSTIG_ORG, INTERN_ARBEIDSFORHOLD_ID_2, BekreftetPermisjonStatus.IKKE_BRUK_PERMISJON)));
+            List.of(new AvklarPermisjonUtenSluttdatoDto(NAV_ORGNR, UUID.fromString(INTERN_ARBEIDSFORHOLD_ID), BekreftetPermisjonStatus.BRUK_PERMISJON),
+                new AvklarPermisjonUtenSluttdatoDto(KUNSTIG_ORG, UUID.fromString(INTERN_ARBEIDSFORHOLD_ID_2), BekreftetPermisjonStatus.IKKE_BRUK_PERMISJON)));
 
         //Act
         var resultat = avklarArbeidPermisjonUtenSluttdatoOppdaterer.oppdater(bekreftetArbeidMedPermisjonUtenSluttdato, new AksjonspunktOppdaterParameter(
@@ -146,7 +147,7 @@ class AvklarArbeidPermisjonUtenSluttdatoOppdatererTest {
             AksjonspunktDefinisjon.VURDER_PERMISJON_UTEN_SLUTTDATO);
 
         var bekreftetArbeidMedPermisjonUtenSluttdato = new BekreftArbeidMedPermisjonUtenSluttdatoDto("Har tatt stilling til dette",
-            List.of(new AvklarPermisjonUtenSluttdatoDto(NAV_ORGNR, INTERN_ARBEIDSFORHOLD_ID, BekreftetPermisjonStatus.BRUK_PERMISJON)));
+            List.of(new AvklarPermisjonUtenSluttdatoDto(NAV_ORGNR, UUID.fromString(INTERN_ARBEIDSFORHOLD_ID), BekreftetPermisjonStatus.BRUK_PERMISJON)));
 
         var skjæringstidspunkt = Skjæringstidspunkt.builder()
             .medUtledetSkjæringstidspunkt(LocalDate.of(2019, 1, 1))

--- a/domenetjenester/arbeidsforhold/src/test/java/no/nav/foreldrepenger/domene/arbeidInntektsmelding/historikk/ArbeidPermHistorikkInnslagTjenesteTest.java
+++ b/domenetjenester/arbeidsforhold/src/test/java/no/nav/foreldrepenger/domene/arbeidInntektsmelding/historikk/ArbeidPermHistorikkInnslagTjenesteTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
+import java.util.UUID;
 
 import jakarta.inject.Inject;
 
@@ -47,8 +48,8 @@ class ArbeidPermHistorikkInnslagTjenesteTest {
         var arbeidPermHistorikkInnslagTjenesteTest = new ArbeidPermHistorikkInnslagTjeneste(historikkRepository, arbeidsgiverTjeneste);
 
         var avklarteArbForhold = List.of(
-            new AvklarPermisjonUtenSluttdatoDto(KUNSTIG_ORG, INTERN_ARBEIDSFORHOLD_ID, BekreftetPermisjonStatus.BRUK_PERMISJON),
-            new AvklarPermisjonUtenSluttdatoDto(NAV_ORGNR, INTERN_ARBEIDSFORHOLD_ID_2, BekreftetPermisjonStatus.IKKE_BRUK_PERMISJON)
+            new AvklarPermisjonUtenSluttdatoDto(KUNSTIG_ORG, UUID.fromString(INTERN_ARBEIDSFORHOLD_ID), BekreftetPermisjonStatus.BRUK_PERMISJON),
+            new AvklarPermisjonUtenSluttdatoDto(NAV_ORGNR, UUID.fromString(INTERN_ARBEIDSFORHOLD_ID_2), BekreftetPermisjonStatus.IKKE_BRUK_PERMISJON)
         );
         var ref = getBehandlingReferanse();
         arbeidPermHistorikkInnslagTjenesteTest.opprettHistorikkinnslag(ref, avklarteArbForhold, "begrunnelse");

--- a/domenetjenester/beregningsgrunnlag/src/main/java/no/nav/foreldrepenger/domene/aksjonspunkt/OppdatererDtoMapper.java
+++ b/domenetjenester/beregningsgrunnlag/src/main/java/no/nav/foreldrepenger/domene/aksjonspunkt/OppdatererDtoMapper.java
@@ -3,6 +3,7 @@ package no.nav.foreldrepenger.domene.aksjonspunkt;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 import no.nav.folketrygdloven.kalkulus.håndtering.v1.fakta.FaktaOmBeregningTilfelleDto;
@@ -327,7 +328,7 @@ public class OppdatererDtoMapper {
         return new no.nav.folketrygdloven.kalkulus.håndtering.v1.refusjon.VurderRefusjonAndelBeregningsgrunnlagDto(
             andel.getArbeidsgiverOrgnr(),
             andel.getArbeidsgiverAktoerId(),
-            andel.getInternArbeidsforholdRef().toString(),
+            Optional.ofNullable(andel.getInternArbeidsforholdRef()).map(UUID::toString).orElse(null),
             andel.getFastsattRefusjonFom(),
             andel.getDelvisRefusjonPrMndFørStart());
     }

--- a/domenetjenester/beregningsgrunnlag/src/main/java/no/nav/foreldrepenger/domene/aksjonspunkt/OppdatererDtoMapper.java
+++ b/domenetjenester/beregningsgrunnlag/src/main/java/no/nav/foreldrepenger/domene/aksjonspunkt/OppdatererDtoMapper.java
@@ -327,7 +327,7 @@ public class OppdatererDtoMapper {
         return new no.nav.folketrygdloven.kalkulus.håndtering.v1.refusjon.VurderRefusjonAndelBeregningsgrunnlagDto(
             andel.getArbeidsgiverOrgnr(),
             andel.getArbeidsgiverAktoerId(),
-            andel.getInternArbeidsforholdRef(),
+            andel.getInternArbeidsforholdRef().toString(),
             andel.getFastsattRefusjonFom(),
             andel.getDelvisRefusjonPrMndFørStart());
     }

--- a/domenetjenester/beregningsgrunnlag/src/main/java/no/nav/foreldrepenger/domene/rest/dto/ArbeidstakerandelUtenIMMottarYtelseDto.java
+++ b/domenetjenester/beregningsgrunnlag/src/main/java/no/nav/foreldrepenger/domene/rest/dto/ArbeidstakerandelUtenIMMottarYtelseDto.java
@@ -1,10 +1,14 @@
 package no.nav.foreldrepenger.domene.rest.dto;
 
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 
 public class ArbeidstakerandelUtenIMMottarYtelseDto {
 
     @NotNull
+    @Min(0)
+    @Max(100)
     private long andelsnr;
     private Boolean mottarYtelse;
 

--- a/domenetjenester/beregningsgrunnlag/src/main/java/no/nav/foreldrepenger/domene/rest/dto/BeregningsaktivitetLagreDto.java
+++ b/domenetjenester/beregningsgrunnlag/src/main/java/no/nav/foreldrepenger/domene/rest/dto/BeregningsaktivitetLagreDto.java
@@ -23,6 +23,7 @@ public class BeregningsaktivitetLagreDto {
     @Pattern(regexp = InputValideringRegex.ARBEIDSGIVER)
     private String oppdragsgiverOrg;
 
+    @Pattern(regexp = "^[\\p{Graph}\\p{Space}\\p{Sc}\\p{L}\\p{M}\\p{N}]+$", message = "'${validatedValue}' matcher ikke tillatt pattern '{regexp}'")
     private String arbeidsgiverIdentifikator;
 
     @Size(max = 100)

--- a/domenetjenester/beregningsgrunnlag/src/main/java/no/nav/foreldrepenger/domene/rest/dto/FastsattePerioderTidsbegrensetDto.java
+++ b/domenetjenester/beregningsgrunnlag/src/main/java/no/nav/foreldrepenger/domene/rest/dto/FastsattePerioderTidsbegrensetDto.java
@@ -3,6 +3,7 @@ package no.nav.foreldrepenger.domene.rest.dto;
 import java.time.LocalDate;
 import java.util.List;
 
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 
 public class FastsattePerioderTidsbegrensetDto {
@@ -11,7 +12,7 @@ public class FastsattePerioderTidsbegrensetDto {
     private LocalDate periodeFom;
     private LocalDate periodeTom;
 
-    private List<FastsatteAndelerTidsbegrensetDto> fastsatteTidsbegrensedeAndeler;
+    private List<@Valid FastsatteAndelerTidsbegrensetDto> fastsatteTidsbegrensedeAndeler;
 
     FastsattePerioderTidsbegrensetDto() {
         // Jackson

--- a/domenetjenester/beregningsgrunnlag/src/main/java/no/nav/foreldrepenger/domene/rest/dto/FastsatteVerdierDto.java
+++ b/domenetjenester/beregningsgrunnlag/src/main/java/no/nav/foreldrepenger/domene/rest/dto/FastsatteVerdierDto.java
@@ -16,6 +16,8 @@ public class FastsatteVerdierDto {
     @Max(Integer.MAX_VALUE)
     private Integer refusjon;
 
+    @Min(0)
+    @Max(Integer.MAX_VALUE)
     private Integer refusjonPrÅr;
 
     @Min(0)

--- a/domenetjenester/beregningsgrunnlag/src/main/java/no/nav/foreldrepenger/domene/rest/dto/FastsatteVerdierDto.java
+++ b/domenetjenester/beregningsgrunnlag/src/main/java/no/nav/foreldrepenger/domene/rest/dto/FastsatteVerdierDto.java
@@ -6,6 +6,7 @@ import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 
 import no.nav.foreldrepenger.behandlingslager.behandling.beregning.Inntektskategori;
+import no.nav.foreldrepenger.validering.ValidKodeverk;
 
 
 public class FastsatteVerdierDto {
@@ -32,6 +33,7 @@ public class FastsatteVerdierDto {
     @Max(Integer.MAX_VALUE)
     private Integer fastsattÅrsbeløpInklNaturalytelse;
 
+    @ValidKodeverk
     private Inntektskategori inntektskategori;
 
     private Boolean skalHaBesteberegning;

--- a/domenetjenester/beregningsgrunnlag/src/main/java/no/nav/foreldrepenger/domene/rest/dto/FastsettBeregningsgrunnlagAndelDto.java
+++ b/domenetjenester/beregningsgrunnlag/src/main/java/no/nav/foreldrepenger/domene/rest/dto/FastsettBeregningsgrunnlagAndelDto.java
@@ -1,6 +1,8 @@
 package no.nav.foreldrepenger.domene.rest.dto;
 
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 
 import no.nav.foreldrepenger.behandlingslager.behandling.opptjening.OpptjeningAktivitetType;
@@ -14,7 +16,11 @@ public class FastsettBeregningsgrunnlagAndelDto extends RedigerbarAndelDto {
     private FastsatteVerdierDto fastsatteVerdier;
     @ValidKodeverk
     private Inntektskategori forrigeInntektskategori;
+    @Min(0)
+    @Max(Integer.MAX_VALUE)
     private Integer forrigeRefusjonPrÅr;
+    @Min(0)
+    @Max(Integer.MAX_VALUE)
     private Integer forrigeArbeidsinntektPrÅr;
 
     FastsettBeregningsgrunnlagAndelDto() {

--- a/domenetjenester/beregningsgrunnlag/src/main/java/no/nav/foreldrepenger/domene/rest/dto/FastsettEtterlønnSluttpakkeDto.java
+++ b/domenetjenester/beregningsgrunnlag/src/main/java/no/nav/foreldrepenger/domene/rest/dto/FastsettEtterlønnSluttpakkeDto.java
@@ -1,10 +1,14 @@
 package no.nav.foreldrepenger.domene.rest.dto;
 
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 
 public class FastsettEtterlønnSluttpakkeDto {
 
     @NotNull
+    @Min(0)
+    @Max(178956970)
     private Integer fastsattPrMnd;
 
     FastsettEtterlønnSluttpakkeDto() {

--- a/domenetjenester/beregningsgrunnlag/src/main/java/no/nav/foreldrepenger/domene/rest/dto/OverstyrBeregningsgrunnlagDto.java
+++ b/domenetjenester/beregningsgrunnlag/src/main/java/no/nav/foreldrepenger/domene/rest/dto/OverstyrBeregningsgrunnlagDto.java
@@ -23,7 +23,7 @@ public class OverstyrBeregningsgrunnlagDto extends OverstyringAksjonspunktDto {
     @NotNull
     private List<@Valid FastsettBeregningsgrunnlagAndelDto> overstyrteAndeler;
 
-    private Set<Lønnsendring> endringer;
+    private Set<@Valid Lønnsendring> endringer;
 
     @SuppressWarnings("unused")
     private OverstyrBeregningsgrunnlagDto() {

--- a/domenetjenester/beregningsgrunnlag/src/main/java/no/nav/foreldrepenger/domene/rest/dto/RedigerbarAndelDto.java
+++ b/domenetjenester/beregningsgrunnlag/src/main/java/no/nav/foreldrepenger/domene/rest/dto/RedigerbarAndelDto.java
@@ -9,9 +9,10 @@ import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 
-import no.nav.foreldrepenger.behandlingslager.behandling.opptjening.OpptjeningAktivitetType;
 import no.nav.foreldrepenger.behandlingslager.behandling.beregning.AktivitetStatus;
+import no.nav.foreldrepenger.behandlingslager.behandling.opptjening.OpptjeningAktivitetType;
 import no.nav.foreldrepenger.domene.typer.InternArbeidsforholdRef;
+import no.nav.foreldrepenger.validering.ValidKodeverk;
 import no.nav.vedtak.util.InputValideringRegex;
 
 public class RedigerbarAndelDto {
@@ -25,7 +26,9 @@ public class RedigerbarAndelDto {
     private String arbeidsforholdId;
     @NotNull
     private Boolean nyAndel;
+    @ValidKodeverk
     private AktivitetStatus aktivitetStatus;
+    @ValidKodeverk
     private OpptjeningAktivitetType arbeidsforholdType;
     private Boolean lagtTilAvSaksbehandler;
     private LocalDate beregningsperiodeFom;

--- a/domenetjenester/beregningsgrunnlag/src/main/java/no/nav/foreldrepenger/domene/rest/dto/RedigerbarAndelDto.java
+++ b/domenetjenester/beregningsgrunnlag/src/main/java/no/nav/foreldrepenger/domene/rest/dto/RedigerbarAndelDto.java
@@ -21,6 +21,7 @@ public class RedigerbarAndelDto {
     private Long andelsnr;
     @Pattern(regexp = InputValideringRegex.ARBEIDSGIVER)
     private String arbeidsgiverId;
+    @Pattern(regexp = "^[\\p{Graph}\\p{Space}\\p{Sc}\\p{L}\\p{M}\\p{N}]+$", message = "'${validatedValue}' matcher ikke tillatt pattern '{regexp}'")
     private String arbeidsforholdId;
     @NotNull
     private Boolean nyAndel;

--- a/domenetjenester/beregningsgrunnlag/src/main/java/no/nav/foreldrepenger/domene/rest/dto/VurderRefusjonAndelBeregningsgrunnlagDto.java
+++ b/domenetjenester/beregningsgrunnlag/src/main/java/no/nav/foreldrepenger/domene/rest/dto/VurderRefusjonAndelBeregningsgrunnlagDto.java
@@ -1,26 +1,35 @@
 package no.nav.foreldrepenger.domene.rest.dto;
 
 import java.time.LocalDate;
+import java.util.UUID;
 
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+
+import no.nav.vedtak.util.InputValideringRegex;
 
 public class VurderRefusjonAndelBeregningsgrunnlagDto {
 
     @Valid
+    @Pattern(regexp = InputValideringRegex.ARBEIDSGIVER)
     private String arbeidsgiverOrgnr;
 
     @Valid
+    @Pattern(regexp = InputValideringRegex.ARBEIDSGIVER)
     private String arbeidsgiverAktoerId;
 
-    @Valid
-    private String internArbeidsforholdRef;
+    private UUID internArbeidsforholdRef;
 
     @Valid
     @NotNull
     private LocalDate fastsattRefusjonFom;
 
     @Valid
+    @Min(0)
+    @Max(Integer.MAX_VALUE)
     private Integer delvisRefusjonPrMndFørStart;
 
     VurderRefusjonAndelBeregningsgrunnlagDto() {
@@ -29,7 +38,7 @@ public class VurderRefusjonAndelBeregningsgrunnlagDto {
 
     public VurderRefusjonAndelBeregningsgrunnlagDto(@Valid String arbeidsgiverOrgnr,
                                                     @Valid String arbeidsgiverAktoerId,
-                                                    @Valid String internArbeidsforholdRef,
+                                                    @Valid UUID internArbeidsforholdRef,
                                                     @Valid @NotNull LocalDate fastsattRefusjonFom,
                                                     @Valid Integer delvisRefusjonPrMndFørStart) {
         this.arbeidsgiverOrgnr = arbeidsgiverOrgnr;
@@ -47,7 +56,7 @@ public class VurderRefusjonAndelBeregningsgrunnlagDto {
         return arbeidsgiverAktoerId;
     }
 
-    public String getInternArbeidsforholdRef() {
+    public UUID getInternArbeidsforholdRef() {
         return internArbeidsforholdRef;
     }
 

--- a/domenetjenester/beregningsgrunnlag/src/main/java/no/nav/foreldrepenger/domene/rest/dto/fordeling/FordelBeregningsgrunnlagAndelDto.java
+++ b/domenetjenester/beregningsgrunnlag/src/main/java/no/nav/foreldrepenger/domene/rest/dto/fordeling/FordelBeregningsgrunnlagAndelDto.java
@@ -1,6 +1,8 @@
 package no.nav.foreldrepenger.domene.rest.dto.fordeling;
 
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 
 import no.nav.foreldrepenger.behandlingslager.behandling.beregning.Inntektskategori;
@@ -13,7 +15,11 @@ public class FordelBeregningsgrunnlagAndelDto extends FordelRedigerbarAndelDto {
     private FordelFastsatteVerdierDto fastsatteVerdier;
     @ValidKodeverk
     private Inntektskategori forrigeInntektskategori;
+    @Min(0)
+    @Max(178956970)
     private Integer forrigeRefusjonPrÅr;
+    @Min(0)
+    @Max(178956970)
     private Integer forrigeArbeidsinntektPrÅr;
 
     public FordelBeregningsgrunnlagAndelDto() {

--- a/domenetjenester/beregningsgrunnlag/src/main/java/no/nav/foreldrepenger/domene/rest/dto/fordeling/FordelRedigerbarAndelDto.java
+++ b/domenetjenester/beregningsgrunnlag/src/main/java/no/nav/foreldrepenger/domene/rest/dto/fordeling/FordelRedigerbarAndelDto.java
@@ -2,7 +2,9 @@ package no.nav.foreldrepenger.domene.rest.dto.fordeling;
 
 
 import java.time.LocalDate;
+import java.util.UUID;
 
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
@@ -12,6 +14,7 @@ import no.nav.foreldrepenger.behandlingslager.behandling.opptjening.OpptjeningAk
 import no.nav.foreldrepenger.behandlingslager.behandling.beregning.AktivitetStatus;
 import no.nav.foreldrepenger.domene.modell.kodeverk.AndelKilde;
 import no.nav.foreldrepenger.domene.typer.InternArbeidsforholdRef;
+import no.nav.foreldrepenger.validering.ValidKodeverk;
 import no.nav.vedtak.util.InputValideringRegex;
 
 public class FordelRedigerbarAndelDto {
@@ -21,11 +24,14 @@ public class FordelRedigerbarAndelDto {
     private Long andelsnr;
     @Pattern(regexp = InputValideringRegex.ARBEIDSGIVER)
     private String arbeidsgiverId;
-    private String arbeidsforholdId;
+    private UUID arbeidsforholdId;
     @NotNull
     private Boolean nyAndel;
+    @ValidKodeverk
     private AndelKilde kilde;
+    @ValidKodeverk
     private AktivitetStatus aktivitetStatus;
+    @ValidKodeverk
     private OpptjeningAktivitetType arbeidsforholdType;
     private Boolean lagtTilAvSaksbehandler;
     private LocalDate beregningsperiodeFom;
@@ -38,7 +44,7 @@ public class FordelRedigerbarAndelDto {
 
     public FordelRedigerbarAndelDto(@Min(0) @Max(Long.MAX_VALUE) Long andelsnr,
                                     @Pattern(regexp = InputValideringRegex.ARBEIDSGIVER) String arbeidsgiverId,
-                                    String arbeidsforholdId, @NotNull Boolean nyAndel,
+                                    UUID arbeidsforholdId, @NotNull Boolean nyAndel,
                                     AndelKilde kilde,
                                     AktivitetStatus aktivitetStatus,
                                     OpptjeningAktivitetType arbeidsforholdType,

--- a/domenetjenester/beregningsgrunnlag/src/main/java/no/nav/foreldrepenger/domene/rest/historikk/ArbeidsgiverDto.java
+++ b/domenetjenester/beregningsgrunnlag/src/main/java/no/nav/foreldrepenger/domene/rest/historikk/ArbeidsgiverDto.java
@@ -1,0 +1,52 @@
+package no.nav.foreldrepenger.domene.rest.historikk;
+
+import static no.nav.foreldrepenger.behandlingslager.virksomhet.OrgNummer.tilMaskertNummer;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Pattern;
+
+import no.nav.foreldrepenger.domene.typer.AktørId;
+import no.nav.vedtak.util.InputValideringRegex;
+
+public record ArbeidsgiverDto(@Pattern(regexp = InputValideringRegex.ARBEIDSGIVER) String arbeidsgiverOrgnr,
+                              @Valid AktørId arbeidsgiverAktørId)  {
+
+
+
+    public ArbeidsgiverDto {
+        if (arbeidsgiverAktørId==null && arbeidsgiverOrgnr==null) {
+            throw new IllegalArgumentException("Utvikler-feil: arbeidsgiver uten hverken orgnr eller aktørId");
+        }
+        if (arbeidsgiverAktørId!=null && arbeidsgiverOrgnr!=null) {
+            throw new IllegalArgumentException("Utvikler-feil: arbeidsgiver med både orgnr og aktørId");
+        }
+    }
+
+    public static ArbeidsgiverDto virksomhet(String arbeidsgiverOrgnr) {
+        return new ArbeidsgiverDto(arbeidsgiverOrgnr, null);
+    }
+
+    public static ArbeidsgiverDto person(AktørId arbeidsgiverAktørId) {
+        return new ArbeidsgiverDto(null, arbeidsgiverAktørId);
+    }
+
+    public String getIdentifikator() {
+        if (arbeidsgiverAktørId != null) {
+            return arbeidsgiverAktørId().getId();
+        }
+        return arbeidsgiverOrgnr();
+    }
+
+    public boolean getErVirksomhet() {
+        return arbeidsgiverOrgnr() != null;
+    }
+
+    @Override
+    public String toString() {
+        return "Arbeidsgiver{" +
+            "virksomhet=" + tilMaskertNummer(arbeidsgiverOrgnr()) +
+            ", arbeidsgiverAktørId='" + arbeidsgiverAktørId() + '\'' +
+            '}';
+    }
+
+}

--- a/domenetjenester/beregningsgrunnlag/src/main/java/no/nav/foreldrepenger/domene/rest/historikk/FordelBeregningsgrunnlagHistorikkUtil.java
+++ b/domenetjenester/beregningsgrunnlag/src/main/java/no/nav/foreldrepenger/domene/rest/historikk/FordelBeregningsgrunnlagHistorikkUtil.java
@@ -8,15 +8,14 @@ import java.util.List;
 import java.util.Optional;
 
 import no.nav.foreldrepenger.behandling.aksjonspunkt.AksjonspunktOppdaterParameter;
+import no.nav.foreldrepenger.behandlingslager.behandling.beregning.Inntektskategori;
 import no.nav.foreldrepenger.behandlingslager.behandling.historikk.HistorikkAktør;
 import no.nav.foreldrepenger.behandlingslager.behandling.historikk.HistorikkBeløp;
 import no.nav.foreldrepenger.behandlingslager.behandling.historikk.Historikkinnslag;
 import no.nav.foreldrepenger.behandlingslager.behandling.historikk.HistorikkinnslagLinjeBuilder;
 import no.nav.foreldrepenger.behandlingslager.behandling.skjermlenke.SkjermlenkeType;
-import no.nav.foreldrepenger.behandlingslager.virksomhet.Arbeidsgiver;
 import no.nav.foreldrepenger.behandlingslager.virksomhet.OrgNummer;
 import no.nav.foreldrepenger.domene.aksjonspunkt.BeregningsgrunnlagPeriodeEndring;
-import no.nav.foreldrepenger.behandlingslager.behandling.beregning.Inntektskategori;
 import no.nav.foreldrepenger.domene.rest.dto.fordeling.FordelBeregningsgrunnlagAndelDto;
 import no.nav.foreldrepenger.domene.rest.dto.fordeling.FordelBeregningsgrunnlagPeriodeDto;
 import no.nav.foreldrepenger.domene.typer.AktørId;
@@ -141,12 +140,12 @@ public final class FordelBeregningsgrunnlagHistorikkUtil {
         endring.medArbeidsforholdRef(endretAndel.getArbeidsforholdId()).medArbeidsgiver(finnArbeidsgiver(endretAndel));
     }
 
-    private static Arbeidsgiver finnArbeidsgiver(FordelBeregningsgrunnlagAndelDto endretAndel) {
-        Arbeidsgiver arbeidsgiver;
+    private static ArbeidsgiverDto finnArbeidsgiver(FordelBeregningsgrunnlagAndelDto endretAndel) {
+        ArbeidsgiverDto arbeidsgiver;
         if (OrgNummer.erGyldigOrgnr(endretAndel.getArbeidsgiverId())) {
-            arbeidsgiver = Arbeidsgiver.virksomhet(endretAndel.getArbeidsgiverId());
+            arbeidsgiver = ArbeidsgiverDto.virksomhet(endretAndel.getArbeidsgiverId());
         } else {
-            arbeidsgiver = Arbeidsgiver.person(new AktørId(endretAndel.getArbeidsgiverId()));
+            arbeidsgiver = ArbeidsgiverDto.person(new AktørId(endretAndel.getArbeidsgiverId()));
         }
         return arbeidsgiver;
     }

--- a/domenetjenester/beregningsgrunnlag/src/main/java/no/nav/foreldrepenger/domene/rest/historikk/Lønnsendring.java
+++ b/domenetjenester/beregningsgrunnlag/src/main/java/no/nav/foreldrepenger/domene/rest/historikk/Lønnsendring.java
@@ -2,6 +2,10 @@ package no.nav.foreldrepenger.domene.rest.historikk;
 
 import java.util.Optional;
 
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+
 import no.nav.foreldrepenger.behandlingslager.virksomhet.Arbeidsgiver;
 import no.nav.foreldrepenger.behandlingslager.behandling.beregning.AktivitetStatus;
 import no.nav.foreldrepenger.behandlingslager.behandling.beregning.Inntektskategori;
@@ -10,19 +14,35 @@ import no.nav.foreldrepenger.validering.ValidKodeverk;
 
 
 public class Lønnsendring {
+    @Min(0)
+    @Max(Integer.MAX_VALUE)
     private Integer gammelArbeidsinntekt;
+    @Min(0)
+    @Max(Integer.MAX_VALUE)
     private Integer nyArbeidsinntekt;
+    @Min(0)
+    @Max(Integer.MAX_VALUE)
     private Integer nyArbeidsinntektPrÅr;
     @ValidKodeverk
     private Inntektskategori gammelInntektskategori;
     @ValidKodeverk
     private Inntektskategori nyInntektskategori;
+    @Min(0)
+    @Max(Integer.MAX_VALUE)
     private Integer gammelRefusjonPrÅr;
+    @Min(0)
+    @Max(Integer.MAX_VALUE)
     private Integer nyRefusjonPrÅr;
+    @Min(0)
+    @Max(Integer.MAX_VALUE)
     private Integer nyTotalRefusjonPrÅr;
     private boolean nyAndel;
+    @Min(0)
+    @Max(Integer.MAX_VALUE)
     private Integer gammelArbeidsinntektPrÅr;
-    private Arbeidsgiver arbeidsgiver;
+    @Valid
+    private ArbeidsgiverDto arbeidsgiver;
+    @Valid
     private InternArbeidsforholdRef arbeidsforholdRef;
     @ValidKodeverk
     private AktivitetStatus aktivitetStatus;
@@ -75,7 +95,8 @@ public class Lønnsendring {
     }
 
     public Optional<Arbeidsgiver> getArbeidsgiver() {
-        return Optional.ofNullable(arbeidsgiver);
+        return Optional.ofNullable(arbeidsgiver)
+            .map(ag -> ag.getErVirksomhet() ? Arbeidsgiver.virksomhet(ag.arbeidsgiverOrgnr()) : Arbeidsgiver.person(ag.arbeidsgiverAktørId()));
     }
 
     public Optional<InternArbeidsforholdRef> getArbeidsforholdRef() {
@@ -158,7 +179,7 @@ public class Lønnsendring {
             return this;
         }
 
-        public Builder medArbeidsgiver(Arbeidsgiver arbeidsgiver) {
+        public Builder medArbeidsgiver(ArbeidsgiverDto arbeidsgiver) {
             lønnsendringMal.arbeidsgiver = arbeidsgiver;
             return this;
         }

--- a/domenetjenester/beregningsgrunnlag/src/main/java/no/nav/foreldrepenger/domene/rest/historikk/VurderRefusjonBeregningsgrunnlagHistorikkKalkulusTjeneste.java
+++ b/domenetjenester/beregningsgrunnlag/src/main/java/no/nav/foreldrepenger/domene/rest/historikk/VurderRefusjonBeregningsgrunnlagHistorikkKalkulusTjeneste.java
@@ -100,7 +100,7 @@ public class VurderRefusjonBeregningsgrunnlagHistorikkKalkulusTjeneste {
     }
 
     private boolean matcherReferanse(InternArbeidsforholdRef arbeidsforholdRef, VurderRefusjonAndelBeregningsgrunnlagDto fastsattAndel) {
-        return Objects.equals(arbeidsforholdRef.getReferanse(), fastsattAndel.getInternArbeidsforholdRef());
+        return Objects.equals(arbeidsforholdRef.getUUIDReferanse(), fastsattAndel.getInternArbeidsforholdRef());
     }
 
     private boolean matcherAG(Arbeidsgiver arbeidsgiver, VurderRefusjonAndelBeregningsgrunnlagDto fastsattAndel) {

--- a/domenetjenester/familie-hendelse/src/main/java/no/nav/foreldrepenger/familiehendelse/aksjonspunkt/omsorgsovertakelse/dto/OmsorgsovertakelseBarnDto.java
+++ b/domenetjenester/familie-hendelse/src/main/java/no/nav/foreldrepenger/familiehendelse/aksjonspunkt/omsorgsovertakelse/dto/OmsorgsovertakelseBarnDto.java
@@ -1,8 +1,10 @@
 package no.nav.foreldrepenger.familiehendelse.aksjonspunkt.omsorgsovertakelse.dto;
 
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 
 import java.time.LocalDate;
 
-public record OmsorgsovertakelseBarnDto(@NotNull LocalDate fødselsdato, @NotNull Integer barnNummer) {
+public record OmsorgsovertakelseBarnDto(@NotNull LocalDate fødselsdato, @NotNull @Min(0) @Max(10) Integer barnNummer) {
 }

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
         <felles.version>7.6.9</felles.version>
         <prosesstask.version>5.2.1</prosesstask.version>
         <openapi-spec-utils.version>2.0.6</openapi-spec-utils.version>
-        <fp-kontrakter.version>9.4.12</fp-kontrakter.version>
+        <fp-kontrakter.version>9.4.13</fp-kontrakter.version>
         <abakus-kontrakt.version>2.3.6</abakus-kontrakt.version>
 
         <sonar.moduleKey>${project.artifactId}</sonar.moduleKey>

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/risikoklassifisering/VurderFaresignalerDto.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/risikoklassifisering/VurderFaresignalerDto.java
@@ -1,7 +1,6 @@
 package no.nav.foreldrepenger.web.app.tjenester.behandling.risikoklassifisering;
 
 
-import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 
 import com.fasterxml.jackson.annotation.JsonTypeName;
@@ -9,12 +8,13 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 import no.nav.foreldrepenger.behandling.aksjonspunkt.BekreftetAksjonspunktDto;
 import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.AksjonspunktKodeDefinisjon;
 import no.nav.foreldrepenger.behandlingslager.risikoklassifisering.FaresignalVurdering;
+import no.nav.foreldrepenger.validering.ValidKodeverk;
 
 @JsonTypeName(AksjonspunktKodeDefinisjon.VURDER_FARESIGNALER_KODE)
 public class VurderFaresignalerDto extends BekreftetAksjonspunktDto {
 
     @NotNull
-    @Valid
+    @ValidKodeverk
     private FaresignalVurdering faresignalVurdering;
 
     VurderFaresignalerDto() {

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/svp/SvangerskapspengerTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/svp/SvangerskapspengerTjeneste.java
@@ -261,7 +261,7 @@ public class SvangerskapspengerTjeneste {
         arbeidsforholdDto.setSkalBrukes(svpTilrettelegging.getSkalBrukes());
         arbeidsforholdDto.setUttakArbeidType(ARBTYPE_MAP.getOrDefault(svpTilrettelegging.getArbeidType(), UttakArbeidType.ANNET));
         svpTilrettelegging.getArbeidsgiver().ifPresent(ag -> arbeidsforholdDto.setArbeidsgiverReferanse(ag.getIdentifikator()));
-        svpTilrettelegging.getInternArbeidsforholdRef().ifPresent(ref -> arbeidsforholdDto.setInternArbeidsforholdReferanse(ref.getReferanse()));
+        svpTilrettelegging.getInternArbeidsforholdRef().ifPresent(ref -> arbeidsforholdDto.setInternArbeidsforholdReferanse(ref.getUUIDReferanse()));
         registerFilter.flatMap(rf -> utledStillingsprosentForTilrPeriode(rf, overstyringer, svpTilrettelegging)).ifPresent(arbeidsforholdDto::setStillingsprosentStartTilrettelegging);
         arbeidsforholdDto.setVelferdspermisjoner(finnRelevanteVelferdspermisjoner(svpTilrettelegging, registerFilter, saksbehandletFilter));
         finnEksternRef(svpTilrettelegging, arbeidsforholdInformasjon).ifPresent(arbeidsforholdDto::setEksternArbeidsforholdReferanse);

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/svp/SvpArbeidsforholdDto.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/svp/SvpArbeidsforholdDto.java
@@ -4,29 +4,44 @@ import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 
 import no.nav.foreldrepenger.behandlingslager.uttak.UttakArbeidType;
+import no.nav.foreldrepenger.validering.ValidKodeverk;
 import no.nav.vedtak.util.InputValideringRegex;
 
 
 public class SvpArbeidsforholdDto {
 
-    @NotNull private Long tilretteleggingId;
+    @NotNull
+    @Min(0L)
+    @Max(Long.MAX_VALUE)
+    private Long tilretteleggingId;
     @NotNull private LocalDate tilretteleggingBehovFom;
-    @NotNull private List<SvpTilretteleggingDatoDto> tilretteleggingDatoer = new ArrayList<>();
+    @NotNull private List<@Valid SvpTilretteleggingDatoDto> tilretteleggingDatoer = new ArrayList<>();
+    @ValidKodeverk
     private UttakArbeidType uttakArbeidType;
+    @Pattern(regexp = InputValideringRegex.ARBEIDSGIVER)
     private String arbeidsgiverReferanse;
-    private String internArbeidsforholdReferanse;
+    private UUID internArbeidsforholdReferanse;
+    @Pattern(regexp = InputValideringRegex.FRITEKST)
     private String eksternArbeidsforholdReferanse;
     @NotNull private boolean skalBrukes = true;
     @NotNull private boolean kanTilrettelegges = true;
+    @DecimalMin("0.00")
+    @DecimalMax("100.00")
     private BigDecimal stillingsprosentStartTilrettelegging;
-    @NotNull private List<VelferdspermisjonDto> velferdspermisjoner = new ArrayList<>();
-    @NotNull private List<SvpAvklartOppholdPeriodeDto> avklarteOppholdPerioder = new ArrayList<>();
+    @NotNull private List<@Valid VelferdspermisjonDto> velferdspermisjoner = new ArrayList<>();
+    @NotNull private List<@Valid SvpAvklartOppholdPeriodeDto> avklarteOppholdPerioder = new ArrayList<>();
 
     @Size(max = 4000)
     @Pattern(regexp = InputValideringRegex.FRITEKST)
@@ -65,11 +80,11 @@ public class SvpArbeidsforholdDto {
     }
 
 
-    public void setInternArbeidsforholdReferanse(String internArbeidsforholdRef) {
+    public void setInternArbeidsforholdReferanse(UUID internArbeidsforholdRef) {
         this.internArbeidsforholdReferanse = internArbeidsforholdRef;
     }
 
-    public String getInternArbeidsforholdReferanse() {
+    public UUID getInternArbeidsforholdReferanse() {
         return internArbeidsforholdReferanse;
     }
 

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/svp/SvpAvklartOppholdPeriodeDto.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/svp/SvpAvklartOppholdPeriodeDto.java
@@ -2,14 +2,15 @@ package no.nav.foreldrepenger.web.app.tjenester.behandling.svp;
 
 import java.time.LocalDate;
 
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 
 import no.nav.foreldrepenger.behandlingslager.behandling.tilrettelegging.SvpOppholdÅrsak;
 
 public record SvpAvklartOppholdPeriodeDto(@NotNull LocalDate fom,
                                           @NotNull LocalDate tom,
-                                          @NotNull SvpOppholdÅrsak oppholdÅrsak,
-                                          SvpOppholdKilde oppholdKilde,
+                                          @NotNull @Valid SvpOppholdÅrsak oppholdÅrsak,
+                                          @Valid SvpOppholdKilde oppholdKilde,
                                           boolean forVisning) {
 
     public enum SvpOppholdKilde {

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/svp/SvpTilretteleggingDatoDto.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/svp/SvpTilretteleggingDatoDto.java
@@ -3,6 +3,9 @@ package no.nav.foreldrepenger.web.app.tjenester.behandling.svp;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
 import jakarta.validation.constraints.NotNull;
 
 import no.nav.foreldrepenger.behandlingslager.behandling.tilrettelegging.SvpTilretteleggingFomKilde;
@@ -12,9 +15,14 @@ import no.nav.foreldrepenger.validering.ValidKodeverk;
 public class SvpTilretteleggingDatoDto {
     @NotNull private LocalDate fom;
     @NotNull @ValidKodeverk private TilretteleggingType type;
+    @DecimalMin("0.00")
+    @DecimalMax("100.00")
     private BigDecimal stillingsprosent;
+    @DecimalMin("0.00")
+    @DecimalMax("100.00")
     private BigDecimal overstyrtUtbetalingsgrad;
-    @NotNull @ValidKodeverk private SvpTilretteleggingFomKilde kilde;
+    @NotNull @Valid
+    private SvpTilretteleggingFomKilde kilde;
     private LocalDate mottattDato;
 
     public SvpTilretteleggingDatoDto() {

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/svp/VelferdspermisjonDto.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/svp/VelferdspermisjonDto.java
@@ -6,6 +6,8 @@ import java.time.LocalDate;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
 import jakarta.validation.constraints.NotNull;
 
 import no.nav.foreldrepenger.domene.iay.modell.kodeverk.PermisjonsbeskrivelseType;
@@ -18,6 +20,8 @@ public class VelferdspermisjonDto {
     @JsonProperty("permisjonTom")
     private LocalDate permisjonTom;
     @JsonProperty("permisjonsprosent") @NotNull
+    @DecimalMin("0.00")
+    @DecimalMax("100.00")
     private BigDecimal permisjonsprosent;
     @ValidKodeverk
     @JsonProperty("type") @NotNull

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/uttak/dto/OverstyrOmsorgOgRettDto.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/uttak/dto/OverstyrOmsorgOgRettDto.java
@@ -1,5 +1,6 @@
 package no.nav.foreldrepenger.web.app.tjenester.behandling.uttak.dto;
 
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -13,6 +14,7 @@ import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.Rettigh
 public class OverstyrOmsorgOgRettDto extends OverstyringAksjonspunktDto {
 
     @NotNull
+    @Valid
     private Rettighetstype rettighetstype;
 
     OverstyrOmsorgOgRettDto() {

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/uttak/dto/UttakResultatPeriodeAktivitetLagreDto.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/uttak/dto/UttakResultatPeriodeAktivitetLagreDto.java
@@ -39,9 +39,7 @@ public class UttakResultatPeriodeAktivitetLagreDto {
     @Pattern(regexp = InputValideringRegex.ARBEIDSGIVER)
     private String arbeidsgiverReferanse;
 
-    @Pattern(regexp = InputValideringRegex.FRITEKST)
-    @Size(max = 200)
-    private String arbeidsforholdId;
+    private UUID arbeidsforholdId;
 
     @Valid
     private Utbetalingsgrad utbetalingsgrad;
@@ -112,16 +110,12 @@ public class UttakResultatPeriodeAktivitetLagreDto {
         }
 
         public Builder medArbeidsforholdId(InternArbeidsforholdRef internReferanse) {
-            kladd.arbeidsforholdId = internReferanse.getReferanse();
+            kladd.arbeidsforholdId = internReferanse.getUUIDReferanse();
             return this;
         }
         /** skal kun ta intern arbeidsforhold refearnse. */
-        public Builder medArbeidsforholdId(String arbeidsforholdId) {
-            if(arbeidsforholdId!=null) {
-                // kjapp validering - sjekk at ingen blander inn ekstern arbeidsforholdId her (fra LPS system, AAregister, Inntektsmelding)
-                UUID.fromString(arbeidsforholdId);
-            }
-            kladd.arbeidsforholdId = arbeidsforholdId;
+        public Builder medArbeidsforholdId(UUID arbeidsforholdId) {
+            kladd.arbeidsforholdId = arbeidsforholdId ;
             return this;
         }
 

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/forvaltning/dto/BeregningSatsDto.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/forvaltning/dto/BeregningSatsDto.java
@@ -13,9 +13,9 @@ import jakarta.ws.rs.DefaultValue;
 import jakarta.ws.rs.QueryParam;
 
 import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.media.Schema;
 import no.nav.foreldrepenger.behandlingslager.behandling.beregning.BeregningSats;
 import no.nav.foreldrepenger.behandlingslager.behandling.beregning.BeregningSatsType;
+import no.nav.foreldrepenger.validering.ValidKodeverk;
 import no.nav.vedtak.sikkerhet.abac.AbacDataAttributter;
 import no.nav.vedtak.sikkerhet.abac.AbacDto;
 
@@ -23,6 +23,7 @@ public class BeregningSatsDto implements AbacDto {
 
     @NotNull
     @QueryParam("satsType")
+    @ValidKodeverk
     private BeregningSatsType satsType;
 
     @NotNull

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/forvaltning/dto/HoppTilbakeDto.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/forvaltning/dto/HoppTilbakeDto.java
@@ -4,11 +4,13 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.ws.rs.QueryParam;
 
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingStegType;
+import no.nav.foreldrepenger.validering.ValidKodeverk;
 
 public class HoppTilbakeDto extends ForvaltningBehandlingIdDto {
 
     @NotNull
     @QueryParam("målSteg")
+    @ValidKodeverk
     private BehandlingStegType behandlingStegType;
 
     public BehandlingStegType getBehandlingStegType() {

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/forvaltning/fpoversikt/FpoversiktMigreringRestTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/forvaltning/fpoversikt/FpoversiktMigreringRestTjeneste.java
@@ -18,6 +18,7 @@ import jakarta.ws.rs.core.Response;
 
 import io.swagger.v3.oas.annotations.Operation;
 import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakYtelseType;
+import no.nav.foreldrepenger.validering.ValidKodeverk;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTaskData;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTaskGruppe;
 import no.nav.vedtak.felles.prosesstask.api.ProsessTaskTjeneste;
@@ -75,7 +76,7 @@ public class FpoversiktMigreringRestTjeneste {
         return prosessTaskData;
     }
 
-    private record TaskInput(LocalDate fom, LocalDate tom, FagsakYtelseType ytelseType, @Min(0) @Max(60) int delayBetween) implements AbacDto {
+    private record TaskInput(LocalDate fom, LocalDate tom, @ValidKodeverk FagsakYtelseType ytelseType, @Min(0) @Max(60) int delayBetween) implements AbacDto {
 
         @Override
         public AbacDataAttributter abacAttributter() {

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/registrering/dto/FrilansDto.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/registrering/dto/FrilansDto.java
@@ -5,7 +5,10 @@ import java.util.Collection;
 
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
+
+import no.nav.vedtak.util.InputValideringRegex;
 
 import org.hibernate.validator.constraints.Length;
 
@@ -19,7 +22,7 @@ public class FrilansDto {
     private Boolean erNyoppstartetFrilanser;
     private Boolean harInntektFraFosterhjem;
     private Boolean harHattOppdragForFamilie;
-    private Collection<Oppdragperiode> oppdragPerioder;
+    private Collection<@Valid Oppdragperiode> oppdragPerioder;
 
     public Boolean getHarSokerPeriodeMedFrilans() {
         return harSokerPeriodeMedFrilans;
@@ -95,6 +98,7 @@ public class FrilansDto {
 
     public static class Oppdragperiode {
         @Length(max = 50)
+        @Pattern(regexp = InputValideringRegex.FRITEKST)
         private String oppdragsgiver;
 
         private LocalDate fomDato;

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/registrering/dto/VirksomhetDto.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/registrering/dto/VirksomhetDto.java
@@ -50,6 +50,7 @@ public class VirksomhetDto {
     private String navnRegnskapsforer;
 
     @Size(min = 1, max = 30)
+    @Pattern(regexp = InputValideringRegex.FRITEKST)
     private String tlfRegnskapsforer;
 
     private Boolean familieEllerVennerTilknyttetNaringen;

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/registrering/svp/SvpTilretteleggingArbeidsforholdDto.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/registrering/svp/SvpTilretteleggingArbeidsforholdDto.java
@@ -8,6 +8,8 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
+import jakarta.validation.Valid;
+
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME)
 @JsonSubTypes({
@@ -19,7 +21,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 public abstract class SvpTilretteleggingArbeidsforholdDto {
 
     private LocalDate behovsdato;
-    private List<SvpTilretteleggingDto> tilrettelegginger = new ArrayList<>();
+    private List<@Valid SvpTilretteleggingDto> tilrettelegginger = new ArrayList<>();
 
     public LocalDate getBehovsdato() {
         return behovsdato;

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/registrering/svp/SvpTilretteleggingDto.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/registrering/svp/SvpTilretteleggingDto.java
@@ -3,12 +3,20 @@ package no.nav.foreldrepenger.web.app.tjenester.registrering.svp;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+
 public class SvpTilretteleggingDto {
 
+    @Valid
     private SvpTilretteleggingTypeDto tilretteleggingType;
 
     private LocalDate dato;
 
+    @Valid
+    @Min(0)
+    @Max(100)
     private BigDecimal stillingsprosent;
 
     public SvpTilretteleggingTypeDto getTilretteleggingType() {

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/registrering/svp/SvpTilretteleggingPrivatArbeidsgiverDto.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/registrering/svp/SvpTilretteleggingPrivatArbeidsgiverDto.java
@@ -1,7 +1,12 @@
 package no.nav.foreldrepenger.web.app.tjenester.registrering.svp;
 
+import jakarta.validation.constraints.Pattern;
+
+import no.nav.vedtak.util.InputValideringRegex;
+
 public class SvpTilretteleggingPrivatArbeidsgiverDto extends SvpTilretteleggingArbeidsforholdDto {
 
+    @Pattern(regexp = InputValideringRegex.FRITEKST)
     private String arbeidsgiverIdentifikator;
 
     public String getArbeidsgiverIdentifikator() {

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/registrering/svp/SvpTilretteleggingVirksomhetDto.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/registrering/svp/SvpTilretteleggingVirksomhetDto.java
@@ -1,7 +1,12 @@
 package no.nav.foreldrepenger.web.app.tjenester.registrering.svp;
 
+import jakarta.validation.constraints.Pattern;
+
+import no.nav.vedtak.util.InputValideringRegex;
+
 public class SvpTilretteleggingVirksomhetDto extends SvpTilretteleggingArbeidsforholdDto {
 
+    @Pattern(regexp = InputValideringRegex.ARBEIDSGIVER)
     private String organisasjonsnummer;
 
     public String getOrganisasjonsnummer() {

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/registrering/svp/YtelseSøknadMapper.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/registrering/svp/YtelseSøknadMapper.java
@@ -102,16 +102,15 @@ public class YtelseSøknadMapper implements SøknadMapper {
     }
 
     private static void mapTilArbeidsforhold(SvpTilretteleggingArbeidsforholdDto arbeidsforholdDto, Tilrettelegging tilrettelegging) {
-        if (arbeidsforholdDto instanceof SvpTilretteleggingVirksomhetDto) {
-            tilrettelegging.setArbeidsforhold(mapTilArbeidsforhold((SvpTilretteleggingVirksomhetDto) arbeidsforholdDto));
-        } else if (arbeidsforholdDto instanceof SvpTilretteleggingPrivatArbeidsgiverDto) {
-            tilrettelegging.setArbeidsforhold(mapTilArbeidsforhold((SvpTilretteleggingPrivatArbeidsgiverDto) arbeidsforholdDto));
-        } else if (arbeidsforholdDto instanceof SvpTilretteleggingSelvstendigNæringsdrivendeDto) {
-            tilrettelegging.setArbeidsforhold(mapTilSelvstendigNæringsdrivende());
-        } else if (arbeidsforholdDto instanceof SvpTilretteleggingFrilanserDto) {
-            tilrettelegging.setArbeidsforhold(mapTilFrilanser());
-        } else {
-            throw new IllegalArgumentException("Utvikler-feil: det skal ikke finnes flere konkrete subklasser.");
+        switch (arbeidsforholdDto) {
+            case SvpTilretteleggingVirksomhetDto svpTilretteleggingVirksomhetDto ->
+                tilrettelegging.setArbeidsforhold(mapTilArbeidsforhold(svpTilretteleggingVirksomhetDto));
+            case SvpTilretteleggingPrivatArbeidsgiverDto svpTilretteleggingPrivatArbeidsgiverDto ->
+                tilrettelegging.setArbeidsforhold(mapTilArbeidsforhold(svpTilretteleggingPrivatArbeidsgiverDto));
+            case SvpTilretteleggingSelvstendigNæringsdrivendeDto _ ->
+                tilrettelegging.setArbeidsforhold(mapTilSelvstendigNæringsdrivende());
+            case SvpTilretteleggingFrilanserDto _ -> tilrettelegging.setArbeidsforhold(mapTilFrilanser());
+            case null, default -> throw new IllegalArgumentException("Utvikler-feil: det skal ikke finnes flere konkrete subklasser.");
         }
     }
 

--- a/web/src/test/java/no/nav/foreldrepenger/web/app/konfig/RestApiOppdragInputValideringDtoTest.java
+++ b/web/src/test/java/no/nav/foreldrepenger/web/app/konfig/RestApiOppdragInputValideringDtoTest.java
@@ -177,12 +177,11 @@ class RestApiOppdragInputValideringDtoTest extends RestApiTester {
             if (field.getAnnotation(JsonIgnore.class) != null) {
                 continue; // feltet blir hverken serialisert elle deserialisert, unntas fra sjekk
             }
-            if (field.getType().isEnum()) {
-                validerEnum(field);
-                continue; // enum er OK
-            }
             if (erKodeverk(field.getType())) {
                 validerHarValidkodeverkAnnotering(field);
+            } else if (field.getType().isEnum()) {
+                validerEnum(field);
+                continue; // enum er OK
             } else if (isCollectionOrMapNotProperties(field)) { // Containers håndteres av brukergenerics
                 validerCollectionOrMap(field);
             } else if (getVurderingsalternativer(field) != null) {

--- a/web/src/test/java/no/nav/foreldrepenger/web/app/konfig/RestApiOppdragInputValideringDtoTest.java
+++ b/web/src/test/java/no/nav/foreldrepenger/web/app/konfig/RestApiOppdragInputValideringDtoTest.java
@@ -95,8 +95,7 @@ class RestApiOppdragInputValideringDtoTest extends RestApiTester {
             put(long.class, asList(asList(Min.class, Max.class), List.of(Digits.class)));
             put(Integer.class, singletonList(asList(Min.class, Max.class)));
             put(int.class, singletonList(asList(Min.class, Max.class)));
-            put(BigDecimal.class, asList(asList(Min.class, Max.class, Digits.class),
-                asList(DecimalMin.class, DecimalMax.class, Digits.class)));
+            put(BigDecimal.class, asList(asList(Min.class, Max.class), asList(DecimalMin.class, DecimalMax.class), List.of(Digits.class)));
 
             UNNTATT_FRA_VALIDERING.forEach(k -> put(k, List.of(List.of())));
         }
@@ -129,6 +128,7 @@ class RestApiOppdragInputValideringDtoTest extends RestApiTester {
                 }
             }
         }
+        parametre.addAll(RestApiTester.finnAlleJsonTypeNameClasses());
         Set<Class<?>> filtreteParametre = new TreeSet<>(Comparator.comparing(Class::getName));
         for (var klasse : parametre) {
             if (klasse.getName().startsWith("java") || klasse.isInterface()) {
@@ -168,6 +168,9 @@ class RestApiOppdragInputValideringDtoTest extends RestApiTester {
         var klasseLocation = codeSource.getLocation();
         for (var subklasse : IndexClasses.getIndexFor(klasseLocation.toURI())
             .getSubClassesWithAnnotation(klasse, JsonTypeName.class)) {
+            validerRekursivt(besøkteKlasser, subklasse, forrigeKlasse);
+        }
+        for (var subklasse : finnAlleJsonSubTypeClasses(klasse)) {
             validerRekursivt(besøkteKlasser, subklasse, forrigeKlasse);
         }
         for (var field : getRelevantFields(klasse)) {

--- a/web/src/test/java/no/nav/foreldrepenger/web/app/konfig/RestApiTester.java
+++ b/web/src/test/java/no/nav/foreldrepenger/web/app/konfig/RestApiTester.java
@@ -10,6 +10,8 @@ import java.util.List;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.core.Application;
 
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+
 import io.swagger.v3.jaxrs2.integration.resources.OpenApiResource;
 
 public class RestApiTester {
@@ -26,6 +28,21 @@ public class RestApiTester {
             }
         }
         return liste;
+    }
+
+    static Collection<Class<?>> finnAlleJsonTypeNameClasses() {
+        return ApiConfig.allJsonTypeNameClasses();
+    }
+
+    static Collection<Class<?>> finnAlleJsonSubTypeClasses(Class<?> klasse) {
+        var resultat = new ArrayList<Class<?>>();
+        if (klasse.isAnnotationPresent(JsonSubTypes.class)) {
+            var jsonSubTypes = klasse.getAnnotation(JsonSubTypes.class);
+            for (var subtype : jsonSubTypes.value()) {
+                resultat.add(subtype.value());
+            }
+        }
+        return resultat;
     }
 
     private static Collection<Class<?>> finnAlleRestTjenester() {

--- a/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/svp/BekreftSvangerskapspengerOppdatererTest.java
+++ b/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/svp/BekreftSvangerskapspengerOppdatererTest.java
@@ -410,7 +410,7 @@ class BekreftSvangerskapspengerOppdatererTest {
         arbeidsforholdDto.setAvklarteOppholdPerioder(avklarteOppholdPerioder);
         arbeidsforholdDto.setArbeidsgiverReferanse(ARBEIDSGIVER_IDENT);
         arbeidsforholdDto.setInternArbeidsforholdReferanse(
-            internArbeidsforholdRef == null ? null : internArbeidsforholdRef.getReferanse());
+            internArbeidsforholdRef == null ? null : internArbeidsforholdRef.getUUIDReferanse());
         arbeidsforholdDto.setTilretteleggingId(id);
         arbeidsforholdDto.setSkalBrukes(skalBrukes);
         if (permisjonDto != null) {

--- a/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/uttak/aksjonspunkt/FastsettUttakOppdatererTest.java
+++ b/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/uttak/aksjonspunkt/FastsettUttakOppdatererTest.java
@@ -72,7 +72,7 @@ class FastsettUttakOppdatererTest {
     void skalReturnereUtenOveropp() {
         var fom = LocalDate.now();
         var tom = LocalDate.now().plusWeeks(2);
-        var aktivitetLagreDto = new UttakResultatPeriodeAktivitetLagreDto.Builder().medArbeidsforholdId(ARBEIDSFORHOLD_ID.getReferanse())
+        var aktivitetLagreDto = new UttakResultatPeriodeAktivitetLagreDto.Builder().medArbeidsforholdId(ARBEIDSFORHOLD_ID.getUUIDReferanse())
             .medUttakArbeidType(UttakArbeidType.ORDINÆRT_ARBEID)
             .medArbeidsgiver(new ArbeidsgiverLagreDto(ORGNR, null))
             .medTrekkdager(BigDecimal.ZERO)

--- a/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/uttak/aksjonspunkt/UttakOverstyringshåndtererTest.java
+++ b/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/uttak/aksjonspunkt/UttakOverstyringshåndtererTest.java
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.mock;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.List;
+import java.util.UUID;
 
 import jakarta.inject.Inject;
 
@@ -45,7 +46,7 @@ import no.nav.foreldrepenger.web.app.tjenester.behandling.uttak.overstyring.Utta
 class UttakOverstyringshåndtererTest {
 
     private static final String ORGNR = OrgNummer.KUNSTIG_ORG;
-    private static final String ARBEIDSFORHOLD_ID = InternArbeidsforholdRef.nyRef().getReferanse();
+    private static final UUID ARBEIDSFORHOLD_ID = InternArbeidsforholdRef.nyRef().getUUIDReferanse();
 
     @Inject
     private BehandlingRepositoryProvider repositoryProvider;


### PR DESCRIPTION
Den eksisterende sjekken gravde ikke dypt nok - denne øker sjekken fra 80 til 240 klasser og feiler solid. 
* Det er mye grums - spesielt at Embeddable ble brukt i AP-oppdaterere (OrgNummer og Arbeidsgiver)
* Jeg kommer med en fikser i neste commit - den vil kreve finlesing
* En ting til senere full oppgradering: bruk UUID for arbeidsforholdId
* Vi bør ta en diskusjon om hvilke valideringer som vi bør ha, ref SIF sin diskusjon