### PR TITLE
fjern ø i path til søknad som blir enkodet til s%C3%B8knad

### DIFF
--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/søknad/SøknadRestTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/søknad/SøknadRestTjeneste.java
@@ -32,7 +32,7 @@ import no.nav.vedtak.sikkerhet.abac.beskyttet.ResourceType;
 public class SøknadRestTjeneste {
 
     static final String BASE_PATH = "/behandling";
-    private static final String SØKNAD_PART_PATH = "/søknad";
+    private static final String SØKNAD_PART_PATH = "/soknad";
     public static final String SØKNAD_PATH = BASE_PATH + SØKNAD_PART_PATH;
 
     private BehandlingRepository behandlingRepository;


### PR DESCRIPTION
Litt pirk men når man ser på nettverkskallene fra fpsak er det litt utydelig at det er søknaden vi henter når pathen er enkodet:

<img width="278" height="117" alt="Screenshot 2025-11-20 at 11 06 59" src="https://github.com/user-attachments/assets/ed531b6d-1cba-4d62-9903-24925d512912" />
