### PR TITLE
TFP-6477 - svp - dersom  stillingsprosentStartTilrettelegging er over…

### DIFF
--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/svp/SvangerskapspengerTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/svp/SvangerskapspengerTjeneste.java
@@ -160,8 +160,12 @@ public class SvangerskapspengerTjeneste {
                 .map(yrkesaktivitet -> finnStillingsprosentForDato(yrkesaktivitet, førsteTilrStartDato, finnOverstyring(yrkesaktivitet.getArbeidsgiver(), yrkesaktivitet.getArbeidsforholdRef(), overstyringer).orElse(null)))
                 .reduce(BigDecimal.ZERO, BigDecimal::add);
 
+            // Todo må legge inn regler for hvordan vi skal håndtere stillingsprosent over 100%, enn så lenge setter jeg den til 100% siden den ikke brukes i front end. Logger resultatet for å få en oversikt over hvor ofte dette skjer.
             if (stillingsprosent.compareTo(BigDecimal.valueOf(100)) > 0) {
                 LOG.info("SvangerskapspengerTjeneste: utledStillingsprosentForTilrPeriode: Stillingsprosent over 100% for tilrettelegging med id:{} og arbeidsgiver:{}, stillingsprosent:{}", tilrettelegging.getId(), tilrettelegging.getArbeidsgiver(), stillingsprosent);
+                yrkesaktiviteter.forEach( yrkesaktivitet -> LOG.info("SvangerskapspengerTjeneste: Yrkesaktivitet {}, stillingsprosent {} ",yrkesaktivitet.getArbeidsgiver(),
+                    finnStillingsprosentForDato(yrkesaktivitet, førsteTilrStartDato, finnOverstyring(yrkesaktivitet.getArbeidsgiver(), yrkesaktivitet.getArbeidsforholdRef(), overstyringer).orElse(null))));
+                stillingsprosent = BigDecimal.valueOf(100);
             }
             return Optional.of(stillingsprosent);
         } else {

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/svp/SvpArbeidsforholdDto.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/svp/SvpArbeidsforholdDto.java
@@ -38,7 +38,7 @@ public class SvpArbeidsforholdDto {
     @NotNull private boolean skalBrukes = true;
     @NotNull private boolean kanTilrettelegges = true;
     @DecimalMin("0.00")
-    @DecimalMax("200.00")
+    @DecimalMax("100.00")
     private BigDecimal stillingsprosentStartTilrettelegging;
     @NotNull private List<@Valid VelferdspermisjonDto> velferdspermisjoner = new ArrayList<>();
     @NotNull private List<@Valid SvpAvklartOppholdPeriodeDto> avklarteOppholdPerioder = new ArrayList<>();

--- a/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/svp/SvangerskapspengerTjenesteTest.java
+++ b/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/svp/SvangerskapspengerTjenesteTest.java
@@ -105,7 +105,7 @@ class SvangerskapspengerTjenesteTest {
     @Test
     void skal_summere_stillingsprosent_hvis_flere_arbeidsforhold_i_samme_virksomhet() {
         var arbeidsgiver = Arbeidsgiver.virksomhet("123456789");
-        var forventetStillingsprosent = BigDecimal.valueOf(150);
+        var forventetStillingsprosent = BigDecimal.valueOf(100);
 
         var avtaler1 = List.of(AktivitetsAvtaleBuilder.ny()
             .medPeriode(DatoIntervallEntitet.fraOgMed(FØRSTE_FRA_DATO_TILR.minusYears(1).minusWeeks(1)))


### PR DESCRIPTION
… 100 logges den, også per yrkesaktivietet og setter feltet til 100 inntil vi har regler på plass pga validering. Feltet benyttes ikke av front end i dag nettopp av denne grunn.