### PR TITLE
chore: fjerne ubrukt getKodeverk fra Kodeverdi

### DIFF
--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/aktør/AdresseType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/aktør/AdresseType.java
@@ -1,6 +1,5 @@
 package no.nav.foreldrepenger.behandlingslager.aktør;
 
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/aktør/AdresseType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/aktør/AdresseType.java
@@ -25,8 +25,6 @@ public enum AdresseType implements Kodeverdi {
 
     private static final Map<String, AdresseType> KODER = new LinkedHashMap<>();
 
-    private static final String KODEVERK = "ADRESSE_TYPE";
-
     static {
         for (var v : values()) {
             if (KODER.putIfAbsent(v.kode, v) != null) {
@@ -45,18 +43,9 @@ public enum AdresseType implements Kodeverdi {
         this.navn = navn;
     }
 
-    public static Map<String, AdresseType> kodeMap() {
-        return Collections.unmodifiableMap(KODER);
-    }
-
     @Override
     public String getNavn() {
         return navn;
-    }
-
-    @Override
-    public String getKodeverk() {
-        return KODEVERK;
     }
 
     @Override

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/aktør/NavBrukerKjønn.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/aktør/NavBrukerKjønn.java
@@ -18,7 +18,6 @@ public enum NavBrukerKjønn implements Kodeverdi {
     UDEFINERT(STANDARDKODE_UDEFINERT, "Ikke definert"),
     ;
 
-    public static final String KODEVERK = "BRUKER_KJOENN";
     private static final Map<String, NavBrukerKjønn> KODER = new LinkedHashMap<>();
 
     static {
@@ -39,10 +38,6 @@ public enum NavBrukerKjønn implements Kodeverdi {
         this.navn = navn;
     }
 
-    public static Map<String, NavBrukerKjønn> kodeMap() {
-        return Collections.unmodifiableMap(KODER);
-    }
-
     @Override
     public String getNavn() {
         return navn;
@@ -51,11 +46,6 @@ public enum NavBrukerKjønn implements Kodeverdi {
     @Override
     public String getKode() {
         return kode;
-    }
-
-    @Override
-    public String getKodeverk() {
-        return KODEVERK;
     }
 
     @Converter(autoApply = true)

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/aktør/NavBrukerKjønn.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/aktør/NavBrukerKjønn.java
@@ -1,6 +1,5 @@
 package no.nav.foreldrepenger.behandlingslager.aktør;
 
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/aktør/OppholdstillatelseType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/aktør/OppholdstillatelseType.java
@@ -1,7 +1,6 @@
 package no.nav.foreldrepenger.behandlingslager.aktør;
 
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/aktør/OppholdstillatelseType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/aktør/OppholdstillatelseType.java
@@ -23,9 +23,6 @@ public enum OppholdstillatelseType implements Kodeverdi {
     private static final Map<String, OppholdstillatelseType> KODER = Arrays.stream(values())
         .collect(Collectors.toMap(OppholdstillatelseType::getKode, Function.identity()));
 
-    public static final String KODEVERK = "OPPHOLDSTILLATELSE_TYPE";
-
-
     private String navn;
 
     @JsonValue
@@ -36,18 +33,9 @@ public enum OppholdstillatelseType implements Kodeverdi {
         this.navn = navn;
     }
 
-    public static Map<String, OppholdstillatelseType> kodeMap() {
-        return Collections.unmodifiableMap(KODER);
-    }
-
     @Override
     public String getNavn() {
         return navn;
-    }
-
-    @Override
-    public String getKodeverk() {
-        return KODEVERK;
     }
 
     @Override

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/aktør/PersonstatusType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/aktør/PersonstatusType.java
@@ -1,6 +1,5 @@
 package no.nav.foreldrepenger.behandlingslager.aktør;
 
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/aktør/PersonstatusType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/aktør/PersonstatusType.java
@@ -38,8 +38,6 @@ public enum PersonstatusType implements Kodeverdi {
 
     private static final Map<String, PersonstatusType> KODER = new LinkedHashMap<>();
 
-    public static final String KODEVERK = "PERSONSTATUS_TYPE";
-
     private String navn;
 
     @JsonValue
@@ -54,19 +52,9 @@ public enum PersonstatusType implements Kodeverdi {
         return DØD.equals(personstatus);
     }
 
-
-    public static Map<String, PersonstatusType> kodeMap() {
-        return Collections.unmodifiableMap(KODER);
-    }
-
     @Override
     public String getNavn() {
         return navn;
-    }
-
-    @Override
-    public String getKodeverk() {
-        return KODEVERK;
     }
 
     @Override

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/BehandlingResultatType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/BehandlingResultatType.java
@@ -1,6 +1,5 @@
 package no.nav.foreldrepenger.behandlingslager.behandling;
 
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/BehandlingResultatType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/BehandlingResultatType.java
@@ -64,8 +64,6 @@ public enum BehandlingResultatType implements Kodeverdi {
 
     private static final Map<String, BehandlingResultatType> KODER = new LinkedHashMap<>();
 
-    public static final String KODEVERK = "BEHANDLING_RESULTAT_TYPE";
-
     static {
         for (var v : values()) {
             if (KODER.putIfAbsent(v.kode, v) != null) {
@@ -94,10 +92,6 @@ public enum BehandlingResultatType implements Kodeverdi {
         return ad;
     }
 
-    public static Map<String, BehandlingResultatType> kodeMap() {
-        return Collections.unmodifiableMap(KODER);
-    }
-
     @Override
     public String getNavn() {
         return navn;
@@ -106,11 +100,6 @@ public enum BehandlingResultatType implements Kodeverdi {
     @Override
     public String getKode() {
         return kode;
-    }
-
-    @Override
-    public String getKodeverk() {
-        return KODEVERK;
     }
 
     public static Set<BehandlingResultatType> getAlleHenleggelseskoder() {

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/BehandlingStatus.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/BehandlingStatus.java
@@ -1,6 +1,5 @@
 package no.nav.foreldrepenger.behandlingslager.behandling;
 
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/BehandlingStatus.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/BehandlingStatus.java
@@ -28,8 +28,6 @@ public enum BehandlingStatus implements Kodeverdi {
 
     private static final Map<String, BehandlingStatus> KODER = new LinkedHashMap<>();
 
-    public static final String KODEVERK = "BEHANDLING_STATUS";
-
     private static final Set<BehandlingStatus> FERDIGBEHANDLET_STATUS = Set.of(AVSLUTTET, IVERKSETTER_VEDTAK);
 
     private final String navn;
@@ -39,10 +37,6 @@ public enum BehandlingStatus implements Kodeverdi {
     BehandlingStatus(String kode, String navn) {
         this.kode = kode;
         this.navn = navn;
-    }
-
-    public static Map<String, BehandlingStatus> kodeMap() {
-        return Collections.unmodifiableMap(KODER);
     }
 
     public static BehandlingStatus fraKode(String kode) {
@@ -67,11 +61,6 @@ public enum BehandlingStatus implements Kodeverdi {
 
     public boolean erFerdigbehandletStatus() {
         return FERDIGBEHANDLET_STATUS.contains(this);
-    }
-
-    @Override
-    public String getKodeverk() {
-        return KODEVERK;
     }
 
     @Override

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/BehandlingStegStatus.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/BehandlingStegStatus.java
@@ -23,7 +23,6 @@ import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
  */
 public enum BehandlingStegStatus implements Kodeverdi {
 
-
     /** midlertidig intern tilstand når steget startes (etter inngang). */
     STARTET("STARTET", "Steget er startet"),
     INNGANG("INNGANG", "Inngangkriterier er ikke oppfylt"),
@@ -41,8 +40,6 @@ public enum BehandlingStegStatus implements Kodeverdi {
     private static final Set<BehandlingStegStatus> SLUTT_STATUSER = new HashSet<>(Arrays.asList(AVBRUTT, UTFØRT, TILBAKEFØRT));
 
     private static final Map<String, BehandlingStegStatus> KODER = new LinkedHashMap<>();
-
-    public static final String KODEVERK = "BEHANDLING_STEG_STATUS";
 
     private final String navn;
     @JsonValue
@@ -76,15 +73,6 @@ public enum BehandlingStegStatus implements Kodeverdi {
 
     public static boolean erVedUtgang(BehandlingStegStatus stegStatus) {
         return Objects.equals(UTGANG, stegStatus);
-    }
-
-    public static Map<String, BehandlingStegStatus> kodeMap() {
-        return Collections.unmodifiableMap(KODER);
-    }
-
-    @Override
-    public String getKodeverk() {
-        return KODEVERK;
     }
 
     @Override

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/BehandlingStegStatus.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/BehandlingStegStatus.java
@@ -1,7 +1,6 @@
 package no.nav.foreldrepenger.behandlingslager.behandling;
 
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.Map;

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/BehandlingStegType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/BehandlingStegType.java
@@ -47,7 +47,6 @@ public enum BehandlingStegType implements Kodeverdi {
     VURDER_INNSYN("VURDINNSYN", "Vurder innsynskrav", UTREDES),
     INNHENT_PERSONOPPLYSNINGER("INPER", "Innhent personopplysninger", UTREDES),
 
-
     // Kun for Engangsstønad
     VURDER_SØKNADSFRISTVILKÅR("VURDERSFV", "Vurder felles inngangsvilkår", UTREDES),
 
@@ -100,8 +99,6 @@ public enum BehandlingStegType implements Kodeverdi {
     VULOMED("VULOMED", "Vurder løpende medlemskap", UTREDES), // Gammelt steg fortsatt medlemskap. Håndteres nå som inngangsvilkår
     ;
 
-    static final String KODEVERK = "BEHANDLING_STEG_TYPE";
-
     private static final Map<String, BehandlingStegType> KODER = new LinkedHashMap<>();
 
     static {
@@ -120,7 +117,6 @@ public enum BehandlingStegType implements Kodeverdi {
     private String navn;
 
     private String kode;
-
 
     BehandlingStegType(String kode, String navn, BehandlingStatus definertBehandlingStatus) {
         this.kode = kode;
@@ -155,11 +151,6 @@ public enum BehandlingStegType implements Kodeverdi {
         return navn;
     }
 
-    @Override
-    public String getKodeverk() {
-        return KODEVERK;
-    }
-
     // Denne metoden brukes ifm @QueryParam ved setting av verdi fra kode. For at dette skal være mulig må navnet enten være 'fromString' eller 'valueOf'. 'valueOf' kan ikke overskrives.
     public static BehandlingStegType fromString(String kode) {
         if (kode == null) {
@@ -177,10 +168,6 @@ public enum BehandlingStegType implements Kodeverdi {
         return super.toString() + "('" + getKode() + "')";
     }
 
-    public static Map<String, BehandlingStegType> kodeMap() {
-        return Collections.unmodifiableMap(KODER);
-    }
-
     @Converter(autoApply = true)
     public static class KodeverdiConverter implements AttributeConverter<BehandlingStegType, String> {
         @Override
@@ -193,6 +180,5 @@ public enum BehandlingStegType implements Kodeverdi {
             return dbData == null ? null : BehandlingStegType.fromString(dbData);
         }
     }
-
 
 }

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/BehandlingStegType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/BehandlingStegType.java
@@ -3,7 +3,6 @@ package no.nav.foreldrepenger.behandlingslager.behandling;
 import static no.nav.foreldrepenger.behandlingslager.behandling.BehandlingStatus.IVERKSETTER_VEDTAK;
 import static no.nav.foreldrepenger.behandlingslager.behandling.BehandlingStatus.UTREDES;
 
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/BehandlingTema.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/BehandlingTema.java
@@ -25,8 +25,6 @@ public enum BehandlingTema implements Kodeverdi, MedOffisiellKode {
 
     ;
 
-    public static final String KODEVERK = "BEHANDLING_TEMA";
-
     private final String navn;
 
     private final String offisiellKode;
@@ -39,15 +37,9 @@ public enum BehandlingTema implements Kodeverdi, MedOffisiellKode {
         this.offisiellKode = offisiellKode;
     }
 
-
     @Override
     public String getNavn() {
         return navn;
-    }
-
-    @Override
-    public String getKodeverk() {
-        return KODEVERK;
     }
 
     @Override

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/BehandlingType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/BehandlingType.java
@@ -1,6 +1,5 @@
 package no.nav.foreldrepenger.behandlingslager.behandling;
 
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/BehandlingType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/BehandlingType.java
@@ -36,7 +36,6 @@ public enum BehandlingType implements Kodeverdi, MedOffisiellKode {
     private static final Set<BehandlingType> KLAGE_BEHANDLING_TYPER = Set.of(KLAGE, ANKE);
     private static final Set<BehandlingType> ANDRE_BEHANDLING_TYPER = Set.of(KLAGE, ANKE, INNSYN);
 
-    public static final String KODEVERK = "BEHANDLING_TYPE";
     private static final Map<String, BehandlingType> KODER = new LinkedHashMap<>();
 
     static {
@@ -77,10 +76,6 @@ public enum BehandlingType implements Kodeverdi, MedOffisiellKode {
         return ad;
     }
 
-    public static Map<String, BehandlingType> kodeMap() {
-        return Collections.unmodifiableMap(KODER);
-    }
-
     @Override
     public String getNavn() {
         return navn;
@@ -89,11 +84,6 @@ public enum BehandlingType implements Kodeverdi, MedOffisiellKode {
     @Override
     public String getKode() {
         return kode;
-    }
-
-    @Override
-    public String getKodeverk() {
-        return KODEVERK;
     }
 
     @Override

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/BehandlingÅrsakType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/BehandlingÅrsakType.java
@@ -78,7 +78,6 @@ public enum BehandlingÅrsakType implements Kodeverdi {
     // Skille klageområder
     KLAGE_TILBAKEBETALING("KLAGE_TILBAKE", "Tilbakebetaling"),
 
-
     // UTGÅTT. men ikke slett - BehandlingÅrsak-tabellen er rensket og ikke bruk disse som nye behandlingsårsaker!
     // Det ligger en hel del i historikk-innslag (inntil evt konvertert) og de brukes til vise tekst frontend.
     // OPPLYSNINGER_OM_YTELSER brukes til å lage nye historikkinnslag - de øvrige er historiske
@@ -99,8 +98,6 @@ public enum BehandlingÅrsakType implements Kodeverdi {
     UDEFINERT(STANDARDKODE_UDEFINERT, "Ikke definert"),
 
     ;
-
-    public static final String KODEVERK = "BEHANDLING_AARSAK";
 
     private static final Set<BehandlingÅrsakType> SPESIELLE_BEHANDLINGER = Set.of(BehandlingÅrsakType.BERØRT_BEHANDLING,
         BehandlingÅrsakType.REBEREGN_FERIEPENGER, BehandlingÅrsakType.RE_UTSATT_START);
@@ -128,18 +125,9 @@ public enum BehandlingÅrsakType implements Kodeverdi {
         return ad;
     }
 
-    public static Map<String, BehandlingÅrsakType> kodeMap() {
-        return Collections.unmodifiableMap(KODER);
-    }
-
     @Override
     public String getNavn() {
         return navn;
-    }
-
-    @Override
-    public String getKodeverk() {
-        return KODEVERK;
     }
 
     @Override

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/BehandlingÅrsakType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/BehandlingÅrsakType.java
@@ -1,14 +1,15 @@
 package no.nav.foreldrepenger.behandlingslager.behandling;
 
-import com.fasterxml.jackson.annotation.JsonValue;
-import jakarta.persistence.AttributeConverter;
-import jakarta.persistence.Converter;
-import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
-
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
 
 public enum BehandlingÅrsakType implements Kodeverdi {
 

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/DokumentKategori.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/DokumentKategori.java
@@ -33,8 +33,6 @@ public enum DokumentKategori implements Kodeverdi, MedOffisiellKode {
     VBRV("VBRV", "Vedtaksbrev", "VB"),
     ;
 
-    public static final String KODEVERK = "DOKUMENT_KATEGORI";
-
     private static final Map<String, DokumentKategori> KODER = new LinkedHashMap<>();
 
     private String navn;
@@ -49,18 +47,9 @@ public enum DokumentKategori implements Kodeverdi, MedOffisiellKode {
         this.offisiellKode = offisiellKode;
     }
 
-    public static Map<String, DokumentKategori> kodeMap() {
-        return Collections.unmodifiableMap(KODER);
-    }
-
     @Override
     public String getNavn() {
         return navn;
-    }
-
-    @Override
-    public String getKodeverk() {
-        return KODEVERK;
     }
 
     @Override

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/DokumentKategori.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/DokumentKategori.java
@@ -1,6 +1,5 @@
 package no.nav.foreldrepenger.behandlingslager.behandling;
 
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/DokumentTypeId.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/DokumentTypeId.java
@@ -100,7 +100,6 @@ public enum DokumentTypeId implements Kodeverdi, MedOffisiellKode {
     I000109("I000109", "Skjema for tilrettelegging og omplassering ved graviditet"),
     MEDISINSK_DOK("I000142", "Medisinsk dokumentasjon"),
 
-
     // Opptjening/beregning/etc
     INNTEKTSOPPLYSNING_SELVSTENDIG("INNTEKTSOPPLYSNING_SELVSTENDIG", "I000007", "Inntektsopplysninger om selvstendig næringsdrivende og/eller frilansere som skal ha foreldrepenger eller svangerskapspenger"),
     DOK_INNTEKT("DOK_INNTEKT", "I000016", "Dokumentasjon av inntekt"),
@@ -122,7 +121,6 @@ public enum DokumentTypeId implements Kodeverdi, MedOffisiellKode {
     I000110("I000110", "Dokumentasjon av aleneomsorg"),
     I000111("I000111", "Dokumentasjon av begrunnelse for hvorfor man søker tilbake i tid"),
     SEN_SØKNAD("I000118", "Begrunnelse for sen søknad"),
-
 
     // Ettersendelse forsider - bør unngås som hoveddokument
     ETTERSENDT_SØKNAD_SVANGERSKAPSPENGER_SELVSTENDIG("ETTERSENDT_SØKNAD_SVANGERSKAPSPENGER_SELVSTENDIG", "I500001",
@@ -151,8 +149,6 @@ public enum DokumentTypeId implements Kodeverdi, MedOffisiellKode {
 
     UDEFINERT(STANDARDKODE_UDEFINERT, "", "Ikke definert"),
     ;
-
-    public static final String KODEVERK = "DOKUMENT_TYPE_ID";
 
     private static final Map<String, DokumentTypeId> KODER = new LinkedHashMap<>();
 
@@ -190,18 +186,9 @@ public enum DokumentTypeId implements Kodeverdi, MedOffisiellKode {
         return KODER.getOrDefault(kode, ANNET);
     }
 
-    public static Map<String, DokumentTypeId> kodeMap() {
-        return Collections.unmodifiableMap(KODER);
-    }
-
     @Override
     public String getNavn() {
         return navn;
-    }
-
-    @Override
-    public String getKodeverk() {
-        return KODEVERK;
     }
 
     @Override
@@ -269,7 +256,6 @@ public enum DokumentTypeId implements Kodeverdi, MedOffisiellKode {
         ETTERSENDT_SØKNAD_FORELDREPENGER_FØDSEL, ETTERSENDT_SØKNAD_FORELDREPENGER_ADOPSJON,
         ETTERSENDT_FORELDREPENGER_ENDRING_SØKNAD, ETTERSENDT_FLEKSIBELT_UTTAK_FORELDREPENGER);
 
-
     public static Set<DokumentTypeId> getSpesialTyperKoder() {
         Set<DokumentTypeId> typer = new LinkedHashSet<>(SØKNAD_TYPER);
         typer.addAll(ENDRING_SØKNAD_TYPER);
@@ -327,8 +313,6 @@ public enum DokumentTypeId implements Kodeverdi, MedOffisiellKode {
         Set.of(I000111, SEN_SØKNAD),
         Set.of(SKATTEMELDING, KOPI_SKATTEMELDING)
     );
-
-
 
     // Ulike titler er brukt i selvbetjening, fordel, sak og kodeverk
     private static final Map<String, DokumentTypeId> ALT_TITLER = Map.ofEntries(

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/KonsekvensForYtelsen.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/KonsekvensForYtelsen.java
@@ -13,7 +13,6 @@ import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
 
 public enum KonsekvensForYtelsen implements Kodeverdi{
 
-
     FORELDREPENGER_OPPHØRER("FORELDREPENGER_OPPHØRER", "Foreldrepenger opphører"),
     ENDRING_I_BEREGNING("ENDRING_I_BEREGNING", "Endring i beregning"),
     ENDRING_I_UTTAK("ENDRING_I_UTTAK", "Endring i uttak"),
@@ -22,8 +21,6 @@ public enum KonsekvensForYtelsen implements Kodeverdi{
     ;
 
     private static final Map<String, KonsekvensForYtelsen> KODER = new LinkedHashMap<>();
-
-    public static final String KODEVERK = "KONSEKVENS_FOR_YTELSEN";
 
     private String navn;
 
@@ -34,18 +31,9 @@ public enum KonsekvensForYtelsen implements Kodeverdi{
         this.kode = kode;
         this.navn = navn;
     }
-    public static Map<String, KonsekvensForYtelsen> kodeMap() {
-        return Collections.unmodifiableMap(KODER);
-    }
-
     @Override
     public String getNavn() {
         return navn;
-    }
-
-    @Override
-    public String getKodeverk() {
-        return KODEVERK;
     }
 
     @Override
@@ -84,8 +72,6 @@ public enum KonsekvensForYtelsen implements Kodeverdi{
             return ad;
         }
 
-
     }
-
 
 }

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/KonsekvensForYtelsen.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/KonsekvensForYtelsen.java
@@ -1,6 +1,5 @@
 package no.nav.foreldrepenger.behandlingslager.behandling;
 
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/RettenTil.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/RettenTil.java
@@ -1,6 +1,5 @@
 package no.nav.foreldrepenger.behandlingslager.behandling;
 
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/RettenTil.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/RettenTil.java
@@ -18,8 +18,6 @@ public enum RettenTil implements Kodeverdi {
     UDEFINERT(STANDARDKODE_UDEFINERT, "Udefinert"),
     ;
 
-    public static final String KODEVERK = "RETTEN_TIL";
-
     private static final Map<String, RettenTil> KODER = new LinkedHashMap<>();
 
     private String navn;
@@ -32,18 +30,9 @@ public enum RettenTil implements Kodeverdi {
         this.navn = navn;
     }
 
-    public static Map<String, RettenTil> kodeMap() {
-        return Collections.unmodifiableMap(KODER);
-    }
-
     @Override
     public String getNavn() {
         return navn;
-    }
-
-    @Override
-    public String getKodeverk() {
-        return KODEVERK;
     }
 
     @Override

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/RevurderingVarslingÅrsak.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/RevurderingVarslingÅrsak.java
@@ -23,8 +23,6 @@ public enum RevurderingVarslingÅrsak implements Kodeverdi {
 
     private static final Map<String, RevurderingVarslingÅrsak> KODER = new LinkedHashMap<>();
 
-    public static final String KODEVERK = "REVURDERING_VARSLING_AARSAK";
-
     static {
         for (var v : values()) {
             if (KODER.putIfAbsent(v.kode, v) != null) {
@@ -43,18 +41,9 @@ public enum RevurderingVarslingÅrsak implements Kodeverdi {
         this.navn = navn;
     }
 
-    public static Map<String, RevurderingVarslingÅrsak> kodeMap() {
-        return Collections.unmodifiableMap(KODER);
-    }
-
     @Override
     public String getNavn() {
         return navn;
-    }
-
-    @Override
-    public String getKodeverk() {
-        return KODEVERK;
     }
 
     @Override

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/RevurderingVarslingÅrsak.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/RevurderingVarslingÅrsak.java
@@ -1,6 +1,5 @@
 package no.nav.foreldrepenger.behandlingslager.behandling;
 
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/Tema.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/Tema.java
@@ -15,8 +15,6 @@ public enum Tema implements Kodeverdi, MedOffisiellKode {
     UDEFINERT(STANDARDKODE_UDEFINERT, "Ikke definert", null)
     ;
 
-    public static final String KODEVERK = "TEMA";
-
     private String navn;
 
     private String offisiellKode;
@@ -32,11 +30,6 @@ public enum Tema implements Kodeverdi, MedOffisiellKode {
     @Override
     public String getNavn() {
         return navn;
-    }
-
-    @Override
-    public String getKodeverk() {
-        return KODEVERK;
     }
 
     @Override

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/Temagrupper.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/Temagrupper.java
@@ -11,8 +11,6 @@ public enum Temagrupper implements Kodeverdi, MedOffisiellKode {
     UDEFINERT(STANDARDKODE_UDEFINERT, "Udefinert", null),
     ;
 
-    public static final String KODEVERK = "TEMAGRUPPER";
-
     @JsonValue
     private String kode;
 
@@ -24,11 +22,6 @@ public enum Temagrupper implements Kodeverdi, MedOffisiellKode {
         this.kode = kode;
         this.navn = navn;
         this.offisiellKode = offisiellKode;
-    }
-
-    @Override
-    public String getKodeverk() {
-        return KODEVERK;
     }
 
     @Override

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/VariantFormat.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/VariantFormat.java
@@ -21,7 +21,6 @@ public enum VariantFormat implements Kodeverdi, MedOffisiellKode {
     UDEFINERT(STANDARDKODE_UDEFINERT, "Ikke definert", null),
 
     ;
-    private static final String KODEVERK = "VARIANT_FORMAT";
 
     private String navn;
 
@@ -35,15 +34,9 @@ public enum VariantFormat implements Kodeverdi, MedOffisiellKode {
         this.offisiellKode = offisiellKode;
     }
 
-
     @Override
     public String getNavn() {
         return navn;
-    }
-
-    @Override
-    public String getKodeverk() {
-        return KODEVERK;
     }
 
     @Override

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/aksjonspunkt/AksjonspunktDefinisjon.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/aksjonspunkt/AksjonspunktDefinisjon.java
@@ -477,7 +477,6 @@ public enum AksjonspunktDefinisjon implements Kodeverdi {
     @Deprecated
     UTGÅTT_7041("7041", AksjonspunktType.AUTOPUNKT, "Vent på vedtak om lovendring vedrørende beregning av næring i kombinasjon med arbeid eller frilans"),
     ;
-    public static final String KODEVERK = "AKSJONSPUNKT_DEF";
 
     private static final Map<String, AksjonspunktDefinisjon> KODER = new LinkedHashMap<>();
 
@@ -500,7 +499,6 @@ public enum AksjonspunktDefinisjon implements Kodeverdi {
 
     private static final Set<AksjonspunktDefinisjon> IKKE_KLAR_FOR_INNTEKTSMELDING = Set.of(AksjonspunktDefinisjon.VENT_PGA_FOR_TIDLIG_SØKNAD,
         AksjonspunktDefinisjon.VENT_PÅ_SØKNAD, AksjonspunktDefinisjon.REGISTRER_PAPIRSØKNAD_FORELDREPENGER);
-
 
     private static final Map<AksjonspunktDefinisjon, Set<AksjonspunktDefinisjon>> UTELUKKENDE_AP_MAP = Map.ofEntries(
         Map.entry(AksjonspunktDefinisjon.SJEKK_MANGLENDE_FØDSEL, Set.of(AksjonspunktDefinisjon.SJEKK_TERMINBEKREFTELSE)),
@@ -606,7 +604,6 @@ public enum AksjonspunktDefinisjon implements Kodeverdi {
         this.utviderBehandlingsfrist = utviderBehandlingsfrist;
     }
 
-
     /**
      * @deprecated Bruk heller
      *             {@link Historikkinnslag.Builder#medTittel(SkjermlenkeType)}
@@ -688,11 +685,6 @@ public enum AksjonspunktDefinisjon implements Kodeverdi {
         return vurderingspunktType;
     }
 
-    @Override
-    public String getKodeverk() {
-        return KODEVERK;
-    }
-
     /** Aksjonspunkt tidligere brukt, nå utgått (kan ikke gjenoppstå). */
     public boolean erUtgått() {
         return erUtgått;
@@ -712,10 +704,6 @@ public enum AksjonspunktDefinisjon implements Kodeverdi {
             throw new IllegalArgumentException("Ukjent AksjonspunktDefinisjon: " + kode);
         }
         return ad;
-    }
-
-    public static Map<String, AksjonspunktDefinisjon> kodeMap() {
-        return Collections.unmodifiableMap(KODER);
     }
 
     public static List<AksjonspunktDefinisjon> finnAksjonspunktDefinisjoner(BehandlingStegType behandlingStegType, VurderingspunktType vurderingspunktType) {

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/aksjonspunkt/AksjonspunktStatus.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/aksjonspunkt/AksjonspunktStatus.java
@@ -1,7 +1,6 @@
 package no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/aksjonspunkt/AksjonspunktStatus.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/aksjonspunkt/AksjonspunktStatus.java
@@ -15,13 +15,11 @@ import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
 
 public enum AksjonspunktStatus implements Kodeverdi {
 
-
     AVBRUTT ("AVBR", "Avbrutt"),
     OPPRETTET("OPPR", "Opprettet"),
     UTFØRT ("UTFO", "Utført"),
     ;
 
-    public static final String KODEVERK = "AKSJONSPUNKT_STATUS";
     private static final Map<String, AksjonspunktStatus> KODER = new LinkedHashMap<>();
     private static final List<AksjonspunktStatus> ÅPNE_AKSJONSPUNKT_KODER = List.of(OPPRETTET);
 
@@ -46,15 +44,6 @@ public enum AksjonspunktStatus implements Kodeverdi {
     @Override
     public String getKode() {
         return kode;
-    }
-
-    @Override
-    public String getKodeverk() {
-        return KODEVERK;
-    }
-
-    public static Map<String, AksjonspunktStatus> kodeMap() {
-        return Collections.unmodifiableMap(KODER);
     }
 
     @Override

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/aksjonspunkt/AksjonspunktType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/aksjonspunkt/AksjonspunktType.java
@@ -1,6 +1,5 @@
 package no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt;
 
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/aksjonspunkt/AksjonspunktType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/aksjonspunkt/AksjonspunktType.java
@@ -19,7 +19,6 @@ public enum AksjonspunktType implements Kodeverdi {
     ;
 
     private static final Map<String, AksjonspunktType> KODER = new LinkedHashMap<>();
-    public static final String KODEVERK = "AKSJONSPUNKT_TYPE";
 
     static {
         for (var v : values()) {
@@ -40,7 +39,6 @@ public enum AksjonspunktType implements Kodeverdi {
         this.navn = navn;
     }
 
-
     @Override
     public String getNavn() {
         return navn;
@@ -49,15 +47,6 @@ public enum AksjonspunktType implements Kodeverdi {
     @Override
     public String getKode() {
         return kode;
-    }
-
-    @Override
-    public String getKodeverk() {
-        return KODEVERK;
-    }
-
-    public static Map<String, AksjonspunktType> kodeMap() {
-        return Collections.unmodifiableMap(KODER);
     }
 
     public boolean erAutopunkt() {

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/aksjonspunkt/Venteårsak.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/aksjonspunkt/Venteårsak.java
@@ -74,7 +74,6 @@ public enum Venteårsak implements Kodeverdi {
     VENT_ØKONOMI("VENT_ØKONOMI", "Venter på økonomiløsningen"),
 
     ;
-    public static final String KODEVERK = "VENT_AARSAK";
     private static final Map<String, Venteårsak> KODER = new LinkedHashMap<>();
 
     static {
@@ -106,10 +105,6 @@ public enum Venteårsak implements Kodeverdi {
         return ad;
     }
 
-    public static Map<String, Venteårsak> kodeMap() {
-        return Collections.unmodifiableMap(KODER);
-    }
-
     @Override
     public String getNavn() {
         return navn;
@@ -118,11 +113,6 @@ public enum Venteårsak implements Kodeverdi {
     @Override
     public String getKode() {
         return kode;
-    }
-
-    @Override
-    public String getKodeverk() {
-        return KODEVERK;
     }
 
     @Converter(autoApply = true)

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/aksjonspunkt/Venteårsak.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/aksjonspunkt/Venteårsak.java
@@ -1,6 +1,5 @@
 package no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt;
 
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/aksjonspunkt/VurderÅrsak.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/aksjonspunkt/VurderÅrsak.java
@@ -1,13 +1,14 @@
 package no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt;
 
-import com.fasterxml.jackson.annotation.JsonValue;
-import jakarta.persistence.AttributeConverter;
-import jakarta.persistence.Converter;
-import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
-
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
 
 public enum VurderÅrsak implements Kodeverdi {
 

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/aksjonspunkt/VurderÅrsak.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/aksjonspunkt/VurderÅrsak.java
@@ -26,7 +26,6 @@ public enum VurderÅrsak implements Kodeverdi {
     ;
 
     private static final Map<String, VurderÅrsak> KODER = new LinkedHashMap<>();
-    public static final String KODEVERK = "VURDER_AARSAK";
 
     static {
         for (var v : values()) {
@@ -57,10 +56,6 @@ public enum VurderÅrsak implements Kodeverdi {
         return ad;
     }
 
-    public static Map<String, VurderÅrsak> kodeMap() {
-        return Collections.unmodifiableMap(KODER);
-    }
-
     @Override
     public String getNavn() {
         return navn;
@@ -69,11 +64,6 @@ public enum VurderÅrsak implements Kodeverdi {
     @Override
     public String getKode() {
         return kode;
-    }
-
-    @Override
-    public String getKodeverk() {
-        return KODEVERK;
     }
 
     @Converter(autoApply = true)

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/aktivitetskrav/AktivitetskravPermisjonType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/aktivitetskrav/AktivitetskravPermisjonType.java
@@ -22,8 +22,6 @@ public enum AktivitetskravPermisjonType implements Kodeverdi {
 
     private static final Map<String, AktivitetskravPermisjonType> KODER = new LinkedHashMap<>();
 
-    public static final String KODEVERK = "AKTIVITETSKRAV_PERMISJON_TYPE";
-
     static {
         for (var v : values()) {
             if (KODER.putIfAbsent(v.kode, v) != null) {
@@ -53,18 +51,9 @@ public enum AktivitetskravPermisjonType implements Kodeverdi {
         return ad;
     }
 
-    public static Map<String, AktivitetskravPermisjonType> kodeMap() {
-        return Collections.unmodifiableMap(KODER);
-    }
-
     @Override
     public String getNavn() {
         return navn;
-    }
-
-    @Override
-    public String getKodeverk() {
-        return KODEVERK;
     }
 
     @Override

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/aktivitetskrav/AktivitetskravPermisjonType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/aktivitetskrav/AktivitetskravPermisjonType.java
@@ -1,6 +1,5 @@
 package no.nav.foreldrepenger.behandlingslager.behandling.aktivitetskrav;
 
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/anke/AnkeAvvistÅrsak.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/anke/AnkeAvvistÅrsak.java
@@ -15,8 +15,6 @@ public enum AnkeAvvistÅrsak implements Kodeverdi {
     UDEFINERT(STANDARDKODE_UDEFINERT, "Udefinert"),
     ;
 
-    public static final String KODEVERK = "ANKE_AVVIST_AARSAK";
-
     private String navn;
 
     @JsonValue
@@ -30,11 +28,6 @@ public enum AnkeAvvistÅrsak implements Kodeverdi {
     @Override
     public String getNavn() {
         return navn;
-    }
-
-    @Override
-    public String getKodeverk() {
-        return KODEVERK;
     }
 
     @Override

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/anke/AnkeOmgjørÅrsak.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/anke/AnkeOmgjørÅrsak.java
@@ -22,8 +22,6 @@ public enum AnkeOmgjørÅrsak implements Kodeverdi {
 
     private static final Map<String, AnkeOmgjørÅrsak> KODER = new LinkedHashMap<>();
 
-    public static final String KODEVERK = "ANKE_OMGJOER_AARSAK";
-
     static {
         for (var v : values()) {
             if (KODER.putIfAbsent(v.kode, v) != null) {
@@ -42,18 +40,9 @@ public enum AnkeOmgjørÅrsak implements Kodeverdi {
         this.navn = navn;
     }
 
-    public static Map<String, AnkeOmgjørÅrsak> kodeMap() {
-        return Collections.unmodifiableMap(KODER);
-    }
-
     @Override
     public String getNavn() {
         return navn;
-    }
-
-    @Override
-    public String getKodeverk() {
-        return KODEVERK;
     }
 
     @Override

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/anke/AnkeOmgjørÅrsak.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/anke/AnkeOmgjørÅrsak.java
@@ -1,6 +1,5 @@
 package no.nav.foreldrepenger.behandlingslager.behandling.anke;
 
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/anke/AnkeVurdering.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/anke/AnkeVurdering.java
@@ -1,6 +1,5 @@
 package no.nav.foreldrepenger.behandlingslager.behandling.anke;
 
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/anke/AnkeVurdering.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/anke/AnkeVurdering.java
@@ -24,8 +24,6 @@ public enum AnkeVurdering implements Kodeverdi {
 
     private static final Map<String, AnkeVurdering> KODER = new LinkedHashMap<>();
 
-    public static final String KODEVERK = "ANKEVURDERING";
-
     static {
         for (var v : values()) {
             if (KODER.putIfAbsent(v.kode, v) != null) {
@@ -44,18 +42,9 @@ public enum AnkeVurdering implements Kodeverdi {
         this.navn = navn;
     }
 
-    public static Map<String, AnkeVurdering> kodeMap() {
-        return Collections.unmodifiableMap(KODER);
-    }
-
     @Override
     public String getNavn() {
         return navn;
-    }
-
-    @Override
-    public String getKodeverk() {
-        return KODEVERK;
     }
 
     @Override

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/anke/AnkeVurderingOmgjør.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/anke/AnkeVurderingOmgjør.java
@@ -1,6 +1,5 @@
 package no.nav.foreldrepenger.behandlingslager.behandling.anke;
 
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/anke/AnkeVurderingOmgjør.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/anke/AnkeVurderingOmgjør.java
@@ -11,7 +11,6 @@ import com.fasterxml.jackson.annotation.JsonValue;
 
 import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
 
-
 public enum AnkeVurderingOmgjør implements Kodeverdi {
 
     ANKE_TIL_GUNST("ANKE_TIL_GUNST", "Gunst omgjør i anke"),
@@ -20,8 +19,6 @@ public enum AnkeVurderingOmgjør implements Kodeverdi {
     UDEFINERT(STANDARDKODE_UDEFINERT, "Udefinert"),
     ;
     private static final Map<String, AnkeVurderingOmgjør> KODER = new LinkedHashMap<>();
-
-    public static final String KODEVERK = "ANKE_VURDERING_OMGJOER";
 
     static {
         for (var v : values()) {
@@ -41,18 +38,9 @@ public enum AnkeVurderingOmgjør implements Kodeverdi {
         this.navn = navn;
     }
 
-    public static Map<String, AnkeVurderingOmgjør> kodeMap() {
-        return Collections.unmodifiableMap(KODER);
-    }
-
     @Override
     public String getNavn() {
         return navn;
-    }
-
-    @Override
-    public String getKodeverk() {
-        return KODEVERK;
     }
 
     @Override

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/arbeidsforhold/ArbeidsforholdKomplettVurderingType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/arbeidsforhold/ArbeidsforholdKomplettVurderingType.java
@@ -40,7 +40,6 @@ public enum ArbeidsforholdKomplettVurderingType implements Kodeverdi {
 
     UDEFINERT(STANDARDKODE_UDEFINERT, "Ikke definert"),
     ;
-    public static final String KODEVERK = "ARBEIDSFORHOLD_KOMPLETT_VURDERING_TYPE";
 
     private static final Map<String, ArbeidsforholdKomplettVurderingType> KODER = new LinkedHashMap<>();
 
@@ -62,18 +61,9 @@ public enum ArbeidsforholdKomplettVurderingType implements Kodeverdi {
         this.navn = navn;
     }
 
-    public static Map<String, ArbeidsforholdKomplettVurderingType> kodeMap() {
-        return Collections.unmodifiableMap(KODER);
-    }
-
     @Override
     public String getNavn() {
         return navn;
-    }
-
-    @Override
-    public String getKodeverk() {
-        return KODEVERK;
     }
 
     @Override

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/arbeidsforhold/ArbeidsforholdKomplettVurderingType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/arbeidsforhold/ArbeidsforholdKomplettVurderingType.java
@@ -1,6 +1,5 @@
 package no.nav.foreldrepenger.behandlingslager.behandling.arbeidsforhold;
 
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/beregning/AktivitetStatus.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/beregning/AktivitetStatus.java
@@ -1,13 +1,10 @@
 package no.nav.foreldrepenger.behandlingslager.behandling.beregning;
 
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
-
-import com.fasterxml.jackson.annotation.JsonValue;
 
 import jakarta.persistence.AttributeConverter;
 import jakarta.persistence.Converter;
@@ -17,6 +14,7 @@ import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
 
 import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
 

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/beregning/AktivitetStatus.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/beregning/AktivitetStatus.java
@@ -20,7 +20,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
 
-
 @JsonAutoDetect(getterVisibility = Visibility.NONE, setterVisibility = Visibility.NONE, fieldVisibility = Visibility.ANY)
 public enum AktivitetStatus implements Kodeverdi {
     ARBEIDSAVKLARINGSPENGER("AAP", "Arbeidsavklaringspenger", Inntektskategori.ARBEIDSAVKLARINGSPENGER),
@@ -40,8 +39,6 @@ public enum AktivitetStatus implements Kodeverdi {
     VENTELØNN_VARTPENGER("VENTELØNN_VARTPENGER", "Ventelønn/Vartpenger", Inntektskategori.UDEFINERT),
 
     UDEFINERT(STANDARDKODE_UDEFINERT, "Ikke definert", Inntektskategori.UDEFINERT);
-
-    public static final String KODEVERK = "AKTIVITET_STATUS";
 
     private static final Map<String, AktivitetStatus> KODER = new LinkedHashMap<>();
 
@@ -79,10 +76,6 @@ public enum AktivitetStatus implements Kodeverdi {
         return ad;
     }
 
-    public static Map<String, AktivitetStatus> kodeMap() {
-        return Collections.unmodifiableMap(KODER);
-    }
-
     private static final Set<AktivitetStatus> AT_STATUSER = new HashSet<>(Arrays.asList(ARBEIDSTAKER,
         KOMBINERT_AT_FL_SN, KOMBINERT_AT_SN, KOMBINERT_AT_FL));
 
@@ -107,12 +100,6 @@ public enum AktivitetStatus implements Kodeverdi {
     @Override
     public String getNavn() {
         return navn;
-    }
-
-    @JsonProperty
-    @Override
-    public String getKodeverk() {
-        return KODEVERK;
     }
 
     @JsonProperty

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/beregning/BeregningSatsType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/beregning/BeregningSatsType.java
@@ -17,7 +17,6 @@ public enum BeregningSatsType implements Kodeverdi {
     GSNITT("GSNITT", "Grunnbeløp årsgjennomsnitt"),
     UDEFINERT(STANDARDKODE_UDEFINERT, "Ikke definert"),
     ;
-    public static final String KODEVERK = "SATS_TYPE";
 
     private static final Map<String, BeregningSatsType> KODER = new LinkedHashMap<>();
 
@@ -39,18 +38,9 @@ public enum BeregningSatsType implements Kodeverdi {
         this.navn = navn;
     }
 
-    public static Map<String, BeregningSatsType> kodeMap() {
-        return Collections.unmodifiableMap(KODER);
-    }
-
     @Override
     public String getNavn() {
         return navn;
-    }
-
-    @Override
-    public String getKodeverk() {
-        return KODEVERK;
     }
 
     @Override

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/beregning/BeregningSatsType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/beregning/BeregningSatsType.java
@@ -1,6 +1,5 @@
 package no.nav.foreldrepenger.behandlingslager.behandling.beregning;
 
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/beregning/Inntektskategori.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/beregning/Inntektskategori.java
@@ -1,6 +1,5 @@
 package no.nav.foreldrepenger.behandlingslager.behandling.beregning;
 
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/beregning/Inntektskategori.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/beregning/Inntektskategori.java
@@ -12,7 +12,6 @@ import com.fasterxml.jackson.annotation.JsonValue;
 
 import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
 
-
 public enum Inntektskategori implements Kodeverdi {
 
     ARBEIDSTAKER("ARBEIDSTAKER", "Arbeidstaker"),
@@ -29,8 +28,6 @@ public enum Inntektskategori implements Kodeverdi {
     ;
     private static final Map<String, Inntektskategori> KODER = new LinkedHashMap<>();
     private static final Set<Inntektskategori> GIR_FERIEPENGER = Set.of(ARBEIDSTAKER, SJØMANN);
-
-    public static final String KODEVERK = "INNTEKTSKATEGORI";
 
     static {
         for (var v : values()) {
@@ -50,11 +47,6 @@ public enum Inntektskategori implements Kodeverdi {
         this.navn = navn;
     }
 
-
-    public static Map<String, Inntektskategori> kodeMap() {
-        return Collections.unmodifiableMap(KODER);
-    }
-
     public static Set<Inntektskategori> girFeriepenger() {
         return GIR_FERIEPENGER;
     }
@@ -62,11 +54,6 @@ public enum Inntektskategori implements Kodeverdi {
     @Override
     public String getNavn() {
         return navn;
-    }
-
-    @Override
-    public String getKodeverk() {
-        return KODEVERK;
     }
 
     @Override

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/dokument/DokumentMalType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/dokument/DokumentMalType.java
@@ -97,10 +97,6 @@ public enum DokumentMalType implements Kodeverdi {
         return kode;
     }
 
-    @Override
-    public String getKodeverk() {
-        return "DOKUMENT_MAL_TYPE";
-    }
 
     @Override
     public String getNavn() {

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/familiehendelse/FamilieHendelseType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/familiehendelse/FamilieHendelseType.java
@@ -23,8 +23,6 @@ public enum FamilieHendelseType implements Kodeverdi {
 
     private static final Map<String, FamilieHendelseType> KODER = new LinkedHashMap<>();
 
-    public static final String KODEVERK = "FAMILIE_HENDELSE_TYPE";
-
     private final String navn;
 
     @JsonValue
@@ -33,10 +31,6 @@ public enum FamilieHendelseType implements Kodeverdi {
     FamilieHendelseType(String kode, String navn) {
         this.kode = kode;
         this.navn = navn;
-    }
-
-    public static Map<String, FamilieHendelseType> kodeMap() {
-        return Collections.unmodifiableMap(KODER);
     }
 
     @Override
@@ -50,11 +44,6 @@ public enum FamilieHendelseType implements Kodeverdi {
 
     public static boolean gjelderAdopsjon(FamilieHendelseType type) {
         return ADOPSJON.equals(type) || OMSORG.equals(type);
-    }
-
-    @Override
-    public String getKodeverk() {
-        return KODEVERK;
     }
 
     @Override

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/familiehendelse/FamilieHendelseType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/familiehendelse/FamilieHendelseType.java
@@ -1,6 +1,5 @@
 package no.nav.foreldrepenger.behandlingslager.behandling.familiehendelse;
 
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/familiehendelse/OmsorgsovertakelseVilkårType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/familiehendelse/OmsorgsovertakelseVilkårType.java
@@ -1,7 +1,6 @@
 package no.nav.foreldrepenger.behandlingslager.behandling.familiehendelse;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/familiehendelse/OmsorgsovertakelseVilkårType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/familiehendelse/OmsorgsovertakelseVilkårType.java
@@ -51,8 +51,6 @@ public enum OmsorgsovertakelseVilkårType implements Kodeverdi {
 
     private static final Map<String, OmsorgsovertakelseVilkårType> KODER = new LinkedHashMap<>();
 
-    public static final String KODEVERK = "OMSORGSOVERTAKELSE_VILKAR";
-
     private final String navn;
 
     private final Set<Avslagsårsak> avslagsårsaker;
@@ -66,18 +64,9 @@ public enum OmsorgsovertakelseVilkårType implements Kodeverdi {
         this.avslagsårsaker = Set.of(avslagsårsaker);
     }
 
-    public static Map<String, OmsorgsovertakelseVilkårType> kodeMap() {
-        return Collections.unmodifiableMap(KODER);
-    }
-
     @Override
     public String getNavn() {
         return navn;
-    }
-
-    @Override
-    public String getKodeverk() {
-        return KODEVERK;
     }
 
     @Override

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/historikk/HistorikkAktør.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/historikk/HistorikkAktør.java
@@ -1,6 +1,5 @@
 package no.nav.foreldrepenger.behandlingslager.behandling.historikk;
 
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/historikk/HistorikkAktør.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/historikk/HistorikkAktør.java
@@ -23,8 +23,6 @@ public enum HistorikkAktør implements Kodeverdi {
 
     private static final Map<String, HistorikkAktør> KODER = new LinkedHashMap<>();
 
-    public static final String KODEVERK = "HISTORIKK_AKTOER";
-
     static {
         for (var v : values()) {
             if (KODER.putIfAbsent(v.kode, v) != null) {
@@ -43,18 +41,9 @@ public enum HistorikkAktør implements Kodeverdi {
         this.navn = navn;
     }
 
-    public static Map<String, HistorikkAktør> kodeMap() {
-        return Collections.unmodifiableMap(KODER);
-    }
-
     @Override
     public String getNavn() {
         return navn;
-    }
-
-    @Override
-    public String getKodeverk() {
-        return KODEVERK;
     }
 
     @Override

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/innsyn/InnsynResultatType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/innsyn/InnsynResultatType.java
@@ -21,8 +21,6 @@ public enum InnsynResultatType implements Kodeverdi {
 
     private static final Map<String, InnsynResultatType> KODER = new LinkedHashMap<>();
 
-    public static final String KODEVERK = "INNSYN_RESULTAT_TYPE";
-
     static {
         for (var v : values()) {
             if (KODER.putIfAbsent(v.kode, v) != null) {
@@ -41,18 +39,9 @@ public enum InnsynResultatType implements Kodeverdi {
         this.navn = navn;
     }
 
-    public static Map<String, InnsynResultatType> kodeMap() {
-        return Collections.unmodifiableMap(KODER);
-    }
-
     @Override
     public String getNavn() {
         return navn;
-    }
-
-    @Override
-    public String getKodeverk() {
-        return KODEVERK;
     }
 
     @Override

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/innsyn/InnsynResultatType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/innsyn/InnsynResultatType.java
@@ -1,6 +1,5 @@
 package no.nav.foreldrepenger.behandlingslager.behandling.innsyn;
 
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/klage/KlageAvvistÅrsak.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/klage/KlageAvvistÅrsak.java
@@ -21,8 +21,6 @@ public enum KlageAvvistÅrsak implements Kodeverdi {
 
     private static final Map<String, KlageAvvistÅrsak> KODER = new LinkedHashMap<>();
 
-    public static final String KODEVERK = "KLAGE_AVVIST_AARSAK";
-
     static {
         for (var v : values()) {
             if (KODER.putIfAbsent(v.kode, v) != null) {
@@ -30,7 +28,6 @@ public enum KlageAvvistÅrsak implements Kodeverdi {
             }
         }
     }
-
 
     private final String navn;
 
@@ -42,24 +39,14 @@ public enum KlageAvvistÅrsak implements Kodeverdi {
         this.navn = navn;
     }
 
-    public static Map<String, KlageAvvistÅrsak> kodeMap() {
-        return Collections.unmodifiableMap(KODER);
-    }
-
     @Override
     public String getNavn() {
         return navn;
     }
 
     @Override
-    public String getKodeverk() {
-        return KODEVERK;
-    }
-
-    @Override
     public String getKode() {
         return kode;
     }
-
 
 }

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/klage/KlageAvvistÅrsak.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/klage/KlageAvvistÅrsak.java
@@ -1,6 +1,5 @@
 package no.nav.foreldrepenger.behandlingslager.behandling.klage;
 
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/klage/KlageHjemmel.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/klage/KlageHjemmel.java
@@ -47,8 +47,6 @@ public enum KlageHjemmel implements Kodeverdi {
 
     private static final Map<String, KlageHjemmel> KODER = new LinkedHashMap<>();
 
-    public static final String KODEVERK = "KLAGE_HJEMMEL";
-
     static {
         for (var v : values()) {
             if (KODER.putIfAbsent(v.kode, v) != null) {
@@ -56,7 +54,6 @@ public enum KlageHjemmel implements Kodeverdi {
             }
         }
     }
-
 
     private final String navn;
 
@@ -84,18 +81,9 @@ public enum KlageHjemmel implements Kodeverdi {
         return ad;
     }
 
-    public static Map<String, KlageHjemmel> kodeMap() {
-        return Collections.unmodifiableMap(KODER);
-    }
-
     @Override
     public String getNavn() {
         return navn;
-    }
-
-    @Override
-    public String getKodeverk() {
-        return KODEVERK;
     }
 
     @Override

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/klage/KlageHjemmel.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/klage/KlageHjemmel.java
@@ -5,7 +5,6 @@ import static no.nav.foreldrepenger.behandlingslager.fagsak.FagsakYtelseType.Yte
 import static no.nav.foreldrepenger.behandlingslager.fagsak.FagsakYtelseType.YtelseType.SVP;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/klage/KlageMedholdÅrsak.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/klage/KlageMedholdÅrsak.java
@@ -22,8 +22,6 @@ public enum KlageMedholdÅrsak implements Kodeverdi {
 
     private static final Map<String, KlageMedholdÅrsak> KODER = new LinkedHashMap<>();
 
-    public static final String KODEVERK = "KLAGE_MEDHOLD_AARSAK";
-
     static {
         for (var v : values()) {
             if (KODER.putIfAbsent(v.kode, v) != null) {
@@ -42,18 +40,9 @@ public enum KlageMedholdÅrsak implements Kodeverdi {
         this.navn = navn;
     }
 
-    public static Map<String, KlageMedholdÅrsak> kodeMap() {
-        return Collections.unmodifiableMap(KODER);
-    }
-
     @Override
     public String getNavn() {
         return navn;
-    }
-
-    @Override
-    public String getKodeverk() {
-        return KODEVERK;
     }
 
     @Override

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/klage/KlageMedholdÅrsak.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/klage/KlageMedholdÅrsak.java
@@ -1,6 +1,5 @@
 package no.nav.foreldrepenger.behandlingslager.behandling.klage;
 
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/klage/KlageVurdering.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/klage/KlageVurdering.java
@@ -23,8 +23,6 @@ public enum KlageVurdering implements Kodeverdi {
 
     private static final Map<String, KlageVurdering> KODER = new LinkedHashMap<>();
 
-    public static final String KODEVERK = "KLAGEVURDERING";
-
     static {
         for (var v : values()) {
             if (KODER.putIfAbsent(v.kode, v) != null) {
@@ -43,18 +41,9 @@ public enum KlageVurdering implements Kodeverdi {
         this.navn = navn;
     }
 
-    public static Map<String, KlageVurdering> kodeMap() {
-        return Collections.unmodifiableMap(KODER);
-    }
-
     @Override
     public String getNavn() {
         return navn;
-    }
-
-    @Override
-    public String getKodeverk() {
-        return KODEVERK;
     }
 
     @Override

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/klage/KlageVurdering.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/klage/KlageVurdering.java
@@ -1,6 +1,5 @@
 package no.nav.foreldrepenger.behandlingslager.behandling.klage;
 
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/klage/KlageVurderingOmgjør.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/klage/KlageVurderingOmgjør.java
@@ -1,6 +1,5 @@
 package no.nav.foreldrepenger.behandlingslager.behandling.klage;
 
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/klage/KlageVurderingOmgjør.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/klage/KlageVurderingOmgjør.java
@@ -21,8 +21,6 @@ public enum KlageVurderingOmgjør implements Kodeverdi {
 
     private static final Map<String, KlageVurderingOmgjør> KODER = new LinkedHashMap<>();
 
-    public static final String KODEVERK = "KLAGE_VURDERING_OMGJOER";
-
     static {
         for (var v : values()) {
             if (KODER.putIfAbsent(v.kode, v) != null) {
@@ -41,18 +39,9 @@ public enum KlageVurderingOmgjør implements Kodeverdi {
         this.navn = navn;
     }
 
-    public static Map<String, KlageVurderingOmgjør> kodeMap() {
-        return Collections.unmodifiableMap(KODER);
-    }
-
     @Override
     public String getNavn() {
         return navn;
-    }
-
-    @Override
-    public String getKodeverk() {
-        return KODEVERK;
     }
 
     @Override

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/klage/KlageVurdertAv.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/klage/KlageVurdertAv.java
@@ -19,8 +19,6 @@ public enum KlageVurdertAv implements Kodeverdi {
 
     private static final Map<String, KlageVurdertAv> KODER = new LinkedHashMap<>();
 
-    public static final String KODEVERK = "KLAGE_VURDERT_AV";
-
     static {
         for (var v : values()) {
             if (KODER.putIfAbsent(v.kode, v) != null) {
@@ -39,19 +37,9 @@ public enum KlageVurdertAv implements Kodeverdi {
         this.navn = navn;
     }
 
-
-    public static Map<String, KlageVurdertAv> kodeMap() {
-        return Collections.unmodifiableMap(KODER);
-    }
-
     @Override
     public String getNavn() {
         return navn;
-    }
-
-    @Override
-    public String getKodeverk() {
-        return KODEVERK;
     }
 
     @Override

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/klage/KlageVurdertAv.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/klage/KlageVurdertAv.java
@@ -1,6 +1,5 @@
 package no.nav.foreldrepenger.behandlingslager.behandling.klage;
 
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/medlemskap/MedlemskapDekningType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/medlemskap/MedlemskapDekningType.java
@@ -3,7 +3,6 @@ package no.nav.foreldrepenger.behandlingslager.behandling.medlemskap;
 import static java.util.Arrays.asList;
 import static java.util.Collections.unmodifiableList;
 
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/medlemskap/MedlemskapDekningType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/medlemskap/MedlemskapDekningType.java
@@ -33,7 +33,6 @@ public enum MedlemskapDekningType implements Kodeverdi {
     UDEFINERT(STANDARDKODE_UDEFINERT, "Ikke definert"),
     ;
 
-
     public static final List<MedlemskapDekningType> DEKNINGSTYPER = unmodifiableList(asList(
         FTL_2_6, FTL_2_7_A, FTL_2_7_B, FTL_2_9_1_A, FTL_2_9_1_B, FTL_2_9_1_C, FTL_2_9_2_A, FTL_2_9_2_C,
         FULL,
@@ -49,10 +48,7 @@ public enum MedlemskapDekningType implements Kodeverdi {
 
     public static final List<MedlemskapDekningType> DEKNINGSTYPE_ER_UAVKLART = List.of(IHT_AVTALE, OPPHOR);
 
-
     private static final Map<String, MedlemskapDekningType> KODER = new LinkedHashMap<>();
-
-    public static final String KODEVERK = "MEDLEMSKAP_DEKNING";
 
     static {
         for (var v : values()) {
@@ -72,18 +68,9 @@ public enum MedlemskapDekningType implements Kodeverdi {
         this.navn = navn;
     }
 
-    public static Map<String, MedlemskapDekningType> kodeMap() {
-        return Collections.unmodifiableMap(KODER);
-    }
-
     @Override
     public String getNavn() {
         return navn;
-    }
-
-    @Override
-    public String getKodeverk() {
-        return KODEVERK;
     }
 
     @Override

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/medlemskap/MedlemskapKildeType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/medlemskap/MedlemskapKildeType.java
@@ -1,6 +1,5 @@
 package no.nav.foreldrepenger.behandlingslager.behandling.medlemskap;
 
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/medlemskap/MedlemskapKildeType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/medlemskap/MedlemskapKildeType.java
@@ -31,8 +31,6 @@ public enum MedlemskapKildeType implements Kodeverdi {
 
     private static final Map<String, MedlemskapKildeType> KODER = new LinkedHashMap<>();
 
-    public static final String KODEVERK = "MEDLEMSKAP_KILDE";
-
     static {
         for (var v : values()) {
             if (KODER.putIfAbsent(v.kode, v) != null) {
@@ -62,18 +60,9 @@ public enum MedlemskapKildeType implements Kodeverdi {
         return ad;
     }
 
-    public static Map<String, MedlemskapKildeType> kodeMap() {
-        return Collections.unmodifiableMap(KODER);
-    }
-
     @Override
     public String getNavn() {
         return navn;
-    }
-
-    @Override
-    public String getKodeverk() {
-        return KODEVERK;
     }
 
     @Override

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/medlemskap/MedlemskapManuellVurderingType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/medlemskap/MedlemskapManuellVurderingType.java
@@ -27,8 +27,6 @@ public enum MedlemskapManuellVurderingType implements Kodeverdi {
 
     private static final Map<String, MedlemskapManuellVurderingType> KODER = new LinkedHashMap<>();
 
-    public static final String KODEVERK = "MEDLEMSKAP_MANUELL_VURD";
-
     @JsonIgnore
     private final String navn;
 
@@ -51,10 +49,6 @@ public enum MedlemskapManuellVurderingType implements Kodeverdi {
         return ad;
     }
 
-    public static Map<String, MedlemskapManuellVurderingType> kodeMap() {
-        return Collections.unmodifiableMap(KODER);
-    }
-
     @Override
     public String getNavn() {
         return navn;
@@ -62,11 +56,6 @@ public enum MedlemskapManuellVurderingType implements Kodeverdi {
 
     public boolean visesPåKlient() {
         return GUI.contains(this);
-    }
-
-    @Override
-    public String getKodeverk() {
-        return KODEVERK;
     }
 
     @Override

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/medlemskap/MedlemskapManuellVurderingType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/medlemskap/MedlemskapManuellVurderingType.java
@@ -1,6 +1,5 @@
 package no.nav.foreldrepenger.behandlingslager.behandling.medlemskap;
 
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/medlemskap/MedlemskapType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/medlemskap/MedlemskapType.java
@@ -1,6 +1,5 @@
 package no.nav.foreldrepenger.behandlingslager.behandling.medlemskap;
 
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/medlemskap/MedlemskapType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/medlemskap/MedlemskapType.java
@@ -21,8 +21,6 @@ public enum MedlemskapType implements Kodeverdi {
 
     private static final Map<String, MedlemskapType> KODER = new LinkedHashMap<>();
 
-    public static final String KODEVERK = "MEDLEMSKAP_TYPE";
-
     static {
         for (var v : values()) {
             if (KODER.putIfAbsent(v.kode, v) != null) {
@@ -41,18 +39,9 @@ public enum MedlemskapType implements Kodeverdi {
         this.navn = navn;
     }
 
-    public static Map<String, MedlemskapType> kodeMap() {
-        return Collections.unmodifiableMap(KODER);
-    }
-
     @Override
     public String getNavn() {
         return navn;
-    }
-
-    @Override
-    public String getKodeverk() {
-        return KODEVERK;
     }
 
     @Override

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/opptjening/OpptjeningAktivitetKlassifisering.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/opptjening/OpptjeningAktivitetKlassifisering.java
@@ -1,6 +1,5 @@
 package no.nav.foreldrepenger.behandlingslager.behandling.opptjening;
 
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/opptjening/OpptjeningAktivitetKlassifisering.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/opptjening/OpptjeningAktivitetKlassifisering.java
@@ -22,8 +22,6 @@ public enum OpptjeningAktivitetKlassifisering implements Kodeverdi {
 
     private static final Map<String, OpptjeningAktivitetKlassifisering> KODER = new LinkedHashMap<>();
 
-    public static final String KODEVERK = "OPPTJENING_AKTIVITET_KLASSIFISERING";
-
     static {
         for (var v : values()) {
             if (KODER.putIfAbsent(v.kode, v) != null) {
@@ -42,18 +40,9 @@ public enum OpptjeningAktivitetKlassifisering implements Kodeverdi {
         this.navn = navn;
     }
 
-    public static Map<String, OpptjeningAktivitetKlassifisering> kodeMap() {
-        return Collections.unmodifiableMap(KODER);
-    }
-
     @Override
     public String getNavn() {
         return navn;
-    }
-
-    @Override
-    public String getKodeverk() {
-        return KODEVERK;
     }
 
     @Override

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/opptjening/OpptjeningAktivitetType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/opptjening/OpptjeningAktivitetType.java
@@ -93,8 +93,6 @@ public enum OpptjeningAktivitetType implements Kodeverdi {
     private static final Map<OpptjeningAktivitetType, Set<ArbeidType>> INDEKS_OPPTJ_ARBEID = new LinkedHashMap<>();
     private static final Map<OpptjeningAktivitetType, Set<RelatertYtelseType>> INDEKS_OPPTJ_RELYT = new LinkedHashMap<>();
 
-    public static final String KODEVERK = "OPPTJENING_AKTIVITET_TYPE";
-
     static {
         for (var v : values()) {
             if (KODER.putIfAbsent(v.kode, v) != null) {
@@ -139,18 +137,9 @@ public enum OpptjeningAktivitetType implements Kodeverdi {
         return ad;
     }
 
-    public static Map<String, OpptjeningAktivitetType> kodeMap() {
-        return Collections.unmodifiableMap(KODER);
-    }
-
     @Override
     public String getNavn() {
         return navn;
-    }
-
-    @Override
-    public String getKodeverk() {
-        return KODEVERK;
     }
 
     @Override

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/opptjening/ReferanseType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/opptjening/ReferanseType.java
@@ -20,8 +20,6 @@ public enum ReferanseType implements Kodeverdi {
 
     private static final Map<String, ReferanseType> KODER = new LinkedHashMap<>();
 
-    public static final String KODEVERK = "REFERANSE_TYPE";
-
     static {
         for (var v : values()) {
             if (KODER.putIfAbsent(v.kode, v) != null) {
@@ -40,18 +38,9 @@ public enum ReferanseType implements Kodeverdi {
         this.navn = navn;
     }
 
-    public static Map<String, ReferanseType> kodeMap() {
-        return Collections.unmodifiableMap(KODER);
-    }
-
     @Override
     public String getNavn() {
         return navn;
-    }
-
-    @Override
-    public String getKodeverk() {
-        return KODEVERK;
     }
 
     @Override

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/opptjening/ReferanseType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/opptjening/ReferanseType.java
@@ -1,6 +1,5 @@
 package no.nav.foreldrepenger.behandlingslager.behandling.opptjening;
 
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/personopplysning/Diskresjonskode.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/personopplysning/Diskresjonskode.java
@@ -16,8 +16,6 @@ public enum Diskresjonskode implements Kodeverdi, MedOffisiellKode {
 
     ;
 
-    private static final String KODEVERK = "DISKRESJONSKODE";
-
     private String navn;
 
     private String offisiellKode;
@@ -33,11 +31,6 @@ public enum Diskresjonskode implements Kodeverdi, MedOffisiellKode {
     @Override
     public String getNavn() {
         return navn;
-    }
-
-    @Override
-    public String getKodeverk() {
-        return KODEVERK;
     }
 
     @Override

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/personopplysning/RelasjonsRolleType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/personopplysning/RelasjonsRolleType.java
@@ -1,6 +1,5 @@
 package no.nav.foreldrepenger.behandlingslager.behandling.personopplysning;
 
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/personopplysning/RelasjonsRolleType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/personopplysning/RelasjonsRolleType.java
@@ -30,8 +30,6 @@ public enum RelasjonsRolleType implements Kodeverdi {
 
     private static final Map<String, RelasjonsRolleType> KODER = new LinkedHashMap<>();
 
-    public static final String KODEVERK = "RELASJONSROLLE_TYPE";
-
     private static final Set<RelasjonsRolleType> FORELDRE_ROLLER = Set.of(RelasjonsRolleType.MORA, RelasjonsRolleType.FARA, RelasjonsRolleType.MEDMOR);
 
     static {
@@ -41,7 +39,6 @@ public enum RelasjonsRolleType implements Kodeverdi {
             }
         }
     }
-
 
     private String navn;
     @JsonValue
@@ -57,18 +54,9 @@ public enum RelasjonsRolleType implements Kodeverdi {
             .orElseThrow(() -> new IllegalArgumentException("Ukjent RelasjonsRolleType: " + kode));
     }
 
-    public static Map<String, RelasjonsRolleType> kodeMap() {
-        return Collections.unmodifiableMap(KODER);
-    }
-
     @Override
     public String getNavn() {
         return navn;
-    }
-
-    @Override
-    public String getKodeverk() {
-        return KODEVERK;
     }
 
     @Override

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/personopplysning/SivilstandType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/personopplysning/SivilstandType.java
@@ -27,8 +27,6 @@ public enum SivilstandType implements Kodeverdi {
     UGIFT("UGIF", "Ugift"),
     ;
 
-    public static final String KODEVERK = "SIVILSTAND_TYPE";
-
     private static final Map<String, SivilstandType> KODER = new LinkedHashMap<>();
 
     static {
@@ -38,7 +36,6 @@ public enum SivilstandType implements Kodeverdi {
             }
         }
     }
-
 
     private String navn;
     @JsonValue
@@ -55,19 +52,9 @@ public enum SivilstandType implements Kodeverdi {
     }
 
     @Override
-    public String getKodeverk() {
-        return KODEVERK;
-    }
-
-    @Override
     public String getNavn() {
         return navn;
     }
-
-    public static Map<String, SivilstandType> kodeMap() {
-        return Collections.unmodifiableMap(KODER);
-    }
-
 
     @Converter(autoApply = true)
     public static class KodeverdiConverter implements AttributeConverter<SivilstandType, String> {

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/personopplysning/SivilstandType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/personopplysning/SivilstandType.java
@@ -1,6 +1,5 @@
 package no.nav.foreldrepenger.behandlingslager.behandling.personopplysning;
 
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/skjermlenke/SkjermlenkeType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/skjermlenke/SkjermlenkeType.java
@@ -1,6 +1,5 @@
 package no.nav.foreldrepenger.behandlingslager.behandling.skjermlenke;
 
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/skjermlenke/SkjermlenkeType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/skjermlenke/SkjermlenkeType.java
@@ -64,10 +64,6 @@ public enum SkjermlenkeType implements Kodeverdi {
 
     private static final Map<String, SkjermlenkeType> KODER = new LinkedHashMap<>();
 
-    public static final String KODEVERK = "SKJERMLENKE_TYPE";
-
-
-
     static {
         for (var v : values()) {
             if (KODER.putIfAbsent(v.kode, v) != null) {
@@ -96,10 +92,6 @@ public enum SkjermlenkeType implements Kodeverdi {
         return ad;
     }
 
-    public static Map<String, SkjermlenkeType> kodeMap() {
-        return Collections.unmodifiableMap(KODER);
-    }
-
     @Override
     public String getNavn() {
         return navn;
@@ -108,11 +100,6 @@ public enum SkjermlenkeType implements Kodeverdi {
     @Override
     public String getKode() {
         return kode;
-    }
-
-    @Override
-    public String getKodeverk() {
-        return KODEVERK;
     }
 
     public static boolean totrinnsSkjermlenke(SkjermlenkeType skjermlenkeType) {
@@ -131,7 +118,6 @@ public enum SkjermlenkeType implements Kodeverdi {
         return aksjonspunktDefinisjon.getSkjermlenkeType();
     }
 
-
     public static SkjermlenkeType getSkjermlenkeTypeForMottattStotte(Behandlingsresultat behandlingsresultat) {
         var vilkårType = Optional.ofNullable(behandlingsresultat)
             .map(Behandlingsresultat::getVilkårResultat)
@@ -148,7 +134,6 @@ public enum SkjermlenkeType implements Kodeverdi {
         }
         return SkjermlenkeType.UDEFINERT;
     }
-
 
     @Converter(autoApply = true)
     public static class KodeverdiConverter implements AttributeConverter<SkjermlenkeType, String> {

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/søknad/FarSøkerType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/søknad/FarSøkerType.java
@@ -1,6 +1,5 @@
 package no.nav.foreldrepenger.behandlingslager.behandling.søknad;
 
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/søknad/FarSøkerType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/søknad/FarSøkerType.java
@@ -20,8 +20,6 @@ public enum FarSøkerType implements Kodeverdi {
     UDEFINERT(STANDARDKODE_UDEFINERT, "Ikke definert"),
     ;
 
-    public static final String KODEVERK = "FAR_SOEKER_TYPE";
-
     private static final Map<String, FarSøkerType> KODER = new LinkedHashMap<>();
 
     static {
@@ -52,10 +50,6 @@ public enum FarSøkerType implements Kodeverdi {
         return ad;
     }
 
-    public static Map<String, FarSøkerType> kodeMap() {
-        return Collections.unmodifiableMap(KODER);
-    }
-
     @Override
     public String getNavn() {
         return navn;
@@ -64,11 +58,6 @@ public enum FarSøkerType implements Kodeverdi {
     @Override
     public String getKode() {
         return kode;
-    }
-
-    @Override
-    public String getKodeverk() {
-        return KODEVERK;
     }
 
     @Converter(autoApply = true)

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/søknad/ForeldreType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/søknad/ForeldreType.java
@@ -1,6 +1,5 @@
 package no.nav.foreldrepenger.behandlingslager.behandling.søknad;
 
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/søknad/ForeldreType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/søknad/ForeldreType.java
@@ -21,8 +21,6 @@ public enum ForeldreType implements Kodeverdi {
 
     private static final Map<String, ForeldreType> KODER = new LinkedHashMap<>();
 
-    public static final String KODEVERK = "FORELDRE_TYPE";
-
     static {
         for (var v : values()) {
             if (KODER.putIfAbsent(v.kode, v) != null) {
@@ -41,18 +39,9 @@ public enum ForeldreType implements Kodeverdi {
         this.navn = navn;
     }
 
-    public static Map<String, ForeldreType> kodeMap() {
-        return Collections.unmodifiableMap(KODER);
-    }
-
     @Override
     public String getNavn() {
         return navn;
-    }
-
-    @Override
-    public String getKodeverk() {
-        return KODEVERK;
     }
 
     @Override

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/søknad/Innsendingsvalg.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/søknad/Innsendingsvalg.java
@@ -1,6 +1,5 @@
 package no.nav.foreldrepenger.behandlingslager.behandling.søknad;
 
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/søknad/Innsendingsvalg.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/søknad/Innsendingsvalg.java
@@ -23,8 +23,6 @@ public enum Innsendingsvalg implements Kodeverdi {
 
     private static final Map<String, Innsendingsvalg> KODER = new LinkedHashMap<>();
 
-    public static final String KODEVERK = "INNSENDINGSVALG";
-
     static {
         for (var v : values()) {
             if (KODER.putIfAbsent(v.kode, v) != null) {
@@ -53,18 +51,9 @@ public enum Innsendingsvalg implements Kodeverdi {
         return ad;
     }
 
-    public static Map<String, Innsendingsvalg> kodeMap() {
-        return Collections.unmodifiableMap(KODER);
-    }
-
     @Override
     public String getNavn() {
         return navn;
-    }
-
-    @Override
-    public String getKodeverk() {
-        return KODEVERK;
     }
 
     @Override

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/søknad/SøknadAnnenPartType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/søknad/SøknadAnnenPartType.java
@@ -23,8 +23,6 @@ public enum SøknadAnnenPartType implements Kodeverdi {
 
     private static final Map<String, SøknadAnnenPartType> KODER = new LinkedHashMap<>();
 
-    public static final String KODEVERK = "SOEKNAD_ANNEN_PART";
-
     static {
         for (var v : values()) {
             if (KODER.putIfAbsent(v.kode, v) != null) {
@@ -42,18 +40,9 @@ public enum SøknadAnnenPartType implements Kodeverdi {
         this.navn = navn;
     }
 
-    public static Map<String, SøknadAnnenPartType> kodeMap() {
-        return Collections.unmodifiableMap(KODER);
-    }
-
     @Override
     public String getNavn() {
         return navn;
-    }
-
-    @Override
-    public String getKodeverk() {
-        return KODEVERK;
     }
 
     @Override

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/søknad/SøknadAnnenPartType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/søknad/SøknadAnnenPartType.java
@@ -1,7 +1,6 @@
 
 package no.nav.foreldrepenger.behandlingslager.behandling.søknad;
 
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/tilbakekreving/TilbakekrevingVidereBehandling.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/tilbakekreving/TilbakekrevingVidereBehandling.java
@@ -22,8 +22,6 @@ public enum TilbakekrevingVidereBehandling implements Kodeverdi {
 
     private static final Map<String, TilbakekrevingVidereBehandling> KODER = new LinkedHashMap<>();
 
-    public static final String KODEVERK = "TILBAKEKR_VIDERE_BEH";
-
     static {
         for (var v : values()) {
             if (KODER.putIfAbsent(v.kode, v) != null) {
@@ -42,18 +40,9 @@ public enum TilbakekrevingVidereBehandling implements Kodeverdi {
         this.navn = navn;
     }
 
-    public static Map<String, TilbakekrevingVidereBehandling> kodeMap() {
-        return Collections.unmodifiableMap(KODER);
-    }
-
     @Override
     public String getNavn() {
         return navn;
-    }
-
-    @Override
-    public String getKodeverk() {
-        return KODEVERK;
     }
 
     @Override

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/tilbakekreving/TilbakekrevingVidereBehandling.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/tilbakekreving/TilbakekrevingVidereBehandling.java
@@ -1,6 +1,5 @@
 package no.nav.foreldrepenger.behandlingslager.behandling.tilbakekreving;
 
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/tilrettelegging/TilretteleggingType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/tilrettelegging/TilretteleggingType.java
@@ -1,6 +1,5 @@
 package no.nav.foreldrepenger.behandlingslager.behandling.tilrettelegging;
 
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/tilrettelegging/TilretteleggingType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/tilrettelegging/TilretteleggingType.java
@@ -20,8 +20,6 @@ public enum TilretteleggingType implements Kodeverdi {
 
     private static final Map<String, TilretteleggingType> KODER = new LinkedHashMap<>();
 
-    public static final String KODEVERK = "SVP_TILRETTELEGGING_TYPE";
-
     static {
         for (var v : values()) {
             if (KODER.putIfAbsent(v.kode, v) != null) {
@@ -40,18 +38,9 @@ public enum TilretteleggingType implements Kodeverdi {
         this.navn = navn;
     }
 
-    public static Map<String, TilretteleggingType> kodeMap() {
-        return Collections.unmodifiableMap(KODER);
-    }
-
     @Override
     public String getNavn() {
         return navn;
-    }
-
-    @Override
-    public String getKodeverk() {
-        return KODEVERK;
     }
 
     @Override

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/vedtak/IverksettingStatus.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/vedtak/IverksettingStatus.java
@@ -1,6 +1,5 @@
 package no.nav.foreldrepenger.behandlingslager.behandling.vedtak;
 
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/vedtak/IverksettingStatus.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/vedtak/IverksettingStatus.java
@@ -20,7 +20,6 @@ public enum IverksettingStatus implements Kodeverdi {
 
     ;
 
-    public static final String KODEVERK = "IVERKSETTING_STATUS";
     private static final Map<String, IverksettingStatus> KODER = new LinkedHashMap<>();
 
     private String navn;
@@ -33,18 +32,9 @@ public enum IverksettingStatus implements Kodeverdi {
         this.navn = navn;
     }
 
-    public static Map<String, IverksettingStatus> kodeMap() {
-        return Collections.unmodifiableMap(KODER);
-    }
-
     @Override
     public String getNavn() {
         return navn;
-    }
-
-    @Override
-    public String getKodeverk() {
-        return KODEVERK;
     }
 
     @Override

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/vedtak/OppgaveType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/vedtak/OppgaveType.java
@@ -1,6 +1,5 @@
 package no.nav.foreldrepenger.behandlingslager.behandling.vedtak;
 
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/vedtak/OppgaveType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/vedtak/OppgaveType.java
@@ -13,7 +13,6 @@ public enum OppgaveType implements Kodeverdi {
     VUR_KONSEKVENS("VUR_KONSEKVENS", "Vurder konsekvens for ytelse"),
     VUR_DOKUMENT("VUR_DOKUMENT", "Vurder dokument");
 
-    public static final String KODEVERK = "OPPGAVE_TYPE";
     private static final Map<String, OppgaveType> KODER = new LinkedHashMap<>();
 
     static {
@@ -34,18 +33,9 @@ public enum OppgaveType implements Kodeverdi {
         this.navn = navn;
     }
 
-    public static Map<String, OppgaveType> kodeMap() {
-        return Collections.unmodifiableMap(KODER);
-    }
-
     @Override
     public String getNavn() {
         return navn;
-    }
-
-    @Override
-    public String getKodeverk() {
-        return KODEVERK;
     }
 
     @Override

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/vedtak/VedtakResultatType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/vedtak/VedtakResultatType.java
@@ -1,6 +1,5 @@
 package no.nav.foreldrepenger.behandlingslager.behandling.vedtak;
 
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/vedtak/VedtakResultatType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/vedtak/VedtakResultatType.java
@@ -25,8 +25,6 @@ public enum VedtakResultatType implements Kodeverdi {
 
     private static final Map<String, VedtakResultatType> KODER = new LinkedHashMap<>();
 
-    public static final String KODEVERK = "VEDTAK_RESULTAT_TYPE";
-
     private final String navn;
 
     @JsonValue
@@ -37,18 +35,9 @@ public enum VedtakResultatType implements Kodeverdi {
         this.navn = navn;
     }
 
-    public static Map<String, VedtakResultatType> kodeMap() {
-        return Collections.unmodifiableMap(KODER);
-    }
-
     @Override
     public String getNavn() {
         return navn;
-    }
-
-    @Override
-    public String getKodeverk() {
-        return KODEVERK;
     }
 
     @Override

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/vedtak/Vedtaksbrev.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/vedtak/Vedtaksbrev.java
@@ -21,8 +21,6 @@ public enum Vedtaksbrev implements Kodeverdi {
 
     private static final Map<String, Vedtaksbrev> KODER = new LinkedHashMap<>();
 
-    public static final String KODEVERK = "VEDTAKSBREV";
-
     private String navn;
     @JsonValue
     private String kode;
@@ -32,19 +30,9 @@ public enum Vedtaksbrev implements Kodeverdi {
         this.navn = navn;
     }
 
-
-    public static Map<String, Vedtaksbrev> kodeMap() {
-        return Collections.unmodifiableMap(KODER);
-    }
-
     @Override
     public String getNavn() {
         return navn;
-    }
-
-    @Override
-    public String getKodeverk() {
-        return KODEVERK;
     }
 
     @Override
@@ -83,6 +71,5 @@ public enum Vedtaksbrev implements Kodeverdi {
             return ad;
         }
     }
-
 
 }

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/vedtak/Vedtaksbrev.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/vedtak/Vedtaksbrev.java
@@ -1,6 +1,5 @@
 package no.nav.foreldrepenger.behandlingslager.behandling.vedtak;
 
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/verge/VergeType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/verge/VergeType.java
@@ -1,6 +1,5 @@
 package no.nav.foreldrepenger.behandlingslager.behandling.verge;
 
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/verge/VergeType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/verge/VergeType.java
@@ -22,8 +22,6 @@ public enum VergeType implements Kodeverdi {
 
     private static final Map<String, VergeType> KODER = new LinkedHashMap<>();
 
-    public static final String KODEVERK = "VERGE_TYPE";
-
     static {
         for (var v : values()) {
             if (KODER.putIfAbsent(v.kode, v) != null) {
@@ -42,18 +40,9 @@ public enum VergeType implements Kodeverdi {
         this.navn = navn;
     }
 
-    public static Map<String, VergeType> kodeMap() {
-        return Collections.unmodifiableMap(KODER);
-    }
-
     @Override
     public String getNavn() {
         return navn;
-    }
-
-    @Override
-    public String getKodeverk() {
-        return KODEVERK;
     }
 
     @Override

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/vilkår/Avslagsårsak.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/vilkår/Avslagsårsak.java
@@ -1,6 +1,5 @@
 package no.nav.foreldrepenger.behandlingslager.behandling.vilkår;
 
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/vilkår/Avslagsårsak.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/vilkår/Avslagsårsak.java
@@ -71,8 +71,6 @@ public enum Avslagsårsak implements Kodeverdi {
         }
     }
 
-    public static final String KODEVERK = "AVSLAGSARSAK";
-
     private String navn;
     @JsonValue
     private String kode;
@@ -97,10 +95,6 @@ public enum Avslagsårsak implements Kodeverdi {
         return Optional.ofNullable(fraKode(kode)).filter(a -> !UDEFINERT.equals(a));
     }
 
-    public static Map<String, Avslagsårsak> kodeMap() {
-        return Collections.unmodifiableMap(KODER);
-    }
-
     @Override
     public String getNavn() {
         return navn;
@@ -109,11 +103,6 @@ public enum Avslagsårsak implements Kodeverdi {
     @Override
     public String getKode() {
         return kode;
-    }
-
-    @Override
-    public String getKodeverk() {
-        return KODEVERK;
     }
 
     /**
@@ -135,6 +124,5 @@ public enum Avslagsårsak implements Kodeverdi {
             return dbData == null ? null : fraKode(dbData);
         }
     }
-
 
 }

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/vilkår/VilkårType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/vilkår/VilkårType.java
@@ -121,7 +121,6 @@ public enum VilkårType implements Kodeverdi {
     private static final Map<String, VilkårType> KODER = new LinkedHashMap<>();
     private static final Map<VilkårType, Set<Avslagsårsak>> INDEKS_VILKÅR_AVSLAGSÅRSAKER = new LinkedHashMap<>();
     private static final Map<Avslagsårsak, Set<VilkårType>> INDEKS_AVSLAGSÅRSAK_VILKÅR = new LinkedHashMap<>();
-    public static final String KODEVERK = "VILKAR_TYPE";
 
     private Map<FagsakYtelseType, String> lovReferanser = Map.of();
 
@@ -161,10 +160,6 @@ public enum VilkårType implements Kodeverdi {
         return RELASJON_TIL_BARN.contains(this);
     }
 
-    public static Map<String, VilkårType> kodeMap() {
-        return Collections.unmodifiableMap(KODER);
-    }
-
     public Set<Avslagsårsak> getAvslagsårsaker() {
         return avslagsårsaker;
     }
@@ -175,11 +170,6 @@ public enum VilkårType implements Kodeverdi {
 
     public static Set<VilkårType> getVilkårTyper(Avslagsårsak avslagsårsak) {
         return INDEKS_AVSLAGSÅRSAK_VILKÅR.get(avslagsårsak);
-    }
-
-    @Override
-    public String getKodeverk() {
-        return KODEVERK;
     }
 
     @Override

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/vilkår/VilkårUtfallMerknad.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/vilkår/VilkårUtfallMerknad.java
@@ -51,8 +51,6 @@ public enum VilkårUtfallMerknad implements Kodeverdi {
 
     private static final Map<String, VilkårUtfallMerknad> KODER = new LinkedHashMap<>();
 
-    public static final String KODEVERK = "VILKAR_UTFALL_MERKNAD";
-
     private final String navn;
     @JsonValue
     private final String kode;
@@ -73,18 +71,9 @@ public enum VilkårUtfallMerknad implements Kodeverdi {
         return ad;
     }
 
-    public static Map<String, VilkårUtfallMerknad> kodeMap() {
-        return Collections.unmodifiableMap(KODER);
-    }
-
     @Override
     public String getNavn() {
         return navn;
-    }
-
-    @Override
-    public String getKodeverk() {
-        return KODEVERK;
     }
 
     @Override

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/vilkår/VilkårUtfallMerknad.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/vilkår/VilkårUtfallMerknad.java
@@ -1,6 +1,5 @@
 package no.nav.foreldrepenger.behandlingslager.behandling.vilkår;
 
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/vilkår/VilkårUtfallType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/vilkår/VilkårUtfallType.java
@@ -1,6 +1,5 @@
 package no.nav.foreldrepenger.behandlingslager.behandling.vilkår;
 
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/vilkår/VilkårUtfallType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/vilkår/VilkårUtfallType.java
@@ -22,9 +22,6 @@ public enum VilkårUtfallType implements Kodeverdi {
 
     private static final Map<String, VilkårUtfallType> KODER = new LinkedHashMap<>();
 
-    public static final String KODEVERK = "VILKAR_UTFALL_TYPE";
-
-
     private final String navn;
     @JsonValue
     private final String kode;
@@ -34,10 +31,6 @@ public enum VilkårUtfallType implements Kodeverdi {
         this.navn = navn;
     }
 
-    public static Map<String, VilkårUtfallType> kodeMap() {
-        return Collections.unmodifiableMap(KODER);
-    }
-
     public static boolean erFastsatt(VilkårUtfallType type) {
         return OPPFYLT.equals(type) || IKKE_OPPFYLT.equals(type);
     }
@@ -45,12 +38,6 @@ public enum VilkårUtfallType implements Kodeverdi {
     @Override
     public String getNavn() {
         return navn;
-    }
-
-
-    @Override
-    public String getKodeverk() {
-        return KODEVERK;
     }
 
     @Override

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/ytelsefordeling/MorsAktivitet.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/ytelsefordeling/MorsAktivitet.java
@@ -1,6 +1,5 @@
 package no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling;
 
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/ytelsefordeling/MorsAktivitet.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/ytelsefordeling/MorsAktivitet.java
@@ -12,7 +12,6 @@ import com.fasterxml.jackson.annotation.JsonValue;
 
 import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
 
-
 public enum MorsAktivitet implements Kodeverdi {
 
     UDEFINERT(STANDARDKODE_UDEFINERT, "Ikke satt eller valgt kode"),
@@ -29,8 +28,6 @@ public enum MorsAktivitet implements Kodeverdi {
     private static final Map<String, MorsAktivitet> KODER = new LinkedHashMap<>();
 
     private static final Set<String> LEGACY_KODER = Set.of("SAMTIDIGUTTAK");
-
-    public static final String KODEVERK = "MORS_AKTIVITET";
 
     static {
         for (var v : values()) {
@@ -63,10 +60,6 @@ public enum MorsAktivitet implements Kodeverdi {
         }
         return ad;
     }
-    public static Map<String, MorsAktivitet> kodeMap() {
-        return Collections.unmodifiableMap(KODER);
-    }
-
     public static boolean forventerDokumentasjon(MorsAktivitet aktivitet) {
         return aktivitet != null && !Set.of(UDEFINERT, UFØRE, IKKE_OPPGITT).contains(aktivitet);
     }
@@ -74,11 +67,6 @@ public enum MorsAktivitet implements Kodeverdi {
     @Override
     public String getNavn() {
         return navn;
-    }
-
-    @Override
-    public String getKodeverk() {
-        return KODEVERK;
     }
 
     @Override

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/ytelsefordeling/periode/DokumentasjonVurdering.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/ytelsefordeling/periode/DokumentasjonVurdering.java
@@ -30,7 +30,6 @@ public record DokumentasjonVurdering(Type type, MorsStillingsprosent morsStillin
         return type.erGodkjent();
     }
 
-
     public enum Type implements Kodeverdi {
         ///Både utsettelse
         SYKDOM_SØKER_GODKJENT("SYKDOM_SØKER_GODKJENT", "Søker er syk", true),
@@ -66,8 +65,6 @@ public record DokumentasjonVurdering(Type type, MorsStillingsprosent morsStillin
 
         private static final Map<String, Type> KODER = new LinkedHashMap<>();
 
-        public static final String KODEVERK = "DOKUMENTASJON_VURDERING";
-
         static {
             for (var v : values()) {
                 if (KODER.putIfAbsent(v.kode, v) != null) {
@@ -88,18 +85,9 @@ public record DokumentasjonVurdering(Type type, MorsStillingsprosent morsStillin
             this.godkjent = godkjent;
         }
 
-        public static Map<String, Type> kodeMap() {
-            return Collections.unmodifiableMap(KODER);
-        }
-
         @Override
         public String getNavn() {
             return navn;
-        }
-
-        @Override
-        public String getKodeverk() {
-            return KODEVERK;
         }
 
         @Override

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/ytelsefordeling/periode/DokumentasjonVurdering.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/ytelsefordeling/periode/DokumentasjonVurdering.java
@@ -1,6 +1,5 @@
 package no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.periode;
 
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/ytelsefordeling/periode/FordelingPeriodeKilde.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/ytelsefordeling/periode/FordelingPeriodeKilde.java
@@ -1,6 +1,5 @@
 package no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.periode;
 
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/ytelsefordeling/periode/FordelingPeriodeKilde.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/ytelsefordeling/periode/FordelingPeriodeKilde.java
@@ -11,7 +11,6 @@ import com.fasterxml.jackson.annotation.JsonValue;
 
 import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
 
-
 public enum FordelingPeriodeKilde implements Kodeverdi {
 
     SØKNAD("SØKNAD", "Søknad"),
@@ -20,8 +19,6 @@ public enum FordelingPeriodeKilde implements Kodeverdi {
     SAKSBEHANDLER("SAKSBEHANDLER", "Saksbehandler")
     ;
     private static final Map<String, FordelingPeriodeKilde> KODER = new LinkedHashMap<>();
-
-    public static final String KODEVERK = "FORDELING_PERIODE_KILDE";
 
     static {
         for (var v : values()) {
@@ -40,18 +37,9 @@ public enum FordelingPeriodeKilde implements Kodeverdi {
         this.navn = navn;
     }
 
-    public static Map<String, FordelingPeriodeKilde> kodeMap() {
-        return Collections.unmodifiableMap(KODER);
-    }
-
     @Override
     public String getNavn() {
         return navn;
-    }
-
-    @Override
-    public String getKodeverk() {
-        return KODEVERK;
     }
 
     @Override

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/ytelsefordeling/periode/UttakPeriodeType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/ytelsefordeling/periode/UttakPeriodeType.java
@@ -1,6 +1,5 @@
 package no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.periode;
 
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/ytelsefordeling/periode/UttakPeriodeType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/ytelsefordeling/periode/UttakPeriodeType.java
@@ -12,7 +12,6 @@ import com.fasterxml.jackson.annotation.JsonValue;
 
 import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
 
-
 public enum UttakPeriodeType implements Kodeverdi {
 
     FELLESPERIODE("FELLESPERIODE", "Fellesperioden"),
@@ -23,8 +22,6 @@ public enum UttakPeriodeType implements Kodeverdi {
     UDEFINERT(STANDARDKODE_UDEFINERT, "Ikke satt eller valgt kode"),
     ;
     private static final Map<String, UttakPeriodeType> KODER = new LinkedHashMap<>();
-
-    public static final String KODEVERK = "UTTAK_PERIODE_TYPE";
 
     static {
         for (var v : values()) {
@@ -54,18 +51,9 @@ public enum UttakPeriodeType implements Kodeverdi {
         }
         return ad;
     }
-    public static Map<String, UttakPeriodeType> kodeMap() {
-        return Collections.unmodifiableMap(KODER);
-    }
-
     @Override
     public String getNavn() {
         return navn;
-    }
-
-    @Override
-    public String getKodeverk() {
-        return KODEVERK;
     }
 
     @Override

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/ytelsefordeling/årsak/OppholdÅrsak.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/ytelsefordeling/årsak/OppholdÅrsak.java
@@ -1,6 +1,5 @@
 package no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.årsak;
 
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/ytelsefordeling/årsak/OppholdÅrsak.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/ytelsefordeling/årsak/OppholdÅrsak.java
@@ -9,7 +9,6 @@ import jakarta.persistence.Converter;
 
 import com.fasterxml.jackson.annotation.JsonValue;
 
-
 public enum OppholdÅrsak implements Årsak {
 
     UDEFINERT(STANDARDKODE_UDEFINERT, "Ikke satt eller valgt kode"),
@@ -19,8 +18,6 @@ public enum OppholdÅrsak implements Årsak {
     KVOTE_FORELDREPENGER_ANNEN_FORELDER("UTTAK_FORELDREPENGER_ANNEN_FORELDER", "Annen forelder har uttak av Foreldrepenger"),
     ;
     private static final Map<String, OppholdÅrsak> KODER = new LinkedHashMap<>();
-
-    public static final String KODEVERK = "OPPHOLD_AARSAK_TYPE";
 
     public static final String DISKRIMINATOR = "OPPHOLD_AARSAK_TYPE";
 
@@ -52,18 +49,10 @@ public enum OppholdÅrsak implements Årsak {
         }
         return ad;
     }
-    public static Map<String, OppholdÅrsak> kodeMap() {
-        return Collections.unmodifiableMap(KODER);
-    }
 
     @Override
     public String getNavn() {
         return navn;
-    }
-
-    @Override
-    public String getKodeverk() {
-        return KODEVERK;
     }
 
     @Override

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/ytelsefordeling/årsak/OverføringÅrsak.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/ytelsefordeling/årsak/OverføringÅrsak.java
@@ -1,6 +1,5 @@
 package no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.årsak;
 
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/ytelsefordeling/årsak/OverføringÅrsak.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/ytelsefordeling/årsak/OverføringÅrsak.java
@@ -19,8 +19,6 @@ public enum OverføringÅrsak implements Årsak {
     ;
     private static final Map<String, OverføringÅrsak> KODER = new LinkedHashMap<>();
 
-    public static final String KODEVERK = "OVERFOERING_AARSAK_TYPE";
-
     public static final String DISKRIMINATOR = "OVERFOERING_AARSAK_TYPE";
 
     static {
@@ -51,18 +49,10 @@ public enum OverføringÅrsak implements Årsak {
         }
         return ad;
     }
-    public static Map<String, OverføringÅrsak> kodeMap() {
-        return Collections.unmodifiableMap(KODER);
-    }
 
     @Override
     public String getNavn() {
         return navn;
-    }
-
-    @Override
-    public String getKodeverk() {
-        return KODEVERK;
     }
 
     @Override

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/ytelsefordeling/årsak/UtsettelseÅrsak.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/ytelsefordeling/årsak/UtsettelseÅrsak.java
@@ -1,6 +1,5 @@
 package no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.årsak;
 
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/ytelsefordeling/årsak/UtsettelseÅrsak.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/ytelsefordeling/årsak/UtsettelseÅrsak.java
@@ -6,7 +6,6 @@ import java.util.Map;
 
 import com.fasterxml.jackson.annotation.JsonValue;
 
-
 public enum UtsettelseÅrsak implements Årsak {
 
     ARBEID("ARBEID", "Arbeid"),
@@ -20,8 +19,6 @@ public enum UtsettelseÅrsak implements Årsak {
     UDEFINERT(STANDARDKODE_UDEFINERT, "Ikke satt eller valgt kode"),
     ;
     private static final Map<String, UtsettelseÅrsak> KODER = new LinkedHashMap<>();
-
-    public static final String KODEVERK = "UTSETTELSE_AARSAK_TYPE";
 
     public static final String DISKRIMINATOR = "UTSETTELSE_AARSAK_TYPE";
 
@@ -53,9 +50,6 @@ public enum UtsettelseÅrsak implements Årsak {
         }
         return ad;
     }
-    public static Map<String, UtsettelseÅrsak> kodeMap() {
-        return Collections.unmodifiableMap(KODER);
-    }
 
     @Override
     public String getNavn() {
@@ -63,20 +57,13 @@ public enum UtsettelseÅrsak implements Årsak {
     }
 
     @Override
-    public String getKodeverk() {
-        return KODEVERK;
-    }
-
-    @Override
     public String getKode() {
         return kode;
     }
-
 
     @Override
     public String getDiskriminator() {
         return DISKRIMINATOR;
     }
-
 
 }

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/ytelsefordeling/årsak/Årsak.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/ytelsefordeling/årsak/Årsak.java
@@ -13,10 +13,6 @@ public interface Årsak extends Kodeverdi {
             return "Ikke definert";
         }
 
-        @Override
-        public String getKodeverk() {
-            return "AARSAK_TYPE";
-        }
 
         @Override
         public String getKode() {

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/etterkontroll/KontrollType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/etterkontroll/KontrollType.java
@@ -1,6 +1,5 @@
 package no.nav.foreldrepenger.behandlingslager.etterkontroll;
 
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/etterkontroll/KontrollType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/etterkontroll/KontrollType.java
@@ -17,7 +17,6 @@ public enum KontrollType implements Kodeverdi {
 
     ;
 
-    private static final String KODEVERK = "ETTERKONTROLL_TYPE";
     private static final Map<String, KontrollType> KODER = new LinkedHashMap<>();
 
     private final String navn;
@@ -30,18 +29,9 @@ public enum KontrollType implements Kodeverdi {
         this.navn = navn;
     }
 
-    public static Map<String, KontrollType> kodeMap() {
-        return Collections.unmodifiableMap(KODER);
-    }
-
     @Override
     public String getNavn() {
         return navn;
-    }
-
-    @Override
-    public String getKodeverk() {
-        return KODEVERK;
     }
 
     @Override

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/fagsak/FagsakStatus.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/fagsak/FagsakStatus.java
@@ -1,6 +1,5 @@
 package no.nav.foreldrepenger.behandlingslager.fagsak;
 
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/fagsak/FagsakStatus.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/fagsak/FagsakStatus.java
@@ -22,8 +22,6 @@ public enum FagsakStatus implements Kodeverdi {
     public static final FagsakStatus DEFAULT = OPPRETTET;
     private static final Map<String, FagsakStatus> KODER = new LinkedHashMap<>();
 
-    public static final String KODEVERK = "FAGSAK_STATUS";
-
     static {
         for (var v : values()) {
             if (KODER.putIfAbsent(v.kode, v) != null) {
@@ -41,10 +39,6 @@ public enum FagsakStatus implements Kodeverdi {
         this.navn = navn;
     }
 
-    public static Map<String, FagsakStatus> kodeMap() {
-        return Collections.unmodifiableMap(KODER);
-    }
-
     @Override
     public String getNavn() {
         return navn;
@@ -53,11 +47,6 @@ public enum FagsakStatus implements Kodeverdi {
     @Override
     public String getKode() {
         return kode;
-    }
-
-    @Override
-    public String getKodeverk() {
-        return KODEVERK;
     }
 
     @Converter(autoApply = true)
@@ -82,7 +71,6 @@ public enum FagsakStatus implements Kodeverdi {
             }
             return ad;
         }
-
 
     }
 

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/fagsak/FagsakYtelseType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/fagsak/FagsakYtelseType.java
@@ -19,8 +19,6 @@ public enum FagsakYtelseType implements Kodeverdi {
     UDEFINERT(STANDARDKODE_UDEFINERT, "Ikke definert"),
     ;
 
-    public static final String KODEVERK = "FAGSAK_YTELSE";
-
     private static final Map<String, FagsakYtelseType> KODER = new LinkedHashMap<>();
 
     static {
@@ -56,18 +54,9 @@ public enum FagsakYtelseType implements Kodeverdi {
         return ad;
     }
 
-    public static Map<String, FagsakYtelseType> kodeMap() {
-        return Collections.unmodifiableMap(KODER);
-    }
-
     @Override
     public String getKode() {
         return kode;
-    }
-
-    @Override
-    public String getKodeverk() {
-        return KODEVERK;
     }
 
     @Override

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/fagsak/FagsakYtelseType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/fagsak/FagsakYtelseType.java
@@ -1,6 +1,5 @@
 package no.nav.foreldrepenger.behandlingslager.fagsak;
 
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/fagsak/egenskaper/FagsakMarkering.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/fagsak/egenskaper/FagsakMarkering.java
@@ -1,6 +1,5 @@
 package no.nav.foreldrepenger.behandlingslager.fagsak.egenskaper;
 
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/fagsak/egenskaper/FagsakMarkering.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/fagsak/egenskaper/FagsakMarkering.java
@@ -54,10 +54,6 @@ public enum FagsakMarkering implements EgenskapVerdi, Kodeverdi {
         return name();
     }
 
-    @Override
-    public String getKodeverk() {
-        return EgenskapNøkkel.FAGSAK_MARKERING.name();
-    }
 
     @Override
     public String getNavn() {
@@ -78,7 +74,4 @@ public enum FagsakMarkering implements EgenskapVerdi, Kodeverdi {
         }
     }
 
-    public static Map<String, FagsakMarkering> kodeMap() {
-        return Collections.unmodifiableMap(KODER);
-    }
 }

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/geografisk/Landkoder.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/geografisk/Landkoder.java
@@ -277,7 +277,6 @@ public enum Landkoder implements Kodeverdi {
     UDEFINERT(STANDARDKODE_UDEFINERT, "Ikke definert"),
     ;
 
-    public static final String KODEVERK = "LANDKODER";
     private static final Map<String, Landkoder> KODER = new LinkedHashMap<>();
 
     static {
@@ -315,10 +314,6 @@ public enum Landkoder implements Kodeverdi {
         return KODER.getOrDefault(kode, UDEFINERT);
     }
 
-    public static Map<String, Landkoder> kodeMap() {
-        return Collections.unmodifiableMap(KODER);
-    }
-
     @Override
     public String getNavn() {
         return navn;
@@ -327,11 +322,6 @@ public enum Landkoder implements Kodeverdi {
     @Override
     public String getKode() {
         return kode;
-    }
-
-    @Override
-    public String getKodeverk() {
-        return KODEVERK;
     }
 
     public static boolean erNorge(String kode) {

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/geografisk/Landkoder.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/geografisk/Landkoder.java
@@ -1,6 +1,5 @@
 package no.nav.foreldrepenger.behandlingslager.geografisk;
 
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/geografisk/Region.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/geografisk/Region.java
@@ -1,6 +1,5 @@
 package no.nav.foreldrepenger.behandlingslager.geografisk;
 
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.Map;

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/geografisk/Region.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/geografisk/Region.java
@@ -22,7 +22,6 @@ public enum Region implements Kodeverdi {
 
     public static final Comparator<Region> COMPARATOR = Comparator.comparing(Region::getRank);
 
-    public static final String KODEVERK = "REGION";
     private static final Map<String, Region> KODER = new LinkedHashMap<>();
 
     static {
@@ -45,10 +44,6 @@ public enum Region implements Kodeverdi {
         this.rank = rank;
     }
 
-    public static Map<String, Region> kodeMap() {
-        return Collections.unmodifiableMap(KODER);
-    }
-
     public int getRank() {
         return rank;
     }
@@ -61,11 +56,6 @@ public enum Region implements Kodeverdi {
     @Override
     public String getKode() {
         return kode;
-    }
-
-    @Override
-    public String getKodeverk() {
-        return KODEVERK;
     }
 
 }

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/geografisk/Språkkode.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/geografisk/Språkkode.java
@@ -1,6 +1,5 @@
 package no.nav.foreldrepenger.behandlingslager.geografisk;
 
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/geografisk/Språkkode.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/geografisk/Språkkode.java
@@ -26,7 +26,6 @@ public enum Språkkode implements Kodeverdi, MedOffisiellKode {
     UDEFINERT(STANDARDKODE_UDEFINERT, "Ikke definert", null),
     ;
 
-    public static final String KODEVERK = "SPRAAK_KODE";
     private static final Map<String, Språkkode> KODER = new LinkedHashMap<>();
 
     static {
@@ -36,7 +35,6 @@ public enum Språkkode implements Kodeverdi, MedOffisiellKode {
             }
         }
     }
-
 
     private String navn;
 
@@ -51,10 +49,6 @@ public enum Språkkode implements Kodeverdi, MedOffisiellKode {
         this.offisiellKode = offisiellKode;
     }
 
-    public static Map<String, Språkkode> kodeMap() {
-        return Collections.unmodifiableMap(KODER);
-    }
-
     @Override
     public String getNavn() {
         return navn;
@@ -63,11 +57,6 @@ public enum Språkkode implements Kodeverdi, MedOffisiellKode {
     @Override
     public String getKode() {
         return kode;
-    }
-
-    @Override
-    public String getKodeverk() {
-        return KODEVERK;
     }
 
     @Override
@@ -87,7 +76,6 @@ public enum Språkkode implements Kodeverdi, MedOffisiellKode {
             return dbData == null ? null : defaultNorsk(dbData);
         }
     }
-
 
     public static Språkkode finnForKodeverkEiersKode(String offisiellSpråkkode) {
         var kode = offisiellSpråkkode == null ? null : offisiellSpråkkode.toUpperCase();

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/hendelser/ForretningshendelseType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/hendelser/ForretningshendelseType.java
@@ -21,8 +21,6 @@ public enum ForretningshendelseType implements Kodeverdi {
 
     private static final Map<String, ForretningshendelseType> KODER = new LinkedHashMap<>();
 
-    public static final String KODEVERK = "FORRETNINGSHENDELSE_TYPE";
-
     private String navn;
     @JsonValue
     private String kode;
@@ -43,18 +41,9 @@ public enum ForretningshendelseType implements Kodeverdi {
         return ad;
     }
 
-    public static Map<String, ForretningshendelseType> kodeMap() {
-        return Collections.unmodifiableMap(KODER);
-    }
-
     @Override
     public String getNavn() {
         return navn;
-    }
-
-    @Override
-    public String getKodeverk() {
-        return KODEVERK;
     }
 
     @Override
@@ -69,6 +58,5 @@ public enum ForretningshendelseType implements Kodeverdi {
             }
         }
     }
-
 
 }

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/hendelser/ForretningshendelseType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/hendelser/ForretningshendelseType.java
@@ -1,6 +1,5 @@
 package no.nav.foreldrepenger.behandlingslager.hendelser;
 
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/hendelser/StartpunktType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/hendelser/StartpunktType.java
@@ -4,7 +4,6 @@ import static java.util.stream.Collectors.toSet;
 
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.EnumMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/hendelser/StartpunktType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/hendelser/StartpunktType.java
@@ -39,7 +39,6 @@ public enum StartpunktType implements Kodeverdi {
     UDEFINERT(STANDARDKODE_UDEFINERT, "Ikke definert", 99, BehandlingStegType.KONTROLLERER_SØKERS_OPPLYSNINGSPLIKT, Set.of()),
     ;
 
-    public static final String KODEVERK = "STARTPUNKT_TYPE";
     private static final Map<String, StartpunktType> KODER = new LinkedHashMap<>();
 
     static {
@@ -122,10 +121,6 @@ public enum StartpunktType implements Kodeverdi {
         this.unntakYtelseTyper = unntakYtelseTyper;
     }
 
-    public static Map<String, StartpunktType> kodeMap() {
-        return Collections.unmodifiableMap(KODER);
-    }
-
     @Override
     public String getNavn() {
         return navn;
@@ -134,11 +129,6 @@ public enum StartpunktType implements Kodeverdi {
     @Override
     public String getKode() {
         return this.kode;
-    }
-
-    @Override
-    public String getKodeverk() {
-        return KODEVERK;
     }
 
     @Override

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/kodeverk/Fagsystem.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/kodeverk/Fagsystem.java
@@ -1,6 +1,5 @@
 package no.nav.foreldrepenger.behandlingslager.kodeverk;
 
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/kodeverk/Fagsystem.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/kodeverk/Fagsystem.java
@@ -31,8 +31,6 @@ public enum Fagsystem implements Kodeverdi, MedOffisiellKode {
     UDEFINERT(STANDARDKODE_UDEFINERT, "Ikke definert", null),
     ;
 
-    public static final String KODEVERK = "FAGSYSTEM";
-
     private static final Map<String, Fagsystem> KODER = new LinkedHashMap<>();
 
     private final String navn;
@@ -58,10 +56,6 @@ public enum Fagsystem implements Kodeverdi, MedOffisiellKode {
         return ad;
     }
 
-    public static Map<String, Fagsystem> kodeMap() {
-        return Collections.unmodifiableMap(KODER);
-    }
-
     @Override
     public String getNavn() {
         return navn;
@@ -70,11 +64,6 @@ public enum Fagsystem implements Kodeverdi, MedOffisiellKode {
     @Override
     public String getOffisiellKode() {
         return offisiellKode;
-    }
-
-    @Override
-    public String getKodeverk() {
-        return KODEVERK;
     }
 
     @Override

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/kodeverk/Kodeverdi.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/kodeverk/Kodeverdi.java
@@ -10,7 +10,6 @@ public interface Kodeverdi extends IndexKey {
 
     String getKode();
 
-    String getKodeverk();
 
     String getNavn();
 

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/risikoklassifisering/FaresignalVurdering.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/risikoklassifisering/FaresignalVurdering.java
@@ -1,6 +1,5 @@
 package no.nav.foreldrepenger.behandlingslager.risikoklassifisering;
 
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/risikoklassifisering/FaresignalVurdering.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/risikoklassifisering/FaresignalVurdering.java
@@ -21,8 +21,6 @@ public enum FaresignalVurdering implements Kodeverdi {
 
     private static final Map<String, FaresignalVurdering> KODER = new LinkedHashMap<>();
 
-    public static final String KODEVERK = "FARESIGNAL_VURDERING";
-
     static {
         for (var v : values()) {
             if (KODER.putIfAbsent(v.kode, v) != null) {
@@ -41,18 +39,9 @@ public enum FaresignalVurdering implements Kodeverdi {
         this.navn = navn;
     }
 
-    public static Map<String, FaresignalVurdering> kodeMap() {
-        return Collections.unmodifiableMap(KODER);
-    }
-
     @Override
     public String getNavn() {
         return navn;
-    }
-
-    @Override
-    public String getKodeverk() {
-        return KODEVERK;
     }
 
     @Override

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/risikoklassifisering/Kontrollresultat.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/risikoklassifisering/Kontrollresultat.java
@@ -18,8 +18,6 @@ public enum Kontrollresultat implements Kodeverdi {
 
     private static final Map<String, Kontrollresultat> KODER = new LinkedHashMap<>();
 
-    public static final String KODEVERK = "KONTROLLRESULTAT";
-
     static {
         for (var v : values()) {
             if (KODER.putIfAbsent(v.kode, v) != null) {
@@ -37,18 +35,9 @@ public enum Kontrollresultat implements Kodeverdi {
         this.navn = navn;
     }
 
-    public static Map<String, Kontrollresultat> kodeMap() {
-        return Collections.unmodifiableMap(KODER);
-    }
-
     @Override
     public String getNavn() {
         return navn;
-    }
-
-    @Override
-    public String getKodeverk() {
-        return KODEVERK;
     }
 
     @Override

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/uttak/PeriodeResultatType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/uttak/PeriodeResultatType.java
@@ -1,6 +1,5 @@
 package no.nav.foreldrepenger.behandlingslager.uttak;
 
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/uttak/PeriodeResultatType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/uttak/PeriodeResultatType.java
@@ -20,8 +20,6 @@ public enum PeriodeResultatType implements Kodeverdi {
 
     private static final Map<String, PeriodeResultatType> KODER = new LinkedHashMap<>();
 
-    public static final String KODEVERK = "PERIODE_RESULTAT_TYPE";
-
     static {
         for (var v : values()) {
             if (KODER.putIfAbsent(v.kode, v) != null) {
@@ -40,18 +38,9 @@ public enum PeriodeResultatType implements Kodeverdi {
         this.navn = navn;
     }
 
-    public static Map<String, PeriodeResultatType> kodeMap() {
-        return Collections.unmodifiableMap(KODER);
-    }
-
     @Override
     public String getNavn() {
         return navn;
-    }
-
-    @Override
-    public String getKodeverk() {
-        return KODEVERK;
     }
 
     @Override

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/uttak/UttakArbeidType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/uttak/UttakArbeidType.java
@@ -1,6 +1,5 @@
 package no.nav.foreldrepenger.behandlingslager.uttak;
 
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/uttak/UttakArbeidType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/uttak/UttakArbeidType.java
@@ -11,7 +11,6 @@ import com.fasterxml.jackson.annotation.JsonValue;
 
 import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
 
-
 public enum UttakArbeidType implements Kodeverdi {
 
     ORDINÆRT_ARBEID("ORDINÆRT_ARBEID", "Ordinært arbeid"),
@@ -20,8 +19,6 @@ public enum UttakArbeidType implements Kodeverdi {
     ANNET("ANNET", "Annet"),
     ;
     private static final Map<String, UttakArbeidType> KODER = new LinkedHashMap<>();
-
-    public static final String KODEVERK = "UTTAK_ARBEID_TYPE";
 
     static {
         for (var v : values()) {
@@ -41,18 +38,9 @@ public enum UttakArbeidType implements Kodeverdi {
         this.navn = navn;
     }
 
-    public static Map<String, UttakArbeidType> kodeMap() {
-        return Collections.unmodifiableMap(KODER);
-    }
-
     @Override
     public String getNavn() {
         return navn;
-    }
-
-    @Override
-    public String getKodeverk() {
-        return KODEVERK;
     }
 
     @Override

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/uttak/fp/GraderingAvslagÅrsak.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/uttak/fp/GraderingAvslagÅrsak.java
@@ -1,6 +1,5 @@
 package no.nav.foreldrepenger.behandlingslager.uttak.fp;
 
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/uttak/fp/GraderingAvslagÅrsak.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/uttak/fp/GraderingAvslagÅrsak.java
@@ -26,8 +26,6 @@ public enum GraderingAvslagÅrsak implements Kodeverdi {
 
     private static final Map<String, GraderingAvslagÅrsak> KODER = new LinkedHashMap<>();
 
-    public static final String KODEVERK = "GRADERING_AVSLAG_AARSAK";
-
     static {
         for (var v : values()) {
             if (KODER.putIfAbsent(v.kode, v) != null) {
@@ -46,18 +44,9 @@ public enum GraderingAvslagÅrsak implements Kodeverdi {
         this.navn = navn;
     }
 
-    public static Map<String, GraderingAvslagÅrsak> kodeMap() {
-        return Collections.unmodifiableMap(KODER);
-    }
-
     @Override
     public String getNavn() {
         return navn;
-    }
-
-    @Override
-    public String getKodeverk() {
-        return KODEVERK;
     }
 
     @Override

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/uttak/fp/ManuellBehandlingÅrsak.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/uttak/fp/ManuellBehandlingÅrsak.java
@@ -1,6 +1,5 @@
 package no.nav.foreldrepenger.behandlingslager.uttak.fp;
 
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/uttak/fp/ManuellBehandlingÅrsak.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/uttak/fp/ManuellBehandlingÅrsak.java
@@ -11,7 +11,6 @@ import com.fasterxml.jackson.annotation.JsonValue;
 
 import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
 
-
 public enum ManuellBehandlingÅrsak implements Kodeverdi {
 
     UKJENT(STANDARDKODE_UDEFINERT, "Ikke definert"),
@@ -42,8 +41,6 @@ public enum ManuellBehandlingÅrsak implements Kodeverdi {
 
     private static final Map<String, ManuellBehandlingÅrsak> KODER = new LinkedHashMap<>();
 
-    public static final String KODEVERK = "MANUELL_BEHANDLING_AARSAK";
-
     static {
         for (var v : values()) {
             if (KODER.putIfAbsent(v.kode, v) != null) {
@@ -61,7 +58,6 @@ public enum ManuellBehandlingÅrsak implements Kodeverdi {
         this.navn = navn;
     }
 
-
     public static ManuellBehandlingÅrsak fraKode(String kode) {
         if (kode == null) {
             return null;
@@ -72,18 +68,9 @@ public enum ManuellBehandlingÅrsak implements Kodeverdi {
         }
         return ad;
     }
-    public static Map<String, ManuellBehandlingÅrsak> kodeMap() {
-        return Collections.unmodifiableMap(KODER);
-    }
-
     @Override
     public String getNavn() {
         return navn;
-    }
-
-    @Override
-    public String getKodeverk() {
-        return KODEVERK;
     }
 
     @Override

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/uttak/fp/PeriodeResultatÅrsak.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/uttak/fp/PeriodeResultatÅrsak.java
@@ -106,7 +106,6 @@ public enum PeriodeResultatÅrsak implements Kodeverdi {
     MSP_INNVILGET_FØRSTE_6_UKENE("2039", "14-09-6", "§ 14-9 sjette ledd: Innvilget første 6 uker etter fødsel", of(UTTAK), Set.of(MØDREKVOTE), null,
         of(MOR)),
 
-
     // Regel ikke oppfylt, resultat = avslått
     IKKE_STØNADSDAGER_IGJEN("4002", "14-09", "§ 14-9: Ikke stønadsdager igjen på stønadskonto", of(UTTAK)),
     MOR_HAR_IKKE_OMSORG("4003", "14-10-4", "§ 14-10 fjerde ledd: Mor har ikke omsorg", of(UTTAK), null, null, of(MOR)),
@@ -263,9 +262,6 @@ public enum PeriodeResultatÅrsak implements Kodeverdi {
 
     private static final Map<String, PeriodeResultatÅrsak> KODER = new LinkedHashMap<>();
 
-    public static final String KODEVERK = "PERIODE_RESULTAT_AARSAK";
-
-
     static {
         for (var v : values()) {
             if (KODER.putIfAbsent(v.kode, v) != null) {
@@ -352,18 +348,9 @@ public enum PeriodeResultatÅrsak implements Kodeverdi {
         return ad;
     }
 
-    public static Map<String, PeriodeResultatÅrsak> kodeMap() {
-        return Collections.unmodifiableMap(KODER);
-    }
-
     @Override
     public String getNavn() {
         return navn;
-    }
-
-    @Override
-    public String getKodeverk() {
-        return KODEVERK;
     }
 
     @Override

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/uttak/fp/PeriodeResultatÅrsak.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/uttak/fp/PeriodeResultatÅrsak.java
@@ -14,7 +14,6 @@ import static no.nav.foreldrepenger.behandlingslager.uttak.fp.PeriodeResultatÅr
 import static no.nav.foreldrepenger.behandlingslager.uttak.fp.UttakType.UTSETTELSE;
 import static no.nav.foreldrepenger.behandlingslager.uttak.fp.UttakType.UTTAK;
 
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/uttak/fp/StønadskontoType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/uttak/fp/StønadskontoType.java
@@ -1,6 +1,5 @@
 package no.nav.foreldrepenger.behandlingslager.uttak.fp;
 
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/uttak/fp/StønadskontoType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/uttak/fp/StønadskontoType.java
@@ -52,8 +52,6 @@ public enum StønadskontoType implements Kodeverdi {
 
     private static final Map<String, StønadskontoType> KODER = new LinkedHashMap<>();
 
-    public static final String KODEVERK = "STOENADSKONTOTYPE";
-
     static {
         for (var v : values()) {
             if (KODER.putIfAbsent(v.kode, v) != null) {
@@ -75,18 +73,9 @@ public enum StønadskontoType implements Kodeverdi {
         this.kategori = kategori;
     }
 
-    public static Map<String, StønadskontoType> kodeMap() {
-        return Collections.unmodifiableMap(KODER);
-    }
-
     @Override
     public String getNavn() {
         return navn;
-    }
-
-    @Override
-    public String getKodeverk() {
-        return KODEVERK;
     }
 
     @Override

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/uttak/fp/UttakUtsettelseType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/uttak/fp/UttakUtsettelseType.java
@@ -1,6 +1,5 @@
 package no.nav.foreldrepenger.behandlingslager.uttak.fp;
 
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/uttak/fp/UttakUtsettelseType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/uttak/fp/UttakUtsettelseType.java
@@ -11,7 +11,6 @@ import com.fasterxml.jackson.annotation.JsonValue;
 
 import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
 
-
 public enum UttakUtsettelseType implements Kodeverdi {
 
     ARBEID("ARBEID", "Arbeid"),
@@ -25,8 +24,6 @@ public enum UttakUtsettelseType implements Kodeverdi {
     UDEFINERT(STANDARDKODE_UDEFINERT, "Ikke satt eller valgt kode"),
     ;
     private static final Map<String, UttakUtsettelseType> KODER = new LinkedHashMap<>();
-
-    public static final String KODEVERK = "UTTAK_UTSETTELSE_TYPE";
 
     static {
         for (var v : values()) {
@@ -46,18 +43,9 @@ public enum UttakUtsettelseType implements Kodeverdi {
         this.navn = navn;
     }
 
-    public static Map<String, UttakUtsettelseType> kodeMap() {
-        return Collections.unmodifiableMap(KODER);
-    }
-
     @Override
     public String getNavn() {
         return navn;
-    }
-
-    @Override
-    public String getKodeverk() {
-        return KODEVERK;
     }
 
     @Override

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/uttak/svp/ArbeidsforholdIkkeOppfyltÅrsak.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/uttak/svp/ArbeidsforholdIkkeOppfyltÅrsak.java
@@ -1,6 +1,5 @@
 package no.nav.foreldrepenger.behandlingslager.uttak.svp;
 
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/uttak/svp/ArbeidsforholdIkkeOppfyltÅrsak.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/uttak/svp/ArbeidsforholdIkkeOppfyltÅrsak.java
@@ -23,8 +23,6 @@ public enum ArbeidsforholdIkkeOppfyltÅrsak implements Kodeverdi {
 
     private static final Map<String, ArbeidsforholdIkkeOppfyltÅrsak> KODER = new LinkedHashMap<>();
 
-    public static final String KODEVERK = "SVP_ARBEIDSFORHOLD_IKKE_OPPFYLT_AARSAK";
-
     static {
         for (var v : values()) {
             if (KODER.putIfAbsent(v.kode, v) != null) {
@@ -53,18 +51,9 @@ public enum ArbeidsforholdIkkeOppfyltÅrsak implements Kodeverdi {
         return ad;
     }
 
-    public static Map<String, ArbeidsforholdIkkeOppfyltÅrsak> kodeMap() {
-        return Collections.unmodifiableMap(KODER);
-    }
-
     @Override
     public String getNavn() {
         return navn;
-    }
-
-    @Override
-    public String getKodeverk() {
-        return KODEVERK;
     }
 
     @Override

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/uttak/svp/PeriodeIkkeOppfyltÅrsak.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/uttak/svp/PeriodeIkkeOppfyltÅrsak.java
@@ -33,8 +33,6 @@ public enum PeriodeIkkeOppfyltÅrsak implements Kodeverdi {
 
     private static final Map<String, PeriodeIkkeOppfyltÅrsak> KODER = new LinkedHashMap<>();
 
-    public static final String KODEVERK = "SVP_PERIODE_IKKE_OPPFYLT_AARSAK";
-
     static {
         for (var v : values()) {
             if (KODER.putIfAbsent(v.kode, v) != null) {
@@ -63,18 +61,9 @@ public enum PeriodeIkkeOppfyltÅrsak implements Kodeverdi {
         return ad;
     }
 
-    public static Map<String, PeriodeIkkeOppfyltÅrsak> kodeMap() {
-        return Collections.unmodifiableMap(KODER);
-    }
-
     @Override
     public String getNavn() {
         return navn;
-    }
-
-    @Override
-    public String getKodeverk() {
-        return KODEVERK;
     }
 
     @Override

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/uttak/svp/PeriodeIkkeOppfyltÅrsak.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/uttak/svp/PeriodeIkkeOppfyltÅrsak.java
@@ -1,6 +1,5 @@
 package no.nav.foreldrepenger.behandlingslager.uttak.svp;
 
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/virksomhet/ArbeidType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/virksomhet/ArbeidType.java
@@ -72,8 +72,6 @@ public enum ArbeidType implements Kodeverdi, MedOffisiellKode {
         ArbeidType.MARITIMT_ARBEIDSFORHOLD,
         ArbeidType.FORENKLET_OPPGJØRSORDNING);
 
-    public static final String KODEVERK = "ARBEID_TYPE";
-
     private static final Map<String, ArbeidType> KODER = new LinkedHashMap<>();
 
     static {
@@ -112,10 +110,6 @@ public enum ArbeidType implements Kodeverdi, MedOffisiellKode {
         return ad;
     }
 
-    public static Map<String, ArbeidType> kodeMap() {
-        return Collections.unmodifiableMap(KODER);
-    }
-
     public boolean erAnnenOpptjening() {
         return ANNEN_OPPTJENING.contains(this);
     }
@@ -123,11 +117,6 @@ public enum ArbeidType implements Kodeverdi, MedOffisiellKode {
     @Override
     public String getKode() {
         return kode;
-    }
-
-    @Override
-    public String getKodeverk() {
-        return KODEVERK;
     }
 
     @Override

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/virksomhet/ArbeidType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/virksomhet/ArbeidType.java
@@ -16,7 +16,6 @@ package no.nav.foreldrepenger.behandlingslager.virksomhet;
  * </ul>
  */
 
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/virksomhet/Organisasjonstype.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/virksomhet/Organisasjonstype.java
@@ -13,8 +13,6 @@ public enum Organisasjonstype implements Kodeverdi {
     UDEFINERT(STANDARDKODE_UDEFINERT, "Udefinert"),
     ;
 
-    public static final String KODEVERK = "ORGANISASJONSTYPE";
-
     private final String navn;
     @JsonValue
     private final String kode;
@@ -27,11 +25,6 @@ public enum Organisasjonstype implements Kodeverdi {
     @Override
     public String getNavn() {
         return navn;
-    }
-
-    @Override
-    public String getKodeverk() {
-        return KODEVERK;
     }
 
     @Override

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/ytelse/RelatertYtelseType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/ytelse/RelatertYtelseType.java
@@ -38,8 +38,6 @@ public enum RelatertYtelseType implements Kodeverdi {
 
     private static final Map<String, RelatertYtelseType> KODER = new LinkedHashMap<>();
 
-    public static final String KODEVERK = "RELATERT_YTELSE_TYPE";
-
     static {
         for (var v : values()) {
             if (KODER.putIfAbsent(v.kode, v) != null) {
@@ -63,11 +61,6 @@ public enum RelatertYtelseType implements Kodeverdi {
     }
 
     @Override
-    public String getKodeverk() {
-        return KODEVERK;
-    }
-
-    @Override
     public String getKode() {
         return kode;
     }
@@ -79,6 +72,5 @@ public enum RelatertYtelseType implements Kodeverdi {
         }
         return OPPTJENING_RELATERTYTELSE_FELLES.contains(this) || relatertYtelseTypeSet.contains(this);
     }
-
 
 }

--- a/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/iay/modell/kodeverk/ArbeidsforholdHandlingType.java
+++ b/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/iay/modell/kodeverk/ArbeidsforholdHandlingType.java
@@ -6,7 +6,6 @@ package no.nav.foreldrepenger.domene.iay.modell.kodeverk;
  * <p>
  */
 
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;

--- a/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/iay/modell/kodeverk/ArbeidsforholdHandlingType.java
+++ b/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/iay/modell/kodeverk/ArbeidsforholdHandlingType.java
@@ -34,8 +34,6 @@ public enum ArbeidsforholdHandlingType implements Kodeverdi {
 
     private static final Map<String, ArbeidsforholdHandlingType> KODER = new LinkedHashMap<>();
 
-    public static final String KODEVERK = "ARBEIDSFORHOLD_HANDLING_TYPE";
-
     static {
         for (var v : values()) {
             if (KODER.putIfAbsent(v.kode, v) != null) {
@@ -64,18 +62,9 @@ public enum ArbeidsforholdHandlingType implements Kodeverdi {
         return ad;
     }
 
-    public static Map<String, ArbeidsforholdHandlingType> kodeMap() {
-        return Collections.unmodifiableMap(KODER);
-    }
-
     @Override
     public String getNavn() {
         return navn;
-    }
-
-    @Override
-    public String getKodeverk() {
-        return KODEVERK;
     }
 
     @Override

--- a/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/iay/modell/kodeverk/Arbeidskategori.java
+++ b/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/iay/modell/kodeverk/Arbeidskategori.java
@@ -30,8 +30,6 @@ public enum Arbeidskategori implements Kodeverdi {
 
     private static final Map<String, Arbeidskategori> KODER = new LinkedHashMap<>();
 
-    public static final String KODEVERK = "ARBEIDSKATEGORI";
-
     static {
         for (var v : values()) {
             if (KODER.putIfAbsent(v.kode, v) != null) {
@@ -60,18 +58,9 @@ public enum Arbeidskategori implements Kodeverdi {
         return ad;
     }
 
-    public static Map<String, Arbeidskategori> kodeMap() {
-        return Collections.unmodifiableMap(KODER);
-    }
-
     @Override
     public String getNavn() {
         return navn;
-    }
-
-    @Override
-    public String getKodeverk() {
-        return KODEVERK;
     }
 
     @Override

--- a/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/iay/modell/kodeverk/Arbeidskategori.java
+++ b/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/iay/modell/kodeverk/Arbeidskategori.java
@@ -1,6 +1,5 @@
 package no.nav.foreldrepenger.domene.iay.modell.kodeverk;
 
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 

--- a/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/iay/modell/kodeverk/BekreftetPermisjonStatus.java
+++ b/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/iay/modell/kodeverk/BekreftetPermisjonStatus.java
@@ -6,7 +6,6 @@ package no.nav.foreldrepenger.domene.iay.modell.kodeverk;
  * </p>
  */
 
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 

--- a/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/iay/modell/kodeverk/BekreftetPermisjonStatus.java
+++ b/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/iay/modell/kodeverk/BekreftetPermisjonStatus.java
@@ -24,8 +24,6 @@ public enum BekreftetPermisjonStatus implements Kodeverdi {
 
     private static final Map<String, BekreftetPermisjonStatus> KODER = new LinkedHashMap<>();
 
-    public static final String KODEVERK = "BEKREFTET_PERMISJON_STATUS";
-
     static {
         for (var v : values()) {
             if (KODER.putIfAbsent(v.kode, v) != null) {
@@ -55,18 +53,9 @@ public enum BekreftetPermisjonStatus implements Kodeverdi {
         return ad;
     }
 
-    public static Map<String, BekreftetPermisjonStatus> kodeMap() {
-        return Collections.unmodifiableMap(KODER);
-    }
-
     @Override
     public String getNavn() {
         return navn;
-    }
-
-    @Override
-    public String getKodeverk() {
-        return KODEVERK;
     }
 
     @Override

--- a/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/iay/modell/kodeverk/InntektPeriodeType.java
+++ b/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/iay/modell/kodeverk/InntektPeriodeType.java
@@ -23,8 +23,6 @@ public enum InntektPeriodeType implements Kodeverdi {
 
     private static final Map<String, InntektPeriodeType> KODER = new LinkedHashMap<>();
 
-    public static final String KODEVERK = "INNTEKT_PERIODE_TYPE";
-
     static {
         for (var v : values()) {
             if (KODER.putIfAbsent(v.kode, v) != null) {
@@ -56,18 +54,9 @@ public enum InntektPeriodeType implements Kodeverdi {
         return ad;
     }
 
-    public static Map<String, InntektPeriodeType> kodeMap() {
-        return Collections.unmodifiableMap(KODER);
-    }
-
     @Override
     public String getNavn() {
         return navn;
-    }
-
-    @Override
-    public String getKodeverk() {
-        return KODEVERK;
     }
 
     @Override

--- a/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/iay/modell/kodeverk/InntektPeriodeType.java
+++ b/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/iay/modell/kodeverk/InntektPeriodeType.java
@@ -1,7 +1,6 @@
 package no.nav.foreldrepenger.domene.iay.modell.kodeverk;
 
 import java.time.Period;
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 

--- a/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/iay/modell/kodeverk/InntektYtelseType.java
+++ b/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/iay/modell/kodeverk/InntektYtelseType.java
@@ -8,7 +8,6 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
 import no.nav.foreldrepenger.behandlingslager.ytelse.RelatertYtelseType;
 
-
 @JsonAutoDetect(getterVisibility = Visibility.NONE, setterVisibility = Visibility.NONE, fieldVisibility = Visibility.ANY)
 public enum InntektYtelseType implements Kodeverdi {
 
@@ -53,8 +52,6 @@ public enum InntektYtelseType implements Kodeverdi {
     KOMPENSASJON_FOR_TAPT_PERSONINNTEKT("Kompensasjon for tapt personinntekt", Kategori.NÆRING, RelatertYtelseType.FRISINN)
     ;
 
-    public static final String KODEVERK = "INNTEKT_YTELSE_TYPE";
-
     @JsonIgnore
     private final String navn;
     @JsonIgnore
@@ -73,11 +70,6 @@ public enum InntektYtelseType implements Kodeverdi {
     @Override
     public String getNavn() {
         return navn;
-    }
-
-    @Override
-    public String getKodeverk() {
-        return KODEVERK;
     }
 
     @Override

--- a/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/iay/modell/kodeverk/InntektsKilde.java
+++ b/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/iay/modell/kodeverk/InntektsKilde.java
@@ -20,8 +20,6 @@ public enum InntektsKilde implements Kodeverdi {
 
     private static final Map<String, InntektsKilde> KODER = new LinkedHashMap<>();
 
-    public static final String KODEVERK = "INNTEKTS_KILDE";
-
     static {
         for (var v : values()) {
             if (KODER.putIfAbsent(v.kode, v) != null) {
@@ -50,24 +48,14 @@ public enum InntektsKilde implements Kodeverdi {
         return ad;
     }
 
-    public static Map<String, InntektsKilde> kodeMap() {
-        return Collections.unmodifiableMap(KODER);
-    }
-
     @Override
     public String getNavn() {
         return navn;
     }
 
     @Override
-    public String getKodeverk() {
-        return KODEVERK;
-    }
-
-    @Override
     public String getKode() {
         return kode;
     }
-
 
 }

--- a/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/iay/modell/kodeverk/InntektsKilde.java
+++ b/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/iay/modell/kodeverk/InntektsKilde.java
@@ -1,6 +1,5 @@
 package no.nav.foreldrepenger.domene.iay.modell.kodeverk;
 
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 

--- a/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/iay/modell/kodeverk/InntektsmeldingInnsendingsårsak.java
+++ b/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/iay/modell/kodeverk/InntektsmeldingInnsendingsårsak.java
@@ -17,8 +17,6 @@ public enum InntektsmeldingInnsendingsårsak implements Kodeverdi {
 
     private static final Map<String, InntektsmeldingInnsendingsårsak> KODER = new LinkedHashMap<>();
 
-    public static final String KODEVERK = "INNTEKTSMELDING_INNSENDINGSAARSAK";
-
     static {
         for (var v : values()) {
             if (KODER.putIfAbsent(v.kode, v) != null) {
@@ -48,18 +46,9 @@ public enum InntektsmeldingInnsendingsårsak implements Kodeverdi {
         return ad;
     }
 
-    public static Map<String, InntektsmeldingInnsendingsårsak> kodeMap() {
-        return Collections.unmodifiableMap(KODER);
-    }
-
     @Override
     public String getNavn() {
         return navn;
-    }
-
-    @Override
-    public String getKodeverk() {
-        return KODEVERK;
     }
 
     @Override

--- a/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/iay/modell/kodeverk/InntektsmeldingInnsendingsårsak.java
+++ b/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/iay/modell/kodeverk/InntektsmeldingInnsendingsårsak.java
@@ -1,6 +1,5 @@
 package no.nav.foreldrepenger.domene.iay.modell.kodeverk;
 
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 

--- a/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/iay/modell/kodeverk/InntektspostType.java
+++ b/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/iay/modell/kodeverk/InntektspostType.java
@@ -20,8 +20,6 @@ public enum InntektspostType implements Kodeverdi {
 
     private static final Map<String, InntektspostType> KODER = new LinkedHashMap<>();
 
-    public static final String KODEVERK = "INNTEKTSPOST_TYPE";
-
     static {
         for (var v : values()) {
             if (KODER.putIfAbsent(v.kode, v) != null) {
@@ -50,24 +48,14 @@ public enum InntektspostType implements Kodeverdi {
         return ad;
     }
 
-    public static Map<String, InntektspostType> kodeMap() {
-        return Collections.unmodifiableMap(KODER);
-    }
-
     @Override
     public String getNavn() {
         return navn;
     }
 
     @Override
-    public String getKodeverk() {
-        return KODEVERK;
-    }
-
-    @Override
     public String getKode() {
         return kode;
     }
-
 
 }

--- a/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/iay/modell/kodeverk/InntektspostType.java
+++ b/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/iay/modell/kodeverk/InntektspostType.java
@@ -1,6 +1,5 @@
 package no.nav.foreldrepenger.domene.iay.modell.kodeverk;
 
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 

--- a/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/iay/modell/kodeverk/NaturalYtelseType.java
+++ b/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/iay/modell/kodeverk/NaturalYtelseType.java
@@ -1,6 +1,5 @@
 package no.nav.foreldrepenger.domene.iay.modell.kodeverk;
 
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;

--- a/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/iay/modell/kodeverk/NaturalYtelseType.java
+++ b/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/iay/modell/kodeverk/NaturalYtelseType.java
@@ -37,8 +37,6 @@ public enum NaturalYtelseType implements Kodeverdi, MedOffisiellKode {
 
     private static final Map<String, NaturalYtelseType> KODER = new LinkedHashMap<>();
 
-    public static final String KODEVERK = "NATURAL_YTELSE_TYPE";
-
     static {
         for (var v : values()) {
             if (KODER.putIfAbsent(v.kode, v) != null) {
@@ -69,18 +67,9 @@ public enum NaturalYtelseType implements Kodeverdi, MedOffisiellKode {
         return ad;
     }
 
-    public static Map<String, NaturalYtelseType> kodeMap() {
-        return Collections.unmodifiableMap(KODER);
-    }
-
     @Override
     public String getNavn() {
         return navn;
-    }
-
-    @Override
-    public String getKodeverk() {
-        return KODEVERK;
     }
 
     @Override

--- a/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/iay/modell/kodeverk/PermisjonsbeskrivelseType.java
+++ b/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/iay/modell/kodeverk/PermisjonsbeskrivelseType.java
@@ -32,15 +32,11 @@ public enum PermisjonsbeskrivelseType implements Kodeverdi {
 
     private static final Map<String, PermisjonsbeskrivelseType> KODER = new LinkedHashMap<>();
 
-    public static final String KODEVERK = "PERMISJONSBESKRIVELSE_TYPE";
-
     private static final Set<PermisjonsbeskrivelseType> PERMISJON_IKKE_RELEVANT_FOR_ARBEIDSFORHOLD_ELLER_BEREGNING = Set.of(
         PermisjonsbeskrivelseType.UTDANNINGSPERMISJON,
         PermisjonsbeskrivelseType.UTDANNINGSPERMISJON_IKKE_LOVFESTET,
         PermisjonsbeskrivelseType.UTDANNINGSPERMISJON_LOVFESTET,
         PermisjonsbeskrivelseType.PERMISJON_MED_FORELDREPENGER);
-
-
 
     static {
         for (var v : values()) {
@@ -71,18 +67,9 @@ public enum PermisjonsbeskrivelseType implements Kodeverdi {
         return ad;
     }
 
-    public static Map<String, PermisjonsbeskrivelseType> kodeMap() {
-        return Collections.unmodifiableMap(KODER);
-    }
-
     @Override
     public String getNavn() {
         return navn;
-    }
-
-    @Override
-    public String getKodeverk() {
-        return KODEVERK;
     }
 
     @Override

--- a/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/iay/modell/kodeverk/PermisjonsbeskrivelseType.java
+++ b/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/iay/modell/kodeverk/PermisjonsbeskrivelseType.java
@@ -1,6 +1,5 @@
 package no.nav.foreldrepenger.domene.iay.modell.kodeverk;
 
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;

--- a/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/iay/modell/kodeverk/RelatertYtelseTilstand.java
+++ b/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/iay/modell/kodeverk/RelatertYtelseTilstand.java
@@ -17,8 +17,6 @@ public enum RelatertYtelseTilstand implements Kodeverdi {
 
     private static final Map<String, RelatertYtelseTilstand> KODER = new LinkedHashMap<>();
 
-    public static final String KODEVERK = "RELATERT_YTELSE_TILSTAND";
-
     static {
         for (var v : values()) {
             if (KODER.putIfAbsent(v.kode, v) != null) {
@@ -40,11 +38,6 @@ public enum RelatertYtelseTilstand implements Kodeverdi {
     @Override
     public String getNavn() {
         return navn;
-    }
-
-    @Override
-    public String getKodeverk() {
-        return KODEVERK;
     }
 
     @Override

--- a/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/iay/modell/kodeverk/SkatteOgAvgiftsregelType.java
+++ b/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/iay/modell/kodeverk/SkatteOgAvgiftsregelType.java
@@ -29,8 +29,6 @@ public enum SkatteOgAvgiftsregelType implements Kodeverdi {
 
     private static final Map<String, SkatteOgAvgiftsregelType> KODER = new LinkedHashMap<>();
 
-    public static final String KODEVERK = "SKATTE_OG_AVGIFTSREGEL";
-
     static {
         for (var v : values()) {
             if (KODER.putIfAbsent(v.kode, v) != null) {
@@ -61,24 +59,14 @@ public enum SkatteOgAvgiftsregelType implements Kodeverdi {
         return ad;
     }
 
-    public static Map<String, SkatteOgAvgiftsregelType> kodeMap() {
-        return Collections.unmodifiableMap(KODER);
-    }
-
     @Override
     public String getNavn() {
         return navn;
     }
 
     @Override
-    public String getKodeverk() {
-        return KODEVERK;
-    }
-
-    @Override
     public String getKode() {
         return kode;
     }
-
 
 }

--- a/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/iay/modell/kodeverk/SkatteOgAvgiftsregelType.java
+++ b/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/iay/modell/kodeverk/SkatteOgAvgiftsregelType.java
@@ -1,6 +1,5 @@
 package no.nav.foreldrepenger.domene.iay.modell.kodeverk;
 
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 

--- a/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/iay/modell/kodeverk/VirksomhetType.java
+++ b/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/iay/modell/kodeverk/VirksomhetType.java
@@ -27,8 +27,6 @@ public enum VirksomhetType implements Kodeverdi {
 
     private static final Map<String, VirksomhetType> KODER = new LinkedHashMap<>();
 
-    public static final String KODEVERK = "VIRKSOMHET_TYPE";
-
     static {
         for (var v : values()) {
             if (KODER.putIfAbsent(v.kode, v) != null) {
@@ -62,18 +60,9 @@ public enum VirksomhetType implements Kodeverdi {
         return ad;
     }
 
-    public static Map<String, VirksomhetType> kodeMap() {
-        return Collections.unmodifiableMap(KODER);
-    }
-
     @Override
     public String getNavn() {
         return navn;
-    }
-
-    @Override
-    public String getKodeverk() {
-        return KODEVERK;
     }
 
     @Override

--- a/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/iay/modell/kodeverk/VirksomhetType.java
+++ b/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/iay/modell/kodeverk/VirksomhetType.java
@@ -1,6 +1,5 @@
 package no.nav.foreldrepenger.domene.iay.modell.kodeverk;
 
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 

--- a/domenetjenester/beregningsgrunnlag/src/main/java/no/nav/foreldrepenger/domene/modell/kodeverk/AndelKilde.java
+++ b/domenetjenester/beregningsgrunnlag/src/main/java/no/nav/foreldrepenger/domene/modell/kodeverk/AndelKilde.java
@@ -8,7 +8,6 @@ import com.fasterxml.jackson.annotation.JsonValue;
 
 import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
 
-
 public enum AndelKilde implements Kodeverdi {
 
     SAKSBEHANDLER_KOFAKBER("SAKSBEHANDLER_KOFAKBER", "Saksbehandler i steg kontroller fakta beregning"),
@@ -19,8 +18,6 @@ public enum AndelKilde implements Kodeverdi {
     PROSESS_START("PROSESS_START", "Start av beregning"),
     ;
     private static final Map<String, AndelKilde> KODER = new LinkedHashMap<>();
-
-    public static final String KODEVERK = "ANDEL_KILDE";
 
     static {
         for (var v : values()) {
@@ -50,18 +47,9 @@ public enum AndelKilde implements Kodeverdi {
         }
         return ad;
     }
-    public static Map<String, AndelKilde> kodeMap() {
-        return Collections.unmodifiableMap(KODER);
-    }
-
     @Override
     public String getNavn() {
         return navn;
-    }
-
-    @Override
-    public String getKodeverk() {
-        return KODEVERK;
     }
 
     @Override

--- a/domenetjenester/beregningsgrunnlag/src/main/java/no/nav/foreldrepenger/domene/modell/kodeverk/BeregningAktivitetHandlingType.java
+++ b/domenetjenester/beregningsgrunnlag/src/main/java/no/nav/foreldrepenger/domene/modell/kodeverk/BeregningAktivitetHandlingType.java
@@ -8,14 +8,12 @@ import com.fasterxml.jackson.annotation.JsonValue;
 
 import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
 
-
 public enum BeregningAktivitetHandlingType implements Kodeverdi {
 
     BENYTT("BENYTT", "Benytt beregningaktivitet"),
     IKKE_BENYTT("IKKE_BENYTT", "Ikke benytt beregningaktivitet"),
     UDEFINERT(STANDARDKODE_UDEFINERT, "Ikke definert"),
     ;
-    public static final String KODEVERK = "BEREGNING_AKTIVITET_HANDLING_TYPE";
 
     private static final Map<String, BeregningAktivitetHandlingType> KODER = new LinkedHashMap<>();
 
@@ -48,18 +46,9 @@ public enum BeregningAktivitetHandlingType implements Kodeverdi {
         return ad;
     }
 
-    public static Map<String, BeregningAktivitetHandlingType> kodeMap() {
-        return Collections.unmodifiableMap(KODER);
-    }
-
     @Override
     public String getNavn() {
         return navn;
-    }
-
-    @Override
-    public String getKodeverk() {
-        return KODEVERK;
     }
 
     @Override

--- a/domenetjenester/beregningsgrunnlag/src/main/java/no/nav/foreldrepenger/domene/modell/kodeverk/BeregningsgrunnlagPeriodeRegelType.java
+++ b/domenetjenester/beregningsgrunnlag/src/main/java/no/nav/foreldrepenger/domene/modell/kodeverk/BeregningsgrunnlagPeriodeRegelType.java
@@ -8,7 +8,6 @@ import com.fasterxml.jackson.annotation.JsonValue;
 
 import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
 
-
 public enum BeregningsgrunnlagPeriodeRegelType implements Kodeverdi {
     FORESLÅ("FORESLÅ", "Foreslå beregningsgrunnlag"),
     FORESLÅ_2("FORESLÅ_2", "Foreslå beregningsgrunnlag del 2"),
@@ -20,7 +19,6 @@ public enum BeregningsgrunnlagPeriodeRegelType implements Kodeverdi {
     FINN_GRENSEVERDI("FINN_GRENSEVERDI", "Finne grenseverdi til kjøring av fastsett beregningsgrunnlag for SVP"),
     UDEFINERT(STANDARDKODE_UDEFINERT, "Ikke definert"),
     ;
-    public static final String KODEVERK = "BG_PERIODE_REGEL_TYPE";
 
     private static final Map<String, BeregningsgrunnlagPeriodeRegelType> KODER = new LinkedHashMap<>();
 
@@ -53,18 +51,9 @@ public enum BeregningsgrunnlagPeriodeRegelType implements Kodeverdi {
         return ad;
     }
 
-    public static Map<String, BeregningsgrunnlagPeriodeRegelType> kodeMap() {
-        return Collections.unmodifiableMap(KODER);
-    }
-
     @Override
     public String getNavn() {
         return navn;
-    }
-
-    @Override
-    public String getKodeverk() {
-        return KODEVERK;
     }
 
     @Override

--- a/domenetjenester/beregningsgrunnlag/src/main/java/no/nav/foreldrepenger/domene/modell/kodeverk/BeregningsgrunnlagRegelType.java
+++ b/domenetjenester/beregningsgrunnlag/src/main/java/no/nav/foreldrepenger/domene/modell/kodeverk/BeregningsgrunnlagRegelType.java
@@ -21,7 +21,6 @@ public enum BeregningsgrunnlagRegelType implements Kodeverdi {
     PERIODISERING_GRADERING("PERIODISERING_GRADERING", "Periodiser beregningsgrunnlag pga gradering og endring i utbetalingsgrad"),
     UDEFINERT(STANDARDKODE_UDEFINERT, "Ikke definert"),
     ;
-    public static final String KODEVERK = "BG_REGEL_TYPE";
 
     private static final Map<String, BeregningsgrunnlagRegelType> KODER = new LinkedHashMap<>();
 
@@ -54,18 +53,9 @@ public enum BeregningsgrunnlagRegelType implements Kodeverdi {
         return ad;
     }
 
-    public static Map<String, BeregningsgrunnlagRegelType> kodeMap() {
-        return Collections.unmodifiableMap(KODER);
-    }
-
     @Override
     public String getNavn() {
         return navn;
-    }
-
-    @Override
-    public String getKodeverk() {
-        return KODEVERK;
     }
 
     @Override

--- a/domenetjenester/beregningsgrunnlag/src/main/java/no/nav/foreldrepenger/domene/modell/kodeverk/BeregningsgrunnlagTilstand.java
+++ b/domenetjenester/beregningsgrunnlag/src/main/java/no/nav/foreldrepenger/domene/modell/kodeverk/BeregningsgrunnlagTilstand.java
@@ -9,7 +9,6 @@ import com.fasterxml.jackson.annotation.JsonValue;
 
 import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
 
-
 public enum BeregningsgrunnlagTilstand implements Kodeverdi {
 
     OPPRETTET("OPPRETTET", "Opprettet", true),
@@ -29,7 +28,6 @@ public enum BeregningsgrunnlagTilstand implements Kodeverdi {
     FASTSATT("FASTSATT", "Fastsatt", true),
     UDEFINERT(STANDARDKODE_UDEFINERT, "Ikke definert", false),
     ;
-    public static final String KODEVERK = "BEREGNINGSGRUNNLAG_TILSTAND";
 
     private static final Map<String, BeregningsgrunnlagTilstand> KODER = new LinkedHashMap<>();
 
@@ -81,10 +79,6 @@ public enum BeregningsgrunnlagTilstand implements Kodeverdi {
         return ad;
     }
 
-    public static Map<String, BeregningsgrunnlagTilstand> kodeMap() {
-        return Collections.unmodifiableMap(KODER);
-    }
-
     public boolean erObligatoriskTilstand() {
         return this.obligatoriskTilstand;
     }
@@ -98,11 +92,6 @@ public enum BeregningsgrunnlagTilstand implements Kodeverdi {
     @Override
     public String getNavn() {
         return navn;
-    }
-
-    @Override
-    public String getKodeverk() {
-        return KODEVERK;
     }
 
     @Override

--- a/domenetjenester/beregningsgrunnlag/src/main/java/no/nav/foreldrepenger/domene/modell/kodeverk/FaktaOmBeregningTilfelle.java
+++ b/domenetjenester/beregningsgrunnlag/src/main/java/no/nav/foreldrepenger/domene/modell/kodeverk/FaktaOmBeregningTilfelle.java
@@ -1,6 +1,5 @@
 package no.nav.foreldrepenger.domene.modell.kodeverk;
 
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 

--- a/domenetjenester/beregningsgrunnlag/src/main/java/no/nav/foreldrepenger/domene/modell/kodeverk/FaktaOmBeregningTilfelle.java
+++ b/domenetjenester/beregningsgrunnlag/src/main/java/no/nav/foreldrepenger/domene/modell/kodeverk/FaktaOmBeregningTilfelle.java
@@ -30,7 +30,6 @@ public enum FaktaOmBeregningTilfelle implements Kodeverdi {
     FASTSETT_ENDRET_BEREGNINGSGRUNNLAG("FASTSETT_ENDRET_BEREGNINGSGRUNNLAG", "Fastsette endring i beregningsgrunnlag"),
     UDEFINERT(STANDARDKODE_UDEFINERT, "Ikke definert"),
     ;
-    public static final String KODEVERK = "FAKTA_OM_BEREGNING_TILFELLE";
 
     private static final Map<String, FaktaOmBeregningTilfelle> KODER = new LinkedHashMap<>();
 
@@ -62,18 +61,9 @@ public enum FaktaOmBeregningTilfelle implements Kodeverdi {
         return ad;
     }
 
-    public static Map<String, FaktaOmBeregningTilfelle> kodeMap() {
-        return Collections.unmodifiableMap(KODER);
-    }
-
     @Override
     public String getNavn() {
         return navn;
-    }
-
-    @Override
-    public String getKodeverk() {
-        return KODEVERK;
     }
 
     @Override

--- a/domenetjenester/beregningsgrunnlag/src/main/java/no/nav/foreldrepenger/domene/modell/kodeverk/FaktaVurderingKilde.java
+++ b/domenetjenester/beregningsgrunnlag/src/main/java/no/nav/foreldrepenger/domene/modell/kodeverk/FaktaVurderingKilde.java
@@ -17,8 +17,6 @@ public enum FaktaVurderingKilde implements Kodeverdi {
 
     private static final Map<String, FaktaVurderingKilde> KODER = new LinkedHashMap<>();
 
-    public static final String KODEVERK = "FAKTA_VURDERING_KILDE";
-
     static {
         for (var v : values()) {
             if (KODER.putIfAbsent(v.kode, v) != null) {
@@ -47,18 +45,9 @@ public enum FaktaVurderingKilde implements Kodeverdi {
         return ad;
     }
 
-    public static Map<String, FaktaVurderingKilde> kodeMap() {
-        return Collections.unmodifiableMap(KODER);
-    }
-
     @Override
     public String getKode() {
         return kode;
-    }
-
-    @Override
-    public String getKodeverk() {
-        return KODEVERK;
     }
 
     @Override

--- a/domenetjenester/beregningsgrunnlag/src/main/java/no/nav/foreldrepenger/domene/modell/kodeverk/Hjemmel.java
+++ b/domenetjenester/beregningsgrunnlag/src/main/java/no/nav/foreldrepenger/domene/modell/kodeverk/Hjemmel.java
@@ -26,8 +26,6 @@ public enum Hjemmel implements Kodeverdi {
 
     private static final Map<String, Hjemmel> KODER = new LinkedHashMap<>();
 
-    public static final String KODEVERK = "BG_HJEMMEL";
-
     static {
         for (var v : values()) {
             if (KODER.putIfAbsent(v.kode, v) != null) {
@@ -35,7 +33,6 @@ public enum Hjemmel implements Kodeverdi {
             }
         }
     }
-
 
     private final String navn;
     @JsonValue
@@ -57,24 +54,14 @@ public enum Hjemmel implements Kodeverdi {
         return ad;
     }
 
-    public static Map<String, Hjemmel> kodeMap() {
-        return Collections.unmodifiableMap(KODER);
-    }
-
     @Override
     public String getNavn() {
         return navn;
     }
 
     @Override
-    public String getKodeverk() {
-        return KODEVERK;
-    }
-
-    @Override
     public String getKode() {
         return kode;
     }
-
 
 }

--- a/domenetjenester/beregningsgrunnlag/src/main/java/no/nav/foreldrepenger/domene/modell/kodeverk/PeriodeÅrsak.java
+++ b/domenetjenester/beregningsgrunnlag/src/main/java/no/nav/foreldrepenger/domene/modell/kodeverk/PeriodeÅrsak.java
@@ -25,8 +25,6 @@ public enum PeriodeÅrsak implements Kodeverdi {
 
     private static final Map<String, PeriodeÅrsak> KODER = new LinkedHashMap<>();
 
-    public static final String KODEVERK = "PERIODE_AARSAK";
-
     static {
         for (var v : values()) {
             if (KODER.putIfAbsent(v.kode, v) != null) {
@@ -56,18 +54,9 @@ public enum PeriodeÅrsak implements Kodeverdi {
         return ad;
     }
 
-    public static Map<String, PeriodeÅrsak> kodeMap() {
-        return Collections.unmodifiableMap(KODER);
-    }
-
     @Override
     public String getNavn() {
         return navn;
-    }
-
-    @Override
-    public String getKodeverk() {
-        return KODEVERK;
     }
 
     @Override

--- a/domenetjenester/beregningsgrunnlag/src/main/java/no/nav/foreldrepenger/domene/modell/kodeverk/SammenligningsgrunnlagType.java
+++ b/domenetjenester/beregningsgrunnlag/src/main/java/no/nav/foreldrepenger/domene/modell/kodeverk/SammenligningsgrunnlagType.java
@@ -26,8 +26,6 @@ public enum SammenligningsgrunnlagType implements Kodeverdi {
 
     private static final Map<String, SammenligningsgrunnlagType> KODER = new LinkedHashMap<>();
 
-    public static final String KODEVERK = "SAMMENLIGNINGSGRUNNLAG_TYPE";
-
     static {
         for (var v : values()) {
             if (KODER.putIfAbsent(v.kode, v) != null) {
@@ -57,18 +55,9 @@ public enum SammenligningsgrunnlagType implements Kodeverdi {
         return ad;
     }
 
-    public static Map<String, SammenligningsgrunnlagType> kodeMap() {
-        return Collections.unmodifiableMap(KODER);
-    }
-
     @Override
     public String getNavn() {
         return navn;
-    }
-
-    @Override
-    public String getKodeverk() {
-        return KODEVERK;
     }
 
     @Override

--- a/domenetjenester/beregningsgrunnlag/src/main/java/no/nav/foreldrepenger/domene/modell/kodeverk/SammenligningsgrunnlagType.java
+++ b/domenetjenester/beregningsgrunnlag/src/main/java/no/nav/foreldrepenger/domene/modell/kodeverk/SammenligningsgrunnlagType.java
@@ -7,7 +7,6 @@ package no.nav.foreldrepenger.domene.modell.kodeverk;
  *
  */
 
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 


### PR DESCRIPTION
Sonnet 4.5 kom i mål til slutt:
* Fjernet Kodeverdi.getKodeverk()
* Fjernet static String KODEVERK
* Fjernet kodeMap()-metoder

Videre
- ekstrahere Attributt-konverter til egen klasse og innføre Databasekode-grensesnitt
- redusere antall med getNavn - innføre KodeverdiMedNavn-grensesnitt
- Forenkle flest mulig til plain Enum og lage plan for resten