### PR TITLE
legg til statistikk for vedtak

### DIFF
--- a/domenetjenester/datavarehus/src/main/java/no/nav/foreldrepenger/datavarehus/metrikker/StatistikkMetrikkTask.java
+++ b/domenetjenester/datavarehus/src/main/java/no/nav/foreldrepenger/datavarehus/metrikker/StatistikkMetrikkTask.java
@@ -41,7 +41,7 @@ public class StatistikkMetrikkTask implements ProsessTaskHandler {
         }
         var vedtakPerType = vedtakStatistikkRepository.hent();
         for (var vedtakType: vedtakPerType) {
-            VedtakMetrikker.setAntall(vedtakType.vedtakResultatType(), vedtakType.antall());
+            VedtakMetrikker.setAntall(vedtakType.vedtakResultat(), vedtakType.antall());
         }
     }
 }

--- a/domenetjenester/datavarehus/src/main/java/no/nav/foreldrepenger/datavarehus/metrikker/StatistikkMetrikkTask.java
+++ b/domenetjenester/datavarehus/src/main/java/no/nav/foreldrepenger/datavarehus/metrikker/StatistikkMetrikkTask.java
@@ -11,30 +11,37 @@ import no.nav.vedtak.felles.prosesstask.api.ProsessTaskHandler;
 @ProsessTask(value = "statistikk.metrikker", cronExpression = "0 */15 * * * *", maxFailedRuns = 1)
 public class StatistikkMetrikkTask implements ProsessTaskHandler {
 
-    private BehandlingStatistikkRepository statistikkRepository;
+    private BehandlingStatistikkRepository behandlingStatistikkRepository;
     private DokumentStatistikkRepository dokumentStatistikkRepository;
+    private VedtakStatistikkRepository vedtakStatistikkRepository;
 
     public StatistikkMetrikkTask() {
         // CDI
     }
 
     @Inject
-    public StatistikkMetrikkTask(BehandlingStatistikkRepository statistikkRepository,
-                                 DokumentStatistikkRepository dokumentStatistikkRepository) {
-        this.statistikkRepository = statistikkRepository;
+    public StatistikkMetrikkTask(BehandlingStatistikkRepository behandlingStatistikkRepository,
+                                 DokumentStatistikkRepository dokumentStatistikkRepository,
+                                 VedtakStatistikkRepository vedtakStatistikkRepository) {
+        this.behandlingStatistikkRepository = behandlingStatistikkRepository;
         this.dokumentStatistikkRepository = dokumentStatistikkRepository;
+        this.vedtakStatistikkRepository = vedtakStatistikkRepository;
     }
 
 
     @Override
     public void doTask(ProsessTaskData prosessTaskData) {
-        var behandlingerPerÅrsak = statistikkRepository.hentAntallBehandlingsårsaker();
+        var behandlingerPerÅrsak = behandlingStatistikkRepository.hentAntallBehandlingsårsaker();
         for (var behandling: behandlingerPerÅrsak) {
             BehandlingMetrikker.setAntall(behandling.behandlingsårsak(), behandling.antall());
         }
         var dokumentPerType = dokumentStatistikkRepository.hentAntallDokumenttyper();
         for (var dokumenttype: dokumentPerType) {
             DokumentMetrikker.setAntall(dokumenttype.dokumenttype(), dokumenttype.antall());
+        }
+        var vedtakPerType = vedtakStatistikkRepository.hent();
+        for (var vedtakType: vedtakPerType) {
+            VedtakMetrikker.setAntall(vedtakType.vedtakResultatType(), vedtakType.antall());
         }
     }
 }

--- a/domenetjenester/datavarehus/src/main/java/no/nav/foreldrepenger/datavarehus/metrikker/VedtakMetrikker.java
+++ b/domenetjenester/datavarehus/src/main/java/no/nav/foreldrepenger/datavarehus/metrikker/VedtakMetrikker.java
@@ -14,13 +14,13 @@ import static no.nav.vedtak.log.metrics.MetricsUtil.REGISTRY;
 public class VedtakMetrikker {
 
     private static final String VEDTAK_METRIKK_NAVN = "fp.vedtak.antall";
-    private static final Map<VedtakResultatType, AtomicLong> VEDTAK_GAUGES = new EnumMap<>(VedtakResultatType.class);
+    private static final Map<VedtakStatistikkRepository.VedtakResultat, AtomicLong> VEDTAK_GAUGES = new EnumMap<>(VedtakStatistikkRepository.VedtakResultat.class);
 
     VedtakMetrikker() {
         // CDI
     }
 
-    public static void setAntall(VedtakResultatType vedtakResultatType, Long antall) {
+    public static void setAntall(VedtakStatistikkRepository.VedtakResultat vedtakResultatType, Long antall) {
         if (VEDTAK_GAUGES.containsKey(vedtakResultatType)) {
             VEDTAK_GAUGES.get(vedtakResultatType).set(antall);
         } else {
@@ -29,9 +29,9 @@ public class VedtakMetrikker {
         }
     }
 
-    static List<Tag> tilTags(VedtakResultatType vedtakResultatType) {
+    static List<Tag> tilTags(VedtakStatistikkRepository.VedtakResultat vedtakResultatType) {
         return Optional.ofNullable(vedtakResultatType)
-            .map(ba -> List.of(Tag.of("type", vedtakResultatType.name())))
+            .map(ba -> List.of(Tag.of("vedtak_resultat_type", vedtakResultatType.name())))
             .orElseGet(List::of);
     }
 

--- a/domenetjenester/datavarehus/src/main/java/no/nav/foreldrepenger/datavarehus/metrikker/VedtakMetrikker.java
+++ b/domenetjenester/datavarehus/src/main/java/no/nav/foreldrepenger/datavarehus/metrikker/VedtakMetrikker.java
@@ -1,0 +1,38 @@
+package no.nav.foreldrepenger.datavarehus.metrikker;
+
+import io.micrometer.core.instrument.Tag;
+import no.nav.foreldrepenger.behandlingslager.behandling.vedtak.VedtakResultatType;
+
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static no.nav.vedtak.log.metrics.MetricsUtil.REGISTRY;
+
+public class VedtakMetrikker {
+
+    private static final String VEDTAK_METRIKK_NAVN = "fp.vedtak.antall";
+    private static final Map<VedtakResultatType, AtomicLong> VEDTAK_GAUGES = new EnumMap<>(VedtakResultatType.class);
+
+    VedtakMetrikker() {
+        // CDI
+    }
+
+    public static void setAntall(VedtakResultatType vedtakResultatType, Long antall) {
+        if (VEDTAK_GAUGES.containsKey(vedtakResultatType)) {
+            VEDTAK_GAUGES.get(vedtakResultatType).set(antall);
+        } else {
+            var gaugeValue = REGISTRY.gauge(VEDTAK_METRIKK_NAVN, tilTags(vedtakResultatType), new AtomicLong(antall));
+            VEDTAK_GAUGES.put(vedtakResultatType, gaugeValue);
+        }
+    }
+
+    static List<Tag> tilTags(VedtakResultatType vedtakResultatType) {
+        return Optional.ofNullable(vedtakResultatType)
+            .map(ba -> List.of(Tag.of("type", vedtakResultatType.name())))
+            .orElseGet(List::of);
+    }
+
+}

--- a/domenetjenester/datavarehus/src/main/java/no/nav/foreldrepenger/datavarehus/metrikker/VedtakMetrikker.java
+++ b/domenetjenester/datavarehus/src/main/java/no/nav/foreldrepenger/datavarehus/metrikker/VedtakMetrikker.java
@@ -31,7 +31,7 @@ public class VedtakMetrikker {
 
     static List<Tag> tilTags(VedtakStatistikkRepository.VedtakResultat vedtakResultatType) {
         return Optional.ofNullable(vedtakResultatType)
-            .map(ba -> List.of(Tag.of("vedtak_resultat_type", vedtakResultatType.name())))
+            .map(vr -> List.of(Tag.of("vedtak_resultat_type", vr.name())))
             .orElseGet(List::of);
     }
 

--- a/domenetjenester/datavarehus/src/main/java/no/nav/foreldrepenger/datavarehus/metrikker/VedtakStatistikkRepository.java
+++ b/domenetjenester/datavarehus/src/main/java/no/nav/foreldrepenger/datavarehus/metrikker/VedtakStatistikkRepository.java
@@ -39,13 +39,13 @@ public class VedtakStatistikkRepository {
     }
 
     record VedtakResultatQR(VedtakResultatType vedtakResultatType, Long antall) { }
-    public record VedtakStatistikk(VedtakResultatType vedtakResultatType, Long antall) { }
+    public record VedtakStatistikk(VedtakResultat vedtakResultat, Long antall) { }
 
 
-    static List<VedtakStatistikk> map(List<VedtakResultatQR> b) {
-        return b.stream()
+    static List<VedtakStatistikk> map(List<VedtakResultatQR> vedtakResultatQRList) {
+        return vedtakResultatQRList.stream()
             .map(VedtakStatistikkRepository::tilBehandlingStatistikk)
-            .collect(groupingBy(bs -> Optional.ofNullable(bs.vedtakResultatType()).orElse(VedtakResultatType.UDEFINERT),
+            .collect(groupingBy(bs -> Optional.ofNullable(bs.vedtakResultat).orElse(VedtakResultat.ANNET),
                 summarizingLong(bs -> Optional.ofNullable(bs.antall()).orElse(0L))))
             .entrySet()
             .stream()
@@ -54,7 +54,29 @@ public class VedtakStatistikkRepository {
     }
 
     private static VedtakStatistikk tilBehandlingStatistikk(VedtakResultatQR entitet) {
-        return new VedtakStatistikk(entitet.vedtakResultatType, entitet.antall());
+        return new VedtakStatistikk(tilVedtakResultat(entitet.vedtakResultatType), entitet.antall());
+    }
+
+    private static VedtakResultat tilVedtakResultat(VedtakResultatType vedtakResultatType) {
+        return switch (vedtakResultatType) {
+            case AVSLAG -> VedtakResultat.AVSLAG;
+            case OPPHØR -> VedtakResultat.OPPHØR;
+            case INNVILGET -> VedtakResultat.INNVILGET;
+            case VEDTAK_I_KLAGEBEHANDLING -> VedtakResultat.VEDTAK_I_KLAGEBEHANDLING;
+            case VEDTAK_I_ANKEBEHANDLING -> VedtakResultat.VEDTAK_I_ANKEBEHANDLING;
+            case VEDTAK_I_INNSYNBEHANDLING -> VedtakResultat.VEDTAK_I_INNSYNBEHANDLING;
+            default -> VedtakResultat.ANNET;
+        };
+    }
+
+    public enum VedtakResultat {
+        INNVILGET,
+        AVSLAG,
+        OPPHØR,
+        VEDTAK_I_KLAGEBEHANDLING,
+        VEDTAK_I_ANKEBEHANDLING,
+        VEDTAK_I_INNSYNBEHANDLING,
+        ANNET,
     }
 
 }

--- a/domenetjenester/datavarehus/src/main/java/no/nav/foreldrepenger/datavarehus/metrikker/VedtakStatistikkRepository.java
+++ b/domenetjenester/datavarehus/src/main/java/no/nav/foreldrepenger/datavarehus/metrikker/VedtakStatistikkRepository.java
@@ -1,0 +1,60 @@
+package no.nav.foreldrepenger.datavarehus.metrikker;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.persistence.EntityManager;
+
+import no.nav.foreldrepenger.behandlingslager.behandling.vedtak.VedtakResultatType;
+
+import org.hibernate.jpa.HibernateHints;
+
+import java.util.List;
+import java.util.Optional;
+
+import static java.util.stream.Collectors.groupingBy;
+import static java.util.stream.Collectors.summarizingLong;
+
+@ApplicationScoped
+public class VedtakStatistikkRepository {
+    private EntityManager entityManager;
+
+    VedtakStatistikkRepository() {
+        // for CDI proxy
+    }
+
+    @Inject
+    public VedtakStatistikkRepository(EntityManager entityManager) {
+        this.entityManager = entityManager;
+    }
+
+    public List<VedtakStatistikk> hent() {
+        var query = entityManager.createQuery("""
+            select bv.vedtakResultatType, count(1) as antall
+            from BehandlingVedtak bv
+            group by bv.vedtakResultatType
+            """, VedtakResultatQR.class)
+            .setHint(HibernateHints.HINT_READ_ONLY, "true");
+        var behandlingStatistikkEntitet = query.getResultList();
+        return map(behandlingStatistikkEntitet);
+    }
+
+    record VedtakResultatQR(VedtakResultatType vedtakResultatType, Long antall) { }
+    public record VedtakStatistikk(VedtakResultatType vedtakResultatType, Long antall) { }
+
+
+    static List<VedtakStatistikk> map(List<VedtakResultatQR> b) {
+        return b.stream()
+            .map(VedtakStatistikkRepository::tilBehandlingStatistikk)
+            .collect(groupingBy(bs -> Optional.ofNullable(bs.vedtakResultatType()).orElse(VedtakResultatType.UDEFINERT),
+                summarizingLong(bs -> Optional.ofNullable(bs.antall()).orElse(0L))))
+            .entrySet()
+            .stream()
+            .map(vedtakResultatType -> new VedtakStatistikk(vedtakResultatType.getKey(), vedtakResultatType.getValue().getSum()))
+            .toList();
+    }
+
+    private static VedtakStatistikk tilBehandlingStatistikk(VedtakResultatQR entitet) {
+        return new VedtakStatistikk(entitet.vedtakResultatType, entitet.antall());
+    }
+
+}


### PR DESCRIPTION
Lagt til enkel statistikk for vedtakstype. 
Testet lokalt og det viser slik på metrikk-siden http://localhost:8080/fpsak/internal/metrics/prometheus

```
# HELP fp_vedtak_antall  
# TYPE fp_vedtak_antall gauge
fp_vedtak_antall{type="AVSLAG"} 1.0
fp_vedtak_antall{type="INNVILGET"} 4.0
fp_vedtak_antall{type="VEDTAK_I_INNSYNBEHANDLING"} 1.0
```