### PR TITLE
feat: TFP-6259: Legger inn støtte for annulleringsbrev ved tomt uttak

### DIFF
--- a/domenetjenester/behandling-revurdering/src/main/java/no/nav/foreldrepenger/behandling/revurdering/felles/RevurderingBehandlingsresultatutlederFelles.java
+++ b/domenetjenester/behandling-revurdering/src/main/java/no/nav/foreldrepenger/behandling/revurdering/felles/RevurderingBehandlingsresultatutlederFelles.java
@@ -109,14 +109,12 @@ public class RevurderingBehandlingsresultatutlederFelles {
         var behandlingsresultatRevurdering = behandlingsresultatRepository.hentHvisEksisterer(behandlingId).orElseThrow();
         var behandlingsresultatOriginal = finnBehandlingsresultatPåOriginalBehandling(originalBehandling.getId()).orElseThrow();
 
-        if (SpesialBehandling.erOppsagtUttak(revurdering) || erAnnulleringAvUttak(uttakRevurdering)) {
-            return buildBehandlingsresultat(revurdering, behandlingsresultatRevurdering, BehandlingResultatType.FORELDREPENGER_SENERE,
-                RettenTil.HAR_RETT_TIL_FP, Vedtaksbrev.AUTOMATISK, List.of(KonsekvensForYtelsen.ENDRING_I_UTTAK));
-        }
-
         if (erAvslagPåAvslag(behandlingsresultatRevurdering, behandlingsresultatOriginal)) {
             return buildBehandlingsresultat(revurdering, behandlingsresultatRevurdering, BehandlingResultatType.INGEN_ENDRING,
                 RettenTil.HAR_IKKE_RETT_TIL_FP, Vedtaksbrev.INGEN, List.of(KonsekvensForYtelsen.INGEN_ENDRING));
+        } else if (SpesialBehandling.erOppsagtUttak(revurdering) || (erAnnulleringAvUttak(uttakRevurdering) && uttakOriginal.isPresent())) {
+            return buildBehandlingsresultat(revurdering, behandlingsresultatRevurdering, BehandlingResultatType.FORELDREPENGER_SENERE,
+                RettenTil.HAR_RETT_TIL_FP, Vedtaksbrev.AUTOMATISK, List.of(KonsekvensForYtelsen.ENDRING_I_UTTAK));
         }
 
         if (behandlingsresultatRevurdering.isInngangsVilkårAvslått()) {

--- a/domenetjenester/behandling-revurdering/src/main/java/no/nav/foreldrepenger/behandling/revurdering/felles/RevurderingBehandlingsresultatutlederFelles.java
+++ b/domenetjenester/behandling-revurdering/src/main/java/no/nav/foreldrepenger/behandling/revurdering/felles/RevurderingBehandlingsresultatutlederFelles.java
@@ -45,13 +45,8 @@ import no.nav.foreldrepenger.domene.uttak.Uttak;
 import no.nav.foreldrepenger.domene.uttak.UttakTjeneste;
 import no.nav.foreldrepenger.regler.uttak.UttakParametre;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 @ApplicationScoped
 public class RevurderingBehandlingsresultatutlederFelles {
-
-    private static final Logger LOG = LoggerFactory.getLogger(RevurderingBehandlingsresultatutlederFelles.class);
 
     private BeregningTjeneste beregningTjeneste;
     private MedlemTjeneste medlemTjeneste;
@@ -162,11 +157,13 @@ public class RevurderingBehandlingsresultatutlederFelles {
             erKunEndringIFordelingAvYtelsen, harInnvilgetIkkeOpphørtVedtak(revurdering.getFagsak()));
     }
 
-    private static boolean erAnnulleringAvUttak(Optional<Uttak> uttak, Behandling revurdering) {
-        if (uttak.isEmpty()) {
+    static boolean erAnnulleringAvUttak(Optional<Uttak> uttak, Behandling revurdering) {
+        if (!erRelevantBehandlingÅrsakSatt(revurdering)) {
+            return false;
+        } else if (uttak.isEmpty()) {
             return true;
         } else if (uttak.get() instanceof ForeldrepengerUttak fpUttak) {
-            return erUttakTomt(fpUttak) && erRelevantBehandlingÅrsakSatt(revurdering);
+            return erUttakTomt(fpUttak);
         } else {
             return false;
         }
@@ -174,15 +171,15 @@ public class RevurderingBehandlingsresultatutlederFelles {
 
     private static boolean erRelevantBehandlingÅrsakSatt(Behandling revurdering) {
         return revurdering.harNoenBehandlingÅrsaker(
-            Set.of(BehandlingÅrsakType.RE_VEDTAK_PLEIEPENGER, BehandlingÅrsakType.RE_OPPLYSNINGER_OM_FORDELING, BehandlingÅrsakType.BERØRT_BEHANDLING));
+            Set.of(BehandlingÅrsakType.RE_VEDTAK_PLEIEPENGER, BehandlingÅrsakType.RE_OPPLYSNINGER_OM_FORDELING,
+                BehandlingÅrsakType.BERØRT_BEHANDLING));
     }
 
     private static boolean erUttakTomt(ForeldrepengerUttak uttak) {
         if (uttak == null || uttak.getGjeldendePerioder().isEmpty()) {
             return true;
         }
-        return uttak.getGjeldendePerioder().stream()
-            .noneMatch(periode -> periode.harUtbetaling() || periode.harTrekkdager());
+        return uttak.getGjeldendePerioder().stream().noneMatch(periode -> periode.harUtbetaling() || periode.harTrekkdager());
     }
 
     private boolean erEndringIUttak(Optional<Uttak> uttakRevurdering, Optional<Uttak> uttakOriginal, BehandlingReferanse revurderingRef) {

--- a/domenetjenester/behandling-revurdering/src/main/java/no/nav/foreldrepenger/behandling/revurdering/felles/RevurderingBehandlingsresultatutlederFelles.java
+++ b/domenetjenester/behandling-revurdering/src/main/java/no/nav/foreldrepenger/behandling/revurdering/felles/RevurderingBehandlingsresultatutlederFelles.java
@@ -112,9 +112,6 @@ public class RevurderingBehandlingsresultatutlederFelles {
         if (erAvslagPåAvslag(behandlingsresultatRevurdering, behandlingsresultatOriginal)) {
             return buildBehandlingsresultat(revurdering, behandlingsresultatRevurdering, BehandlingResultatType.INGEN_ENDRING,
                 RettenTil.HAR_IKKE_RETT_TIL_FP, Vedtaksbrev.INGEN, List.of(KonsekvensForYtelsen.INGEN_ENDRING));
-        } else if (SpesialBehandling.erOppsagtUttak(revurdering) || (erAnnulleringAvUttak(uttakRevurdering) && uttakOriginal.isPresent())) {
-            return buildBehandlingsresultat(revurdering, behandlingsresultatRevurdering, BehandlingResultatType.FORELDREPENGER_SENERE,
-                RettenTil.HAR_RETT_TIL_FP, Vedtaksbrev.AUTOMATISK, List.of(KonsekvensForYtelsen.ENDRING_I_UTTAK));
         }
 
         if (behandlingsresultatRevurdering.isInngangsVilkårAvslått()) {
@@ -140,6 +137,13 @@ public class RevurderingBehandlingsresultatutlederFelles {
                 return opphør(revurdering, behandlingsresultatRevurdering);
             }
         }
+
+        // Denne er viktig å kjøre etter opphørs-sjekkene er ferdige overfor pga de kan føre til tom uttak også.
+        if (SpesialBehandling.erOppsagtUttak(revurdering) || (erAnnulleringAvUttak(uttakRevurdering) && uttakOriginal.isPresent())) {
+            return buildBehandlingsresultat(revurdering, behandlingsresultatRevurdering, BehandlingResultatType.FORELDREPENGER_SENERE,
+                RettenTil.HAR_RETT_TIL_FP, Vedtaksbrev.AUTOMATISK, List.of(KonsekvensForYtelsen.ENDRING_I_UTTAK));
+        }
+
         var revurderingsGrunnlagOpt = beregningTjeneste.hent(BehandlingReferanse.fra(revurdering))
             .flatMap(BeregningsgrunnlagGrunnlag::getBeregningsgrunnlag);
         var originalGrunnlagOpt = beregningTjeneste.hent(BehandlingReferanse.fra(originalBehandling))

--- a/domenetjenester/behandling-revurdering/src/test/java/no/nav/foreldrepenger/behandling/revurdering/felles/RevurderingBehandlingsresultatutlederFellesTest.java
+++ b/domenetjenester/behandling-revurdering/src/test/java/no/nav/foreldrepenger/behandling/revurdering/felles/RevurderingBehandlingsresultatutlederFellesTest.java
@@ -113,40 +113,19 @@ class RevurderingBehandlingsresultatutlederFellesTest {
 
     @Test
     void skal_returnere_true_når_uttak_er_tomt_med_riktig_årsak() {
-        // Arrange
-        var originalBehandling = opprettOriginalBehandling();
-        var revurdering = lagRevurdering(originalBehandling, BehandlingÅrsakType.RE_OPPLYSNINGER_OM_FORDELING);
-
         // Act
-        var resultat = erAnnulleringAvUttak(Optional.empty(), revurdering);
+        var resultat = erAnnulleringAvUttak(Optional.empty());
 
         // Assert
         assertThat(resultat).isTrue();
     }
 
     @Test
-    void skal_returnere_false_når_feil_årsak_satt() {
-        // Arrange
-        var originalBehandling = opprettOriginalBehandling();
-        var revurdering = lagRevurdering(originalBehandling, BehandlingÅrsakType.REBEREGN_FERIEPENGER);
-
-        // Act
-        var resultat = erAnnulleringAvUttak(Optional.empty(), revurdering);
-
-        // Assert
-        assertThat(resultat).isFalse();
-    }
-
-    @Test
     void skal_returnere_true_når_uttak_har_perioder_uten_utbetaling_og_trekk_med_riktig_årsak() {
-        // Arrange
-        var originalBehandling = opprettOriginalBehandling();
-        var revurdering = lagRevurdering(originalBehandling, BehandlingÅrsakType.RE_OPPLYSNINGER_OM_FORDELING);
-
         var foreldrepengerUttak = new ForeldrepengerUttak(List.of(lagPeriode(List.of(lagAktivitet(Utbetalingsgrad.ZERO, Trekkdager.ZERO)))));
 
         // Act
-        var resultat = erAnnulleringAvUttak(Optional.of(foreldrepengerUttak), revurdering);
+        var resultat = erAnnulleringAvUttak(Optional.of(foreldrepengerUttak));
 
         // Assert
         assertThat(resultat).isTrue();
@@ -154,14 +133,10 @@ class RevurderingBehandlingsresultatutlederFellesTest {
 
     @Test
     void skal_returnere_false_når_uttak_har_perioder_med_utbetaling_og_trekk_med_riktig_årsak() {
-        // Arrange
-        var originalBehandling = opprettOriginalBehandling();
-        var revurdering = lagRevurdering(originalBehandling, BehandlingÅrsakType.BERØRT_BEHANDLING);
-
         var foreldrepengerUttak = new ForeldrepengerUttak(List.of(lagPeriode(List.of(lagAktivitet(Utbetalingsgrad.HUNDRED, Trekkdager.ZERO)))));
 
         // Act
-        var resultat = erAnnulleringAvUttak(Optional.of(foreldrepengerUttak), revurdering);
+        var resultat = erAnnulleringAvUttak(Optional.of(foreldrepengerUttak));
 
         // Assert
         assertThat(resultat).isFalse();
@@ -169,14 +144,10 @@ class RevurderingBehandlingsresultatutlederFellesTest {
 
     @Test
     void skal_returnere_false_når_uttak_har_perioder_uten_utbetaling_men_med_trekk_og_riktig_årsak() {
-        // Arrange
-        var originalBehandling = opprettOriginalBehandling();
-        var revurdering = lagRevurdering(originalBehandling, BehandlingÅrsakType.RE_VEDTAK_PLEIEPENGER);
-
         var foreldrepengerUttak = new ForeldrepengerUttak(List.of(lagPeriode(List.of(lagAktivitet(Utbetalingsgrad.ZERO, new Trekkdager(BigDecimal.TEN))))));
 
         // Act
-        var resultat = erAnnulleringAvUttak(Optional.of(foreldrepengerUttak), revurdering);
+        var resultat = erAnnulleringAvUttak(Optional.of(foreldrepengerUttak));
 
         // Assert
         assertThat(resultat).isFalse();
@@ -184,14 +155,10 @@ class RevurderingBehandlingsresultatutlederFellesTest {
 
     @Test
     void skal_returnere_false_hvis_ikke_foreldrepenger_uttak() {
-        // Arrange
-        var originalBehandling = opprettOriginalBehandling();
-        var revurdering = lagRevurdering(originalBehandling, BehandlingÅrsakType.RE_VEDTAK_PLEIEPENGER);
-
         var svangerskapspengerUttak = new SvangerskapspengerUttak(null);
 
         // Act
-        var resultat = erAnnulleringAvUttak(Optional.of(svangerskapspengerUttak), revurdering);
+        var resultat = erAnnulleringAvUttak(Optional.of(svangerskapspengerUttak));
 
         // Assert
         assertThat(resultat).isFalse();
@@ -205,6 +172,15 @@ class RevurderingBehandlingsresultatutlederFellesTest {
             .build();
     }
 
+    @Test
+    void skal_returnere_true_når_uttak_er_null_med_riktig_årsak() {
+        // Act
+        var resultat = erAnnulleringAvUttak(Optional.empty());
+
+        // Assert
+        assertThat(resultat).isTrue();
+    }
+
     private static ForeldrepengerUttakPeriodeAktivitet lagAktivitet(Utbetalingsgrad utbetalingsgrad, Trekkdager trekkdager) {
         return new ForeldrepengerUttakPeriodeAktivitet.Builder()
             .medAktivitet(new ForeldrepengerUttakAktivitet(UttakArbeidType.ORDINÆRT_ARBEID, null, null))
@@ -212,20 +188,6 @@ class RevurderingBehandlingsresultatutlederFellesTest {
             .medUtbetalingsgrad(utbetalingsgrad)
             .medTrekkdager(trekkdager)
             .build();
-    }
-
-    @Test
-    void skal_returnere_true_når_uttak_er_null_med_riktig_årsak() {
-        // Arrange
-        var originalBehandling = opprettOriginalBehandling();
-        var revurdering = lagRevurdering(originalBehandling, BehandlingÅrsakType.RE_OPPLYSNINGER_OM_FORDELING);
-        behandlingRepository.lagre(revurdering, behandlingRepository.taSkriveLås(revurdering));
-
-        // Act
-        var resultat = erAnnulleringAvUttak(Optional.empty(), revurdering);
-
-        // Assert
-        assertThat(resultat).isTrue();
     }
 
     private Behandling lagRevurdering(Behandling originalBehandling, BehandlingÅrsakType behandlingÅrsak) {

--- a/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/ForeldrepengerUttak.java
+++ b/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/ForeldrepengerUttak.java
@@ -82,6 +82,10 @@ public class ForeldrepengerUttak implements Uttak {
         return getGjeldendePerioder().stream().anyMatch(ForeldrepengerUttakPeriode::harUtbetaling);
     }
 
+    public boolean harTrekkdager() {
+        return getGjeldendePerioder().stream().anyMatch(ForeldrepengerUttakPeriode::harTrekkdager);
+    }
+
     public boolean harAvslagPgaMedlemskap() {
         return getGjeldendePerioder().stream().anyMatch(ForeldrepengerUttakPeriode::harAvslagPgaMedlemskap);
     }


### PR DESCRIPTION
Tenkte å støtte her de vanligste casene:

brukeren søker selv og annullerer uttaket (støttet allerede i dag)
saksbehandleren fjerner uttaket (revurdering med Nye opplysninger om uttak årsak)
innvilget Pleiepenger (revurdering med Pleiepenger årsak)
annet part søker om perioden (revurdering med Berørt behandling årsak)