### PR TITLE
TFP-6543 avbryt fattevedtak ved tilbakeføring til foreslå vedtak

### DIFF
--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/aksjonspunkt/AksjonspunktDefinisjon.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/aksjonspunkt/AksjonspunktDefinisjon.java
@@ -695,6 +695,10 @@ public enum AksjonspunktDefinisjon implements Kodeverdi {
         return PAPIRSØKNAD_AP.contains(this);
     }
 
+    public boolean avbrytVedTilbakeføring() {
+        return FATTER_VEDTAK.equals(this);
+    }
+
     @Override
     public String toString() {
         return super.toString() + "('" + getKode() + "')";

--- a/domenetjenester/behandlingskontroll/src/main/java/no/nav/foreldrepenger/behandlingskontroll/impl/observer/BehandlingskontrollTransisjonTilbakeføringEventObserver.java
+++ b/domenetjenester/behandlingskontroll/src/main/java/no/nav/foreldrepenger/behandlingskontroll/impl/observer/BehandlingskontrollTransisjonTilbakeføringEventObserver.java
@@ -151,7 +151,11 @@ public class BehandlingskontrollTransisjonTilbakeføringEventObserver {
         var erManueltOpprettet = a.erManueltOpprettet();
         var erOpprettetIFørsteSteg = erOpprettetIFørsteSteg(a, førsteSteg);
         var hensyntaÅpneOpprettetIFørste = erOpprettetIFørsteSteg && tilInngangFørsteSteg && a.erÅpentAksjonspunkt();
-        return !erManueltOpprettet && erFunnetIFørsteStegEllerSenere && (hensyntaÅpneOpprettetIFørste || !erOpprettetIFørsteSteg);
+        // Tilpasning for å avbryte FatteVedtak (VP FatteVedtak.INN) ved tilbakeføring av ForeslåVedtakAP (VP ForeslåVedtak.UT).
+        var hensyntaFatteTilForeslåVedtak = erOpprettetIFørsteSteg && a.getAksjonspunktDefinisjon().avbrytVedTilbakeføring();
+        var ulikeHensynOppfylt = hensyntaÅpneOpprettetIFørste || !erOpprettetIFørsteSteg || hensyntaFatteTilForeslåVedtak;
+        var avbryt = !erManueltOpprettet && erFunnetIFørsteStegEllerSenere && ulikeHensynOppfylt;
+        return avbryt;
     }
 
     private boolean erOpprettetIFørsteSteg(Aksjonspunkt ap, BehandlingStegType førsteSteg) {

--- a/domenetjenester/behandlingskontroll/src/test/java/no/nav/foreldrepenger/behandlingskontroll/impl/observer/TilbakehoppTest.java
+++ b/domenetjenester/behandlingskontroll/src/test/java/no/nav/foreldrepenger/behandlingskontroll/impl/observer/TilbakehoppTest.java
@@ -96,6 +96,14 @@ class TilbakehoppTest {
     }
 
     @Test
+    void tilfelle_fatte_tilbake_til_foreslå_vedtak() {
+        var foreslå = BehandlingStegType.FORESLÅ_VEDTAK;
+        var fatte = BehandlingStegType.FATTE_VEDTAK;
+        // Tilfelle Fatte til Foreslå vedtak
+        assertAPAvbrytesVedTilbakehopp(fra(fatte, INN), til(foreslå, UT), medUtførtAP(identifisertI(foreslå), løsesI(fatte, INN)));
+    }
+
+    @Test
     void skal_ikke_endre_aksjonspunkter_som_oppsto_før_til_steget_og_som_skulle_utføres_i_eller_etter_til_steget() {
         assertAPUendretVedTilbakehopp(fra(steg3, INN), til(steg2), medUtførtAP(identifisertI(steg1), løsesI(steg2, UT)));
         assertAPUendretVedTilbakehopp(fra(steg3, INN), til(steg2), medUtførtAP(identifisertI(steg1), løsesI(steg3, INN)));


### PR DESCRIPTION
Takk til @palfi for grundig test som oppdaget dette spesialtilfellet ved tilbakeføring til forrige steg sin utgang.
Gjør en spesiell tilpasning først. Det mer generelle tilfellet krever mer undersøkelser - men vi ønsker oss vekk fra aksjonspunkt med vurderingspunkt inngang (tidligere mønster fra inngangsvilkår og fatte vedtak)