### PR TITLE
TFP-5437 bruk standard jsonmapper framfor abakus/kontrakt

### DIFF
--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/domene/json/StandardJsonConfig.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/domene/json/StandardJsonConfig.java
@@ -59,7 +59,7 @@ public final class StandardJsonConfig {
 
     public static <T> T fromJson(URL json, Class<T> clazz) {
         try {
-            return OM.readerFor(clazz).readValue(json);
+            return OM.readerFor(clazz).readValue(json.openStream());
         } catch (IOException e) {
             throw deserialiseringException(e);
         }

--- a/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/abakus/AbakusTjeneste.java
+++ b/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/abakus/AbakusTjeneste.java
@@ -20,11 +20,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
 import com.fasterxml.jackson.databind.ObjectWriter;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 
-import no.nav.abakus.iaygrunnlag.JsonObjectMapper;
 import no.nav.abakus.iaygrunnlag.UuidDto;
 import no.nav.abakus.iaygrunnlag.arbeidsforhold.v1.ArbeidsforholdDto;
 import no.nav.abakus.iaygrunnlag.inntektsmelding.v1.InntektsmeldingerDto;
@@ -52,13 +51,14 @@ import no.nav.vedtak.felles.integrasjon.rest.RestConfig;
 import no.nav.vedtak.felles.integrasjon.rest.RestRequest;
 import no.nav.vedtak.felles.integrasjon.rest.TokenFlow;
 import no.nav.vedtak.konfig.Tid;
+import no.nav.vedtak.mapper.json.DefaultJsonMapper;
 
 @ApplicationScoped
 @RestClientConfig(tokenConfig = TokenFlow.ADAPTIVE, application = FpApplication.FPABAKUS, scopesProperty = "abakus.scopes")
 public class AbakusTjeneste {
 
     private static final Logger LOG = LoggerFactory.getLogger(AbakusTjeneste.class);
-    private final ObjectMapper iayMapper = JsonObjectMapper.getMapper();
+    private final JsonMapper iayMapper = DefaultJsonMapper.getJsonMapper();
     private final ObjectWriter iayJsonWriter = iayMapper.writerWithDefaultPrettyPrinter();
     private final ObjectReader iayGrunnlagReader = iayMapper.readerFor(InntektArbeidYtelseGrunnlagDto.class);
     private final ObjectReader arbeidsforholdReader = iayMapper.readerFor(ArbeidsforholdDto[].class);

--- a/pom.xml
+++ b/pom.xml
@@ -36,10 +36,10 @@
         <fp-ytelse-beregn.version>1.0.4</fp-ytelse-beregn.version>
         <fpkalkulus.kontrakt.version>1.0.1</fpkalkulus.kontrakt.version>
 
-        <felles.version>7.6.12</felles.version>
+        <felles.version>7.6.14</felles.version>
         <prosesstask.version>5.2.2</prosesstask.version>
         <openapi-spec-utils.version>2.1.0</openapi-spec-utils.version>
-        <fp-kontrakter.version>9.4.23</fp-kontrakter.version>
+        <fp-kontrakter.version>9.4.24</fp-kontrakter.version>
         <abakus-kontrakt.version>2.3.6</abakus-kontrakt.version>
 
         <sonar.moduleKey>${project.artifactId}</sonar.moduleKey>

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/rest/ResourceLinks.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/rest/ResourceLinks.java
@@ -1,10 +1,10 @@
 package no.nav.foreldrepenger.web.app.rest;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 import no.nav.foreldrepenger.konfig.Environment;
 import no.nav.foreldrepenger.web.app.konfig.ApiConfig;
+import no.nav.vedtak.mapper.json.DefaultJsonMapper;
 
 public final class ResourceLinks {
 
@@ -46,8 +46,7 @@ public final class ResourceLinks {
 
     public static String toQuery(Object queryParams) {
         if (queryParams != null) {
-            var mapper = new ObjectMapper();
-            var mappedQueryParams = mapper.convertValue(queryParams, UriFormat.class).toString();
+            var mappedQueryParams = DefaultJsonMapper.getJsonMapper().convertValue(queryParams, UriFormat.class).toString();
             if (!mappedQueryParams.isEmpty()) {
                 return "?" + mappedQueryParams;
             }
@@ -61,7 +60,7 @@ public final class ResourceLinks {
 
         @JsonAnySetter
         public void addToUri(String name, Object property) {
-            if (builder.length() > 0) {
+            if (!builder.isEmpty()) {
                 builder.append("&");
             }
             builder.append(name).append("=").append(property);

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/los/LosRestTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/los/LosRestTjeneste.java
@@ -83,7 +83,7 @@ public class LosRestTjeneste {
     @BeskyttetRessurs(actionType = ActionType.READ, resourceType = ResourceType.FAGSAK, sporingslogg = false)
     public Response hentFagsakEgenskaper(@TilpassetAbacAttributt(supplierClass = SaksnummerAbacSupplier.Supplier.class) @NotNull @QueryParam("saksnummer") @Valid SaksnummerDto s) {
         return fagsakRepository.hentSakGittSaksnummer(new Saksnummer(s.getVerdi()))
-            .map(f -> new LosFagsakEgenskaperDto(losBehandlingDtoTjeneste.lagFagsakEgenskaperString(f), null))
+            .map(f -> new LosFagsakEgenskaperDto(losBehandlingDtoTjeneste.lagFagsakEgenskaperString(f)))
             .map(Response::ok)
             .orElseGet(() -> Response.status(Response.Status.FORBIDDEN)).build(); // Etablert praksis
     }


### PR DESCRIPTION
Første fase i standardisering av JsonMapper - bruk felles-mapper framfor den som ligger i abakus-kontrakten.
Fjerner også en løs ObjectMapper for ressurslenker

Neste faser: Bruke felles-mapper i StandardJsonConfig. Forenkle JacksonJsonConfig - felles-mapper og fjerne kodeverdiserializers.