### PR TITLE
TFP-6038 fullfør renaming av kelvin-scopes property for overlappsjekk

### DIFF
--- a/web/src/main/resources/application-dev-fss.properties
+++ b/web/src/main/resources/application-dev-fss.properties
@@ -48,7 +48,7 @@ dagpengerdatadeling.base.url=https://dp-datadeling.intern.dev.nav.no
 
 # Kelvin
 kelvin.base.url=https://aap-api.intern.dev.nav.no
-kelvin.maksimum.scopes=api://dev-gcp.aap.api-intern/.default
+kelvin.scopes=api://dev-gcp.aap.api-intern/.default
 
 # Interne integrasjoner
 abakus.scopes=api://dev-fss.teamforeldrepenger.fpabakus/.default

--- a/web/src/main/resources/application-prod-fss.properties
+++ b/web/src/main/resources/application-prod-fss.properties
@@ -44,7 +44,7 @@ dagpengerdatadeling.base.url=https://dp-datadeling.intern.nav.no
 
 # Kelvin
 kelvin.base.url=https://aap-api.intern.nav.no
-kelvin.maksimum.scopes=api://prod-gcp.aap.api-intern/.default
+kelvin.scopes=api://prod-gcp.aap.api-intern/.default
 
 # Interne integrasjoner
 abakus.scopes=api://prod-fss.teamforeldrepenger.fpabakus/.default

--- a/web/src/test/resources/application-vtp.properties
+++ b/web/src/test/resources/application-vtp.properties
@@ -75,7 +75,7 @@ spokelse.grunnlag.scopes=testscope
 dagpengerdatadeling.base.url=http://localhost:8060/rest
 dagpengerdatadeling.scopes=testscope
 kelvin.base.url=http://localhost:8060/rest/kelvin
-kelvin.maksimum.scopes=testscope
+kelvin.scopes=testscope
 
 AZURE_APP_CLIENT_ID=vtp
 AZURE_APP_CLIENT_SECRET=vtp


### PR DESCRIPTION
Slik går det når man ikke endrer i propertyfiler, bare i klienten