### PR TITLE
TFP-6866 lagre riktig familiehendelsetype/adopsjon

### DIFF
--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/familiehendelse/FamilieHendelseBuilder.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/familiehendelse/FamilieHendelseBuilder.java
@@ -155,12 +155,7 @@ public class FamilieHendelseBuilder {
             throw new IllegalStateException("Utviklerfeil: Kan ikke både ha terminbekreftelse og adopsjon");
         }
         if (hendelse.getAdopsjon().isPresent()) {
-            if (hendelse.getAdopsjon().get().getOmsorgovertakelseVilkår().equals(OmsorgsovertakelseVilkårType.UDEFINERT)
-                && !erSøknadEllerBekreftetVersjonOgSattTilOmsorg()) {
-                hendelse.setType(FamilieHendelseType.ADOPSJON);
-            } else {
-                hendelse.setType(FamilieHendelseType.OMSORG);
-            }
+            håndterAdopsjon(hendelse.getAdopsjon().get());
         } else if (!hendelse.getBarna().isEmpty() || erHendelsenSattTil(FamilieHendelseType.FØDSEL)) {
             hendelse.setType(FamilieHendelseType.FØDSEL);
         } else if (hendelse.getTerminbekreftelse().isPresent()) {
@@ -175,9 +170,18 @@ public class FamilieHendelseBuilder {
         return hendelse;
     }
 
-    private boolean erSøknadEllerBekreftetVersjonOgSattTilOmsorg() {
-        return (type.equals(HendelseVersjonType.SØKNAD) || type.equals(HendelseVersjonType.BEKREFTET)) && hendelse.getType() != null
-            && hendelse.getType().equals(FamilieHendelseType.OMSORG);
+    private void håndterAdopsjon(AdopsjonEntitet adopsjon) {
+        var delVilkår = adopsjon.getOmsorgovertakelseVilkår();
+        if (erHendelsenSattTil(FamilieHendelseType.OMSORG)) {
+            if (OmsorgsovertakelseVilkårType.gjelderAdopsjon(delVilkår)) {
+                throw new IllegalStateException("Utviklerfeil: Mismatch familiehendelse OMSORGO og omsorgsvilkårtype " + delVilkår);
+            }
+            hendelse.setType(FamilieHendelseType.OMSORG);
+        } else if (OmsorgsovertakelseVilkårType.gjelderOmsorg(delVilkår)) {
+            hendelse.setType(FamilieHendelseType.OMSORG);
+        } else {
+            hendelse.setType(FamilieHendelseType.ADOPSJON);
+        }
     }
 
     private boolean erHendelsenSattTil(FamilieHendelseType type) {

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/familiehendelse/OmsorgsovertakelseVilkårType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/familiehendelse/OmsorgsovertakelseVilkårType.java
@@ -50,6 +50,8 @@ public enum OmsorgsovertakelseVilkårType implements Kodeverdi {
 
     private static final Map<String, OmsorgsovertakelseVilkårType> KODER = new LinkedHashMap<>();
 
+    private static final Set<OmsorgsovertakelseVilkårType> ADOPSJON = Set.of(ES_ADOPSJONSVILKÅRET, FP_ADOPSJONSVILKÅRET, FP_STEBARNSADOPSJONSVILKÅRET);
+
     private final String navn;
 
     private final Set<Avslagsårsak> avslagsårsaker;
@@ -71,6 +73,14 @@ public enum OmsorgsovertakelseVilkårType implements Kodeverdi {
     @Override
     public String getKode() {
         return kode;
+    }
+
+    public static boolean gjelderAdopsjon(OmsorgsovertakelseVilkårType type) {
+        return ADOPSJON.contains(type);
+    }
+
+    public static boolean gjelderOmsorg(OmsorgsovertakelseVilkårType type) {
+        return !ADOPSJON.contains(type) && !UDEFINERT.equals(type);
     }
 
     public List<Avslagsårsak> getAvslagsårsaker() {

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/forvaltning/ForvaltningSøknadRestTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/forvaltning/ForvaltningSøknadRestTjeneste.java
@@ -1,7 +1,9 @@
 package no.nav.foreldrepenger.web.app.tjenester.forvaltning;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.Month;
 import java.util.List;
 
 import jakarta.enterprise.context.ApplicationScoped;
@@ -23,6 +25,7 @@ import no.nav.foreldrepenger.behandlingslager.behandling.MottattDokument;
 import no.nav.foreldrepenger.behandlingslager.behandling.SpesialBehandling;
 import no.nav.foreldrepenger.behandlingslager.behandling.familiehendelse.FamilieHendelseGrunnlagEntitet;
 import no.nav.foreldrepenger.behandlingslager.behandling.familiehendelse.FamilieHendelseRepository;
+import no.nav.foreldrepenger.behandlingslager.behandling.familiehendelse.FamilieHendelseType;
 import no.nav.foreldrepenger.behandlingslager.behandling.personopplysning.PersonopplysningRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepositoryProvider;
@@ -233,6 +236,27 @@ public class ForvaltningSøknadRestTjeneste {
                 .setParameter("apid", oap.getId())
                 .setParameter("begr", dto.getBegrunnelse())
                 .executeUpdate();
+        entityManager.flush();
+
+        return Response.ok(antall).build();
+    }
+
+    @POST
+    @Path("/endreTilAdopsjon")
+    @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+    @Operation(description = "Fikse tilfelle som er feilaktig satt til omsorgsovertakelse", tags = "FORVALTNING-søknad")
+    @BeskyttetRessurs(actionType = ActionType.CREATE, resourceType = ResourceType.DRIFT, sporingslogg = true)
+    public Response endreTilAdopsjon() {
+        var dato = LocalDate.of(2025, Month.OCTOBER, 28).atStartOfDay();
+        var antall = entityManager.createNativeQuery("""
+                    update fh_familie_hendelse fh
+                    set fh.familie_hendelse_type = :adopsjon
+                    where nvl(fh.endret_tid, fh.opprettet_tid) > :tid
+                    and fh.id in (select familie_hendelse_id from fh_adopsjon where omsorg_vilkaar_type in ('-', 'FP_VK_4','FP_VK_16','FP_VK_16S'))
+                    """)
+            .setParameter("adopsjon", FamilieHendelseType.ADOPSJON.getKode())
+            .setParameter("tid", dato)
+            .executeUpdate();
         entityManager.flush();
 
         return Response.ok(antall).build();


### PR DESCRIPTION
En subtil feil som ble innført sent oktober 2025 - som følge av at OmsorgsVilkårType ble tatt i bruk for adopsjon (fra før kun omsorgsovertagelse). FamilihendelseOversetter lager en adopsjon og setter type dersom omsorg.
Logikken i build() satte dermed alle adopsjonssaker til omsorgsovertakelse, tross at delvilkår tilsier noe annet.
Dette har ikke hatt noen praktisk konsekvens for mødre, men har gitt feil STP for annenpart.
Rapportert via FAGSYSTEM-418685 