### PR TITLE
TFP-6616: Bumper fp-felles og fjerner egen feilhåndtering av oppgave

### DIFF
--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/kabal/KabalHendelseHåndterer.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/kabal/KabalHendelseHåndterer.java
@@ -195,7 +195,7 @@ public class KabalHendelseHåndterer implements KafkaMessageHandler.KafkaStringM
     }
 
     @Override
-    public Optional<OffsetResetStrategy> autoOffsetReset() {
-        return Optional.of(OffsetResetStrategy.EARLIEST); // For sikkerhets skyld - dersom lavt ferievolum
+    public Optional<StrategyType> autoOffsetReset() {
+        return Optional.of(StrategyType.EARLIEST); // For sikkerhets skyld - dersom lavt ferievolum
     }
 }

--- a/domenetjenester/produksjonsstyring/src/main/java/no/nav/foreldrepenger/produksjonsstyring/oppgavebehandling/OppgaveTjeneste.java
+++ b/domenetjenester/produksjonsstyring/src/main/java/no/nav/foreldrepenger/produksjonsstyring/oppgavebehandling/OppgaveTjeneste.java
@@ -6,8 +6,6 @@ import java.util.List;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 
-import no.nav.vedtak.felles.integrasjon.oppgave.v1.Oppgavestatus;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -199,14 +197,11 @@ public class OppgaveTjeneste {
     }
 
     public void ferdigstillOppgave(String oppgaveId) {
-        var oppgave = hentOppgave(oppgaveId);
-        if (!oppgave.status().equals(Oppgavestatus.FEILREGISTRERT) && !oppgave.status().equals(Oppgavestatus.FERDIGSTILT)) {
-            try {
-                avslutt(oppgaveId);
-            } catch (Exception e) {
-                LOG.warn("Kunne ikke ferdigstille oppgave med id {}", oppgaveId, e);
-                throw new TekniskException("FP-395342", "Noe feilet ved ferdigstilling av oppgave", e);
-            }
+        try {
+            avslutt(oppgaveId);
+        } catch (Exception e) {
+            LOG.warn("Kunne ikke ferdigstille oppgave med id {}", oppgaveId, e);
+            throw new TekniskException("FP-395342", "Noe feilet ved ferdigstilling av oppgave", e);
         }
     }
 
@@ -219,14 +214,5 @@ public class OppgaveTjeneste {
     public void avslutt(String oppgaveId) {
         restKlient.ferdigstillOppgave(oppgaveId);
         LOG.info("FPSAK GOSYS ferdigstilte oppgave {}", oppgaveId);
-    }
-
-    private Oppgave hentOppgave(String oppgaveId) {
-        try {
-            return restKlient.hentOppgave(oppgaveId);
-        } catch (Exception e) {
-            LOG.warn("Kunne ikke hente oppgave med id {}", oppgaveId, e);
-            throw new TekniskException("FP-395343", "Noe feilet ved henting av oppgave", e);
-        }
     }
 }

--- a/domenetjenester/produksjonsstyring/src/test/java/no/nav/foreldrepenger/produksjonsstyring/oppgavebehandling/OppgaveTjenesteTest.java
+++ b/domenetjenester/produksjonsstyring/src/test/java/no/nav/foreldrepenger/produksjonsstyring/oppgavebehandling/OppgaveTjenesteTest.java
@@ -43,9 +43,7 @@ class OppgaveTjenesteTest {
     private static final Oppgave OPPGAVE = new Oppgave(99L, null, null, null, null,
             Tema.FOR.getOffisiellKode(), null, null, null, 1, "4806",
             LocalDate.now().plusDays(1), LocalDate.now(), Prioritet.NORM, Oppgavestatus.AAPNET, "beskrivelse", "null");
-    private static final Oppgave FERDIGSTILT_OPPGAVE = new Oppgave(101L, null, null, null, null,
-            Tema.FOR.getOffisiellKode(), null, null, null, 1, "4806",
-            LocalDate.now().plusDays(1), LocalDate.now(), Prioritet.NORM, Oppgavestatus.FERDIGSTILT, "beskrivelse", "null");
+    private static final String OPPGAVE_ID = OPPGAVE.id().toString();
 
     @Mock
     private PersoninfoAdapter personinfoAdapter;
@@ -85,7 +83,7 @@ class OppgaveTjenesteTest {
         var request = captor.getValue();
         assertThat(request.saksreferanse()).isEqualTo(behandling.getSaksnummer().getVerdi());
         assertThat(request.oppgavetype()).isEqualTo(Oppgavetype.VURDER_DOKUMENT);
-        assertThat(oppgaveId).isEqualTo(OPPGAVE.id().toString());
+        assertThat(oppgaveId).isEqualTo(OPPGAVE_ID);
     }
 
     @Test
@@ -114,7 +112,7 @@ class OppgaveTjenesteTest {
         var request = captor.getValue();
         assertThat(request.saksreferanse()).isEqualTo(behandling.getSaksnummer().getVerdi());
         assertThat(request.oppgavetype()).isEqualTo(Oppgavetype.VURDER_KONSEKVENS_YTELSE);
-        assertThat(oppgaveId).isEqualTo(OPPGAVE.id().toString());
+        assertThat(oppgaveId).isEqualTo(OPPGAVE_ID);
     }
 
     @Test
@@ -138,7 +136,7 @@ class OppgaveTjenesteTest {
         assertThat(request.fristFerdigstillelse()).isEqualTo(forventetFrist);
         assertThat(request.beskrivelse())
                 .isEqualTo("Samordning arenaytelse. Vedtak foreldrepenger fra " + førsteAugust);
-        assertThat(oppgaveId).isEqualTo(OPPGAVE.id().toString());
+        assertThat(oppgaveId).isEqualTo(OPPGAVE_ID);
     }
 
     @Test
@@ -171,43 +169,22 @@ class OppgaveTjenesteTest {
         assertThat(request.fristFerdigstillelse()).isEqualTo(forventetFrist);
         assertThat(request.beskrivelse()).isEqualTo(beskrivelse);
         assertThat(request.prioritet()).isEqualTo(Prioritet.HOY);
-        assertThat(oppgaveId).isEqualTo(OPPGAVE.id().toString());
+        assertThat(oppgaveId).isEqualTo(OPPGAVE_ID);
     }
 
     @Test
     void ferdigstille_oppgave_kalles_videre_til_rest_klient() {
         var tjeneste = lagTjeneste(lagScenario());
-        when(oppgaveRestKlient.hentOppgave(OPPGAVE.id().toString())).thenReturn(OPPGAVE);
-        tjeneste.ferdigstillOppgave(OPPGAVE.id().toString());
-        verify(oppgaveRestKlient, times(1)).hentOppgave(OPPGAVE.id().toString());
-        verify(oppgaveRestKlient, times(1)).ferdigstillOppgave(OPPGAVE.id().toString());
-    }
-
-    @Test
-    void ferdigstille_oppgave_feiler_for_oppgaveId_null() {
-        var tjeneste = lagTjeneste(lagScenario());
-        when(oppgaveRestKlient.hentOppgave(null)).thenThrow(new IllegalArgumentException("Feil"));
-
-        assertThatThrownBy(() -> tjeneste.ferdigstillOppgave(null)).isInstanceOf(TekniskException.class)
-            .hasMessageContaining("Noe feilet ved henting av oppgave");
+        tjeneste.ferdigstillOppgave(OPPGAVE_ID);
+        verify(oppgaveRestKlient, times(1)).ferdigstillOppgave(OPPGAVE_ID);
     }
 
     @Test
     void ferdigstille_oppgave_feiler_for_feil_fra_rest_klient() {
         var tjeneste = lagTjeneste(lagScenario());
-        when(oppgaveRestKlient.hentOppgave(OPPGAVE.id().toString())).thenReturn(OPPGAVE);
-        doThrow(new IllegalArgumentException("Feil")).when(oppgaveRestKlient).ferdigstillOppgave(OPPGAVE.id().toString());
+        doThrow(new IllegalArgumentException("Feil")).when(oppgaveRestKlient).ferdigstillOppgave(OPPGAVE_ID);
 
-        assertThatThrownBy(() -> tjeneste.ferdigstillOppgave(OPPGAVE.id().toString())).isInstanceOf(TekniskException.class)
+        assertThatThrownBy(() -> tjeneste.ferdigstillOppgave(OPPGAVE_ID)).isInstanceOf(TekniskException.class)
             .hasMessageContaining("Noe feilet ved ferdigstilling av oppgave");
-    }
-
-    @Test
-    void ferdigstille_oppgave_for_allerede_ferdigstilt_kaller_ikke_rest_klient() {
-        var tjeneste = lagTjeneste(lagScenario());
-        when(oppgaveRestKlient.hentOppgave(FERDIGSTILT_OPPGAVE.id().toString())).thenReturn(FERDIGSTILT_OPPGAVE);
-        tjeneste.ferdigstillOppgave(FERDIGSTILT_OPPGAVE.id().toString());
-        verify(oppgaveRestKlient, times(1)).hentOppgave(FERDIGSTILT_OPPGAVE.id().toString());
-        verify(oppgaveRestKlient, times(0)).ferdigstillOppgave(FERDIGSTILT_OPPGAVE.id().toString());
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
         <fp-ytelse-beregn.version>1.0.4</fp-ytelse-beregn.version>
         <fpkalkulus.kontrakt.version>1.0.2</fpkalkulus.kontrakt.version>
 
-        <felles.version>7.6.16</felles.version>
+        <felles.version>7.6.17</felles.version>
         <prosesstask.version>5.2.4</prosesstask.version>
         <openapi-spec-utils.version>2.1.0</openapi-spec-utils.version>
         <fp-kontrakter.version>9.4.29</fp-kontrakter.version>


### PR DESCRIPTION
* Fp-felles er oppdatert, og man trenger ikke lenger å gjøre sjekk på feilregistrert/ferdigstilt oppgave her
* Fjerner tester som ikke lenger er aktuelle
* Oppdaterer også kafka autoOffsetReset