### PR TITLE
TFP-6549 attribconvert til enumvalue - del2 uten udefinert

### DIFF
--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/personopplysning/PersonopplysningEntitet.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/personopplysning/PersonopplysningEntitet.java
@@ -9,6 +9,8 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Convert;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -44,7 +46,7 @@ public class PersonopplysningEntitet extends BaseEntitet implements HarAktørId,
     private NavBrukerKjønn brukerKjønn = NavBrukerKjønn.UDEFINERT;
 
     @ChangeTracked
-    @Convert(converter = SivilstandType.KodeverdiConverter.class)
+    @Enumerated(EnumType.STRING)
     @Column(name = "sivilstand_type", nullable = false)
     private SivilstandType sivilstand = SivilstandType.UOPPGITT;
 

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/personopplysning/SivilstandType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/personopplysning/SivilstandType.java
@@ -3,8 +3,7 @@ package no.nav.foreldrepenger.behandlingslager.behandling.personopplysning;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-import jakarta.persistence.AttributeConverter;
-import jakarta.persistence.Converter;
+import jakarta.persistence.EnumeratedValue;
 
 import com.fasterxml.jackson.annotation.JsonValue;
 
@@ -36,9 +35,11 @@ public enum SivilstandType implements Kodeverdi {
         }
     }
 
-    private String navn;
+    private final String navn;
+
     @JsonValue
-    private String kode;
+    @EnumeratedValue
+    private final String kode;
 
     SivilstandType(String kode, String navn) {
         this.kode = kode;
@@ -53,30 +54,6 @@ public enum SivilstandType implements Kodeverdi {
     @Override
     public String getNavn() {
         return navn;
-    }
-
-    @Converter(autoApply = true)
-    public static class KodeverdiConverter implements AttributeConverter<SivilstandType, String> {
-        @Override
-        public String convertToDatabaseColumn(SivilstandType attribute) {
-            return attribute == null ? null : attribute.getKode();
-        }
-
-        @Override
-        public SivilstandType convertToEntityAttribute(String dbData) {
-            return dbData == null ? null : fraKode(dbData);
-        }
-
-        private static SivilstandType fraKode(String kode) {
-            if (kode == null) {
-                return null;
-            }
-            var ad = KODER.get(kode);
-            if (ad == null) {
-                throw new IllegalArgumentException("Ukjent FagsakYtelseType: " + kode);
-            }
-            return ad;
-        }
     }
 
 }

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/tilbakekreving/TilbakekrevingValgEntitet.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/tilbakekreving/TilbakekrevingValgEntitet.java
@@ -5,6 +5,8 @@ import java.util.Objects;
 import jakarta.persistence.Column;
 import jakarta.persistence.Convert;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -45,7 +47,7 @@ class TilbakekrevingValgEntitet extends BaseEntitet {
     @Column(name = "varseltekst")
     private String varseltekst;
 
-    @Convert(converter = TilbakekrevingVidereBehandling.KodeverdiConverter.class)
+    @Enumerated(EnumType.STRING)
     @Column(name="videre_behandling")
     private TilbakekrevingVidereBehandling tilbakekrevningsVidereBehandling;
 

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/tilbakekreving/TilbakekrevingVidereBehandling.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/tilbakekreving/TilbakekrevingVidereBehandling.java
@@ -3,8 +3,7 @@ package no.nav.foreldrepenger.behandlingslager.behandling.tilbakekreving;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-import jakarta.persistence.AttributeConverter;
-import jakarta.persistence.Converter;
+import jakarta.persistence.EnumeratedValue;
 
 import com.fasterxml.jackson.annotation.JsonValue;
 
@@ -32,6 +31,7 @@ public enum TilbakekrevingVidereBehandling implements Kodeverdi {
     private final String navn;
 
     @JsonValue
+    @EnumeratedValue
     private final String kode;
 
     TilbakekrevingVidereBehandling(String kode, String navn) {
@@ -49,27 +49,4 @@ public enum TilbakekrevingVidereBehandling implements Kodeverdi {
         return kode;
     }
 
-    @Converter(autoApply = true)
-    public static class KodeverdiConverter implements AttributeConverter<TilbakekrevingVidereBehandling, String> {
-        @Override
-        public String convertToDatabaseColumn(TilbakekrevingVidereBehandling attribute) {
-            return attribute == null ? null : attribute.getKode();
-        }
-
-        @Override
-        public TilbakekrevingVidereBehandling convertToEntityAttribute(String dbData) {
-            return dbData == null ? null : fraKode(dbData);
-        }
-
-        private static TilbakekrevingVidereBehandling fraKode(String kode) {
-            if (kode == null) {
-                return null;
-            }
-            var ad = KODER.get(kode);
-            if (ad == null) {
-                throw new IllegalArgumentException("Ukjent TilbakekrevingVidereBehandling: " + kode);
-            }
-            return ad;
-        }
-    }
 }

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/tilrettelegging/TilretteleggingFOM.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/tilrettelegging/TilretteleggingFOM.java
@@ -5,7 +5,6 @@ import java.time.LocalDate;
 import java.util.Objects;
 
 import jakarta.persistence.Column;
-import jakarta.persistence.Convert;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -24,7 +23,7 @@ public class TilretteleggingFOM extends BaseEntitet {
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "SEQ_TILRETTELEGGING_FOM")
     private Long id;
 
-    @Convert(converter = TilretteleggingType.KodeverdiConverter.class)
+    @Enumerated(EnumType.STRING)
     @Column(name = "type", nullable = false)
     private TilretteleggingType type;
 

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/tilrettelegging/TilretteleggingType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/tilrettelegging/TilretteleggingType.java
@@ -3,8 +3,7 @@ package no.nav.foreldrepenger.behandlingslager.behandling.tilrettelegging;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-import jakarta.persistence.AttributeConverter;
-import jakarta.persistence.Converter;
+import jakarta.persistence.EnumeratedValue;
 
 import com.fasterxml.jackson.annotation.JsonValue;
 
@@ -30,6 +29,7 @@ public enum TilretteleggingType implements Kodeverdi {
     private final String navn;
 
     @JsonValue
+    @EnumeratedValue
     private final String kode;
 
     TilretteleggingType(String kode, String navn) {
@@ -47,27 +47,4 @@ public enum TilretteleggingType implements Kodeverdi {
         return kode;
     }
 
-    @Converter(autoApply = true)
-    public static class KodeverdiConverter implements AttributeConverter<TilretteleggingType, String> {
-        @Override
-        public String convertToDatabaseColumn(TilretteleggingType attribute) {
-            return attribute == null ? null : attribute.getKode();
-        }
-
-        @Override
-        public TilretteleggingType convertToEntityAttribute(String dbData) {
-            return dbData == null ? null : fraKode(dbData);
-        }
-
-        private static TilretteleggingType fraKode(String kode) {
-            if (kode == null) {
-                return null;
-            }
-            var ad = KODER.get(kode);
-            if (ad == null) {
-                throw new IllegalArgumentException("Ukjent TilretteleggingType: " + kode);
-            }
-            return ad;
-        }
-    }
 }

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/verge/VergeEntitet.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/verge/VergeEntitet.java
@@ -7,9 +7,10 @@ import java.util.Optional;
 import jakarta.persistence.AttributeOverride;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
-import jakarta.persistence.Convert;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -39,7 +40,7 @@ public class VergeEntitet extends BaseCreateableEntitet {
     @AttributeOverride(name = "tomDato", column = @Column(name = "gyldig_tom"))
     private DatoIntervallEntitet gyldigPeriode;
 
-    @Convert(converter = VergeType.KodeverdiConverter.class)
+    @Enumerated(EnumType.STRING)
     @Column(name = "verge_type", nullable = false)
     private VergeType vergeType;
 

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/verge/VergeType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/verge/VergeType.java
@@ -3,8 +3,7 @@ package no.nav.foreldrepenger.behandlingslager.behandling.verge;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-import jakarta.persistence.AttributeConverter;
-import jakarta.persistence.Converter;
+import jakarta.persistence.EnumeratedValue;
 
 import com.fasterxml.jackson.annotation.JsonValue;
 
@@ -32,6 +31,7 @@ public enum VergeType implements Kodeverdi {
     private final String navn;
 
     @JsonValue
+    @EnumeratedValue
     private final String kode;
 
     VergeType(String kode, String navn) {
@@ -49,28 +49,5 @@ public enum VergeType implements Kodeverdi {
         return kode;
     }
 
-    @Converter(autoApply = true)
-    public static class KodeverdiConverter implements AttributeConverter<VergeType, String> {
-        @Override
-        public String convertToDatabaseColumn(VergeType attribute) {
-            return attribute == null ? null : attribute.getKode();
-        }
-
-        @Override
-        public VergeType convertToEntityAttribute(String dbData) {
-            return dbData == null ? null : fraKode(dbData);
-        }
-
-        private static VergeType fraKode(String kode) {
-            if (kode == null) {
-                return null;
-            }
-            var ad = KODER.get(kode);
-            if (ad == null) {
-                throw new IllegalArgumentException("Ukjent VergeType: " + kode);
-            }
-            return ad;
-        }
-    }
 
 }

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/ytelsefordeling/periode/DokumentasjonVurdering.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/ytelsefordeling/periode/DokumentasjonVurdering.java
@@ -4,8 +4,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
 
-import jakarta.persistence.AttributeConverter;
-import jakarta.persistence.Converter;
+import jakarta.persistence.EnumeratedValue;
 
 import com.fasterxml.jackson.annotation.JsonValue;
 
@@ -72,11 +71,12 @@ public record DokumentasjonVurdering(Type type, MorsStillingsprosent morsStillin
             }
         }
 
-        private String navn;
+        private final String navn;
         @JsonValue
-        private String kode;
+        @EnumeratedValue
+        private final String kode;
 
-        private boolean godkjent;
+        private final boolean godkjent;
 
         Type(String kode, String navn, boolean godkjent) {
             this.kode = kode;
@@ -96,30 +96,6 @@ public record DokumentasjonVurdering(Type type, MorsStillingsprosent morsStillin
 
         public boolean erGodkjent() {
             return godkjent;
-        }
-
-        @Converter(autoApply = true)
-        public static class KodeverdiConverter implements AttributeConverter<Type, String> {
-            @Override
-            public String convertToDatabaseColumn(Type attribute) {
-                return attribute == null ? null : attribute.getKode();
-            }
-
-            @Override
-            public Type convertToEntityAttribute(String dbData) {
-                return dbData == null ? null : fraKode(dbData);
-            }
-
-            private static Type fraKode(String kode) {
-                if (kode == null) {
-                    return null;
-                }
-                var ad = KODER.get(kode);
-                if (ad == null) {
-                    throw new IllegalArgumentException("Ukjent Dokumentasjonsvurdering: " + kode);
-                }
-                return ad;
-            }
         }
     }
 }

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/ytelsefordeling/periode/FordelingPeriodeKilde.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/ytelsefordeling/periode/FordelingPeriodeKilde.java
@@ -3,8 +3,7 @@ package no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.period
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-import jakarta.persistence.AttributeConverter;
-import jakarta.persistence.Converter;
+import jakarta.persistence.EnumeratedValue;
 
 import com.fasterxml.jackson.annotation.JsonValue;
 
@@ -27,9 +26,10 @@ public enum FordelingPeriodeKilde implements Kodeverdi {
         }
     }
 
-    private String navn;
+    private final String navn;
     @JsonValue
-    private String kode;
+    @EnumeratedValue
+    private final String kode;
 
     FordelingPeriodeKilde(String kode, String navn) {
         this.kode = kode;
@@ -46,27 +46,4 @@ public enum FordelingPeriodeKilde implements Kodeverdi {
         return kode;
     }
 
-    @Converter(autoApply = true)
-    public static class KodeverdiConverter implements AttributeConverter<FordelingPeriodeKilde, String> {
-        @Override
-        public String convertToDatabaseColumn(FordelingPeriodeKilde attribute) {
-            return attribute == null ? null : attribute.getKode();
-        }
-
-        @Override
-        public FordelingPeriodeKilde convertToEntityAttribute(String dbData) {
-            return dbData == null ? null : fraKode(dbData);
-        }
-
-        private static FordelingPeriodeKilde fraKode(String kode) {
-            if (kode == null) {
-                return null;
-            }
-            var ad = KODER.get(kode);
-            if (ad == null) {
-                throw new IllegalArgumentException("Ukjent FordelingPeriodeKilde: " + kode);
-            }
-            return ad;
-        }
-    }
 }

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/ytelsefordeling/periode/OppgittPeriodeEntitet.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/ytelsefordeling/periode/OppgittPeriodeEntitet.java
@@ -9,6 +9,8 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Convert;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -111,8 +113,8 @@ public class OppgittPeriodeEntitet extends BaseEntitet implements IndexKey {
     @ChangeTracked
     private SamtidigUttaksprosent samtidigUttaksprosent;
 
+    @Enumerated(EnumType.STRING)
     @Column(name = "FORDELING_PERIODE_KILDE", nullable = false, updatable = false)
-    @Convert(converter = FordelingPeriodeKilde.KodeverdiConverter.class)
     private FordelingPeriodeKilde periodeKilde = FordelingPeriodeKilde.SØKNAD;
 
     //Hvis bruker søker om en periode flere ganger så oppdateres mottattDato med ny dato, men tidligst mottatt dato settes til
@@ -122,8 +124,8 @@ public class OppgittPeriodeEntitet extends BaseEntitet implements IndexKey {
     @Column(name = "tidligst_mottatt_dato")
     private LocalDate tidligstMottattDato;
 
+    @Enumerated(EnumType.STRING)
     @Column(name = "DOKUMENTASJON_VURDERING")
-    @Convert(converter = DokumentasjonVurdering.Type.KodeverdiConverter.class)
     private DokumentasjonVurdering.Type dokumentasjonVurderingType;
 
     @ChangeTracked

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/etterkontroll/Etterkontroll.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/etterkontroll/Etterkontroll.java
@@ -6,6 +6,8 @@ import java.util.Objects;
 import jakarta.persistence.Column;
 import jakarta.persistence.Convert;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -32,7 +34,7 @@ public class Etterkontroll extends BaseEntitet {
     @Column(name = "kontroll_tid", nullable = false)
     private LocalDateTime kontrollTidspunkt;
 
-    @Convert(converter = KontrollType.KodeverdiConverter.class)
+    @Enumerated(EnumType.STRING)
     @Column(name = "kontroll_type", nullable = false)
     private KontrollType kontrollType;
 

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/etterkontroll/KontrollType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/etterkontroll/KontrollType.java
@@ -3,8 +3,7 @@ package no.nav.foreldrepenger.behandlingslager.etterkontroll;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-import jakarta.persistence.AttributeConverter;
-import jakarta.persistence.Converter;
+import jakarta.persistence.EnumeratedValue;
 
 import com.fasterxml.jackson.annotation.JsonValue;
 
@@ -21,6 +20,7 @@ public enum KontrollType implements Kodeverdi {
     private final String navn;
 
     @JsonValue
+    @EnumeratedValue
     private final String kode;
 
     KontrollType(String kode, String navn) {
@@ -46,28 +46,5 @@ public enum KontrollType implements Kodeverdi {
         }
     }
 
-    @Converter(autoApply = true)
-    public static class KodeverdiConverter implements AttributeConverter<KontrollType, String> {
-        @Override
-        public String convertToDatabaseColumn(KontrollType attribute) {
-            return attribute == null ? null : attribute.getKode();
-        }
-
-        @Override
-        public KontrollType convertToEntityAttribute(String dbData) {
-            return dbData == null ? null : fraKode(dbData);
-        }
-
-        private static KontrollType fraKode(String kode) {
-            if (kode == null) {
-                return null;
-            }
-            var ad = KODER.get(kode);
-            if (ad == null) {
-                throw new IllegalArgumentException("Ukjent KontrollType: " + kode);
-            }
-            return ad;
-        }
-    }
 
 }

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/fagsak/Fagsak.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/fagsak/Fagsak.java
@@ -7,6 +7,8 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Convert;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -49,7 +51,7 @@ public class Fagsak extends BaseEntitet {
     @Column(name = "bruker_rolle", nullable = false)
     private RelasjonsRolleType brukerRolle = RelasjonsRolleType.UDEFINERT;
 
-    @Convert(converter = FagsakStatus.KodeverdiConverter.class)
+    @Enumerated(EnumType.STRING)
     @Column(name = "fagsak_status", nullable = false)
     private FagsakStatus fagsakStatus = FagsakStatus.DEFAULT;
 

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/fagsak/FagsakStatus.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/fagsak/FagsakStatus.java
@@ -3,8 +3,7 @@ package no.nav.foreldrepenger.behandlingslager.fagsak;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-import jakarta.persistence.AttributeConverter;
-import jakarta.persistence.Converter;
+import jakarta.persistence.EnumeratedValue;
 
 import com.fasterxml.jackson.annotation.JsonValue;
 
@@ -31,6 +30,7 @@ public enum FagsakStatus implements Kodeverdi {
 
     private final String navn;
     @JsonValue
+    @EnumeratedValue
     private final String kode;
 
     FagsakStatus(String kode, String navn) {
@@ -48,29 +48,5 @@ public enum FagsakStatus implements Kodeverdi {
         return kode;
     }
 
-    @Converter(autoApply = true)
-    public static class KodeverdiConverter implements AttributeConverter<FagsakStatus, String> {
-        @Override
-        public String convertToDatabaseColumn(FagsakStatus attribute) {
-            return attribute == null ? null : attribute.getKode();
-        }
-
-        @Override
-        public FagsakStatus convertToEntityAttribute(String dbData) {
-            return dbData == null ? null : fraKode(dbData);
-        }
-
-        private static FagsakStatus fraKode(String kode) {
-            if (kode == null) {
-                return null;
-            }
-            var ad = KODER.get(kode);
-            if (ad == null) {
-                throw new IllegalArgumentException("Ukjent FagsakStatus: " + kode);
-            }
-            return ad;
-        }
-
-    }
 
 }

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/uttak/fp/UttakResultatPeriodeSøknadEntitet.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/uttak/fp/UttakResultatPeriodeSøknadEntitet.java
@@ -8,6 +8,8 @@ import java.util.Optional;
 import jakarta.persistence.Column;
 import jakarta.persistence.Convert;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -57,8 +59,8 @@ public class UttakResultatPeriodeSøknadEntitet extends BaseEntitet {
     @Convert(converter = MorsAktivitet.KodeverdiConverter.class)
     private MorsAktivitet morsAktivitet = MorsAktivitet.UDEFINERT;
 
+    @Enumerated(EnumType.STRING)
     @Column(name = "DOKUMENTASJON_VURDERING")
-    @Convert(converter = DokumentasjonVurdering.Type.KodeverdiConverter.class)
     private DokumentasjonVurdering.Type dokumentasjonVurderingType;
 
     @ChangeTracked

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/økonomioppdrag/OppdragKvittering.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/økonomioppdrag/OppdragKvittering.java
@@ -3,8 +3,9 @@ package no.nav.foreldrepenger.behandlingslager.økonomioppdrag;
 import java.util.Objects;
 
 import jakarta.persistence.Column;
-import jakarta.persistence.Convert;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -24,7 +25,7 @@ public class OppdragKvittering extends BaseCreateableEntitet {
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "SEQ_OPPDRAG_KVITTERING")
     private Long id;
 
-    @Convert(converter = Alvorlighetsgrad.KodeverdiConverter.class)
+    @Enumerated(EnumType.STRING)
     @Column(name = "alvorlighetsgrad")
     private Alvorlighetsgrad alvorlighetsgrad;
 

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/økonomioppdrag/koder/Alvorlighetsgrad.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/økonomioppdrag/koder/Alvorlighetsgrad.java
@@ -4,8 +4,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
 
-import jakarta.persistence.AttributeConverter;
-import jakarta.persistence.Converter;
+import jakarta.persistence.EnumeratedValue;
 
 public enum Alvorlighetsgrad {
     OK("00"),
@@ -23,6 +22,7 @@ public enum Alvorlighetsgrad {
         }
     }
 
+    @EnumeratedValue
     private final String kode;
 
     Alvorlighetsgrad(String kode) {
@@ -40,18 +40,5 @@ public enum Alvorlighetsgrad {
 
     public String getKode() {
         return kode;
-    }
-
-    @Converter(autoApply = true)
-    public static class KodeverdiConverter implements AttributeConverter<Alvorlighetsgrad, String> {
-        @Override
-        public String convertToDatabaseColumn(Alvorlighetsgrad attribute) {
-            return attribute.getKode();
-        }
-
-        @Override
-        public Alvorlighetsgrad convertToEntityAttribute(String dbData) {
-            return fraKode(dbData);
-        }
     }
 }


### PR DESCRIPTION
Resten av tilfellene som ikke hadde UDEFINERT, men som hadde en kode
Så har vi ett tilfelle av plain Enum uten kode. 
Vi har tenkt på et DatabaseKode interface og Opus foreslår det samme for å indikere at en enum brukes for kolonner.
Det blir neste tiltak å innføre en Databaseverdi for alle tilfellene - litt ReflectionApi bør løse dette.