### PR TITLE
TFP-6549 innfør grensesnitt DatabaseKode

### DIFF
--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/aktør/AdresseType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/aktør/AdresseType.java
@@ -8,9 +8,10 @@ import jakarta.persistence.EnumeratedValue;
 
 import com.fasterxml.jackson.annotation.JsonValue;
 
+import no.nav.foreldrepenger.behandlingslager.kodeverk.DatabaseKode;
 import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
 
-public enum AdresseType implements Kodeverdi {
+public enum AdresseType implements Kodeverdi, DatabaseKode {
 
     BOSTEDSADRESSE("BOSTEDSADRESSE", "Bostedsadresse"),
     BOSTEDSADRESSE_UTLAND("BOSTEDSADRESSE_UTLAND", "Bostedsadresse utland"),

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/aktør/NavBrukerKjønn.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/aktør/NavBrukerKjønn.java
@@ -8,9 +8,10 @@ import jakarta.persistence.Converter;
 
 import com.fasterxml.jackson.annotation.JsonValue;
 
+import no.nav.foreldrepenger.behandlingslager.kodeverk.DatabaseKode;
 import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
 
-public enum NavBrukerKjønn implements Kodeverdi {
+public enum NavBrukerKjønn implements Kodeverdi, DatabaseKode {
 
     KVINNE("K", "Kvinne"),
     MANN("M", "Mann"),

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/aktør/OppholdstillatelseType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/aktør/OppholdstillatelseType.java
@@ -4,9 +4,10 @@ import jakarta.persistence.EnumeratedValue;
 
 import com.fasterxml.jackson.annotation.JsonValue;
 
+import no.nav.foreldrepenger.behandlingslager.kodeverk.DatabaseKode;
 import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
 
-public enum OppholdstillatelseType implements Kodeverdi {
+public enum OppholdstillatelseType implements Kodeverdi, DatabaseKode {
 
     MIDLERTIDIG("MIDLERTIDIG", "Midlertidig oppholdstillatelse"),
     PERMANENT("PERMANENT", "Permanent oppholdstillatelse"),

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/aktør/PersonstatusType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/aktør/PersonstatusType.java
@@ -8,9 +8,10 @@ import jakarta.persistence.Converter;
 
 import com.fasterxml.jackson.annotation.JsonValue;
 
+import no.nav.foreldrepenger.behandlingslager.kodeverk.DatabaseKode;
 import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
 
-public enum PersonstatusType implements Kodeverdi {
+public enum PersonstatusType implements Kodeverdi, DatabaseKode {
 
     ADNR("ADNR", "D-nummer"),
     BOSA("BOSA", "Bosatt (f.reg)"),

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/BehandlingResultatType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/BehandlingResultatType.java
@@ -8,9 +8,10 @@ import jakarta.persistence.EnumeratedValue;
 
 import com.fasterxml.jackson.annotation.JsonValue;
 
+import no.nav.foreldrepenger.behandlingslager.kodeverk.DatabaseKode;
 import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
 
-public enum BehandlingResultatType implements Kodeverdi {
+public enum BehandlingResultatType implements Kodeverdi, DatabaseKode {
 
     IKKE_FASTSATT("IKKE_FASTSATT", "Ikke fastsatt"),
     INNVILGET("INNVILGET", "Innvilget"),

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/BehandlingStatus.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/BehandlingStatus.java
@@ -8,13 +8,14 @@ import jakarta.persistence.EnumeratedValue;
 
 import com.fasterxml.jackson.annotation.JsonValue;
 
+import no.nav.foreldrepenger.behandlingslager.kodeverk.DatabaseKode;
 import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
 
 /**
  * NB: Pass på! Ikke legg koder vilkårlig her
  * Denne definerer etablerte behandlingstatuser ihht. modell angitt av FFA (Forretning og Fag).
  */
-public enum BehandlingStatus implements Kodeverdi {
+public enum BehandlingStatus implements Kodeverdi, DatabaseKode {
 
     AVSLUTTET("AVSLU", "Avsluttet"),
     FATTER_VEDTAK("FVED", "Fatter vedtak"),

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/BehandlingStegStatus.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/BehandlingStegStatus.java
@@ -12,6 +12,7 @@ import jakarta.persistence.Converter;
 
 import com.fasterxml.jackson.annotation.JsonValue;
 
+import no.nav.foreldrepenger.behandlingslager.kodeverk.DatabaseKode;
 import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
 
 /**
@@ -20,7 +21,7 @@ import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
  * Kommer kun til anvendelse dersom det oppstår aksjonspunkter eller noe må legges på vent i et steg. Hvis ikke
  * flyter et rett igjennom til UTFØRT.
  */
-public enum BehandlingStegStatus implements Kodeverdi {
+public enum BehandlingStegStatus implements Kodeverdi, DatabaseKode {
 
     /** midlertidig intern tilstand når steget startes (etter inngang). */
     STARTET("STARTET", "Steget er startet"),

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/BehandlingStegType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/BehandlingStegType.java
@@ -13,9 +13,10 @@ import com.fasterxml.jackson.annotation.JsonValue;
 
 import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.AksjonspunktDefinisjon;
 import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.VurderingspunktType;
+import no.nav.foreldrepenger.behandlingslager.kodeverk.DatabaseKode;
 import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
 
-public enum BehandlingStegType implements Kodeverdi {
+public enum BehandlingStegType implements Kodeverdi, DatabaseKode {
 
     // Steg koder som deles av alle ytelser
     REGISTRER_SØKNAD("REGSØK", "Registrer søknad", UTREDES),

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/BehandlingType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/BehandlingType.java
@@ -9,10 +9,11 @@ import jakarta.persistence.Converter;
 
 import com.fasterxml.jackson.annotation.JsonValue;
 
+import no.nav.foreldrepenger.behandlingslager.kodeverk.DatabaseKode;
 import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
 import no.nav.foreldrepenger.behandlingslager.kodeverk.MedOffisiellKode;
 
-public enum BehandlingType implements Kodeverdi, MedOffisiellKode {
+public enum BehandlingType implements Kodeverdi, DatabaseKode, MedOffisiellKode {
 
     /**
      * Konstanter for å skrive ned kodeverdi. For å hente ut andre data konfigurert, må disse leses fra databasen (eks.

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/BehandlingÅrsakType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/BehandlingÅrsakType.java
@@ -9,9 +9,10 @@ import jakarta.persistence.Converter;
 
 import com.fasterxml.jackson.annotation.JsonValue;
 
+import no.nav.foreldrepenger.behandlingslager.kodeverk.DatabaseKode;
 import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
 
-public enum BehandlingÅrsakType implements Kodeverdi {
+public enum BehandlingÅrsakType implements Kodeverdi, DatabaseKode {
 
     // MANUELL OPPRETTING - GUI-anvendelse
     RE_FEIL_I_LOVANDVENDELSE("RE-LOV", "Lovanvendelse"),

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/DokumentKategori.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/DokumentKategori.java
@@ -10,10 +10,11 @@ import jakarta.persistence.Converter;
 
 import com.fasterxml.jackson.annotation.JsonValue;
 
+import no.nav.foreldrepenger.behandlingslager.kodeverk.DatabaseKode;
 import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
 import no.nav.foreldrepenger.behandlingslager.kodeverk.MedOffisiellKode;
 
-public enum DokumentKategori implements Kodeverdi, MedOffisiellKode {
+public enum DokumentKategori implements Kodeverdi, DatabaseKode, MedOffisiellKode {
 
     UDEFINERT(STANDARDKODE_UDEFINERT, "Ikke definert", null),
     KLAGE_ELLER_ANKE("KLGA", "Klage eller anke", "KA"),

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/DokumentTypeId.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/DokumentTypeId.java
@@ -16,6 +16,7 @@ import jakarta.persistence.Converter;
 
 import com.fasterxml.jackson.annotation.JsonValue;
 
+import no.nav.foreldrepenger.behandlingslager.kodeverk.DatabaseKode;
 import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
 import no.nav.foreldrepenger.behandlingslager.kodeverk.MedOffisiellKode;
 
@@ -42,7 +43,7 @@ import no.nav.foreldrepenger.behandlingslager.kodeverk.MedOffisiellKode;
  * - select skjemanummer, count(1) from SOEKNAD_VEDLEGG group by skjemanummer;
  * - select type, count(*) from MOTTATT_DOKUMENT group by type;
  */
-public enum DokumentTypeId implements Kodeverdi, MedOffisiellKode {
+public enum DokumentTypeId implements Kodeverdi, DatabaseKode, MedOffisiellKode {
 
     // Søknader
     SØKNAD_SVANGERSKAPSPENGER("SØKNAD_SVANGERSKAPSPENGER", "I000001", "Søknad om svangerskapspenger"),

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/KonsekvensForYtelsen.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/KonsekvensForYtelsen.java
@@ -7,9 +7,10 @@ import jakarta.persistence.EnumeratedValue;
 
 import com.fasterxml.jackson.annotation.JsonValue;
 
+import no.nav.foreldrepenger.behandlingslager.kodeverk.DatabaseKode;
 import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
 
-public enum KonsekvensForYtelsen implements Kodeverdi{
+public enum KonsekvensForYtelsen implements Kodeverdi, DatabaseKode{
 
     FORELDREPENGER_OPPHØRER("FORELDREPENGER_OPPHØRER", "Foreldrepenger opphører"),
     ENDRING_I_BEREGNING("ENDRING_I_BEREGNING", "Endring i beregning"),

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/RettenTil.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/RettenTil.java
@@ -8,9 +8,10 @@ import jakarta.persistence.Converter;
 
 import com.fasterxml.jackson.annotation.JsonValue;
 
+import no.nav.foreldrepenger.behandlingslager.kodeverk.DatabaseKode;
 import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
 
-public enum RettenTil implements Kodeverdi {
+public enum RettenTil implements Kodeverdi, DatabaseKode {
 
     HAR_RETT_TIL_FP("HAR_RETT_TIL_FP", "Bruker har rett til foreldrepenger"),
     HAR_IKKE_RETT_TIL_FP("HAR_IKKE_RETT_TIL_FP", "Bruker har ikke rett til foreldrepenger"),

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/aksjonspunkt/AksjonspunktDefinisjon.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/aksjonspunkt/AksjonspunktDefinisjon.java
@@ -33,13 +33,14 @@ import no.nav.foreldrepenger.behandlingslager.behandling.skjermlenke.Skjermlenke
 import no.nav.foreldrepenger.behandlingslager.behandling.vilkår.VilkårType;
 import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakYtelseType;
 import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakYtelseType.YtelseType;
+import no.nav.foreldrepenger.behandlingslager.kodeverk.DatabaseKode;
 import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
 
 /**
  * Definerer mulige Aksjonspunkter inkludert hvilket Vurderingspunkt de må løses i.
  * Inkluderer også konstanter for å enklere kunne referere til dem i eksisterende logikk.
  */
-public enum AksjonspunktDefinisjon implements Kodeverdi {
+public enum AksjonspunktDefinisjon implements Kodeverdi, DatabaseKode {
 
     // Gruppe : 500
 

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/aksjonspunkt/AksjonspunktStatus.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/aksjonspunkt/AksjonspunktStatus.java
@@ -9,9 +9,10 @@ import jakarta.persistence.EnumeratedValue;
 
 import com.fasterxml.jackson.annotation.JsonValue;
 
+import no.nav.foreldrepenger.behandlingslager.kodeverk.DatabaseKode;
 import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
 
-public enum AksjonspunktStatus implements Kodeverdi {
+public enum AksjonspunktStatus implements Kodeverdi, DatabaseKode {
 
     AVBRUTT ("AVBR", "Avbrutt"),
     OPPRETTET("OPPR", "Opprettet"),

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/aksjonspunkt/Venteårsak.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/aksjonspunkt/Venteårsak.java
@@ -8,9 +8,10 @@ import jakarta.persistence.Converter;
 
 import com.fasterxml.jackson.annotation.JsonValue;
 
+import no.nav.foreldrepenger.behandlingslager.kodeverk.DatabaseKode;
 import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
 
-public enum Venteårsak implements Kodeverdi {
+public enum Venteårsak implements Kodeverdi, DatabaseKode {
 
     UDEFINERT(STANDARDKODE_UDEFINERT, "Ikke definert"),
 

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/aksjonspunkt/VurderÅrsak.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/aksjonspunkt/VurderÅrsak.java
@@ -8,9 +8,10 @@ import jakarta.persistence.Converter;
 
 import com.fasterxml.jackson.annotation.JsonValue;
 
+import no.nav.foreldrepenger.behandlingslager.kodeverk.DatabaseKode;
 import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
 
-public enum VurderÅrsak implements Kodeverdi {
+public enum VurderÅrsak implements Kodeverdi, DatabaseKode {
 
     FEIL_FAKTA("FEIL_FAKTA", "Fakta"),
     FEIL_LOV("FEIL_LOV", "Regel-/lovanvendelse"),

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/aktivitetskrav/AktivitetskravPermisjonType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/aktivitetskrav/AktivitetskravPermisjonType.java
@@ -8,9 +8,10 @@ import jakarta.persistence.Converter;
 
 import com.fasterxml.jackson.annotation.JsonValue;
 
+import no.nav.foreldrepenger.behandlingslager.kodeverk.DatabaseKode;
 import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
 
-public enum AktivitetskravPermisjonType implements Kodeverdi {
+public enum AktivitetskravPermisjonType implements Kodeverdi, DatabaseKode {
 
     UDEFINERT(STANDARDKODE_UDEFINERT, "Ikke definert"),
     UTDANNING("UTDANNING", "Utdanning"),

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/anke/AnkeOmgjørÅrsak.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/anke/AnkeOmgjørÅrsak.java
@@ -8,9 +8,10 @@ import jakarta.persistence.Converter;
 
 import com.fasterxml.jackson.annotation.JsonValue;
 
+import no.nav.foreldrepenger.behandlingslager.kodeverk.DatabaseKode;
 import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
 
-public enum AnkeOmgjørÅrsak implements Kodeverdi {
+public enum AnkeOmgjørÅrsak implements Kodeverdi, DatabaseKode {
 
     NYE_OPPLYSNINGER("NYE_OPPLYSNINGER", "Nye opplysninger"),
     ULIK_REGELVERKSTOLKNING("ULIK_REGELVERKSTOLKNING", "Ulik regelverkstolkning"),

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/anke/AnkeVurdering.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/anke/AnkeVurdering.java
@@ -9,9 +9,10 @@ import jakarta.persistence.Converter;
 
 import com.fasterxml.jackson.annotation.JsonValue;
 
+import no.nav.foreldrepenger.behandlingslager.kodeverk.DatabaseKode;
 import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
 
-public enum AnkeVurdering implements Kodeverdi {
+public enum AnkeVurdering implements Kodeverdi, DatabaseKode {
 
     ANKE_STADFESTE_YTELSESVEDTAK("ANKE_STADFESTE_YTELSESVEDTAK", "Ytelsesvedtaket stadfestes"),
     ANKE_HJEMSEND_UTEN_OPPHEV("ANKE_HJEMSENDE_UTEN_OPPHEV", "Hjemsende uten å oppheve"),

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/anke/AnkeVurderingOmgjør.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/anke/AnkeVurderingOmgjør.java
@@ -8,9 +8,10 @@ import jakarta.persistence.Converter;
 
 import com.fasterxml.jackson.annotation.JsonValue;
 
+import no.nav.foreldrepenger.behandlingslager.kodeverk.DatabaseKode;
 import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
 
-public enum AnkeVurderingOmgjør implements Kodeverdi {
+public enum AnkeVurderingOmgjør implements Kodeverdi, DatabaseKode {
 
     ANKE_TIL_GUNST("ANKE_TIL_GUNST", "Gunst omgjør i anke"),
     ANKE_DELVIS_OMGJOERING_TIL_GUNST("ANKE_DELVIS_OMGJOERING_TIL_GUNST", "Delvis omgjøring, til gunst i anke"),

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/arbeidsforhold/ArbeidsforholdKomplettVurderingType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/arbeidsforhold/ArbeidsforholdKomplettVurderingType.java
@@ -8,9 +8,10 @@ import jakarta.persistence.Converter;
 
 import com.fasterxml.jackson.annotation.JsonValue;
 
+import no.nav.foreldrepenger.behandlingslager.kodeverk.DatabaseKode;
 import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
 
-public enum ArbeidsforholdKomplettVurderingType implements Kodeverdi {
+public enum ArbeidsforholdKomplettVurderingType implements Kodeverdi, DatabaseKode {
 
     KONTAKT_ARBEIDSGIVER_VED_MANGLENDE_INNTEKTSMELDING("KONTAKT_ARBEIDSGIVER_VED_MANGLENDE_INNTEKTSMELDING", "Saksbehandler kontakter arbeidsgiver for å avklare manglende inntektsmelding"),
     FORTSETT_UTEN_INNTEKTSMELDING("FORTSETT_UTEN_INNTEKTSMELDING", "Behandlingen kan fortsette uten inntektsmelding for dette arbeidsforholdet"),

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/beregning/AktivitetStatus.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/beregning/AktivitetStatus.java
@@ -16,10 +16,11 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonValue;
 
+import no.nav.foreldrepenger.behandlingslager.kodeverk.DatabaseKode;
 import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
 
 @JsonAutoDetect(getterVisibility = Visibility.NONE, setterVisibility = Visibility.NONE, fieldVisibility = Visibility.ANY)
-public enum AktivitetStatus implements Kodeverdi {
+public enum AktivitetStatus implements Kodeverdi, DatabaseKode {
     ARBEIDSAVKLARINGSPENGER("AAP", "Arbeidsavklaringspenger", Inntektskategori.ARBEIDSAVKLARINGSPENGER),
     ARBEIDSTAKER("AT", "Arbeidstaker", Inntektskategori.ARBEIDSTAKER),
     DAGPENGER("DP", "Dagpenger", Inntektskategori.DAGPENGER),

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/beregning/BeregningSatsType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/beregning/BeregningSatsType.java
@@ -8,9 +8,10 @@ import jakarta.persistence.Converter;
 
 import com.fasterxml.jackson.annotation.JsonValue;
 
+import no.nav.foreldrepenger.behandlingslager.kodeverk.DatabaseKode;
 import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
 
-public enum BeregningSatsType implements Kodeverdi {
+public enum BeregningSatsType implements Kodeverdi, DatabaseKode {
     ENGANG("ENGANG", "Engangsstønad"),
     GRUNNBELØP("GRUNNBELØP", "Grunnbeløp"),
     GSNITT("GSNITT", "Grunnbeløp årsgjennomsnitt"),

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/beregning/Inntektskategori.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/beregning/Inntektskategori.java
@@ -9,9 +9,10 @@ import jakarta.persistence.Converter;
 
 import com.fasterxml.jackson.annotation.JsonValue;
 
+import no.nav.foreldrepenger.behandlingslager.kodeverk.DatabaseKode;
 import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
 
-public enum Inntektskategori implements Kodeverdi {
+public enum Inntektskategori implements Kodeverdi, DatabaseKode {
 
     ARBEIDSTAKER("ARBEIDSTAKER", "Arbeidstaker"),
     FRILANSER("FRILANSER", "Frilanser"),

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/dokument/DokumentMalType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/dokument/DokumentMalType.java
@@ -8,9 +8,10 @@ import jakarta.persistence.EnumeratedValue;
 
 import com.fasterxml.jackson.annotation.JsonValue;
 
+import no.nav.foreldrepenger.behandlingslager.kodeverk.DatabaseKode;
 import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
 
-public enum DokumentMalType implements Kodeverdi {
+public enum DokumentMalType implements Kodeverdi, DatabaseKode {
 
     FRITEKSTBREV("FRITEK"),
     VEDTAKSBREV_FRITEKST_HTML("FRIHTM"),

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/familiehendelse/FamilieHendelseType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/familiehendelse/FamilieHendelseType.java
@@ -8,9 +8,10 @@ import jakarta.persistence.Converter;
 
 import com.fasterxml.jackson.annotation.JsonValue;
 
+import no.nav.foreldrepenger.behandlingslager.kodeverk.DatabaseKode;
 import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
 
-public enum FamilieHendelseType implements Kodeverdi {
+public enum FamilieHendelseType implements Kodeverdi, DatabaseKode {
 
     ADOPSJON("ADPSJN", "Adopsjon"),
     OMSORG("OMSRGO", "Omsorgoverdragelse"),

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/familiehendelse/OmsorgsovertakelseVilkårType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/familiehendelse/OmsorgsovertakelseVilkårType.java
@@ -12,9 +12,10 @@ import jakarta.persistence.Converter;
 import com.fasterxml.jackson.annotation.JsonValue;
 
 import no.nav.foreldrepenger.behandlingslager.behandling.vilkår.Avslagsårsak;
+import no.nav.foreldrepenger.behandlingslager.kodeverk.DatabaseKode;
 import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
 
-public enum OmsorgsovertakelseVilkårType implements Kodeverdi {
+public enum OmsorgsovertakelseVilkårType implements Kodeverdi, DatabaseKode {
 
     ES_ADOPSJONSVILKÅRET("FP_VK_4", "Adopsjon § 14-17 første ledd",
         Avslagsårsak.EKTEFELLES_SAMBOERS_BARN,

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/historikk/HistorikkAktør.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/historikk/HistorikkAktør.java
@@ -7,9 +7,10 @@ import jakarta.persistence.EnumeratedValue;
 
 import com.fasterxml.jackson.annotation.JsonValue;
 
+import no.nav.foreldrepenger.behandlingslager.kodeverk.DatabaseKode;
 import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
 
-public enum HistorikkAktør implements Kodeverdi {
+public enum HistorikkAktør implements Kodeverdi, DatabaseKode {
 
     BESLUTTER("BESL", "Beslutter"),
     SAKSBEHANDLER("SBH", "Saksbehandler"),

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/historikk/HistorikkinnslagLinjeType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/historikk/HistorikkinnslagLinjeType.java
@@ -1,6 +1,8 @@
 package no.nav.foreldrepenger.behandlingslager.behandling.historikk;
 
-public enum HistorikkinnslagLinjeType {
+import no.nav.foreldrepenger.behandlingslager.kodeverk.DatabaseKode;
+
+public enum HistorikkinnslagLinjeType implements DatabaseKode {
     TEKST,
     LINJESKIFT
 }

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/innsyn/InnsynResultatType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/innsyn/InnsynResultatType.java
@@ -8,9 +8,10 @@ import jakarta.persistence.Converter;
 
 import com.fasterxml.jackson.annotation.JsonValue;
 
+import no.nav.foreldrepenger.behandlingslager.kodeverk.DatabaseKode;
 import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
 
-public enum InnsynResultatType implements Kodeverdi {
+public enum InnsynResultatType implements Kodeverdi, DatabaseKode {
 
     INNVILGET("INNV", "Innvilget innsyn"),
     DELVIS_INNVILGET("DELV", "Delvis innvilget innsyn"),

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/klage/KlageHjemmel.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/klage/KlageHjemmel.java
@@ -16,9 +16,10 @@ import jakarta.persistence.Converter;
 import com.fasterxml.jackson.annotation.JsonValue;
 
 import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakYtelseType;
+import no.nav.foreldrepenger.behandlingslager.kodeverk.DatabaseKode;
 import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
 
-public enum KlageHjemmel implements Kodeverdi {
+public enum KlageHjemmel implements Kodeverdi, DatabaseKode {
 
     MEDLEM("14-02", "14-2 Medlemskap", "FTRL_14_2", Set.of(ES, FP, SVP)),
     SVANGERSKAP("14-04", "14-4 Svangerskapspenger", "FTRL_14_4", Set.of(SVP)),

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/klage/KlageMedholdÅrsak.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/klage/KlageMedholdÅrsak.java
@@ -8,9 +8,10 @@ import jakarta.persistence.Converter;
 
 import com.fasterxml.jackson.annotation.JsonValue;
 
+import no.nav.foreldrepenger.behandlingslager.kodeverk.DatabaseKode;
 import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
 
-public enum KlageMedholdÅrsak implements Kodeverdi {
+public enum KlageMedholdÅrsak implements Kodeverdi, DatabaseKode {
 
     NYE_OPPLYSNINGER("NYE_OPPLYSNINGER", "Nytt faktum"),
     ULIK_REGELVERKSTOLKNING("ULIK_REGELVERKSTOLKNING", "Feil lovanvendelse"),

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/klage/KlageVurdering.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/klage/KlageVurdering.java
@@ -8,9 +8,10 @@ import jakarta.persistence.Converter;
 
 import com.fasterxml.jackson.annotation.JsonValue;
 
+import no.nav.foreldrepenger.behandlingslager.kodeverk.DatabaseKode;
 import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
 
-public enum KlageVurdering implements Kodeverdi {
+public enum KlageVurdering implements Kodeverdi, DatabaseKode {
 
     OPPHEVE_YTELSESVEDTAK("OPPHEVE_YTELSESVEDTAK", "Ytelsesvedtaket oppheves"),
     STADFESTE_YTELSESVEDTAK("STADFESTE_YTELSESVEDTAK", "Ytelsesvedtaket stadfestes"),

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/klage/KlageVurderingOmgjør.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/klage/KlageVurderingOmgjør.java
@@ -8,9 +8,10 @@ import jakarta.persistence.Converter;
 
 import com.fasterxml.jackson.annotation.JsonValue;
 
+import no.nav.foreldrepenger.behandlingslager.kodeverk.DatabaseKode;
 import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
 
-public enum KlageVurderingOmgjør implements Kodeverdi {
+public enum KlageVurderingOmgjør implements Kodeverdi, DatabaseKode {
 
     GUNST_MEDHOLD_I_KLAGE("GUNST_MEDHOLD_I_KLAGE", "Gunst medhold i klage"),
     DELVIS_MEDHOLD_I_KLAGE("DELVIS_MEDHOLD_I_KLAGE", "Delvis medhold i klage"),

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/klage/KlageVurdertAv.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/klage/KlageVurdertAv.java
@@ -7,9 +7,10 @@ import jakarta.persistence.EnumeratedValue;
 
 import com.fasterxml.jackson.annotation.JsonValue;
 
+import no.nav.foreldrepenger.behandlingslager.kodeverk.DatabaseKode;
 import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
 
-public enum KlageVurdertAv implements Kodeverdi {
+public enum KlageVurdertAv implements Kodeverdi, DatabaseKode {
 
     NFP("NFP", "Nav familie- og pensjonsytelser"),
     NK("NK", "Nav klageinstans"),

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/medlemskap/MedlemskapDekningType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/medlemskap/MedlemskapDekningType.java
@@ -12,9 +12,10 @@ import jakarta.persistence.Converter;
 
 import com.fasterxml.jackson.annotation.JsonValue;
 
+import no.nav.foreldrepenger.behandlingslager.kodeverk.DatabaseKode;
 import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
 
-public enum MedlemskapDekningType implements Kodeverdi {
+public enum MedlemskapDekningType implements Kodeverdi, DatabaseKode {
 
     FTL_2_6("FTL_2_6", "Folketrygdloven § 2-6"),
     FTL_2_7_A("FTL_2_7_a", "Folketrygdloven § 2-7 tredje ledd bokstav a"),

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/medlemskap/MedlemskapKildeType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/medlemskap/MedlemskapKildeType.java
@@ -8,9 +8,10 @@ import jakarta.persistence.Converter;
 
 import com.fasterxml.jackson.annotation.JsonValue;
 
+import no.nav.foreldrepenger.behandlingslager.kodeverk.DatabaseKode;
 import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
 
-public enum MedlemskapKildeType implements Kodeverdi {
+public enum MedlemskapKildeType implements Kodeverdi, DatabaseKode {
 
     E500("E500", "E-500"),
     INFOTR("INFOTR", "Infotrygd"),

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/medlemskap/MedlemskapManuellVurderingType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/medlemskap/MedlemskapManuellVurderingType.java
@@ -10,9 +10,10 @@ import jakarta.persistence.Converter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonValue;
 
+import no.nav.foreldrepenger.behandlingslager.kodeverk.DatabaseKode;
 import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
 
-public enum MedlemskapManuellVurderingType implements Kodeverdi {
+public enum MedlemskapManuellVurderingType implements Kodeverdi, DatabaseKode {
 
     UDEFINERT(STANDARDKODE_UDEFINERT, "Ikke definert"),
     MEDLEM("MEDLEM", "Periode med medlemskap"),

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/medlemskap/MedlemskapType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/medlemskap/MedlemskapType.java
@@ -8,9 +8,10 @@ import jakarta.persistence.Converter;
 
 import com.fasterxml.jackson.annotation.JsonValue;
 
+import no.nav.foreldrepenger.behandlingslager.kodeverk.DatabaseKode;
 import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
 
-public enum MedlemskapType implements Kodeverdi {
+public enum MedlemskapType implements Kodeverdi, DatabaseKode {
 
     ENDELIG("ENDELIG", "Endelig"),
     FORELOPIG("FORELOPIG", "Foreløpig"),

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/opptjening/OpptjeningAktivitetKlassifisering.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/opptjening/OpptjeningAktivitetKlassifisering.java
@@ -8,9 +8,10 @@ import jakarta.persistence.Converter;
 
 import com.fasterxml.jackson.annotation.JsonValue;
 
+import no.nav.foreldrepenger.behandlingslager.kodeverk.DatabaseKode;
 import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
 
-public enum OpptjeningAktivitetKlassifisering implements Kodeverdi {
+public enum OpptjeningAktivitetKlassifisering implements Kodeverdi, DatabaseKode {
 
     BEKREFTET_GODKJENT("BEKREFTET_GODKJENT", "Bekreftet godkjent"),
     BEKREFTET_AVVIST("BEKREFTET_AVVIST", "Bekreftet avvist"),

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/opptjening/OpptjeningAktivitetType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/opptjening/OpptjeningAktivitetType.java
@@ -12,6 +12,7 @@ import jakarta.persistence.Converter;
 
 import com.fasterxml.jackson.annotation.JsonValue;
 
+import no.nav.foreldrepenger.behandlingslager.kodeverk.DatabaseKode;
 import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
 import no.nav.foreldrepenger.behandlingslager.virksomhet.ArbeidType;
 import no.nav.foreldrepenger.behandlingslager.ytelse.RelatertYtelseType;
@@ -24,7 +25,7 @@ import no.nav.foreldrepenger.behandlingslager.ytelse.RelatertYtelseType;
  * Senere benyttes dette i mapping til bla. Beregningsgrunnlag.
  */
 
-public enum OpptjeningAktivitetType implements Kodeverdi {
+public enum OpptjeningAktivitetType implements Kodeverdi, DatabaseKode {
 
     ARBEIDSAVKLARING("AAP", "Arbeidsavklaringspenger",
             Set.of(),

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/opptjening/ReferanseType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/opptjening/ReferanseType.java
@@ -8,9 +8,10 @@ import jakarta.persistence.Converter;
 
 import com.fasterxml.jackson.annotation.JsonValue;
 
+import no.nav.foreldrepenger.behandlingslager.kodeverk.DatabaseKode;
 import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
 
-public enum ReferanseType implements Kodeverdi {
+public enum ReferanseType implements Kodeverdi, DatabaseKode {
 
     ORG_NR("ORG_NR", "Orgnr"),
     AKTØR_ID("AKTØR_ID", "Aktør Id"),

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/personopplysning/RelasjonsRolleType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/personopplysning/RelasjonsRolleType.java
@@ -10,9 +10,10 @@ import jakarta.persistence.Converter;
 
 import com.fasterxml.jackson.annotation.JsonValue;
 
+import no.nav.foreldrepenger.behandlingslager.kodeverk.DatabaseKode;
 import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
 
-public enum RelasjonsRolleType implements Kodeverdi {
+public enum RelasjonsRolleType implements Kodeverdi, DatabaseKode {
 
     EKTE("EKTE", "Ektefelle"),
     BARN("BARN", "Barn"),

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/personopplysning/SivilstandType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/personopplysning/SivilstandType.java
@@ -7,9 +7,10 @@ import jakarta.persistence.EnumeratedValue;
 
 import com.fasterxml.jackson.annotation.JsonValue;
 
+import no.nav.foreldrepenger.behandlingslager.kodeverk.DatabaseKode;
 import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
 
-public enum SivilstandType implements Kodeverdi {
+public enum SivilstandType implements Kodeverdi, DatabaseKode {
 
     ENKEMANN("ENKE", "Enke/-mann"),
     GIFT("GIFT", "Gift"),

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/skjermlenke/SkjermlenkeType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/skjermlenke/SkjermlenkeType.java
@@ -12,9 +12,10 @@ import no.nav.foreldrepenger.behandlingslager.behandling.Behandlingsresultat;
 import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.AksjonspunktDefinisjon;
 import no.nav.foreldrepenger.behandlingslager.behandling.vilkår.VilkårResultat;
 import no.nav.foreldrepenger.behandlingslager.behandling.vilkår.VilkårType;
+import no.nav.foreldrepenger.behandlingslager.kodeverk.DatabaseKode;
 import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
 
-public enum SkjermlenkeType implements Kodeverdi {
+public enum SkjermlenkeType implements Kodeverdi, DatabaseKode {
 
     ANKE_MERKNADER("ANKE_MERKNADER", "Anke merknader"),
     ANKE_VURDERING("ANKE_VURDERING", "Anke vurdering"),

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/søknad/FarSøkerType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/søknad/FarSøkerType.java
@@ -8,9 +8,10 @@ import jakarta.persistence.Converter;
 
 import com.fasterxml.jackson.annotation.JsonValue;
 
+import no.nav.foreldrepenger.behandlingslager.kodeverk.DatabaseKode;
 import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
 
-public enum FarSøkerType implements Kodeverdi {
+public enum FarSøkerType implements Kodeverdi, DatabaseKode {
     ADOPTERER_ALENE("ADOPTERER_ALENE", "Adopterer barnet eller barna alene"),
     ANDRE_FORELDER_DØD("ANDRE_FORELDER_DØD", "Den andre forelderen er død"),
     OVERTATT_OMSORG("OVERTATT_OMSORG", "Overtatt omsorg < 56 uker"),

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/søknad/Innsendingsvalg.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/søknad/Innsendingsvalg.java
@@ -7,9 +7,10 @@ import jakarta.persistence.EnumeratedValue;
 
 import com.fasterxml.jackson.annotation.JsonValue;
 
+import no.nav.foreldrepenger.behandlingslager.kodeverk.DatabaseKode;
 import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
 
-public enum Innsendingsvalg implements Kodeverdi {
+public enum Innsendingsvalg implements Kodeverdi, DatabaseKode {
 
     LASTET_OPP("LASTET_OPP", "Lastet opp"),
     SEND_SENERE("SEND_SENERE", "Send senere"),

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/søknad/SøknadAnnenPartType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/søknad/SøknadAnnenPartType.java
@@ -9,9 +9,10 @@ import jakarta.persistence.Converter;
 
 import com.fasterxml.jackson.annotation.JsonValue;
 
+import no.nav.foreldrepenger.behandlingslager.kodeverk.DatabaseKode;
 import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
 
-public enum SøknadAnnenPartType implements Kodeverdi {
+public enum SøknadAnnenPartType implements Kodeverdi, DatabaseKode {
 
     MOR("MOR", "Mor"),
     MEDMOR("MEDMOR", "Medmor"),

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/tilbakekreving/TilbakekrevingVidereBehandling.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/tilbakekreving/TilbakekrevingVidereBehandling.java
@@ -7,9 +7,10 @@ import jakarta.persistence.EnumeratedValue;
 
 import com.fasterxml.jackson.annotation.JsonValue;
 
+import no.nav.foreldrepenger.behandlingslager.kodeverk.DatabaseKode;
 import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
 
-public enum TilbakekrevingVidereBehandling implements Kodeverdi {
+public enum TilbakekrevingVidereBehandling implements Kodeverdi, DatabaseKode {
 
     UDEFINIERT(STANDARDKODE_UDEFINERT, "Udefinert."),
     OPPRETT_TILBAKEKREVING("TILBAKEKR_OPPRETT", "Feilutbetaling med tilbakekreving"),

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/tilrettelegging/SvpAvklartOpphold.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/tilrettelegging/SvpAvklartOpphold.java
@@ -29,6 +29,7 @@ public class SvpAvklartOpphold extends BaseCreateableEntitet {
     private DatoIntervallEntitet oppholdPeriode;
 
     @Column(name = "svp_opphold_arsak", nullable = false)
+    @Enumerated(EnumType.STRING)
     private SvpOppholdÅrsak svpOppholdÅrsak;
 
     @Column(name = "svp_opphold_kilde")

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/tilrettelegging/SvpAvklartOpphold.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/tilrettelegging/SvpAvklartOpphold.java
@@ -29,7 +29,7 @@ public class SvpAvklartOpphold extends BaseCreateableEntitet {
     private DatoIntervallEntitet oppholdPeriode;
 
     @Column(name = "svp_opphold_arsak", nullable = false)
-    @Enumerated(EnumType.STRING)
+    @Enumerated(EnumType.ORDINAL) // OBS - ikke endre til STRING, databasen inneholder 0/1
     private SvpOppholdÅrsak svpOppholdÅrsak;
 
     @Column(name = "svp_opphold_kilde")

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/tilrettelegging/SvpOppholdKilde.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/tilrettelegging/SvpOppholdKilde.java
@@ -1,6 +1,8 @@
 package no.nav.foreldrepenger.behandlingslager.behandling.tilrettelegging;
 
-public enum SvpOppholdKilde {
+import no.nav.foreldrepenger.behandlingslager.kodeverk.DatabaseKode;
+
+public enum SvpOppholdKilde implements DatabaseKode {
     SØKNAD,
     REGISTRERT_AV_SAKSBEHANDLER,
     TIDLIGERE_VEDTAK,

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/tilrettelegging/SvpOppholdÅrsak.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/tilrettelegging/SvpOppholdÅrsak.java
@@ -3,6 +3,7 @@ package no.nav.foreldrepenger.behandlingslager.behandling.tilrettelegging;
 import no.nav.foreldrepenger.behandlingslager.kodeverk.DatabaseKode;
 
 public enum SvpOppholdÅrsak implements DatabaseKode {
+    // Ikke endre rekkefølgen på disse - de er lagret i databasen som 0,1,2 osv.
     SYKEPENGER,
     FERIE
 }

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/tilrettelegging/SvpOppholdÅrsak.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/tilrettelegging/SvpOppholdÅrsak.java
@@ -1,6 +1,8 @@
 package no.nav.foreldrepenger.behandlingslager.behandling.tilrettelegging;
 
-public enum SvpOppholdÅrsak {
+import no.nav.foreldrepenger.behandlingslager.kodeverk.DatabaseKode;
+
+public enum SvpOppholdÅrsak implements DatabaseKode {
     SYKEPENGER,
     FERIE
 }

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/tilrettelegging/SvpTilretteleggingFomKilde.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/tilrettelegging/SvpTilretteleggingFomKilde.java
@@ -1,5 +1,8 @@
 package no.nav.foreldrepenger.behandlingslager.behandling.tilrettelegging;
-public enum SvpTilretteleggingFomKilde {
+
+import no.nav.foreldrepenger.behandlingslager.kodeverk.DatabaseKode;
+
+public enum SvpTilretteleggingFomKilde implements DatabaseKode {
     ENDRET_AV_SAKSBEHANDLER,
     REGISTRERT_AV_SAKSBEHANDLER,
     TIDLIGERE_VEDTAK,

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/tilrettelegging/TilretteleggingType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/tilrettelegging/TilretteleggingType.java
@@ -7,9 +7,10 @@ import jakarta.persistence.EnumeratedValue;
 
 import com.fasterxml.jackson.annotation.JsonValue;
 
+import no.nav.foreldrepenger.behandlingslager.kodeverk.DatabaseKode;
 import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
 
-public enum TilretteleggingType implements Kodeverdi {
+public enum TilretteleggingType implements Kodeverdi, DatabaseKode {
 
     HEL_TILRETTELEGGING("HEL_TILRETTELEGGING", "Hel tilrettelegging"),
     DELVIS_TILRETTELEGGING("DELVIS_TILRETTELEGGING", "Delvis tilrettelegging"),

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/vedtak/IverksettingStatus.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/vedtak/IverksettingStatus.java
@@ -8,9 +8,10 @@ import jakarta.persistence.Converter;
 
 import com.fasterxml.jackson.annotation.JsonValue;
 
+import no.nav.foreldrepenger.behandlingslager.kodeverk.DatabaseKode;
 import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
 
-public enum IverksettingStatus implements Kodeverdi {
+public enum IverksettingStatus implements Kodeverdi, DatabaseKode {
 
     IKKE_IVERKSATT("IKKE_IVERKSATT", "Ikke iverksatt"),
     IVERKSATT("IVERKSATT", "Iverksatt"),

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/vedtak/VedtakResultatType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/vedtak/VedtakResultatType.java
@@ -8,9 +8,10 @@ import jakarta.persistence.Converter;
 
 import com.fasterxml.jackson.annotation.JsonValue;
 
+import no.nav.foreldrepenger.behandlingslager.kodeverk.DatabaseKode;
 import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
 
-public enum VedtakResultatType implements Kodeverdi {
+public enum VedtakResultatType implements Kodeverdi, DatabaseKode {
 
     INNVILGET("INNVILGET", "Innvilget"),
     AVSLAG("AVSLAG", "Avslag"),

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/vedtak/Vedtaksbrev.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/vedtak/Vedtaksbrev.java
@@ -8,9 +8,10 @@ import jakarta.persistence.Converter;
 
 import com.fasterxml.jackson.annotation.JsonValue;
 
+import no.nav.foreldrepenger.behandlingslager.kodeverk.DatabaseKode;
 import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
 
-public enum Vedtaksbrev implements Kodeverdi {
+public enum Vedtaksbrev implements Kodeverdi, DatabaseKode {
 
     AUTOMATISK("AUTOMATISK", "Automatisk generert vedtaksbrev"),
     FRITEKST("FRITEKST", "Fritekstbrev"),

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/verge/VergeType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/verge/VergeType.java
@@ -7,9 +7,10 @@ import jakarta.persistence.EnumeratedValue;
 
 import com.fasterxml.jackson.annotation.JsonValue;
 
+import no.nav.foreldrepenger.behandlingslager.kodeverk.DatabaseKode;
 import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
 
-public enum VergeType implements Kodeverdi {
+public enum VergeType implements Kodeverdi, DatabaseKode {
 
     BARN("BARN", "Verge for barn under 18 år"),
     FBARN("FBARN", "Verge for foreldreløst barn under 18 år"),

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/vilkår/Avslagsårsak.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/vilkår/Avslagsårsak.java
@@ -10,9 +10,10 @@ import jakarta.persistence.Converter;
 
 import com.fasterxml.jackson.annotation.JsonValue;
 
+import no.nav.foreldrepenger.behandlingslager.kodeverk.DatabaseKode;
 import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
 
-public enum Avslagsårsak implements Kodeverdi {
+public enum Avslagsårsak implements Kodeverdi, DatabaseKode {
 
     SØKT_FOR_TIDLIG("1001", "Søkt for tidlig"),
     SØKER_ER_MEDMOR("1002", "Søker er medmor"),

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/vilkår/VilkårType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/vilkår/VilkårType.java
@@ -12,9 +12,10 @@ import jakarta.persistence.Converter;
 import com.fasterxml.jackson.annotation.JsonValue;
 
 import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakYtelseType;
+import no.nav.foreldrepenger.behandlingslager.kodeverk.DatabaseKode;
 import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
 
-public enum VilkårType implements Kodeverdi {
+public enum VilkårType implements Kodeverdi, DatabaseKode {
 
     FØDSELSVILKÅRET_MOR("FP_VK_1",
         "Fødselsvilkår Mor",

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/vilkår/VilkårUtfallMerknad.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/vilkår/VilkårUtfallMerknad.java
@@ -8,9 +8,10 @@ import jakarta.persistence.Converter;
 
 import com.fasterxml.jackson.annotation.JsonValue;
 
+import no.nav.foreldrepenger.behandlingslager.kodeverk.DatabaseKode;
 import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
 
-public enum VilkårUtfallMerknad implements Kodeverdi {
+public enum VilkårUtfallMerknad implements Kodeverdi, DatabaseKode {
 
     VM_1001("1001", "Søknad er sendt før 26. svangerskapsuke er passert og barnet er ikke født"),
     VM_1002("1002", "Søker er medmor (forelder2) og har søkt om engangsstønad til mor"),

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/vilkår/VilkårUtfallType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/vilkår/VilkårUtfallType.java
@@ -8,9 +8,10 @@ import jakarta.persistence.Converter;
 
 import com.fasterxml.jackson.annotation.JsonValue;
 
+import no.nav.foreldrepenger.behandlingslager.kodeverk.DatabaseKode;
 import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
 
-public enum VilkårUtfallType implements Kodeverdi {
+public enum VilkårUtfallType implements Kodeverdi, DatabaseKode {
     OPPFYLT("OPPFYLT", "Oppfylt"),
     IKKE_OPPFYLT("IKKE_OPPFYLT", "Ikke oppfylt"),
     IKKE_VURDERT("IKKE_VURDERT", "Ikke vurdert"),

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/ytelsefordeling/MorsAktivitet.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/ytelsefordeling/MorsAktivitet.java
@@ -9,9 +9,10 @@ import jakarta.persistence.Converter;
 
 import com.fasterxml.jackson.annotation.JsonValue;
 
+import no.nav.foreldrepenger.behandlingslager.kodeverk.DatabaseKode;
 import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
 
-public enum MorsAktivitet implements Kodeverdi {
+public enum MorsAktivitet implements Kodeverdi, DatabaseKode {
 
     UDEFINERT(STANDARDKODE_UDEFINERT, "Ikke satt eller valgt kode"),
     ARBEID("ARBEID", "Er i arbeid"),

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/ytelsefordeling/Rettighetstype.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/ytelsefordeling/Rettighetstype.java
@@ -1,6 +1,8 @@
 package no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling;
 
-public enum Rettighetstype {
+import no.nav.foreldrepenger.behandlingslager.kodeverk.DatabaseKode;
+
+public enum Rettighetstype implements DatabaseKode {
 
     ALENEOMSORG,
     BEGGE_RETT,

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/ytelsefordeling/periode/DokumentasjonVurdering.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/ytelsefordeling/periode/DokumentasjonVurdering.java
@@ -8,6 +8,7 @@ import jakarta.persistence.EnumeratedValue;
 
 import com.fasterxml.jackson.annotation.JsonValue;
 
+import no.nav.foreldrepenger.behandlingslager.kodeverk.DatabaseKode;
 import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
 import no.nav.foreldrepenger.behandlingslager.uttak.fp.MorsStillingsprosent;
 
@@ -28,7 +29,7 @@ public record DokumentasjonVurdering(Type type, MorsStillingsprosent morsStillin
         return type.erGodkjent();
     }
 
-    public enum Type implements Kodeverdi {
+    public enum Type implements Kodeverdi, DatabaseKode {
         ///Både utsettelse
         SYKDOM_SØKER_GODKJENT("SYKDOM_SØKER_GODKJENT", "Søker er syk", true),
         SYKDOM_SØKER_IKKE_GODKJENT("SYKDOM_SØKER_IKKE_GODKJENT", "Søker er ikke syk", false),

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/ytelsefordeling/periode/FordelingPeriodeKilde.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/ytelsefordeling/periode/FordelingPeriodeKilde.java
@@ -7,9 +7,10 @@ import jakarta.persistence.EnumeratedValue;
 
 import com.fasterxml.jackson.annotation.JsonValue;
 
+import no.nav.foreldrepenger.behandlingslager.kodeverk.DatabaseKode;
 import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
 
-public enum FordelingPeriodeKilde implements Kodeverdi {
+public enum FordelingPeriodeKilde implements Kodeverdi, DatabaseKode {
 
     SØKNAD("SØKNAD", "Søknad"),
     TIDLIGERE_VEDTAK("TIDLIGERE_VEDTAK", "Vedtak"),

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/ytelsefordeling/periode/UttakPeriodeType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/ytelsefordeling/periode/UttakPeriodeType.java
@@ -9,9 +9,10 @@ import jakarta.persistence.Converter;
 
 import com.fasterxml.jackson.annotation.JsonValue;
 
+import no.nav.foreldrepenger.behandlingslager.kodeverk.DatabaseKode;
 import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
 
-public enum UttakPeriodeType implements Kodeverdi {
+public enum UttakPeriodeType implements Kodeverdi, DatabaseKode {
 
     FELLESPERIODE("FELLESPERIODE", "Fellesperioden"),
     MØDREKVOTE("MØDREKVOTE", "Mødrekvoten"),

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/ytelsefordeling/årsak/OppholdÅrsak.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/ytelsefordeling/årsak/OppholdÅrsak.java
@@ -8,7 +8,9 @@ import jakarta.persistence.Converter;
 
 import com.fasterxml.jackson.annotation.JsonValue;
 
-public enum OppholdÅrsak implements Årsak {
+import no.nav.foreldrepenger.behandlingslager.kodeverk.DatabaseKode;
+
+public enum OppholdÅrsak implements Årsak, DatabaseKode {
 
     UDEFINERT(STANDARDKODE_UDEFINERT, "Ikke satt eller valgt kode"),
     MØDREKVOTE_ANNEN_FORELDER("UTTAK_MØDREKVOTE_ANNEN_FORELDER", "Annen forelder har uttak av Mødrekvote"),

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/ytelsefordeling/årsak/OverføringÅrsak.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/ytelsefordeling/årsak/OverføringÅrsak.java
@@ -8,7 +8,9 @@ import jakarta.persistence.Converter;
 
 import com.fasterxml.jackson.annotation.JsonValue;
 
-public enum OverføringÅrsak implements Årsak {
+import no.nav.foreldrepenger.behandlingslager.kodeverk.DatabaseKode;
+
+public enum OverføringÅrsak implements Årsak, DatabaseKode {
 
     INSTITUSJONSOPPHOLD_ANNEN_FORELDER("INSTITUSJONSOPPHOLD_ANNEN_FORELDER", "Den andre foreldren er innlagt i helseinstitusjon"),
     SYKDOM_ANNEN_FORELDER("SYKDOM_ANNEN_FORELDER", "Den andre foreldren er pga sykdom avhengig av hjelp for å ta seg av barnet/barna"),

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/etterkontroll/KontrollType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/etterkontroll/KontrollType.java
@@ -7,9 +7,10 @@ import jakarta.persistence.EnumeratedValue;
 
 import com.fasterxml.jackson.annotation.JsonValue;
 
+import no.nav.foreldrepenger.behandlingslager.kodeverk.DatabaseKode;
 import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
 
-public enum KontrollType implements Kodeverdi {
+public enum KontrollType implements Kodeverdi, DatabaseKode {
 
     MANGLENDE_FØDSEL("MANGLENDE_FØDSEL", "Kontroll manglende fødsel"),
 

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/fagsak/EgenskapNøkkel.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/fagsak/EgenskapNøkkel.java
@@ -3,7 +3,9 @@ package no.nav.foreldrepenger.behandlingslager.fagsak;
 import jakarta.persistence.AttributeConverter;
 import jakarta.persistence.Converter;
 
-public enum EgenskapNøkkel {
+import no.nav.foreldrepenger.behandlingslager.kodeverk.DatabaseKode;
+
+public enum EgenskapNøkkel implements DatabaseKode {
 
     UTLAND_DOKUMENTASJON,
     FAGSAK_MARKERING;

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/fagsak/FagsakStatus.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/fagsak/FagsakStatus.java
@@ -7,9 +7,10 @@ import jakarta.persistence.EnumeratedValue;
 
 import com.fasterxml.jackson.annotation.JsonValue;
 
+import no.nav.foreldrepenger.behandlingslager.kodeverk.DatabaseKode;
 import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
 
-public enum FagsakStatus implements Kodeverdi {
+public enum FagsakStatus implements Kodeverdi, DatabaseKode {
 
     OPPRETTET("OPPR", "Opprettet"),
     UNDER_BEHANDLING("UBEH", "Under behandling"),

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/fagsak/FagsakYtelseType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/fagsak/FagsakYtelseType.java
@@ -8,9 +8,10 @@ import jakarta.persistence.Converter;
 
 import com.fasterxml.jackson.annotation.JsonValue;
 
+import no.nav.foreldrepenger.behandlingslager.kodeverk.DatabaseKode;
 import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
 
-public enum FagsakYtelseType implements Kodeverdi {
+public enum FagsakYtelseType implements Kodeverdi, DatabaseKode {
 
     ENGANGSTØNAD("ES", "Engangsstønad"),
     FORELDREPENGER("FP", "Foreldrepenger"),

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/geografisk/Landkoder.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/geografisk/Landkoder.java
@@ -8,9 +8,10 @@ import jakarta.persistence.Converter;
 
 import com.fasterxml.jackson.annotation.JsonValue;
 
+import no.nav.foreldrepenger.behandlingslager.kodeverk.DatabaseKode;
 import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
 
-public enum Landkoder implements Kodeverdi {
+public enum Landkoder implements Kodeverdi, DatabaseKode {
 
     /**
      * Konstanter for å skrive ned kodeverdi.

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/geografisk/Språkkode.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/geografisk/Språkkode.java
@@ -10,10 +10,11 @@ import jakarta.persistence.Converter;
 
 import com.fasterxml.jackson.annotation.JsonValue;
 
+import no.nav.foreldrepenger.behandlingslager.kodeverk.DatabaseKode;
 import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
 import no.nav.foreldrepenger.behandlingslager.kodeverk.MedOffisiellKode;
 
-public enum Språkkode implements Kodeverdi, MedOffisiellKode {
+public enum Språkkode implements Kodeverdi, DatabaseKode, MedOffisiellKode {
 
     /**
      * Konstanter for å skrive ned kodeverdi.

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/hendelser/StartpunktType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/hendelser/StartpunktType.java
@@ -18,9 +18,10 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingStegType;
 import no.nav.foreldrepenger.behandlingslager.behandling.vilkår.VilkårType;
 import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakYtelseType;
+import no.nav.foreldrepenger.behandlingslager.kodeverk.DatabaseKode;
 import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
 
-public enum StartpunktType implements Kodeverdi {
+public enum StartpunktType implements Kodeverdi, DatabaseKode {
 
     KONTROLLER_ARBEIDSFORHOLD("KONTROLLER_ARBEIDSFORHOLD", "Startpunkt kontroller arbeidsforhold", 1, BehandlingStegType.KONTROLLER_FAKTA_ARBEIDSFORHOLD_INNTEKTSMELDING, Set.of(FagsakYtelseType.ENGANGSTØNAD)),
     KONTROLLER_FAKTA("KONTROLLER_FAKTA", "Kontroller fakta", 2, BehandlingStegType.KONTROLLER_FAKTA, Set.of()),

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/kodeverk/DatabaseKode.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/kodeverk/DatabaseKode.java
@@ -1,0 +1,5 @@
+package no.nav.foreldrepenger.behandlingslager.kodeverk;
+
+/** Kodeverk som er brukt i database via @Enumerated i Entiteter. Bruk @EnumeratedValue i enum dersom egen kode-string */
+public interface DatabaseKode {
+}

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/kodeverk/Fagsystem.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/kodeverk/Fagsystem.java
@@ -8,7 +8,7 @@ import jakarta.persistence.Converter;
 
 import com.fasterxml.jackson.annotation.JsonValue;
 
-public enum Fagsystem implements Kodeverdi, MedOffisiellKode {
+public enum Fagsystem implements Kodeverdi, DatabaseKode, MedOffisiellKode {
 
     FPSAK("FPSAK", "Vedtaksløsning Foreldrepenger", "FS36"),
     TPS("TPS", "TPS", "FS03"),

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/uttak/PeriodeResultatType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/uttak/PeriodeResultatType.java
@@ -4,9 +4,10 @@ import jakarta.persistence.EnumeratedValue;
 
 import com.fasterxml.jackson.annotation.JsonValue;
 
+import no.nav.foreldrepenger.behandlingslager.kodeverk.DatabaseKode;
 import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
 
-public enum PeriodeResultatType implements Kodeverdi {
+public enum PeriodeResultatType implements Kodeverdi, DatabaseKode {
 
     INNVILGET("INNVILGET", "Innvilget"),
     AVSLÅTT("AVSLÅTT", "Avslått"),

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/uttak/UttakArbeidType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/uttak/UttakArbeidType.java
@@ -4,9 +4,10 @@ import jakarta.persistence.EnumeratedValue;
 
 import com.fasterxml.jackson.annotation.JsonValue;
 
+import no.nav.foreldrepenger.behandlingslager.kodeverk.DatabaseKode;
 import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
 
-public enum UttakArbeidType implements Kodeverdi {
+public enum UttakArbeidType implements Kodeverdi, DatabaseKode {
 
     ORDINÆRT_ARBEID("ORDINÆRT_ARBEID", "Ordinært arbeid"),
     SELVSTENDIG_NÆRINGSDRIVENDE("SELVSTENDIG_NÆRINGSDRIVENDE", "Selvstendig næringsdrivende"),

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/uttak/fp/GraderingAvslagÅrsak.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/uttak/fp/GraderingAvslagÅrsak.java
@@ -8,9 +8,10 @@ import jakarta.persistence.Converter;
 
 import com.fasterxml.jackson.annotation.JsonValue;
 
+import no.nav.foreldrepenger.behandlingslager.kodeverk.DatabaseKode;
 import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
 
-public enum GraderingAvslagÅrsak implements Kodeverdi {
+public enum GraderingAvslagÅrsak implements Kodeverdi, DatabaseKode {
 
     //MERK: Lovhjemler til brev hentes fra navn, se pattern i UttakHjemmelUtleder
 

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/uttak/fp/ManuellBehandlingÅrsak.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/uttak/fp/ManuellBehandlingÅrsak.java
@@ -8,9 +8,10 @@ import jakarta.persistence.Converter;
 
 import com.fasterxml.jackson.annotation.JsonValue;
 
+import no.nav.foreldrepenger.behandlingslager.kodeverk.DatabaseKode;
 import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
 
-public enum ManuellBehandlingÅrsak implements Kodeverdi {
+public enum ManuellBehandlingÅrsak implements Kodeverdi, DatabaseKode {
 
     UKJENT(STANDARDKODE_UDEFINERT, "Ikke definert"),
     STØNADSKONTO_TOM("5001", "Stønadskonto tom for stønadsdager. Vurder bruk av annen stønadskonto eller avslå perioden."),

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/uttak/fp/PeriodeResultatÅrsak.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/uttak/fp/PeriodeResultatÅrsak.java
@@ -24,9 +24,10 @@ import jakarta.persistence.Converter;
 import com.fasterxml.jackson.annotation.JsonValue;
 
 import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.periode.UttakPeriodeType;
+import no.nav.foreldrepenger.behandlingslager.kodeverk.DatabaseKode;
 import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
 
-public enum PeriodeResultatÅrsak implements Kodeverdi {
+public enum PeriodeResultatÅrsak implements Kodeverdi, DatabaseKode {
 
     //MERK: Lovhjemler til brev hentes fra navn, se pattern i UttakHjemmelUtleder
 

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/uttak/fp/StønadskontoType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/uttak/fp/StønadskontoType.java
@@ -8,9 +8,10 @@ import jakarta.persistence.EnumeratedValue;
 import com.fasterxml.jackson.annotation.JsonValue;
 
 import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.periode.UttakPeriodeType;
+import no.nav.foreldrepenger.behandlingslager.kodeverk.DatabaseKode;
 import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
 
-public enum StønadskontoType implements Kodeverdi {
+public enum StønadskontoType implements Kodeverdi, DatabaseKode {
 
     /*
      * Alle kvanta av dager som er definert i Ftl 14-9 ... 14-15 fom 1/1-2019

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/uttak/fp/UttakUtsettelseType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/uttak/fp/UttakUtsettelseType.java
@@ -8,9 +8,10 @@ import jakarta.persistence.Converter;
 
 import com.fasterxml.jackson.annotation.JsonValue;
 
+import no.nav.foreldrepenger.behandlingslager.kodeverk.DatabaseKode;
 import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
 
-public enum UttakUtsettelseType implements Kodeverdi {
+public enum UttakUtsettelseType implements Kodeverdi, DatabaseKode {
 
     ARBEID("ARBEID", "Arbeid"),
     FERIE("FERIE", "Lovbestemt ferie"),

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/uttak/svp/ArbeidsforholdIkkeOppfyltÅrsak.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/uttak/svp/ArbeidsforholdIkkeOppfyltÅrsak.java
@@ -8,9 +8,10 @@ import jakarta.persistence.Converter;
 
 import com.fasterxml.jackson.annotation.JsonValue;
 
+import no.nav.foreldrepenger.behandlingslager.kodeverk.DatabaseKode;
 import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
 
-public enum ArbeidsforholdIkkeOppfyltÅrsak implements Kodeverdi {
+public enum ArbeidsforholdIkkeOppfyltÅrsak implements Kodeverdi, DatabaseKode {
 
     // Se også Periode ikke oppfylt - der brukes 8304-83011 + 8313+8314
     INGEN(STANDARDKODE_UDEFINERT, "Ikke definert"),

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/uttak/svp/PeriodeIkkeOppfyltÅrsak.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/uttak/svp/PeriodeIkkeOppfyltÅrsak.java
@@ -9,9 +9,10 @@ import jakarta.persistence.Converter;
 
 import com.fasterxml.jackson.annotation.JsonValue;
 
+import no.nav.foreldrepenger.behandlingslager.kodeverk.DatabaseKode;
 import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
 
-public enum PeriodeIkkeOppfyltÅrsak implements Kodeverdi {
+public enum PeriodeIkkeOppfyltÅrsak implements Kodeverdi, DatabaseKode {
 
     INGEN(STANDARDKODE_UDEFINERT, "Ikke definert"),
 

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/virksomhet/ArbeidType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/virksomhet/ArbeidType.java
@@ -25,10 +25,11 @@ import jakarta.persistence.EnumeratedValue;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonValue;
 
+import no.nav.foreldrepenger.behandlingslager.kodeverk.DatabaseKode;
 import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
 import no.nav.foreldrepenger.behandlingslager.kodeverk.MedOffisiellKode;
 
-public enum ArbeidType implements Kodeverdi, MedOffisiellKode {
+public enum ArbeidType implements Kodeverdi, DatabaseKode, MedOffisiellKode {
 
     ETTERLØNN_SLUTTPAKKE("ETTERLØNN_SLUTTPAKKE", "Etterlønn eller sluttpakke"),
     FORENKLET_OPPGJØRSORDNING("FORENKLET_OPPGJØRSORDNING", "Forenklet oppgjørsordning ", "forenkletOppgjoersordning"),

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/økonomioppdrag/koder/Alvorlighetsgrad.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/økonomioppdrag/koder/Alvorlighetsgrad.java
@@ -6,7 +6,9 @@ import java.util.Objects;
 
 import jakarta.persistence.EnumeratedValue;
 
-public enum Alvorlighetsgrad {
+import no.nav.foreldrepenger.behandlingslager.kodeverk.DatabaseKode;
+
+public enum Alvorlighetsgrad implements DatabaseKode {
     OK("00"),
     OK_MED_MERKNAD("04"),
     FEIL("08")

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/økonomioppdrag/koder/KodeEndring.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/økonomioppdrag/koder/KodeEndring.java
@@ -1,6 +1,8 @@
 package no.nav.foreldrepenger.behandlingslager.økonomioppdrag.koder;
 
-public enum KodeEndring {
+import no.nav.foreldrepenger.behandlingslager.kodeverk.DatabaseKode;
+
+public enum KodeEndring implements DatabaseKode {
     NY, //ny
     ENDR, //endring
     UEND, //uendret

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/økonomioppdrag/koder/KodeEndringLinje.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/økonomioppdrag/koder/KodeEndringLinje.java
@@ -1,6 +1,8 @@
 package no.nav.foreldrepenger.behandlingslager.økonomioppdrag.koder;
 
-public enum KodeEndringLinje {
+import no.nav.foreldrepenger.behandlingslager.kodeverk.DatabaseKode;
+
+public enum KodeEndringLinje implements DatabaseKode {
     NY, //ny
     ENDR, //endring
 }

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/økonomioppdrag/koder/KodeFagområde.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/økonomioppdrag/koder/KodeFagområde.java
@@ -1,6 +1,8 @@
 package no.nav.foreldrepenger.behandlingslager.økonomioppdrag.koder;
 
-public enum KodeFagområde {
+import no.nav.foreldrepenger.behandlingslager.kodeverk.DatabaseKode;
+
+public enum KodeFagområde implements DatabaseKode {
     REFUTG, //engangsstønad
     FP, //foreldrepenger til bruker
     FPREF, //foreldrepenger til arbeidsgiver

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/økonomioppdrag/koder/KodeKlassifik.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/økonomioppdrag/koder/KodeKlassifik.java
@@ -6,7 +6,9 @@ import java.util.Objects;
 
 import jakarta.persistence.EnumeratedValue;
 
-public enum KodeKlassifik {
+import no.nav.foreldrepenger.behandlingslager.kodeverk.DatabaseKode;
+
+public enum KodeKlassifik implements DatabaseKode {
 
     //Engangsstønad fødsel
     ES_FØDSEL("FPENFOD-OP"),

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/økonomioppdrag/koder/KodeStatusLinje.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/økonomioppdrag/koder/KodeStatusLinje.java
@@ -1,5 +1,7 @@
 package no.nav.foreldrepenger.behandlingslager.økonomioppdrag.koder;
 
-public enum KodeStatusLinje {
+import no.nav.foreldrepenger.behandlingslager.kodeverk.DatabaseKode;
+
+public enum KodeStatusLinje implements DatabaseKode {
     OPPH, //opphør
 }

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/økonomioppdrag/koder/TypeSats.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/økonomioppdrag/koder/TypeSats.java
@@ -1,6 +1,8 @@
 package no.nav.foreldrepenger.behandlingslager.økonomioppdrag.koder;
 
-public enum TypeSats {
+import no.nav.foreldrepenger.behandlingslager.kodeverk.DatabaseKode;
+
+public enum TypeSats implements DatabaseKode {
     DAG, //daglig
     ENG, //engang
 }

--- a/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/kodeverk/KodeverdiKonsistensTest.java
+++ b/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/kodeverk/KodeverdiKonsistensTest.java
@@ -12,13 +12,20 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import jakarta.persistence.Convert;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Enumerated;
+
 import org.junit.jupiter.api.Test;
 
+import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
 import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakYtelseType;
+import no.nav.foreldrepenger.behandlingslager.kodeverk.DatabaseKode;
 import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
 import no.nav.foreldrepenger.domene.iay.modell.kodeverk.RelatertYtelseTilstand;
 import no.nav.foreldrepenger.domene.modell.kodeverk.AndelKilde;
 import no.nav.foreldrepenger.web.app.IndexClasses;
+import no.nav.vedtak.felles.jpa.converters.BooleanToStringConverter;
 
 class KodeverdiKonsistensTest {
 
@@ -54,6 +61,22 @@ class KodeverdiKonsistensTest {
             .map(k -> Map.entry(k.getSimpleName(),
                 Arrays.stream(k.getEnumConstants()).collect(Collectors.toMap(Kodeverdi::getKode, Function.identity()))))
             .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
+    }
+
+    @Test
+    void sjekk_alle_kode_kolonner() throws URISyntaxException {
+        var indexClasses = IndexClasses.getIndexFor(Behandling.class.getProtectionDomain().getCodeSource().getLocation().toURI());
+        @SuppressWarnings("unchecked")
+        var entitetsklasser = indexClasses.getClasses(ci -> true, c -> c.isAnnotationPresent(Entity.class));
+        var fieldMedEnumeratedEllerConvert = entitetsklasser.stream()
+            .flatMap(k -> Arrays.stream(k.getDeclaredFields()))
+            .filter(f -> f.isAnnotationPresent(Enumerated.class) ||
+                (f.isAnnotationPresent(Convert.class) && f.getAnnotation(Convert.class).converter() != BooleanToStringConverter.class))
+            .toList();
+        var ikkeDatabaseTyper = fieldMedEnumeratedEllerConvert.stream()
+            .filter(f -> !DatabaseKode.class.isAssignableFrom(f.getType()))
+            .toList();
+        assertThat(ikkeDatabaseTyper).isEmpty();
     }
 
 }

--- a/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/kodeverk/KodeverdiKonsistensTest.java
+++ b/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/kodeverk/KodeverdiKonsistensTest.java
@@ -25,7 +25,6 @@ import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
 import no.nav.foreldrepenger.domene.iay.modell.kodeverk.RelatertYtelseTilstand;
 import no.nav.foreldrepenger.domene.modell.kodeverk.AndelKilde;
 import no.nav.foreldrepenger.web.app.IndexClasses;
-import no.nav.vedtak.felles.jpa.converters.BooleanToStringConverter;
 
 class KodeverdiKonsistensTest {
 
@@ -64,19 +63,25 @@ class KodeverdiKonsistensTest {
     }
 
     @Test
-    void sjekk_alle_kode_kolonner() throws URISyntaxException {
+    void sjekk_alle_kode_kolonner_er_annotert_og_databasekode() throws URISyntaxException {
         var indexClasses = IndexClasses.getIndexFor(Behandling.class.getProtectionDomain().getCodeSource().getLocation().toURI());
         @SuppressWarnings("unchecked")
         var entitetsklasser = indexClasses.getClasses(ci -> true, c -> c.isAnnotationPresent(Entity.class));
-        var fieldMedEnumeratedEllerConvert = entitetsklasser.stream()
+        var enumFields = entitetsklasser.stream()
             .flatMap(k -> Arrays.stream(k.getDeclaredFields()))
-            .filter(f -> f.isAnnotationPresent(Enumerated.class) ||
-                (f.isAnnotationPresent(Convert.class) && f.getAnnotation(Convert.class).converter() != BooleanToStringConverter.class))
+            .filter(f -> f.getType().isEnum())
             .toList();
-        var ikkeDatabaseTyper = fieldMedEnumeratedEllerConvert.stream()
+        // Test om enum-attributt er annotert med @Enumerated eller @Convert
+        var ikkeAnnotert = enumFields.stream()
+            .filter(f -> !f.isAnnotationPresent(Enumerated.class) && !f.isAnnotationPresent(Convert.class))
+            .toList();
+        assertThat(ikkeAnnotert).isEmpty();
+        // Test om enum-attributt er instans av DatabaseKode
+        var ikkeDatabaseKode = enumFields.stream()
             .filter(f -> !DatabaseKode.class.isAssignableFrom(f.getType()))
             .toList();
-        assertThat(ikkeDatabaseTyper).isEmpty();
+        assertThat(ikkeDatabaseKode).isEmpty();
+
     }
 
 }


### PR DESCRIPTION
Bla helt ned til KodeverdiKonsistensTest -  at alle kolonner i entiteter som er Enums er annotert med Enumerated eller Convert og at enumene implementerer Databasekode. 
OBS: Fant ett tilfelle - SvpOppholdÅrsak - som manglet Enumerated - da brukes ORDINAL som default og rekkefølgen har betydning. Lagt inn Enumerated(ORDINAL) og kommentar i enumen. Fasit: Bruk helst enumerated/string

KodeverdiKonsistensTest - her skal det testes for duplikater - dvs at der KODER-map finnes for å sjekke for duplikater kan fjernes.