### PR TITLE
AGENTS og copilot-instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,78 @@
+# Copilot Instructions for fp-sak
+
+## What is fp-sak?
+
+fp-sak is the core case processing application (fagsystem) for Norwegian parental benefits. It handles:
+- **Foreldrepenger** (parental benefits) — the primary benefit type
+- **Engangsstønad** (lump-sum grant) — one-time payment for birth/adoption
+- **Svangerskapspenger** (pregnancy benefits) — benefits during pregnancy
+
+fp-sak is the largest and most central application in the foreldrepenger ecosystem, with dependencies on fp-abakus (historical data), fp-kalkulus (benefit calculation), and many other services.
+
+## Integration Tests
+
+Integration tests for fp-sak live in a **separate repository**: [fp-autotest](https://github.com/navikt/fp-autotest).
+
+### Which test suites apply to fp-sak
+
+| Suite | What it tests | Run command |
+|-------|---------------|-------------|
+| `fpsak` | All fp-sak functionality (19 test classes, ~120 tests) | `mvn test -P fpsak` |
+| `verdikjede` | End-to-end value chain (4 test classes, ~50 tests) | `mvn test -P verdikjede` |
+
+Both suites are triggered automatically in CI when fp-sak merges to master.
+
+### Running integration tests for local fp-sak changes
+
+1. Build fp-sak locally:
+   ```bash
+   mvn clean install -DskipTests
+   docker build -t fp-sak .
+   ```
+
+2. In fp-autotest, generate a fresh `.env` and edit for local build:
+   ```bash
+   cd ../fp-autotest/lokal-utvikling
+   ./setup-lokal-utvikling.sh
+   ```
+   Then edit `docker-compose-lokal/.env`:
+   ```
+   FPSAK_IMAGE=fp-sak:latest
+   ```
+   (replacing the default GAR image reference)
+
+3. Start all services and run tests:
+   ```bash
+   cd ../fp-autotest/lokal-utvikling
+   ./setup-lokal-utvikling.sh
+   cd docker-compose-lokal
+   docker compose up --detach
+   # Wait for healthy: docker compose ps
+   cd ../..
+   mvn test -P fpsak                        # Full fpsak suite
+   mvn test -P fpsak -Dtest=Fodsel          # Specific test class
+   mvn test -P fpsak -Dtest="Fodsel#morSøkerFødselMedEttArbeidsforhold"  # Single test
+   ```
+
+5. Quick setup alternative:
+   ```bash
+   cd ../fp-autotest/lokal-utvikling
+   ./lokal-utvikling-fpsak.sh               # Start all deps in Docker
+   ./lokal-utvikling-ide.sh fpsak           # Start deps, run fpsak in IDE
+   ```
+
+### Finding relevant tests
+
+The fp-autotest repository has an `AGENTS.md` file with a complete searchable test catalog including:
+- All test DisplayNames organized by suite and class
+- Aksjonspunkt codes tested per class
+- Expected results (innvilget/avslag/avvist)
+
+Ask Copilot: "Which fp-autotest tests cover [feature]?" and it will search the catalog.
+
+## Local Development
+
+- Java 25, Maven
+- The application runs on port 8080 (mapped to 8080 in Docker Compose)
+- Database: PostgreSQL (local), Oracle (legacy)
+- All external services are mocked by VTP in the test environment

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,79 @@
+# fp-sak — Agent Instructions
+
+## Integration Testing
+
+This application is tested by the [fp-autotest](https://github.com/navikt/fp-autotest) repository.
+
+**Test suites for fp-sak**: `fpsak`, `verdikjede`
+
+### Quick Reference: Test Classes for fp-sak
+
+#### Suite: fpsak (19 classes)
+**Engangsstønad:** Adopsjon, Fodsel, Innsyn, Klage, Medlemskap, Revurdering, Soknadsfrist, Termin
+**Foreldrepenger:** Aksjonspunkter, ArbeidsforholdVarianter, BeregningVerdikjede, Fodsel, Klage, MorOgFarSammen, RegresjonPreWLB, Revurdering, SammenhengendeUttak, Termin, ToTetteOgMinsterettTester, Ytelser
+**Svangerskapspenger:** Førstegangsbehandling
+
+#### Suite: verdikjede (4 classes)
+VerdikjedeEngangsstonad, VerdikjedeForeldrepenger, VerdikjedeSvangerskapspenger, AdressebeskyttelseOgSkjermetPersonTester
+
+### Run Commands
+```bash
+# Full fpsak suite
+cd ../fp-autotest && mvn test -P fpsak
+
+# Specific class
+mvn test -P fpsak -Dtest=Fodsel
+
+# Single method
+mvn test -P fpsak -Dtest="Fodsel#morSøkerFødselMedEttArbeidsforhold"
+
+# Verdikjede suite
+mvn test -P verdikjede
+```
+
+### Testing Local Changes
+
+1. Build fp-sak and create a local Docker image:
+   ```bash
+   mvn clean install -DskipTests
+   docker build -t fp-sak .
+   ```
+
+2. In fp-autotest, generate a fresh `.env` and edit it for local build:
+   ```bash
+   cd ../fp-autotest/lokal-utvikling
+   ./setup-lokal-utvikling.sh
+   ```
+   Then edit `docker-compose-lokal/.env` — change:
+   ```
+   FPSAK_IMAGE=fp-sak:latest
+   ```
+   (replacing the default GAR image reference)
+
+3. Start the Docker Compose environment (all services are needed):
+   ```bash
+   cd docker-compose-lokal
+   docker compose up --detach
+   ```
+   Wait for all to be healthy: `docker compose ps`
+
+4. Run the integration tests (from fp-autotest root):
+   ```bash
+   cd ../..
+   mvn test -P fpsak -Dtest=<TestClass>
+   ```
+
+5. After tests complete, shut down services (unless more tests are planned):
+   ```bash
+   cd lokal-utvikling/docker-compose-lokal
+   docker compose down
+   ```
+   If code changes are needed before retesting: shut down → rebuild → start again.
+   To restart only fp-sak after a rebuild: `docker compose up --detach --force-recreate fpsak`
+
+### For Full Test Catalog
+
+See `AGENTS.md` in the fp-autotest repository for:
+- Complete list of test DisplayNames
+- Aksjonspunkt codes covered per test class
+- Expected results (innvilget/avslag/avvist)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,7 @@ VerdikjedeEngangsstonad, VerdikjedeForeldrepenger, VerdikjedeSvangerskapspenger,
 ### Run Commands
 ```bash
 # Full fpsak suite
-cd ../fp-autotest && mvn test -P fpsak
+cd ~/git/fp-autotest && mvn test -P fpsak
 
 # Specific class
 mvn test -P fpsak -Dtest=Fodsel
@@ -33,47 +33,15 @@ mvn test -P verdikjede
 
 ### Testing Local Changes
 
-1. Build fp-sak and create a local Docker image:
-   ```bash
-   mvn clean install -DskipTests
-   docker build -t fp-sak .
-   ```
+For building, deploying, and running tests against local fp-sak changes, use the `run-integration-tests` skill in fp-autotest (see `fp-autotest/.github/skills/run-integration-tests/`).
 
-2. In fp-autotest, generate a fresh `.env` and edit it for local build:
-   ```bash
-   cd ../fp-autotest/lokal-utvikling
-   ./setup-lokal-utvikling.sh
-   ```
-   Then edit `docker-compose-lokal/.env` — change:
-   ```
-   FPSAK_IMAGE=fp-sak:latest
-   ```
-   (replacing the default GAR image reference)
-
-3. Start the Docker Compose environment (all services are needed):
-   ```bash
-   cd docker-compose-lokal
-   docker compose up --detach
-   ```
-   Wait for all to be healthy: `docker compose ps`
-
-4. Run the integration tests (from fp-autotest root):
-   ```bash
-   cd ../..
-   mvn test -P fpsak -Dtest=<TestClass>
-   ```
-
-5. After tests complete, shut down services (unless more tests are planned):
-   ```bash
-   cd lokal-utvikling/docker-compose-lokal
-   docker compose down
-   ```
-   If code changes are needed before retesting: shut down → rebuild → start again.
-   To restart only fp-sak after a rebuild: `docker compose up --detach --force-recreate fpsak`
+Quick reference for fp-sak:
+- Docker build tag: `fp-sak`
+- .env variable: `FPSAK_IMAGE`
+- Docker Compose service: `fpsak`
 
 ### For Full Test Catalog
 
 See `AGENTS.md` in the fp-autotest repository for:
-- Complete list of test DisplayNames
-- Aksjonspunkt codes covered per test class
-- Expected results (innvilget/avslag/avvist)
+- Complete list of test methods with DisplayNames
+- Aksjonspunkt code → test method mapping

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,6 +42,6 @@ Quick reference for fp-sak:
 
 ### For Full Test Catalog
 
-See `AGENTS.md` in the fp-autotest repository for:
-- Complete list of test methods with DisplayNames
-- Aksjonspunkt code → test method mapping
+See the fp-autotest repository for:
+- [AKSJONSPUNKT_MAPPING.md](https://github.com/navikt/fp-autotest/blob/master/AKSJONSPUNKT_MAPPING.md) — aksjonspunkt code → test method mapping
+- [TEST_CATALOG.md](https://github.com/navikt/fp-autotest/blob/master/TEST_CATALOG.md) — complete list of test methods with DisplayNames


### PR DESCRIPTION
Kan fort få copilot til å lage tilsvarende for alle repos vi har. Tilpasset Coplilot CLI fra et git-samle-dir med flere repos under
Frontendere må se hva som er vanlig der (bygg, test, generer typer, ....) og hva vi vil ha copilot-støtte for.