### PR TITLE
TFP-6549 oppdater abakus-kontrakt og forenkle enums + exh switches

### DIFF
--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/virksomhet/ArbeidType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/virksomhet/ArbeidType.java
@@ -44,7 +44,6 @@ public enum ArbeidType implements Kodeverdi, DatabaseKode, MedOffisiellKode {
     SELVSTENDIG_NÆRINGSDRIVENDE("NÆRING", "Selvstendig næringsdrivende"),
     UTENLANDSK_ARBEIDSFORHOLD("UTENLANDSK_ARBEIDSFORHOLD", "Arbeid i utlandet"),
     VENTELØNN_VARTPENGER("VENTELØNN_VARTPENGER", "Ventelønn eller vartpenger"),
-    VANLIG("VANLIG", "Vanlig", "VANLIG"),
     ;
 
     private static final Set<ArbeidType> ANNEN_OPPTJENING = Set.of(

--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/ytelse/RelatertYtelseType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/ytelse/RelatertYtelseType.java
@@ -12,7 +12,6 @@ import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
 
 public enum RelatertYtelseType implements Kodeverdi {
 
-    ENSLIG_FORSØRGER("EF", "Enslig forsørger"),
     SYKEPENGER("SP", "Sykepenger"),
     SVANGERSKAPSPENGER("SVP", "Svangerskapspenger"),
     FORELDREPENGER("FP", "Foreldrepenger"),
@@ -24,7 +23,6 @@ public enum RelatertYtelseType implements Kodeverdi {
     OPPLÆRINGSPENGER("OLP", "Opplæringspenger"),
     ARBEIDSAVKLARINGSPENGER("AAP", "Arbeidsavklaringspenger"),
     DAGPENGER("DAG", "Dagpenger"),
-    UDEFINERT(STANDARDKODE_UDEFINERT, "Ikke definert"),
     ;
 
     public static final Set<RelatertYtelseType> PLEIEPENGER = Set.of(PLEIEPENGER_SYKT_BARN, PLEIEPENGER_NÆRSTÅENDE, OPPLÆRINGSPENGER);
@@ -33,7 +31,7 @@ public enum RelatertYtelseType implements Kodeverdi {
         PLEIEPENGER_SYKT_BARN, PLEIEPENGER_NÆRSTÅENDE, OMSORGSPENGER, OPPLÆRINGSPENGER, FRISINN, DAGPENGER);
 
     private static final Map<FagsakYtelseType, Set<RelatertYtelseType>> OPPTJENING_RELATERTYTELSE_CONFIG = Map.of(
-        FagsakYtelseType.FORELDREPENGER, Set.of(ENSLIG_FORSØRGER, ARBEIDSAVKLARINGSPENGER),
+        FagsakYtelseType.FORELDREPENGER, Set.of(ARBEIDSAVKLARINGSPENGER),
         FagsakYtelseType.SVANGERSKAPSPENGER, Collections.emptySet());
 
     private static final Map<String, RelatertYtelseType> KODER = new LinkedHashMap<>();

--- a/behandlingslager/domene/src/test/java/no/nav/foreldrepenger/behandlingslager/geografisk/LandkoderTest.java
+++ b/behandlingslager/domene/src/test/java/no/nav/foreldrepenger/behandlingslager/geografisk/LandkoderTest.java
@@ -5,11 +5,17 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.event.Level;
 
 class LandkoderTest {
 
+    private static final Logger LOG = LoggerFactory.getLogger(LandkoderTest.class);
+
     @Test
     void skal_sjekke_for_norge() {
+        LOG.atLevel(Level.WARN).log("Sjekker om landkoder {} er Norge", Landkoder.SWE);
         assertThat(Landkoder.erNorge("SWE")).isFalse();
         assertThat(Landkoder.erNorge("NOR")).isTrue();
     }

--- a/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/abakus/ArbeidsforholdTjeneste.java
+++ b/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/abakus/ArbeidsforholdTjeneste.java
@@ -17,6 +17,7 @@ import no.nav.abakus.iaygrunnlag.kodeverk.YtelseType;
 import no.nav.abakus.iaygrunnlag.request.AktørDatoRequest;
 import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakYtelseType;
 import no.nav.foreldrepenger.behandlingslager.virksomhet.Arbeidsgiver;
+import no.nav.foreldrepenger.domene.abakus.mapping.KodeverkMapper;
 import no.nav.foreldrepenger.domene.iay.modell.ArbeidsforholdMedPermisjon;
 import no.nav.foreldrepenger.domene.iay.modell.kodeverk.PermisjonsbeskrivelseType;
 import no.nav.foreldrepenger.domene.tid.DatoIntervallEntitet;
@@ -60,7 +61,7 @@ public class ArbeidsforholdTjeneste {
     private static ArbeidsforholdMedPermisjon mapArbeidsforholdMedPermisjon(ArbeidsforholdDto dto) {
         return new ArbeidsforholdMedPermisjon(
             mapTilArbeidsgiver(dto),
-            no.nav.foreldrepenger.behandlingslager.virksomhet.ArbeidType.fraKode(dto.getType().getKode()),
+            KodeverkMapper.mapArbeidType(dto.getType()),
             dto.getArbeidsforholdId() != null ? EksternArbeidsforholdRef.ref(dto.getArbeidsforholdId().getEksternReferanse()) : EksternArbeidsforholdRef.nullRef(),
             tilAktivitetsavtale(dto.getArbeidsavtaler()),
             tilPermisjoner(dto.getPermisjoner()));
@@ -81,7 +82,8 @@ public class ArbeidsforholdTjeneste {
     }
 
     private static Permisjon mapTilPermisjon(PermisjonDto permisjonDto) {
-        return new Permisjon(DatoIntervallEntitet.fraOgMedTilOgMed(permisjonDto.getPeriode().getFom(), permisjonDto.getPeriode().getTom()), PermisjonsbeskrivelseType.fraKode(permisjonDto.getType().getKode()), permisjonDto.getProsentsats());
+        return new Permisjon(DatoIntervallEntitet.fraOgMedTilOgMed(permisjonDto.getPeriode().getFom(), permisjonDto.getPeriode().getTom()),
+            KodeverkMapper.mapPermisjonbeskrivelseTypeFraDto(permisjonDto.getType()), permisjonDto.getProsentsats());
     }
 
     private static AktivitetAvtale mapTilAktivitetsavtale(ArbeidsavtaleDto arbeidsavtaleDto) {

--- a/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/abakus/mapping/KodeverkMapper.java
+++ b/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/abakus/mapping/KodeverkMapper.java
@@ -1,7 +1,5 @@
 package no.nav.foreldrepenger.domene.abakus.mapping;
 
-import java.util.Map;
-
 import no.nav.abakus.iaygrunnlag.kodeverk.InntektskildeType;
 import no.nav.abakus.iaygrunnlag.kodeverk.InntektsmeldingInnsendingsårsakType;
 import no.nav.abakus.iaygrunnlag.kodeverk.NaturalytelseType;
@@ -29,43 +27,26 @@ import no.nav.foreldrepenger.domene.iay.modell.kodeverk.VirksomhetType;
 
 public final class KodeverkMapper {
 
-    private static final Map<YtelseType, RelatertYtelseType> ABAKUS_YTELSE_TIL_RELATERT_YTELSE = Map.ofEntries(
-            Map.entry(YtelseType.DAGPENGER, RelatertYtelseType.DAGPENGER),
-            Map.entry(YtelseType.ARBEIDSAVKLARINGSPENGER, RelatertYtelseType.ARBEIDSAVKLARINGSPENGER),
-            Map.entry(YtelseType.SYKEPENGER, RelatertYtelseType.SYKEPENGER),
-            Map.entry(YtelseType.PLEIEPENGER_SYKT_BARN, RelatertYtelseType.PLEIEPENGER_SYKT_BARN),
-            Map.entry(YtelseType.PLEIEPENGER_NÆRSTÅENDE, RelatertYtelseType.PLEIEPENGER_NÆRSTÅENDE),
-            Map.entry(YtelseType.OMSORGSPENGER, RelatertYtelseType.OMSORGSPENGER),
-            Map.entry(YtelseType.OPPLÆRINGSPENGER, RelatertYtelseType.OPPLÆRINGSPENGER),
-            Map.entry(YtelseType.FRISINN, RelatertYtelseType.FRISINN),
-            Map.entry(YtelseType.ENGANGSTØNAD, RelatertYtelseType.ENGANGSTØNAD),
-            Map.entry(YtelseType.FORELDREPENGER, RelatertYtelseType.FORELDREPENGER),
-            Map.entry(YtelseType.SVANGERSKAPSPENGER, RelatertYtelseType.SVANGERSKAPSPENGER),
-            Map.entry(YtelseType.ENSLIG_FORSØRGER, RelatertYtelseType.ENSLIG_FORSØRGER));
-
-    private static final Map<FagsakYtelseType, YtelseType> FAGSAKYTELSE_TIL_ABAKUS_YTELSE = Map.ofEntries(
-            Map.entry(FagsakYtelseType.ENGANGSTØNAD, YtelseType.ENGANGSTØNAD),
-            Map.entry(FagsakYtelseType.FORELDREPENGER, YtelseType.FORELDREPENGER),
-            Map.entry(FagsakYtelseType.SVANGERSKAPSPENGER, YtelseType.SVANGERSKAPSPENGER));
-
     private KodeverkMapper() {
     }
 
     public static YtelseType fraFagsakYtelseType(FagsakYtelseType fagsakYtelseType) {
-        return FAGSAKYTELSE_TIL_ABAKUS_YTELSE.get(fagsakYtelseType);
+        return switch (fagsakYtelseType) {
+            case ENGANGSTØNAD -> YtelseType.ENGANGSTØNAD;
+            case FORELDREPENGER -> YtelseType.FORELDREPENGER;
+            case SVANGERSKAPSPENGER -> YtelseType.SVANGERSKAPSPENGER;
+            case UDEFINERT -> null;
+            case null -> null;
+        };
     }
 
     static RelatertYtelseTilstand getFpsakRelatertYtelseTilstandForAbakusYtelseStatus(YtelseStatus dto) {
-        if (dto == null) {
-            return null;
-        }
-
         return switch (dto) {
             case OPPRETTET -> RelatertYtelseTilstand.IKKE_STARTET;
             case UNDER_BEHANDLING -> RelatertYtelseTilstand.ÅPEN;
             case AVSLUTTET -> RelatertYtelseTilstand.AVSLUTTET;
             case LØPENDE -> RelatertYtelseTilstand.LØPENDE;
-            default -> throw new IllegalArgumentException("Ukjent YtelseStatus: " + dto);
+            case null -> null;
         };
     }
 
@@ -98,87 +79,184 @@ public final class KodeverkMapper {
             case FPSAK -> Fagsystem.FPSAK;
             case K9SAK -> Fagsystem.K9SAK;
             case VLSP -> Fagsystem.VLSP;
-            case TPS -> Fagsystem.TPS;
-            case JOARK -> Fagsystem.JOARK;
             case INFOTRYGD -> Fagsystem.INFOTRYGD;
             case ARENA -> Fagsystem.ARENA;
             case KELVIN -> Fagsystem.KELVIN;
             case DPSAK -> Fagsystem.DPSAK;
-            case INNTEKT -> Fagsystem.INNTEKT;
-            case MEDL -> Fagsystem.MEDL;
-            case GOSYS -> Fagsystem.GOSYS;
-            case ENHETSREGISTERET -> Fagsystem.ENHETSREGISTERET;
             case AAREGISTERET -> Fagsystem.AAREGISTERET;
-            case BISYS, BIDRAGINNKREVING, FPABAKUS, GRISEN, GSAK, HJE_HEL_ORT, PESYS, SKANNING, VENTELONN,
-                 UNNTAK, ØKONOMI, ØVRIG, UDEFINERT -> Fagsystem.UDEFINERT;
             case null -> Fagsystem.UDEFINERT;
         };
     }
 
     static RelatertYtelseType mapYtelseTypeFraDto(YtelseType ytelseType) {
-        if (ytelseType == null) {
-            return RelatertYtelseType.UDEFINERT;
-        }
-        return ABAKUS_YTELSE_TIL_RELATERT_YTELSE.getOrDefault(ytelseType, RelatertYtelseType.UDEFINERT);
+        return switch (ytelseType) {
+            case YtelseType.DAGPENGER -> RelatertYtelseType.DAGPENGER;
+            case YtelseType.ARBEIDSAVKLARINGSPENGER -> RelatertYtelseType.ARBEIDSAVKLARINGSPENGER;
+            case YtelseType.SYKEPENGER -> RelatertYtelseType.SYKEPENGER;
+            case YtelseType.PLEIEPENGER_SYKT_BARN -> RelatertYtelseType.PLEIEPENGER_SYKT_BARN;
+            case YtelseType.PLEIEPENGER_NÆRSTÅENDE -> RelatertYtelseType.PLEIEPENGER_NÆRSTÅENDE;
+            case YtelseType.OMSORGSPENGER -> RelatertYtelseType.OMSORGSPENGER;
+            case YtelseType.OPPLÆRINGSPENGER -> RelatertYtelseType.OPPLÆRINGSPENGER;
+            case YtelseType.FRISINN -> RelatertYtelseType.FRISINN;
+            case YtelseType.ENGANGSTØNAD -> RelatertYtelseType.ENGANGSTØNAD;
+            case YtelseType.FORELDREPENGER -> RelatertYtelseType.FORELDREPENGER;
+            case YtelseType.SVANGERSKAPSPENGER -> RelatertYtelseType.SVANGERSKAPSPENGER;
+            case null -> null;
+        };
+    }
+
+    public static ArbeidType mapArbeidType(no.nav.abakus.iaygrunnlag.kodeverk.ArbeidType dto) {
+        return switch (dto) {
+            case ETTERLØNN_SLUTTPAKKE -> ArbeidType.ETTERLØNN_SLUTTPAKKE;
+            case FORENKLET_OPPGJØRSORDNING -> ArbeidType.FORENKLET_OPPGJØRSORDNING;
+            case FRILANSER -> ArbeidType.FRILANSER;
+            case FRILANSER_OPPDRAGSTAKER_MED_MER -> ArbeidType.FRILANSER_OPPDRAGSTAKER_MED_MER;
+            case LØNN_UNDER_UTDANNING -> ArbeidType.LØNN_UNDER_UTDANNING;
+            case MARITIMT_ARBEIDSFORHOLD -> ArbeidType.MARITIMT_ARBEIDSFORHOLD;
+            case MILITÆR_ELLER_SIVILTJENESTE -> ArbeidType.MILITÆR_ELLER_SIVILTJENESTE;
+            case ORDINÆRT_ARBEIDSFORHOLD -> ArbeidType.ORDINÆRT_ARBEIDSFORHOLD;
+            case PENSJON_OG_ANDRE_TYPER_YTELSER_UTEN_ANSETTELSESFORHOLD -> ArbeidType.PENSJON_OG_ANDRE_TYPER_YTELSER_UTEN_ANSETTELSESFORHOLD;
+            case SELVSTENDIG_NÆRINGSDRIVENDE -> ArbeidType.SELVSTENDIG_NÆRINGSDRIVENDE;
+            case UTENLANDSK_ARBEIDSFORHOLD -> ArbeidType.UTENLANDSK_ARBEIDSFORHOLD;
+            case VENTELØNN_VARTPENGER -> ArbeidType.VENTELØNN_VARTPENGER;
+            case null -> null;
+        };
     }
 
     static no.nav.abakus.iaygrunnlag.kodeverk.ArbeidType mapArbeidTypeTilDto(ArbeidType arbeidType) {
-        return arbeidType == null ? null : no.nav.abakus.iaygrunnlag.kodeverk.ArbeidType.fraKode(arbeidType.getKode());
+        return switch (arbeidType) {
+            case ETTERLØNN_SLUTTPAKKE -> no.nav.abakus.iaygrunnlag.kodeverk.ArbeidType.ETTERLØNN_SLUTTPAKKE;
+            case FORENKLET_OPPGJØRSORDNING -> no.nav.abakus.iaygrunnlag.kodeverk.ArbeidType.FORENKLET_OPPGJØRSORDNING;
+            case FRILANSER -> no.nav.abakus.iaygrunnlag.kodeverk.ArbeidType.FRILANSER;
+            case FRILANSER_OPPDRAGSTAKER_MED_MER -> no.nav.abakus.iaygrunnlag.kodeverk.ArbeidType.FRILANSER_OPPDRAGSTAKER_MED_MER;
+            case LØNN_UNDER_UTDANNING -> no.nav.abakus.iaygrunnlag.kodeverk.ArbeidType.LØNN_UNDER_UTDANNING;
+            case MARITIMT_ARBEIDSFORHOLD -> no.nav.abakus.iaygrunnlag.kodeverk.ArbeidType.MARITIMT_ARBEIDSFORHOLD;
+            case MILITÆR_ELLER_SIVILTJENESTE -> no.nav.abakus.iaygrunnlag.kodeverk.ArbeidType.MILITÆR_ELLER_SIVILTJENESTE;
+            case ORDINÆRT_ARBEIDSFORHOLD -> no.nav.abakus.iaygrunnlag.kodeverk.ArbeidType.ORDINÆRT_ARBEIDSFORHOLD;
+            case PENSJON_OG_ANDRE_TYPER_YTELSER_UTEN_ANSETTELSESFORHOLD -> no.nav.abakus.iaygrunnlag.kodeverk.ArbeidType.PENSJON_OG_ANDRE_TYPER_YTELSER_UTEN_ANSETTELSESFORHOLD;
+            case SELVSTENDIG_NÆRINGSDRIVENDE -> no.nav.abakus.iaygrunnlag.kodeverk.ArbeidType.SELVSTENDIG_NÆRINGSDRIVENDE;
+            case UTENLANDSK_ARBEIDSFORHOLD -> no.nav.abakus.iaygrunnlag.kodeverk.ArbeidType.UTENLANDSK_ARBEIDSFORHOLD;
+            case VENTELØNN_VARTPENGER -> no.nav.abakus.iaygrunnlag.kodeverk.ArbeidType.VENTELØNN_VARTPENGER;
+            case null -> null;
+        };
+    }
+
+    public static PermisjonsbeskrivelseType mapPermisjonbeskrivelseTypeFraDto(no.nav.abakus.iaygrunnlag.kodeverk.PermisjonsbeskrivelseType dto) {
+        return switch (dto) {
+            case PERMISJON -> PermisjonsbeskrivelseType.PERMISJON;
+            case UTDANNINGSPERMISJON -> PermisjonsbeskrivelseType.UTDANNINGSPERMISJON;
+            case UTDANNINGSPERMISJON_IKKE_LOVFESTET -> PermisjonsbeskrivelseType.UTDANNINGSPERMISJON_IKKE_LOVFESTET;
+            case UTDANNINGSPERMISJON_LOVFESTET -> PermisjonsbeskrivelseType.UTDANNINGSPERMISJON_LOVFESTET;
+            case VELFERDSPERMISJON -> PermisjonsbeskrivelseType.VELFERDSPERMISJON;
+            case ANNEN_PERMISJON_IKKE_LOVFESTET -> PermisjonsbeskrivelseType.ANNEN_PERMISJON_IKKE_LOVFESTET;
+            case ANNEN_PERMISJON_LOVFESTET -> PermisjonsbeskrivelseType.ANNEN_PERMISJON_LOVFESTET;
+            case PERMISJON_MED_FORELDREPENGER -> PermisjonsbeskrivelseType.PERMISJON_MED_FORELDREPENGER;
+            case PERMITTERING -> PermisjonsbeskrivelseType.PERMITTERING;
+            case PERMISJON_VED_MILITÆRTJENESTE -> PermisjonsbeskrivelseType.PERMISJON_VED_MILITÆRTJENESTE;
+            case null -> null;
+        };
     }
 
     static no.nav.abakus.iaygrunnlag.kodeverk.PermisjonsbeskrivelseType mapPermisjonbeskrivelseTypeTilDto(PermisjonsbeskrivelseType kode) {
-        return kode == null || PermisjonsbeskrivelseType.UDEFINERT.equals(
-            kode) ? null : no.nav.abakus.iaygrunnlag.kodeverk.PermisjonsbeskrivelseType.fraKode(kode.getKode());
+        return switch (kode) {
+            case PERMISJON -> no.nav.abakus.iaygrunnlag.kodeverk.PermisjonsbeskrivelseType.PERMISJON;
+            case UTDANNINGSPERMISJON -> no.nav.abakus.iaygrunnlag.kodeverk.PermisjonsbeskrivelseType.UTDANNINGSPERMISJON;
+            case UTDANNINGSPERMISJON_IKKE_LOVFESTET -> no.nav.abakus.iaygrunnlag.kodeverk.PermisjonsbeskrivelseType.UTDANNINGSPERMISJON_IKKE_LOVFESTET;
+            case UTDANNINGSPERMISJON_LOVFESTET -> no.nav.abakus.iaygrunnlag.kodeverk.PermisjonsbeskrivelseType.UTDANNINGSPERMISJON_LOVFESTET;
+            case VELFERDSPERMISJON -> no.nav.abakus.iaygrunnlag.kodeverk.PermisjonsbeskrivelseType.VELFERDSPERMISJON;
+            case ANNEN_PERMISJON_IKKE_LOVFESTET -> no.nav.abakus.iaygrunnlag.kodeverk.PermisjonsbeskrivelseType.ANNEN_PERMISJON_IKKE_LOVFESTET;
+            case ANNEN_PERMISJON_LOVFESTET -> no.nav.abakus.iaygrunnlag.kodeverk.PermisjonsbeskrivelseType.ANNEN_PERMISJON_LOVFESTET;
+            case PERMISJON_MED_FORELDREPENGER -> no.nav.abakus.iaygrunnlag.kodeverk.PermisjonsbeskrivelseType.PERMISJON_MED_FORELDREPENGER;
+            case PERMITTERING -> no.nav.abakus.iaygrunnlag.kodeverk.PermisjonsbeskrivelseType.PERMITTERING;
+            case PERMISJON_VED_MILITÆRTJENESTE -> no.nav.abakus.iaygrunnlag.kodeverk.PermisjonsbeskrivelseType.PERMISJON_VED_MILITÆRTJENESTE;
+            case null -> null;
+        };
+    }
+
+    static ArbeidsforholdHandlingType mapArbeidsforholdHandlingTypeFraDto(no.nav.abakus.iaygrunnlag.kodeverk.ArbeidsforholdHandlingType dto) {
+        return switch (dto) {
+            case BRUK -> ArbeidsforholdHandlingType.BRUK;
+            case NYTT_ARBEIDSFORHOLD -> ArbeidsforholdHandlingType.NYTT_ARBEIDSFORHOLD;
+            case BRUK_UTEN_INNTEKTSMELDING -> ArbeidsforholdHandlingType.BRUK_UTEN_INNTEKTSMELDING;
+            case IKKE_BRUK -> ArbeidsforholdHandlingType.IKKE_BRUK;
+            case SLÅTT_SAMMEN_MED_ANNET -> ArbeidsforholdHandlingType.SLÅTT_SAMMEN_MED_ANNET;
+            case LAGT_TIL_AV_SAKSBEHANDLER -> ArbeidsforholdHandlingType.LAGT_TIL_AV_SAKSBEHANDLER;
+            case BASERT_PÅ_INNTEKTSMELDING -> ArbeidsforholdHandlingType.BASERT_PÅ_INNTEKTSMELDING;
+            case BRUK_MED_OVERSTYRT_PERIODE -> ArbeidsforholdHandlingType.BRUK_MED_OVERSTYRT_PERIODE;
+            case INNTEKT_IKKE_MED_I_BG -> ArbeidsforholdHandlingType.INNTEKT_IKKE_MED_I_BG;
+            case null -> null;
+        };
     }
 
     static no.nav.abakus.iaygrunnlag.kodeverk.ArbeidsforholdHandlingType mapArbeidsforholdHandlingTypeTilDto(ArbeidsforholdHandlingType kode) {
-        return kode == null || ArbeidsforholdHandlingType.UDEFINERT.equals(
-            kode) ? null : no.nav.abakus.iaygrunnlag.kodeverk.ArbeidsforholdHandlingType.fraKode(kode.getKode());
+        return switch (kode) {
+            case BRUK -> no.nav.abakus.iaygrunnlag.kodeverk.ArbeidsforholdHandlingType.BRUK;
+            case NYTT_ARBEIDSFORHOLD -> no.nav.abakus.iaygrunnlag.kodeverk.ArbeidsforholdHandlingType.NYTT_ARBEIDSFORHOLD;
+            case BRUK_UTEN_INNTEKTSMELDING -> no.nav.abakus.iaygrunnlag.kodeverk.ArbeidsforholdHandlingType.BRUK_UTEN_INNTEKTSMELDING;
+            case IKKE_BRUK -> no.nav.abakus.iaygrunnlag.kodeverk.ArbeidsforholdHandlingType.IKKE_BRUK;
+            case SLÅTT_SAMMEN_MED_ANNET -> no.nav.abakus.iaygrunnlag.kodeverk.ArbeidsforholdHandlingType.SLÅTT_SAMMEN_MED_ANNET;
+            case LAGT_TIL_AV_SAKSBEHANDLER -> no.nav.abakus.iaygrunnlag.kodeverk.ArbeidsforholdHandlingType.LAGT_TIL_AV_SAKSBEHANDLER;
+            case BASERT_PÅ_INNTEKTSMELDING -> no.nav.abakus.iaygrunnlag.kodeverk.ArbeidsforholdHandlingType.BASERT_PÅ_INNTEKTSMELDING;
+            case BRUK_MED_OVERSTYRT_PERIODE -> no.nav.abakus.iaygrunnlag.kodeverk.ArbeidsforholdHandlingType.BRUK_MED_OVERSTYRT_PERIODE;
+            case INNTEKT_IKKE_MED_I_BG -> no.nav.abakus.iaygrunnlag.kodeverk.ArbeidsforholdHandlingType.INNTEKT_IKKE_MED_I_BG;
+            case null -> null;
+        };
     }
 
-    static ArbeidType mapArbeidType(no.nav.abakus.iaygrunnlag.kodeverk.ArbeidType dto) {
-        return dto == null ? null : ArbeidType.fraKode(dto.getKode());
+    static InntektsmeldingInnsendingsårsak mapInntektsmeldingInnsendingsårsakFraDto(InntektsmeldingInnsendingsårsakType dto) {
+        return switch (dto) {
+            case NY -> InntektsmeldingInnsendingsårsak.NY;
+            case ENDRING -> InntektsmeldingInnsendingsårsak.ENDRING;
+            case null -> null;
+        };
     }
 
     static InntektsmeldingInnsendingsårsakType mapInntektsmeldingInnsendingsårsak(InntektsmeldingInnsendingsårsak kode) {
         return switch (kode) {
             case NY -> InntektsmeldingInnsendingsårsakType.NY;
             case ENDRING -> InntektsmeldingInnsendingsårsakType.ENDRING;
-            case UDEFINERT -> null;
             case null -> null;
         };
     }
 
+    static NaturalYtelseType mapNaturalYtelseFraDto(NaturalytelseType dto) {
+        return dto == null ? null : NaturalYtelseType.fraKode(dto.getKode());
+    }
+
     static NaturalytelseType mapNaturalYtelseTilDto(NaturalYtelseType kode) {
-        return kode == null || NaturalYtelseType.UDEFINERT.equals(kode) ? null : NaturalytelseType.fraKode(kode.getKode());
+        return kode == null  ? null : NaturalytelseType.fraKode(kode.getKode());
+    }
+
+    static UtsettelseÅrsak mapUtsettelseÅrsakFraDto(UtsettelseÅrsakType dto) {
+        return switch (dto) {
+            case ARBEID -> UtsettelseÅrsak.ARBEID;
+            case FERIE -> UtsettelseÅrsak.FERIE;
+            case SYKDOM -> UtsettelseÅrsak.SYKDOM;
+            case INSTITUSJON_SØKER -> UtsettelseÅrsak.INSTITUSJON_SØKER;
+            case INSTITUSJON_BARN -> UtsettelseÅrsak.INSTITUSJON_BARN;
+            case null -> UtsettelseÅrsak.UDEFINERT;
+        };
     }
 
     static UtsettelseÅrsakType mapUtsettelseÅrsakTilDto(UtsettelseÅrsak kode) {
-        return kode == null || UtsettelseÅrsak.UDEFINERT.equals(kode) ? null : UtsettelseÅrsakType.fraKode(kode.getKode());
+        return switch (kode) {
+            case ARBEID -> UtsettelseÅrsakType.ARBEID;
+            case FERIE -> UtsettelseÅrsakType.FERIE;
+            case SYKDOM -> UtsettelseÅrsakType.SYKDOM;
+            case INSTITUSJON_SØKER -> UtsettelseÅrsakType.INSTITUSJON_SØKER;
+            case INSTITUSJON_BARN -> UtsettelseÅrsakType.INSTITUSJON_BARN;
+            case null, default -> null;
+        };
     }
 
     static InntektsKilde mapInntektsKildeFraDto(InntektskildeType dto) {
         return switch (dto) {
-            case UDEFINERT -> InntektsKilde.UDEFINERT;
             case INNTEKT_OPPTJENING -> InntektsKilde.INNTEKT_OPPTJENING;
             case INNTEKT_BEREGNING -> InntektsKilde.INNTEKT_BEREGNING;
             case INNTEKT_SAMMENLIGNING -> InntektsKilde.INNTEKT_SAMMENLIGNING;
             case SIGRUN -> InntektsKilde.SIGRUN;
-            case VANLIG -> InntektsKilde.VANLIG;
-            case null -> InntektsKilde.UDEFINERT;
+            case null -> null;
         };
-    }
-
-    static ArbeidsforholdHandlingType mapArbeidsforholdHandlingTypeFraDto(no.nav.abakus.iaygrunnlag.kodeverk.ArbeidsforholdHandlingType dto) {
-        return dto == null
-                ? ArbeidsforholdHandlingType.UDEFINERT
-                : ArbeidsforholdHandlingType.fraKode(dto.getKode());
-    }
-
-    static NaturalYtelseType mapNaturalYtelseFraDto(NaturalytelseType dto) {
-        return dto == null
-                ? NaturalYtelseType.UDEFINERT
-                : NaturalYtelseType.fraKode(dto.getKode());
     }
 
     static VirksomhetType mapVirksomhetTypeFraDto(no.nav.abakus.iaygrunnlag.kodeverk.VirksomhetType dto) {
@@ -187,56 +265,55 @@ public final class KodeverkMapper {
             case FISKE -> VirksomhetType.FISKE;
             case JORDBRUK_SKOGBRUK -> VirksomhetType.JORDBRUK_SKOGBRUK;
             case ANNEN -> VirksomhetType.ANNEN;
-            case UDEFINERT -> VirksomhetType.UDEFINERT;
-            case null -> VirksomhetType.UDEFINERT;
+            case null -> null;
         };
     }
 
     static SkatteOgAvgiftsregelType mapSkatteOgAvgiftsregelFraDto(no.nav.abakus.iaygrunnlag.kodeverk.SkatteOgAvgiftsregelType dto) {
-        return dto == null
-                ? SkatteOgAvgiftsregelType.UDEFINERT
-                : SkatteOgAvgiftsregelType.fraKode(dto.getKode());
-    }
-
-    static InntektspostType mapInntektspostTypeFraDto(no.nav.abakus.iaygrunnlag.kodeverk.InntektspostType dto) {
-        return dto == null
-                ? InntektspostType.UDEFINERT
-                : InntektspostType.fraKode(dto.getKode());
-    }
-
-    static PermisjonsbeskrivelseType mapPermisjonbeskrivelseTypeFraDto(no.nav.abakus.iaygrunnlag.kodeverk.PermisjonsbeskrivelseType dto) {
-        return dto == null
-                ? PermisjonsbeskrivelseType.UDEFINERT
-                : PermisjonsbeskrivelseType.fraKode(dto.getKode());
-    }
-
-    static Arbeidskategori mapArbeidskategoriFraDto(no.nav.abakus.iaygrunnlag.kodeverk.Arbeidskategori dto) {
-        return dto == null
-                ? Arbeidskategori.UDEFINERT
-                : Arbeidskategori.fraKode(dto.getKode());
-    }
-
-    static InntektPeriodeType mapInntektPeriodeTypeFraDto(no.nav.abakus.iaygrunnlag.kodeverk.InntektPeriodeType dto) {
-        return dto == null
-                ? InntektPeriodeType.UDEFINERT
-                : InntektPeriodeType.fraKode(dto.getKode());
-    }
-
-    static InntektsmeldingInnsendingsårsak mapInntektsmeldingInnsendingsårsakFraDto(
-            InntektsmeldingInnsendingsårsakType dto) {
         return switch (dto) {
-            case NY -> InntektsmeldingInnsendingsårsak.NY;
-            case ENDRING -> InntektsmeldingInnsendingsårsak.ENDRING;
-            case UDEFINERT -> InntektsmeldingInnsendingsårsak.UDEFINERT;
-            case null -> InntektsmeldingInnsendingsårsak.UDEFINERT;
+            case SÆRSKILT_FRADRAG_FOR_SJØFOLK -> SkatteOgAvgiftsregelType.SÆRSKILT_FRADRAG_FOR_SJØFOLK;
+            case SVALBARD -> SkatteOgAvgiftsregelType.SVALBARD;
+            case SKATTEFRI_ORGANISASJON -> SkatteOgAvgiftsregelType.SKATTEFRI_ORGANISASJON;
+            case NETTOLØNN_FOR_SJØFOLK -> SkatteOgAvgiftsregelType.NETTOLØNN_FOR_SJØFOLK;
+            case NETTOLØNN -> SkatteOgAvgiftsregelType.NETTOLØNN;
+            case KILDESKATT_PÅ_PENSJONER -> SkatteOgAvgiftsregelType.KILDESKATT_PÅ_PENSJONER;
+            case JAN_MAYEN_OG_BILANDENE -> SkatteOgAvgiftsregelType.JAN_MAYEN_OG_BILANDENE;
+            case UDEFINERT -> SkatteOgAvgiftsregelType.UDEFINERT;
+            case null -> SkatteOgAvgiftsregelType.UDEFINERT;
         };
     }
 
-    static UtsettelseÅrsak mapUtsettelseÅrsakFraDto(UtsettelseÅrsakType dto) {
-        return dto == null
-                ? UtsettelseÅrsak.UDEFINERT
-                : UtsettelseÅrsak.fraKode(dto.getKode());
+    static InntektspostType mapInntektspostTypeFraDto(no.nav.abakus.iaygrunnlag.kodeverk.InntektspostType dto) {
+        return switch (dto) {
+            case LØNN -> InntektspostType.LØNN;
+            case YTELSE -> InntektspostType.YTELSE;
+            case SELVSTENDIG_NÆRINGSDRIVENDE -> InntektspostType.SELVSTENDIG_NÆRINGSDRIVENDE;
+            case NÆRING_FISKE_FANGST_FAMBARNEHAGE -> InntektspostType.NÆRING_FISKE_FANGST_FAMBARNEHAGE;
+            case null -> null;
+        };
     }
+
+    static Arbeidskategori mapArbeidskategoriFraDto(no.nav.abakus.iaygrunnlag.kodeverk.Arbeidskategori dto) {
+        return dto == null ? Arbeidskategori.UDEFINERT : Arbeidskategori.fraKode(dto.getKode());
+    }
+
+    static InntektPeriodeType mapInntektPeriodeTypeFraDto(no.nav.abakus.iaygrunnlag.kodeverk.InntektPeriodeType dto) {
+        return switch (dto) {
+            case DAGLIG -> InntektPeriodeType.DAGLIG;
+            case UKENTLIG -> InntektPeriodeType.UKENTLIG;
+            case BIUKENTLIG -> InntektPeriodeType.BIUKENTLIG;
+            case MÅNEDLIG -> InntektPeriodeType.MÅNEDLIG;
+            case ÅRLIG -> InntektPeriodeType.ÅRLIG;
+            case FASTSATT25PAVVIK -> InntektPeriodeType.FASTSATT25PAVVIK;
+            case PREMIEGRUNNLAG -> InntektPeriodeType.PREMIEGRUNNLAG;
+            case UDEFINERT -> InntektPeriodeType.UDEFINERT;
+            case null -> InntektPeriodeType.UDEFINERT;
+        };
+    }
+
+
+
+
 
     static no.nav.abakus.iaygrunnlag.kodeverk.VirksomhetType mapVirksomhetTypeTilDto(VirksomhetType kode) {
         return switch (kode) {
@@ -244,7 +321,6 @@ public final class KodeverkMapper {
             case FISKE -> no.nav.abakus.iaygrunnlag.kodeverk.VirksomhetType.FISKE;
             case JORDBRUK_SKOGBRUK -> no.nav.abakus.iaygrunnlag.kodeverk.VirksomhetType.JORDBRUK_SKOGBRUK;
             case ANNEN -> no.nav.abakus.iaygrunnlag.kodeverk.VirksomhetType.ANNEN;
-            case FRILANSER, UDEFINERT -> null;
             case null -> null;
         };
     }

--- a/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/arbeidsforhold/dto/BehandlingRelaterteYtelserMapper.java
+++ b/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/arbeidsforhold/dto/BehandlingRelaterteYtelserMapper.java
@@ -46,7 +46,7 @@ public class BehandlingRelaterteYtelserMapper {
     }
 
     public static RelatertYtelseType mapFraFagsakYtelseTypeTilRelatertYtelseType(FagsakYtelseType type) {
-        return YTELSE_TYPE_MAP.getOrDefault(type, RelatertYtelseType.UDEFINERT);
+        return YTELSE_TYPE_MAP.get(type);
     }
 
     private static TilgrensendeYtelser lagTilgrensendeYtelse(Ytelse ytelse) {
@@ -54,7 +54,7 @@ public class BehandlingRelaterteYtelserMapper {
     }
 
     public static TilgrensendeYtelser mapFraFagsak(Fagsak fagsak, LocalDate periodeDato) {
-        var relatertYtelseType = YTELSE_TYPE_MAP.getOrDefault(fagsak.getYtelseType(), RelatertYtelseType.UDEFINERT);
+        var relatertYtelseType = YTELSE_TYPE_MAP.get(fagsak.getYtelseType());
         return new TilgrensendeYtelser(relatertYtelseType, periodeDato, endreTomDatoHvisLøpende(periodeDato), fagsak.getStatus().getNavn(), fagsak.getSaksnummer());
     }
 

--- a/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/iay/modell/ArbeidsforholdOverstyring.java
+++ b/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/iay/modell/ArbeidsforholdOverstyring.java
@@ -30,7 +30,7 @@ public class ArbeidsforholdOverstyring implements IndexKey {
     private InternArbeidsforholdRef nyArbeidsforholdRef;
 
     @ChangeTracked
-    private ArbeidsforholdHandlingType handling = ArbeidsforholdHandlingType.UDEFINERT;
+    private ArbeidsforholdHandlingType handling;
 
     private String begrunnelse;
 

--- a/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/iay/modell/Inntektsmelding.java
+++ b/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/iay/modell/Inntektsmelding.java
@@ -71,7 +71,7 @@ public class Inntektsmelding implements IndexKey {
     private List<Refusjon> endringerRefusjon = new ArrayList<>();
 
     @ChangeTracked
-    private InntektsmeldingInnsendingsårsak innsendingsårsak = InntektsmeldingInnsendingsårsak.UDEFINERT;
+        private InntektsmeldingInnsendingsårsak innsendingsårsak;
 
     Inntektsmelding() {
     }

--- a/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/iay/modell/NaturalYtelse.java
+++ b/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/iay/modell/NaturalYtelse.java
@@ -20,7 +20,7 @@ public class NaturalYtelse implements IndexKey {
     @ChangeTracked @NotNull
     private Beløp beloepPerMnd;
 
-    @NotNull private NaturalYtelseType type = NaturalYtelseType.UDEFINERT;
+    @NotNull private NaturalYtelseType type;
 
     NaturalYtelse() {
     }

--- a/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/iay/modell/OppgittEgenNæring.java
+++ b/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/iay/modell/OppgittEgenNæring.java
@@ -19,7 +19,7 @@ public class OppgittEgenNæring implements IndexKey {
     private OrgNummer virksomhetOrgnr;
 
     @ChangeTracked
-    private VirksomhetType virksomhetType = VirksomhetType.UDEFINERT;
+    private VirksomhetType virksomhetType;
 
     private String regnskapsførerNavn;
 

--- a/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/iay/modell/YrkesaktivitetBuilder.java
+++ b/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/iay/modell/YrkesaktivitetBuilder.java
@@ -164,8 +164,4 @@ public class YrkesaktivitetBuilder {
         return resultat;
     }
 
-    public YrkesaktivitetBuilder medArbeidType(String kode) {
-        return medArbeidType(ArbeidType.fraKode(kode));
-    }
-
 }

--- a/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/iay/modell/YrkesaktivitetFilter.java
+++ b/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/iay/modell/YrkesaktivitetFilter.java
@@ -262,7 +262,7 @@ public class YrkesaktivitetFilter {
         var handling = overstyring.getHandling();
 
         var overstyrtePerioder = overstyring.getArbeidsforholdOverstyrtePerioder();
-        if (handling.erPeriodeOverstyrt() && !overstyrtePerioder.isEmpty()) {
+        if (handling != null && handling.erPeriodeOverstyrt() && !overstyrtePerioder.isEmpty()) {
             Set<AktivitetsAvtale> avtaler = new LinkedHashSet<>();
             overstyrtePerioder.forEach(overstyrtPeriode -> yaAvtaler.stream()
                     .filter(AktivitetsAvtale::erAnsettelsesPeriode)

--- a/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/iay/modell/Ytelse.java
+++ b/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/iay/modell/Ytelse.java
@@ -9,7 +9,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import no.nav.foreldrepenger.behandlingslager.BaseEntitet;
 import no.nav.foreldrepenger.behandlingslager.diff.ChangeTracked;
 import no.nav.foreldrepenger.behandlingslager.diff.IndexKey;
 import no.nav.foreldrepenger.behandlingslager.kodeverk.Fagsystem;
@@ -18,11 +17,11 @@ import no.nav.foreldrepenger.domene.iay.modell.kodeverk.RelatertYtelseTilstand;
 import no.nav.foreldrepenger.domene.tid.DatoIntervallEntitet;
 import no.nav.foreldrepenger.domene.typer.Saksnummer;
 
-public class Ytelse extends BaseEntitet implements IndexKey {
+public class Ytelse implements IndexKey {
 
     private YtelseGrunnlag ytelseGrunnlag;
 
-    private RelatertYtelseType relatertYtelseType = RelatertYtelseType.UDEFINERT;
+    private RelatertYtelseType relatertYtelseType;
 
     @ChangeTracked
     private DatoIntervallEntitet periode;

--- a/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/iay/modell/YtelseAnvistAndel.java
+++ b/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/iay/modell/YtelseAnvistAndel.java
@@ -31,7 +31,7 @@ public class YtelseAnvistAndel implements IndexKey {
     private Stillingsprosent refusjonsgradProsent;
 
     @ChangeTracked
-    private Inntektskategori inntektskategori = Inntektskategori.UDEFINERT;
+    private Inntektskategori inntektskategori ;
 
     public YtelseAnvistAndel() {
         // hibernate

--- a/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/iay/modell/kodeverk/ArbeidsforholdHandlingType.java
+++ b/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/iay/modell/kodeverk/ArbeidsforholdHandlingType.java
@@ -16,7 +16,6 @@ import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
 
 public enum ArbeidsforholdHandlingType implements Kodeverdi {
 
-    UDEFINERT(STANDARDKODE_UDEFINERT, "Udefinert"),
     BRUK("BRUK", "Bruk"),
     NYTT_ARBEIDSFORHOLD("NYTT_ARBEIDSFORHOLD", "Arbeidsforholdet er ansett som nytt"),
     BRUK_UTEN_INNTEKTSMELDING("BRUK_UTEN_INNTEKTSMELDING", "Bruk, men ikke benytt inntektsmelding"),

--- a/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/iay/modell/kodeverk/InntektYtelseType.java
+++ b/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/iay/modell/kodeverk/InntektYtelseType.java
@@ -6,61 +6,57 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonValue;
 
 import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
-import no.nav.foreldrepenger.behandlingslager.ytelse.RelatertYtelseType;
 
 @JsonAutoDetect(getterVisibility = Visibility.NONE, setterVisibility = Visibility.NONE, fieldVisibility = Visibility.ANY)
 public enum InntektYtelseType implements Kodeverdi {
 
     // Ytelse utbetalt til person som er arbeidstaker/frilanser/ytelsesmottaker
-    AAP("Arbeidsavklaringspenger", Kategori.YTELSE, RelatertYtelseType.ARBEIDSAVKLARINGSPENGER),
-    DAGPENGER("Dagpenger arbeid og hyre", Kategori.YTELSE, RelatertYtelseType.DAGPENGER),
-    FORELDREPENGER("Foreldrepenger", Kategori.YTELSE, RelatertYtelseType.FORELDREPENGER),
-    SVANGERSKAPSPENGER("Svangerskapspenger", Kategori.YTELSE, RelatertYtelseType.SVANGERSKAPSPENGER),
-    SYKEPENGER("Sykepenger", Kategori.YTELSE, RelatertYtelseType.SYKEPENGER),
-    OMSORGSPENGER("Omsorgspenger", Kategori.YTELSE, RelatertYtelseType.OMSORGSPENGER),
-    OPPLÆRINGSPENGER("Opplæringspenger", Kategori.YTELSE, RelatertYtelseType.OPPLÆRINGSPENGER),
-    PLEIEPENGER("Pleiepenger", Kategori.YTELSE, RelatertYtelseType.PLEIEPENGER_SYKT_BARN),
-    OVERGANGSSTØNAD_ENSLIG("Overgangsstønad til enslig mor eller far", Kategori.YTELSE, RelatertYtelseType.ENSLIG_FORSØRGER),
-    VENTELØNN("Ventelønn", Kategori.YTELSE, RelatertYtelseType.UDEFINERT),
+    AAP("Arbeidsavklaringspenger", Kategori.YTELSE),
+    DAGPENGER("Dagpenger arbeid og hyre", Kategori.YTELSE),
+    FORELDREPENGER("Foreldrepenger", Kategori.YTELSE),
+    SVANGERSKAPSPENGER("Svangerskapspenger", Kategori.YTELSE),
+    SYKEPENGER("Sykepenger", Kategori.YTELSE),
+    OMSORGSPENGER("Omsorgspenger", Kategori.YTELSE),
+    OPPLÆRINGSPENGER("Opplæringspenger", Kategori.YTELSE),
+    PLEIEPENGER("Pleiepenger", Kategori.YTELSE),
+    OVERGANGSSTØNAD_ENSLIG("Overgangsstønad til enslig mor eller far", Kategori.YTELSE),
+    VENTELØNN("Ventelønn", Kategori.YTELSE),
 
     // Feriepenger Ytelse utbetalt til person som er arbeidstaker/frilanser/ytelsesmottaker
     // TODO slå sammen til FERIEPENGER_YTELSE - eller ta de med under hver ytelse???
-    FERIEPENGER_FORELDREPENGER("Feriepenger foreldrepenger", Kategori.YTELSE, RelatertYtelseType.FORELDREPENGER),
-    FERIEPENGER_SVANGERSKAPSPENGER("Feriepenger svangerskapspenger", Kategori.YTELSE, RelatertYtelseType.SVANGERSKAPSPENGER),
-    FERIEPENGER_OMSORGSPENGER("Feriepenger omsorgspenger", Kategori.YTELSE, RelatertYtelseType.OMSORGSPENGER),
-    FERIEPENGER_OPPLÆRINGSPENGER("Feriepenger opplæringspenger", Kategori.YTELSE, RelatertYtelseType.OPPLÆRINGSPENGER),
-    FERIEPENGER_PLEIEPENGER("Feriepenger pleiepenger", Kategori.YTELSE, RelatertYtelseType.PLEIEPENGER_SYKT_BARN),
-    FERIEPENGER_SYKEPENGER("Feriepenger sykepenger", Kategori.YTELSE, RelatertYtelseType.SYKEPENGER),
-    FERIETILLEGG_DAGPENGER("Ferietillegg dagpenger ", Kategori.YTELSE, RelatertYtelseType.DAGPENGER),
+    FERIEPENGER_FORELDREPENGER("Feriepenger foreldrepenger", Kategori.YTELSE),
+    FERIEPENGER_SVANGERSKAPSPENGER("Feriepenger svangerskapspenger", Kategori.YTELSE),
+    FERIEPENGER_OMSORGSPENGER("Feriepenger omsorgspenger", Kategori.YTELSE),
+    FERIEPENGER_OPPLÆRINGSPENGER("Feriepenger opplæringspenger", Kategori.YTELSE),
+    FERIEPENGER_PLEIEPENGER("Feriepenger pleiepenger", Kategori.YTELSE),
+    FERIEPENGER_SYKEPENGER("Feriepenger sykepenger", Kategori.YTELSE),
+    FERIETILLEGG_DAGPENGER("Ferietillegg dagpenger ", Kategori.YTELSE),
 
     // Annen ytelse utbetalt til person
-    KVALIFISERINGSSTØNAD("Kvalifiseringsstønad", Kategori.TRYGD, RelatertYtelseType.UDEFINERT),
+    KVALIFISERINGSSTØNAD("Kvalifiseringsstønad", Kategori.TRYGD),
 
     // Ytelse utbetalt til person som er næringsdrivende, fisker/lott, dagmamma eller jord/skogbruker
-    FORELDREPENGER_NÆRING("Foreldrepenger næring", Kategori.NÆRING, RelatertYtelseType.FORELDREPENGER),
-    SVANGERSKAPSPENGER_NÆRING("Svangerskapspenger næring", Kategori.NÆRING, RelatertYtelseType.SVANGERSKAPSPENGER),
-    SYKEPENGER_NÆRING("Sykepenger næring", Kategori.NÆRING, RelatertYtelseType.SYKEPENGER),
-    OMSORGSPENGER_NÆRING("Omsorgspenger næring", Kategori.NÆRING, RelatertYtelseType.OMSORGSPENGER),
-    OPPLÆRINGSPENGER_NÆRING("Opplæringspenger næring", Kategori.NÆRING, RelatertYtelseType.OPPLÆRINGSPENGER),
-    PLEIEPENGER_NÆRING("Pleiepenger næring", Kategori.NÆRING, RelatertYtelseType.PLEIEPENGER_SYKT_BARN),
-    DAGPENGER_NÆRING("Dagpenger næring", Kategori.NÆRING, RelatertYtelseType.DAGPENGER),
+    FORELDREPENGER_NÆRING("Foreldrepenger næring", Kategori.NÆRING),
+    SVANGERSKAPSPENGER_NÆRING("Svangerskapspenger næring", Kategori.NÆRING),
+    SYKEPENGER_NÆRING("Sykepenger næring", Kategori.NÆRING),
+    OMSORGSPENGER_NÆRING("Omsorgspenger næring", Kategori.NÆRING),
+    OPPLÆRINGSPENGER_NÆRING("Opplæringspenger næring", Kategori.NÆRING),
+    PLEIEPENGER_NÆRING("Pleiepenger næring", Kategori.NÆRING),
+    DAGPENGER_NÆRING("Dagpenger næring", Kategori.NÆRING),
 
     // Annen ytelse utbetalt til person som er næringsdrivende
-    ANNET("Annet", Kategori.NÆRING, RelatertYtelseType.UDEFINERT),
-    VEDERLAG("Vederlag", Kategori.NÆRING, RelatertYtelseType.UDEFINERT),
-    LOTT_KUN_TRYGDEAVGIFT("Lott kun trygdeavgift", Kategori.NÆRING, RelatertYtelseType.UDEFINERT),
-    KOMPENSASJON_FOR_TAPT_PERSONINNTEKT("Kompensasjon for tapt personinntekt", Kategori.NÆRING, RelatertYtelseType.FRISINN)
+    ANNET("Annet", Kategori.NÆRING),
+    VEDERLAG("Vederlag", Kategori.NÆRING),
+    LOTT_KUN_TRYGDEAVGIFT("Lott kun trygdeavgift", Kategori.NÆRING),
+    KOMPENSASJON_FOR_TAPT_PERSONINNTEKT("Kompensasjon for tapt personinntekt", Kategori.NÆRING)
     ;
 
     @JsonIgnore
     private final String navn;
-    @JsonIgnore
-    private final RelatertYtelseType ytelseType;
 
     @SuppressWarnings("unused") // Kategori: Beholder for likhet med Abakus
-    InntektYtelseType(String navn, Kategori kategori, RelatertYtelseType ytelseType) {
+    InntektYtelseType(String navn, Kategori kategori) {
         this.navn = navn;
-        this.ytelseType = ytelseType;
     }
 
     public static InntektYtelseType fraKode(String kode) {
@@ -76,10 +72,6 @@ public enum InntektYtelseType implements Kodeverdi {
     @JsonValue
     public String getKode() {
         return name();
-    }
-
-    public RelatertYtelseType getYtelseType() {
-        return ytelseType;
     }
 
     public enum Kategori { YTELSE, NÆRING, TRYGD }

--- a/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/iay/modell/kodeverk/InntektsKilde.java
+++ b/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/iay/modell/kodeverk/InntektsKilde.java
@@ -9,12 +9,10 @@ import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
 
 public enum InntektsKilde implements Kodeverdi {
 
-    UDEFINERT(STANDARDKODE_UDEFINERT, "Ikke definert"),
     INNTEKT_OPPTJENING("INNTEKT_OPPTJENING", "INNTEKT_OPPTJENING"),
     INNTEKT_BEREGNING("INNTEKT_BEREGNING", "INNTEKT_BEREGNING"),
     INNTEKT_SAMMENLIGNING("INNTEKT_SAMMENLIGNING", "INNTEKT_SAMMENLIGNING"),
     SIGRUN("SIGRUN", "Sigrun"),
-    VANLIG("VANLIG", "Vanlig"),
     ;
 
     private static final Map<String, InntektsKilde> KODER = new LinkedHashMap<>();

--- a/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/iay/modell/kodeverk/InntektsmeldingInnsendingsårsak.java
+++ b/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/iay/modell/kodeverk/InntektsmeldingInnsendingsårsak.java
@@ -11,7 +11,6 @@ public enum InntektsmeldingInnsendingsårsak implements Kodeverdi {
 
     NY("NY", "NY"),
     ENDRING("ENDRING", "ENDRING"),
-    UDEFINERT(STANDARDKODE_UDEFINERT, "UDEFINERT"),
     ;
 
     private static final Map<String, InntektsmeldingInnsendingsårsak> KODER = new LinkedHashMap<>();

--- a/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/iay/modell/kodeverk/InntektspostType.java
+++ b/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/iay/modell/kodeverk/InntektspostType.java
@@ -9,10 +9,8 @@ import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
 
 public enum InntektspostType implements Kodeverdi {
 
-    UDEFINERT(STANDARDKODE_UDEFINERT, "Ikke definert"),
     LØNN("LØNN", "Lønn"),
     YTELSE("YTELSE", "Ytelse"),
-    VANLIG("VANLIG", "Vanlig"),
     SELVSTENDIG_NÆRINGSDRIVENDE("SELVSTENDIG_NÆRINGSDRIVENDE", "Selvstendig næringsdrivende"),
     NÆRING_FISKE_FANGST_FAMBARNEHAGE("NÆRING_FISKE_FANGST_FAMBARNEHAGE", "Jordbruk/Skogbruk/Fiske/FamilieBarnehage"),
     ;

--- a/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/iay/modell/kodeverk/NaturalYtelseType.java
+++ b/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/iay/modell/kodeverk/NaturalYtelseType.java
@@ -31,7 +31,6 @@ public enum NaturalYtelseType implements Kodeverdi, MedOffisiellKode {
     YRKEBIL_TJENESTLIGBEHOV_KILOMETER("YRKESBIL_KILOMETER", "Yrkesbil tjenesteligbehov kilometer", "yrkebilTjenestligbehovKilometer"),
     YRKEBIL_TJENESTLIGBEHOV_LISTEPRIS("YRKESBIL_LISTEPRIS", "Yrkesbil tjenesteligbehov listepris", "yrkebilTjenestligbehovListepris"),
     INNBETALING_TIL_UTENLANDSK_PENSJONSORDNING("UTENLANDSK_PENSJONSORDNING", "Innbetaling utenlandsk pensjonsordning", "innbetalingTilUtenlandskPensjonsordning"),
-    UDEFINERT(STANDARDKODE_UDEFINERT, "Ikke definert", null),
     ;
 
     private static final Map<String, NaturalYtelseType> KODER = new LinkedHashMap<>();
@@ -82,7 +81,7 @@ public enum NaturalYtelseType implements Kodeverdi, MedOffisiellKode {
     }
 
     public static NaturalYtelseType finnForKodeverkEiersKode(String offisiellDokumentType) {
-        return Stream.of(values()).filter(k -> Objects.equals(k.offisiellKode, offisiellDokumentType)).findFirst().orElse(UDEFINERT);
+        return Stream.of(values()).filter(k -> Objects.equals(k.offisiellKode, offisiellDokumentType)).findFirst().orElse(null);
     }
 
 }

--- a/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/iay/modell/kodeverk/PermisjonsbeskrivelseType.java
+++ b/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/iay/modell/kodeverk/PermisjonsbeskrivelseType.java
@@ -10,7 +10,6 @@ import no.nav.foreldrepenger.behandlingslager.kodeverk.Kodeverdi;
 
 public enum PermisjonsbeskrivelseType implements Kodeverdi {
 
-    UDEFINERT(STANDARDKODE_UDEFINERT, "Ikke definert"),
     PERMISJON("PERMISJON", "Permisjon"),
     UTDANNINGSPERMISJON("UTDANNINGSPERMISJON", "Utdanningspermisjon"), // Utgår 31/12-2022
     UTDANNINGSPERMISJON_IKKE_LOVFESTET("UTDANNINGSPERMISJON_IKKE_LOVFESTET", "Utdanningspermisjon (Ikke lovfestet)"),

--- a/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/iay/modell/kodeverk/VirksomhetType.java
+++ b/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/iay/modell/kodeverk/VirksomhetType.java
@@ -18,10 +18,8 @@ public enum VirksomhetType implements Kodeverdi {
 
     DAGMAMMA("DAGMAMMA", "Dagmamma i eget hjem/familiebarnehage", Inntektskategori.DAGMAMMA),
     FISKE("FISKE", "Fiske", Inntektskategori.FISKER),
-    FRILANSER("FRILANSER", "Frilanser", Inntektskategori.FRILANSER),
     JORDBRUK_SKOGBRUK("JORDBRUK_SKOGBRUK", "Jordbruk", Inntektskategori.JORDBRUKER),
     ANNEN("ANNEN", "Annen næringsvirksomhet", Inntektskategori.UDEFINERT),
-    UDEFINERT(STANDARDKODE_UDEFINERT, "Ikke definert", Inntektskategori.UDEFINERT),
     ;
 
     private static final Map<String, VirksomhetType> KODER = new LinkedHashMap<>();
@@ -35,11 +33,11 @@ public enum VirksomhetType implements Kodeverdi {
     }
 
     @JsonIgnore
-    private String navn;
+    private final String navn;
     @JsonIgnore
-    private Inntektskategori inntektskategori;
+    private final Inntektskategori inntektskategori;
     @JsonValue
-    private String kode;
+    private final String kode;
 
     VirksomhetType(String kode, String navn, Inntektskategori inntektskategori) {
         this.kode = kode;

--- a/domenetjenester/arbeidsforhold/src/test/java/no/nav/foreldrepenger/domene/arbeidsforhold/rest/BehandlingRelaterteYtelserMapperTest.java
+++ b/domenetjenester/arbeidsforhold/src/test/java/no/nav/foreldrepenger/domene/arbeidsforhold/rest/BehandlingRelaterteYtelserMapperTest.java
@@ -67,7 +67,7 @@ class BehandlingRelaterteYtelserMapperTest {
                         I_DAG.plusDays(200)),
                 opprettBuilderForBehandlingRelaterteYtelser(RelatertYtelseType.FORELDREPENGER, RelatertYtelseTilstand.LØPENDE, I_DAG.minusDays(5),
                         null),
-                opprettBuilderForBehandlingRelaterteYtelser(RelatertYtelseType.ENSLIG_FORSØRGER, RelatertYtelseTilstand.ÅPEN, I_DAG.minusDays(5),
+                opprettBuilderForBehandlingRelaterteYtelser(RelatertYtelseType.DAGPENGER, RelatertYtelseTilstand.ÅPEN, I_DAG.minusDays(5),
                         null));
 
         var resultatListe = BehandlingRelaterteYtelserMapper.mapFraBehandlingRelaterteYtelser(ytelser);

--- a/domenetjenester/arbeidsforhold/src/test/java/no/nav/foreldrepenger/domene/arbeidsforhold/rest/TilgrensendeYtelserTest.java
+++ b/domenetjenester/arbeidsforhold/src/test/java/no/nav/foreldrepenger/domene/arbeidsforhold/rest/TilgrensendeYtelserTest.java
@@ -41,6 +41,6 @@ class TilgrensendeYtelserTest {
     }
 
     private TilgrensendeYtelser lagTilgrensendeYtelser(LocalDate periodeFraDato) {
-        return new TilgrensendeYtelser(RelatertYtelseType.UDEFINERT, periodeFraDato, null, null, null);
+        return new TilgrensendeYtelser(RelatertYtelseType.SYKEPENGER, periodeFraDato, null, null, null);
     }
 }

--- a/domenetjenester/arbeidsforhold/src/test/java/no/nav/foreldrepenger/domene/iay/modell/ArbeidsforholdOverstyringTest.java
+++ b/domenetjenester/arbeidsforhold/src/test/java/no/nav/foreldrepenger/domene/iay/modell/ArbeidsforholdOverstyringTest.java
@@ -165,7 +165,7 @@ class ArbeidsforholdOverstyringTest {
     void krever_ikke_inntektsmelding_skal_returne_false_hvis_handling_er_lik_UDEFINERT() {
         // Arrange
         var overstyring = new ArbeidsforholdOverstyring();
-        overstyring.setHandling(ArbeidsforholdHandlingType.UDEFINERT);
+        overstyring.setHandling(ArbeidsforholdHandlingType.IKKE_BRUK);
         // Act
         var kreverIkkeInntektsmelding = overstyring.kreverIkkeInntektsmelding();
         // Assert

--- a/domenetjenester/beregningsgrunnlag/src/main/java/no/nav/foreldrepenger/domene/mappers/til_kalkulus/KodeverkTilKalkulusMapper.java
+++ b/domenetjenester/beregningsgrunnlag/src/main/java/no/nav/foreldrepenger/domene/mappers/til_kalkulus/KodeverkTilKalkulusMapper.java
@@ -92,7 +92,6 @@ public class KodeverkTilKalkulusMapper {
             case SELVSTENDIG_NÆRINGSDRIVENDE -> ArbeidType.NÆRING;
             case UTENLANDSK_ARBEIDSFORHOLD -> ArbeidType.UTENLANDSK_ARBEIDSFORHOLD;
             case VENTELØNN_VARTPENGER -> ArbeidType.VENTELØNN_VARTPENGER;
-            case VANLIG -> ArbeidType.VANLIG;
         };
     }
 
@@ -100,16 +99,13 @@ public class KodeverkTilKalkulusMapper {
         return switch (virksomhetType) {
             case DAGMAMMA -> VirksomhetType.DAGMAMMA;
             case FISKE -> VirksomhetType.FISKE;
-            case FRILANSER -> VirksomhetType.FRILANSER;
             case JORDBRUK_SKOGBRUK -> VirksomhetType.JORDBRUK_SKOGBRUK;
             case ANNEN -> VirksomhetType.ANNEN;
-            case UDEFINERT -> VirksomhetType.UDEFINERT;
         };
     }
 
     public static ArbeidsforholdHandlingType mapArbeidsforholdHandling(no.nav.foreldrepenger.domene.iay.modell.kodeverk.ArbeidsforholdHandlingType handling) {
         return switch (handling) {
-            case UDEFINERT -> ArbeidsforholdHandlingType.UDEFINERT;
             case BRUK -> ArbeidsforholdHandlingType.BRUK;
             case NYTT_ARBEIDSFORHOLD -> ArbeidsforholdHandlingType.NYTT_ARBEIDSFORHOLD;
             case BRUK_UTEN_INNTEKTSMELDING -> ArbeidsforholdHandlingType.BRUK_UTEN_INNTEKTSMELDING;
@@ -143,27 +139,22 @@ public class KodeverkTilKalkulusMapper {
             case YRKEBIL_TJENESTLIGBEHOV_KILOMETER -> NaturalYtelseType.YRKESBIL_KILOMETER;
             case YRKEBIL_TJENESTLIGBEHOV_LISTEPRIS -> NaturalYtelseType.YRKESBIL_LISTEPRIS;
             case INNBETALING_TIL_UTENLANDSK_PENSJONSORDNING -> NaturalYtelseType.UTENLANDSK_PENSJONSORDNING;
-            case UDEFINERT -> NaturalYtelseType.UDEFINERT;
         };
     }
 
     public static InntektskildeType mapInntektskilde(InntektsKilde inntektsKilde) {
         return switch (inntektsKilde) {
-            case UDEFINERT -> InntektskildeType.UDEFINERT;
             case INNTEKT_OPPTJENING -> InntektskildeType.INNTEKT_OPPTJENING;
             case INNTEKT_BEREGNING -> InntektskildeType.INNTEKT_BEREGNING;
             case INNTEKT_SAMMENLIGNING -> InntektskildeType.INNTEKT_SAMMENLIGNING;
             case SIGRUN -> InntektskildeType.SIGRUN;
-            case VANLIG -> InntektskildeType.VANLIG;
         };
     }
 
     public static InntektspostType mapInntektspostType(no.nav.foreldrepenger.domene.iay.modell.kodeverk.InntektspostType type) {
         return switch (type) {
-            case UDEFINERT -> InntektspostType.UDEFINERT;
             case LØNN -> InntektspostType.LØNN;
             case YTELSE -> InntektspostType.YTELSE;
-            case VANLIG -> InntektspostType.VANLIG;
             case SELVSTENDIG_NÆRINGSDRIVENDE -> InntektspostType.SELVSTENDIG_NÆRINGSDRIVENDE;
             case NÆRING_FISKE_FANGST_FAMBARNEHAGE -> InntektspostType.NÆRING_FISKE_FANGST_FAMBARNEHAGE;
             case null -> null;
@@ -218,7 +209,7 @@ public class KodeverkTilKalkulusMapper {
 
     public static YtelseType mapYtelsetype(RelatertYtelseType relatertYtelseType) {
         return switch (relatertYtelseType) {
-            case ENSLIG_FORSØRGER -> YtelseType.ENSLIG_FORSØRGER;
+            case null -> null;
             case SYKEPENGER -> YtelseType.SYKEPENGER;
             case SVANGERSKAPSPENGER -> YtelseType.SVANGERSKAPSPENGER;
             case FORELDREPENGER -> YtelseType.FORELDREPENGER;
@@ -230,7 +221,6 @@ public class KodeverkTilKalkulusMapper {
             case OPPLÆRINGSPENGER -> YtelseType.OPPLÆRINGSPENGER;
             case ARBEIDSAVKLARINGSPENGER -> YtelseType.ARBEIDSAVKLARINGSPENGER;
             case DAGPENGER -> YtelseType.DAGPENGER;
-            case UDEFINERT -> YtelseType.UDEFINERT;
         };
     }
 
@@ -250,7 +240,6 @@ public class KodeverkTilKalkulusMapper {
 
     public static PermisjonsbeskrivelseType mapPermisjonbeskrivelsetype(no.nav.foreldrepenger.domene.iay.modell.kodeverk.PermisjonsbeskrivelseType permisjonsbeskrivelseType) {
         return switch (permisjonsbeskrivelseType) {
-            case UDEFINERT -> PermisjonsbeskrivelseType.UDEFINERT;
             case PERMISJON -> PermisjonsbeskrivelseType.PERMISJON;
             case UTDANNINGSPERMISJON -> PermisjonsbeskrivelseType.UTDANNINGSPERMISJON;
             case UTDANNINGSPERMISJON_IKKE_LOVFESTET -> PermisjonsbeskrivelseType.UTDANNINGSPERMISJON_IKKE_LOVFESTET;

--- a/domenetjenester/beregningsgrunnlag/src/main/java/no/nav/foreldrepenger/domene/mappers/til_kalkulus/MapTilYtelsegrunnlagDto.java
+++ b/domenetjenester/beregningsgrunnlag/src/main/java/no/nav/foreldrepenger/domene/mappers/til_kalkulus/MapTilYtelsegrunnlagDto.java
@@ -132,7 +132,6 @@ public class MapTilYtelsegrunnlagDto {
             case DAGPENGER -> AktivitetStatus.DAGPENGER;
             case ARBEIDSAVKLARINGSPENGER -> AktivitetStatus.ARBEIDSAVKLARINGSPENGER;
             case ARBEIDSTAKER, ARBEIDSTAKER_UTEN_FERIEPENGER, SJØMANN, FISKER -> AktivitetStatus.ARBEIDSTAKER;
-            case UDEFINERT -> AktivitetStatus.UDEFINERT;
         };
     }
 
@@ -151,7 +150,6 @@ public class MapTilYtelsegrunnlagDto {
             case JORDBRUKER -> Inntektskategori.JORDBRUKER;
             case FISKER -> Inntektskategori.FISKER;
             case ARBEIDSTAKER_UTEN_FERIEPENGER -> Inntektskategori.ARBEIDSTAKER_UTEN_FERIEPENGER;
-            case UDEFINERT -> Inntektskategori.UDEFINERT;
         };
     }
 

--- a/domenetjenester/datavarehus/src/main/java/no/nav/foreldrepenger/datavarehus/xml/fp/BeregningsgrunnlagXmlTjenesteImpl.java
+++ b/domenetjenester/datavarehus/src/main/java/no/nav/foreldrepenger/datavarehus/xml/fp/BeregningsgrunnlagXmlTjenesteImpl.java
@@ -13,7 +13,6 @@ import no.nav.foreldrepenger.behandling.DekningsgradTjeneste;
 import no.nav.foreldrepenger.behandlingskontroll.FagsakYtelseTypeRef;
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
 import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakYtelseType;
-import no.nav.foreldrepenger.behandlingslager.ytelse.RelatertYtelseType;
 import no.nav.foreldrepenger.datavarehus.xml.BeregningsgrunnlagXmlTjeneste;
 import no.nav.foreldrepenger.datavarehus.xml.VedtakXmlUtil;
 import no.nav.foreldrepenger.domene.modell.BGAndelArbeidsforhold;
@@ -156,7 +155,6 @@ public class BeregningsgrunnlagXmlTjenesteImpl implements BeregningsgrunnlagXmlT
             .ifPresent(nybpå -> kontrakt.setNaturalytelseBortfall(VedtakXmlUtil.lagFloatOpplysning(nybpå.floatValue())));
         kontrakt.setBeregnet(lagFloatOpplysning(beregningsgrunnlagPrStatusOgAndel.getBeregnetPrÅr()));
         kontrakt.setGjennomsnittligPensjonsgivendeInntekt(konverterGjennomsnittligPensjonsgivendeInntektFraDomene(beregningsgrunnlagPrStatusOgAndel));
-        kontrakt.setTilstoetendeYtelseType(VedtakXmlUtil.lagKodeverksOpplysning(RelatertYtelseType.UDEFINERT));
         kontrakt.setTilstoetendeYtelse(lagFloatOpplysning(beregningsgrunnlagPrStatusOgAndel.getÅrsbeløpFraTilstøtendeYtelseVerdi()));
         kontrakt.setAvkortetBrukersAndel(lagFloatOpplysning(beregningsgrunnlagPrStatusOgAndel.getAvkortetBrukersAndelPrÅr()));
         kontrakt.setRedusertBrukersAndel(lagFloatOpplysning(beregningsgrunnlagPrStatusOgAndel.getRedusertBrukersAndelPrÅr()));

--- a/domenetjenester/datavarehus/src/main/java/no/nav/foreldrepenger/datavarehus/xml/svp/BeregningsgrunnlagXmlTjenesteImpl.java
+++ b/domenetjenester/datavarehus/src/main/java/no/nav/foreldrepenger/datavarehus/xml/svp/BeregningsgrunnlagXmlTjenesteImpl.java
@@ -14,7 +14,6 @@ import no.nav.foreldrepenger.behandling.DekningsgradTjeneste;
 import no.nav.foreldrepenger.behandlingskontroll.FagsakYtelseTypeRef;
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
 import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakYtelseType;
-import no.nav.foreldrepenger.behandlingslager.ytelse.RelatertYtelseType;
 import no.nav.foreldrepenger.datavarehus.xml.BeregningsgrunnlagXmlTjeneste;
 import no.nav.foreldrepenger.datavarehus.xml.VedtakXmlUtil;
 import no.nav.foreldrepenger.domene.modell.BGAndelArbeidsforhold;
@@ -163,7 +162,6 @@ public class BeregningsgrunnlagXmlTjenesteImpl implements BeregningsgrunnlagXmlT
         beregningsgrunnlagPrStatusOgAndel.getBgAndelArbeidsforhold().flatMap(BGAndelArbeidsforhold::getNaturalytelseBortfaltPrÅr).ifPresent(nybpå -> kontrakt.setNaturalytelseBortfall(VedtakXmlUtil.lagFloatOpplysning(nybpå.floatValue())));
         kontrakt.setBeregnet(lagFloatOpplysning(beregningsgrunnlagPrStatusOgAndel.getBeregnetPrÅr()));
         kontrakt.setGjennomsnittligPensjonsgivendeInntekt(konverterGjennomsnittligPensjonsgivendeInntektFraDomene(beregningsgrunnlagPrStatusOgAndel));
-        kontrakt.setTilstoetendeYtelseType(VedtakXmlUtil.lagKodeverksOpplysning(RelatertYtelseType.UDEFINERT));
         kontrakt.setTilstoetendeYtelse(lagFloatOpplysning(beregningsgrunnlagPrStatusOgAndel.getÅrsbeløpFraTilstøtendeYtelseVerdi()));
         kontrakt.setAvkortetBrukersAndel(lagFloatOpplysning(beregningsgrunnlagPrStatusOgAndel.getAvkortetBrukersAndelPrÅr()));
         kontrakt.setRedusertBrukersAndel(lagFloatOpplysning(beregningsgrunnlagPrStatusOgAndel.getRedusertBrukersAndelPrÅr()));

--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/dokumentpersiterer/impl/inntektsmelding/v1/InntektsmeldingOversetter.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/dokumentpersiterer/impl/inntektsmelding/v1/InntektsmeldingOversetter.java
@@ -77,7 +77,7 @@ public class InntektsmeldingOversetter implements MottattDokumentOversetter<Innt
                                        Behandling behandling,
                                        Optional<LocalDate> gjelderFra) {
         var aarsakTilInnsending = wrapper.getSkjema().getSkjemainnhold().getAarsakTilInnsending();
-        var innsendingsårsak = aarsakTilInnsending.isEmpty() ? InntektsmeldingInnsendingsårsak.UDEFINERT : INNSENDINGSÅRSAK_MAP
+        var innsendingsårsak = aarsakTilInnsending.isEmpty() ? InntektsmeldingInnsendingsårsak.NY : INNSENDINGSÅRSAK_MAP
             .get(ÅrsakInnsendingKodeliste.fromValue(aarsakTilInnsending));
 
         var builder = InntektsmeldingBuilder.builder();

--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/dokumentpersiterer/impl/inntektsmelding/v2/InntektsmeldingOversetter.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/dokumentpersiterer/impl/inntektsmelding/v2/InntektsmeldingOversetter.java
@@ -84,7 +84,7 @@ public class InntektsmeldingOversetter implements MottattDokumentOversetter<Innt
                                        Behandling behandling,
                                        Optional<LocalDate> gjelderFra) {
         var aarsakTilInnsending = wrapper.getSkjema().getSkjemainnhold().getAarsakTilInnsending();
-        var innsendingsårsak = aarsakTilInnsending.isEmpty() ? InntektsmeldingInnsendingsårsak.UDEFINERT : INNSENDINGSÅRSAK_MAP
+        var innsendingsårsak = aarsakTilInnsending.isEmpty() ? InntektsmeldingInnsendingsårsak.NY : INNSENDINGSÅRSAK_MAP
             .get(ÅrsakInnsendingKodeliste.fromValue(aarsakTilInnsending));
 
         var imBuilder = InntektsmeldingBuilder.builder();

--- a/domenetjenester/registerinnhenting/src/main/java/no/nav/foreldrepenger/domene/registerinnhenting/MorsAktivitetInnhenter.java
+++ b/domenetjenester/registerinnhenting/src/main/java/no/nav/foreldrepenger/domene/registerinnhenting/MorsAktivitetInnhenter.java
@@ -165,7 +165,6 @@ public class MorsAktivitetInnhenter {
 
     private static AktivitetskravPermisjonType map(PermisjonsbeskrivelseType type) {
         return switch (type) {
-            case UDEFINERT -> UDEFINERT;
             case PERMISJON, ANNEN_PERMISJON_LOVFESTET, ANNEN_PERMISJON_IKKE_LOVFESTET, PERMISJON_VED_MILITÆRTJENESTE, VELFERDSPERMISJON ->
                 ANNEN_PERMISJON;
             case UTDANNINGSPERMISJON, UTDANNINGSPERMISJON_LOVFESTET, UTDANNINGSPERMISJON_IKKE_LOVFESTET -> UTDANNING;

--- a/pom.xml
+++ b/pom.xml
@@ -39,8 +39,8 @@
         <felles.version>7.7.2</felles.version>
         <prosesstask.version>5.2.5</prosesstask.version>
         <openapi-spec-utils.version>2.1.0</openapi-spec-utils.version>
-        <fp-kontrakter.version>9.4.29</fp-kontrakter.version>
-        <abakus-kontrakt.version>2.3.8</abakus-kontrakt.version>
+        <fp-kontrakter.version>9.4.30</fp-kontrakter.version>
+        <abakus-kontrakt.version>2.4.1</abakus-kontrakt.version>
 
         <sonar.moduleKey>${project.artifactId}</sonar.moduleKey>
         <sonar.projectName>fp-sak</sonar.projectName>

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/arbeidInntektsmelding/ArbeidOgInntektsmeldingMapper.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/arbeidInntektsmelding/ArbeidOgInntektsmeldingMapper.java
@@ -177,7 +177,7 @@ public class ArbeidOgInntektsmeldingMapper {
 
     private static ArbeidsforholdKomplettVurderingType mapHandlingTilVurdering(ArbeidsforholdHandlingType handling) {
         return switch(handling) {
-            case UDEFINERT -> ArbeidsforholdKomplettVurderingType.UDEFINERT;
+            case null -> null;
             case LAGT_TIL_AV_SAKSBEHANDLER -> ArbeidsforholdKomplettVurderingType.MANUELT_OPPRETTET_AV_SAKSBEHANDLER;
             case BASERT_PÅ_INNTEKTSMELDING -> ArbeidsforholdKomplettVurderingType.OPPRETT_BASERT_PÅ_INNTEKTSMELDING;
             case BRUK_UTEN_INNTEKTSMELDING -> ArbeidsforholdKomplettVurderingType.FORTSETT_UTEN_INNTEKTSMELDING;
@@ -244,7 +244,7 @@ public class ArbeidOgInntektsmeldingMapper {
                                                                                  LocalDate stp,
                                                                                  Optional<ArbeidsforholdOverstyring> arbeidsforholdOverstyring) {
         var oversyrtePerioder = arbeidsforholdOverstyring
-            .filter(os -> os.getHandling().equals(ArbeidsforholdHandlingType.BRUK_MED_OVERSTYRT_PERIODE))
+            .filter(os -> ArbeidsforholdHandlingType.BRUK_MED_OVERSTYRT_PERIODE.equals(os.getHandling()))
             .map(ArbeidsforholdOverstyring::getArbeidsforholdOverstyrtePerioder)
             .orElse(Collections.emptyList());
         if (!oversyrtePerioder.isEmpty()) {

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/fpoversikt/InntektsmeldingDtoTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/fpoversikt/InntektsmeldingDtoTjeneste.java
@@ -1,5 +1,7 @@
 package no.nav.foreldrepenger.web.app.tjenester.fpoversikt;
 
+import static no.nav.vedtak.konfig.Tid.TIDENES_ENDE;
+
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -31,8 +33,6 @@ import no.nav.foreldrepenger.domene.iay.modell.Yrkesaktivitet;
 import no.nav.foreldrepenger.domene.iay.modell.kodeverk.NaturalYtelseType;
 import no.nav.foreldrepenger.domene.typer.Saksnummer;
 import no.nav.foreldrepenger.domene.typer.Stillingsprosent;
-
-import static no.nav.vedtak.konfig.Tid.TIDENES_ENDE;
 
 @ApplicationScoped
 class InntektsmeldingDtoTjeneste {
@@ -192,7 +192,6 @@ class InntektsmeldingDtoTjeneste {
             case YRKEBIL_TJENESTLIGBEHOV_KILOMETER -> FpSakInntektsmeldingDto.NaturalytelseType.YRKEBIL_TJENESTLIGBEHOV_KILOMETER;
             case YRKEBIL_TJENESTLIGBEHOV_LISTEPRIS -> FpSakInntektsmeldingDto.NaturalytelseType.YRKEBIL_TJENESTLIGBEHOV_LISTEPRIS;
             case INNBETALING_TIL_UTENLANDSK_PENSJONSORDNING -> FpSakInntektsmeldingDto.NaturalytelseType.INNBETALING_TIL_UTENLANDSK_PENSJONSORDNING;
-            case UDEFINERT -> throw new IllegalStateException("Kunne ikke mappe NaturalytelseType til FpSakInntektsmeldingDto.NaturalytelseType: " + naturalytelseType);
         };
     }
 }

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/registrering/SøknadMapperFelles.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/registrering/SøknadMapperFelles.java
@@ -424,9 +424,7 @@ public class SøknadMapperFelles {
                 virksomhetstyper.add(virksomhetstype);
             }
         } else {
-            var virksomhetstype = new Virksomhetstyper();
-            virksomhetstype.setKode(VirksomhetType.UDEFINERT.getKode());
-            virksomhetstyper.add(virksomhetstype);
+            throw new IllegalArgumentException("Må ha en type virksomhet for å kunne mappe til egen næring");
         }
     }
 


### PR DESCRIPTION
Siste skrik i abakus-kontrakt - fjerner UDEFINERT der mulig. Beholdes i 4-5 enums pga bestand. 
Mer exhaustive switch framfor Kodeverdi.fraKode() 