### PR TITLE
TFP-6924 ikke simuler førstegangsbehandlinger ved feil

### DIFF
--- a/behandlingsprosess/src/main/java/no/nav/foreldrepenger/behandling/steg/simulering/SimulerOppdragSteg.java
+++ b/behandlingsprosess/src/main/java/no/nav/foreldrepenger/behandling/steg/simulering/SimulerOppdragSteg.java
@@ -96,17 +96,30 @@ public class SimulerOppdragSteg implements BehandlingSteg {
         try {
             startSimulering(behandling);
             return utledAksjonspunkt(behandling);
-        } catch (IntegrasjonException e) {
-            opprettFortsettBehandlingTask(behandling);
-            return BehandleStegResultat.settPåVent();
+        } catch (IntegrasjonException _) {
+            if (behandling.erRevurdering()) {
+                opprettFortsettBehandlingTask(behandling);
+                return BehandleStegResultat.settPåVent();
+            } else {
+                return BehandleStegResultat.utførtUtenAksjonspunkter();
+            }
         }
     }
 
     @Override
     public BehandleStegResultat gjenopptaSteg(BehandlingskontrollKontekst kontekst) {
         var behandling = behandlingRepository.hentBehandling(kontekst.getBehandlingId());
-        startSimulering(behandling);
-        return utledAksjonspunkt(behandling);
+        try {
+            startSimulering(behandling);
+            return utledAksjonspunkt(behandling);
+        } catch (IntegrasjonException e) {
+            if (behandling.erRevurdering()) {
+                throw e;
+            } else {
+                return BehandleStegResultat.utførtUtenAksjonspunkter();
+            }
+        }
+
     }
 
     @Override


### PR DESCRIPTION
Dersom simulering feiler, så går vi videre i tilfelle førstegangsbehandlinger. 
Det skal ikke være feilutbetalinger i disse. Store etterbetalinger er legitime i tilfelle førstegangsbehandlinger.
