### PR TITLE
chore: Legge til nye koder fra Kabal som ikke er relevant for oss

### DIFF
--- a/domenetjenester/behandling-klage/src/main/java/no/nav/foreldrepenger/behandling/kabal/KabalHendelse.java
+++ b/domenetjenester/behandling-klage/src/main/java/no/nav/foreldrepenger/behandling/kabal/KabalHendelse.java
@@ -38,12 +38,6 @@ public record KabalHendelse(UUID eventId,
         KLAGE, ANKE, ANKE_I_TRYGDERETTEN, BEHANDLING_ETTER_TRYGDERETTEN_OPPHEVET,
         OMGJOERINGSKRAV, BEGJAERING_OM_GJENOPPTAK, BEGJAERING_OM_GJENOPPTAK_I_TRYGDERETTEN
     }
-
-    public static boolean ikkeRelevantBehandling(BehandlingType behandlingType) {
-        return behandlingType == BehandlingType.OMGJOERINGSKRAV ||
-            behandlingType == BehandlingType.BEGJAERING_OM_GJENOPPTAK ||
-            behandlingType == BehandlingType.BEGJAERING_OM_GJENOPPTAK_I_TRYGDERETTEN;
-    }
 }
 
 

--- a/domenetjenester/behandling-klage/src/main/java/no/nav/foreldrepenger/behandling/kabal/KabalHendelse.java
+++ b/domenetjenester/behandling-klage/src/main/java/no/nav/foreldrepenger/behandling/kabal/KabalHendelse.java
@@ -35,7 +35,14 @@ public record KabalHendelse(UUID eventId,
     public record BehandlingFeilregistrertDetaljer(LocalDateTime feilregistrert, BehandlingType type, String navIdent, String reason) {}
 
     public enum BehandlingType {
-        KLAGE, ANKE, ANKE_I_TRYGDERETTEN, BEHANDLING_ETTER_TRYGDERETTEN_OPPHEVET, OMGJOERINGSKRAV
+        KLAGE, ANKE, ANKE_I_TRYGDERETTEN, BEHANDLING_ETTER_TRYGDERETTEN_OPPHEVET,
+        OMGJOERINGSKRAV, BEGJAERING_OM_GJENOPPTAK, BEGJAERING_OM_GJENOPPTAK_I_TRYGDERETTEN
+    }
+
+    public static boolean ikkeRelevantBehandling(BehandlingType behandlingType) {
+        return behandlingType == BehandlingType.OMGJOERINGSKRAV ||
+            behandlingType == BehandlingType.BEGJAERING_OM_GJENOPPTAK ||
+            behandlingType == BehandlingType.BEGJAERING_OM_GJENOPPTAK_I_TRYGDERETTEN;
     }
 }
 

--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/kabal/KabalHendelseHåndterer.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/kabal/KabalHendelseHåndterer.java
@@ -10,7 +10,6 @@ import jakarta.enterprise.context.control.ActivateRequestContext;
 import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
 
-import org.apache.kafka.clients.consumer.OffsetResetStrategy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -45,6 +44,8 @@ public class KabalHendelseHåndterer implements KafkaMessageHandler.KafkaStringM
     private static final String KABAL = "KABAL";
     private static final String VKY_DELVIS_TEKST = "Vedtaket er delvis omgjort i ankebehandling og sendt Trygderetten. Opprett en ny behandling for det som allerede er omgjort.";
     private static final String VKY_OMGJØRINGSKRAV_TEKST = "Vedtaket er omgjort av Nav klageinstans etter Fvl 35. Opprett en ny behandling.";
+
+
 
     private String topicName;
     private ProsessTaskTjeneste taskTjeneste;
@@ -145,10 +146,10 @@ public class KabalHendelseHåndterer implements KafkaMessageHandler.KafkaStringM
             LOG.warn("KABAL mottatt hendelse med ukjent referanse hendelse={}", mottattHendelse);
             return null;
         }
-        // Henlagt omgjøringskrav har ingen behandling hos oss, de andre variantene skal ha en klage eller anke
+        // Henlagt omgjøringskrav/begjæring har ingen behandling hos oss, de andre variantene skal ha en klage eller anke
         if (KabalHendelse.BehandlingEventType.BEHANDLING_FEILREGISTRERT.equals(mottattHendelse.type())
-            && KabalHendelse.BehandlingType.OMGJOERINGSKRAV.equals(mottattHendelse.detaljer().behandlingFeilregistrert().type())) {
-            LOG.info("KABAL henlagt omgjøringskrav hendelse={}", mottattHendelse);
+            && KabalHendelse.ikkeRelevantBehandling(mottattHendelse.detaljer().behandlingFeilregistrert().type())) {
+            LOG.info("KABAL henlagt omgjøringskrav/begjæring hendelse={}", mottattHendelse);
             return null;
         }
         // Sjekk om finnes matchende klage eller anke - evt ugyldig kildereferanse

--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/kabal/KabalHendelseHåndterer.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/kabal/KabalHendelseHåndterer.java
@@ -3,6 +3,7 @@ package no.nav.foreldrepenger.mottak.kabal;
 import java.time.format.DateTimeFormatter;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 
 import jakarta.enterprise.context.ApplicationScoped;
@@ -45,7 +46,9 @@ public class KabalHendelseHåndterer implements KafkaMessageHandler.KafkaStringM
     private static final String VKY_DELVIS_TEKST = "Vedtaket er delvis omgjort i ankebehandling og sendt Trygderetten. Opprett en ny behandling for det som allerede er omgjort.";
     private static final String VKY_OMGJØRINGSKRAV_TEKST = "Vedtaket er omgjort av Nav klageinstans etter Fvl 35. Opprett en ny behandling.";
 
-
+    private static final Set<KabalHendelse.BehandlingType> IKKE_RELEVANTE_FEILREGISTRERINGER = Set.of(
+        KabalHendelse.BehandlingType.OMGJOERINGSKRAV, KabalHendelse.BehandlingType.BEGJAERING_OM_GJENOPPTAK,
+        KabalHendelse.BehandlingType.BEGJAERING_OM_GJENOPPTAK_I_TRYGDERETTEN);
 
     private String topicName;
     private ProsessTaskTjeneste taskTjeneste;
@@ -148,7 +151,7 @@ public class KabalHendelseHåndterer implements KafkaMessageHandler.KafkaStringM
         }
         // Henlagt omgjøringskrav/begjæring har ingen behandling hos oss, de andre variantene skal ha en klage eller anke
         if (KabalHendelse.BehandlingEventType.BEHANDLING_FEILREGISTRERT.equals(mottattHendelse.type())
-            && KabalHendelse.ikkeRelevantBehandling(mottattHendelse.detaljer().behandlingFeilregistrert().type())) {
+            && IKKE_RELEVANTE_FEILREGISTRERINGER.contains(mottattHendelse.detaljer().behandlingFeilregistrert().type())) {
             LOG.info("KABAL henlagt omgjøringskrav/begjæring hendelse={}", mottattHendelse);
             return null;
         }


### PR DESCRIPTION
Kabal hadde glemt å informere om nye koder brukt i feilregistrerte behandlinger. Hadde heller ikke oppdatert eget skjema.
Disse begjæringene er ikke speilet til oss - det er rent Kabal-interne ting. Legger de til for å kunne parse meldinger