### PR TITLE
bugfix: Utledningsfeil søkt uttak fom etter maxdato

### DIFF
--- a/domenetjenester/skjaeringstidspunkt/src/main/java/no/nav/foreldrepenger/skjæringstidspunkt/fp/SkjæringstidspunktTjenesteImpl.java
+++ b/domenetjenester/skjaeringstidspunkt/src/main/java/no/nav/foreldrepenger/skjæringstidspunkt/fp/SkjæringstidspunktTjenesteImpl.java
@@ -244,9 +244,10 @@ public class SkjæringstidspunktTjenesteImpl implements SkjæringstidspunktTjene
     }
 
     private LocalDateInterval utledYtelseintervall(Behandling behandling, LocalDateInterval maxstønadsperiode) {
+        // Normalt fra STP til MaxUttak (barn 3år). Dersom siste søkte dato er seneres, så avkortes til MaxUttak
+        // Spesialtifeller: Søknads eller overstyring til uttak etter barnet 3år - tom stp > MaxUttak.
         var sistedato = sisteØnskedeUttaksdag(behandling, hentYtelseFordelingAggregatFor(behandling.getId()), maxstønadsperiode.getFomDato());
-        var bruktomdato = sistedato.isAfter(maxstønadsperiode.getTomDato().minusDays(1)) ?
-            maxstønadsperiode.getTomDato().minusDays(1) : sistedato;
+        var bruktomdato = sistedato.isAfter(maxstønadsperiode.getTomDato()) ? maxstønadsperiode.getTomDato() : sistedato;
         return new LocalDateInterval(maxstønadsperiode.getFomDato(), bruktomdato.isAfter(maxstønadsperiode.getFomDato()) ? bruktomdato : maxstønadsperiode.getFomDato());
     }
 
@@ -259,6 +260,7 @@ public class SkjæringstidspunktTjenesteImpl implements SkjæringstidspunktTjene
     }
 
     private LocalDateInterval maxstønadsperiode(LocalDate skjæringstidspunkt, Optional<FamilieHendelseGrunnlagEntitet> familieHendelseGrunnlag) {
+        // Normalt fra STP til barnet er 3 år (MaxUttak). Dersom STP > MaxUttak: fra MaxUttak til STP.
         var max = familieHendelseGrunnlag.map(FamilieHendelseGrunnlagEntitet::getGjeldendeVersjon)
             .map(FamilieHendelseEntitet::getSkjæringstidspunkt)
             .orElse(skjæringstidspunkt)

--- a/domenetjenester/skjaeringstidspunkt/src/test/java/no/nav/foreldrepenger/skjæringstidspunkt/fp/SkjæringstidspunktTjenesteImplTest.java
+++ b/domenetjenester/skjaeringstidspunkt/src/test/java/no/nav/foreldrepenger/skjæringstidspunkt/fp/SkjæringstidspunktTjenesteImplTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.time.Month;
 import java.time.YearMonth;
 import java.util.List;
 
@@ -38,6 +39,7 @@ import no.nav.foreldrepenger.domene.tid.VirkedagUtil;
 import no.nav.foreldrepenger.domene.typer.InternArbeidsforholdRef;
 import no.nav.foreldrepenger.skjæringstidspunkt.SkjæringstidspunktTjeneste;
 import no.nav.foreldrepenger.skjæringstidspunkt.overganger.MinsterettBehandling2022;
+import no.nav.fpsak.tidsserie.LocalDateInterval;
 
 class SkjæringstidspunktTjenesteImplTest extends EntityManagerAwareTest {
 
@@ -319,6 +321,30 @@ class SkjæringstidspunktTjenesteImplTest extends EntityManagerAwareTest {
         assertThat(stp.getFørsteUttaksdatoGrunnbeløp()).isEqualTo(VirkedagUtil.fomVirkedag(skjæringstidspunktOriginal.plusWeeks(2)));
         assertThat(stp.getUtledetSkjæringstidspunkt()).isEqualTo(skjæringstidspunktOriginal.plusWeeks(2));
     }
+
+    @Test
+    void spesialtilfelle_uttak_starter_etter_maxdato_uttaksintervall_1dag() {
+        var skjæringstidspunkt = LocalDate.of(2026, Month.MAY, 1);
+        var fødselsdato = LocalDate.of(2022, Month.OCTOBER, 19);
+        var oppgittPeriodeBuilder = OppgittPeriodeBuilder.ny()
+            .medPeriode(skjæringstidspunkt, skjæringstidspunkt.plusWeeks(8).minusDays(1))
+            .medPeriodeType(UttakPeriodeType.FORELDREPENGER);
+        var scenario = ScenarioFarSøkerForeldrepenger.forFødsel()
+            .medFordeling(new OppgittFordelingEntitet(List.of(oppgittPeriodeBuilder.build()), true));
+        scenario.medSøknadHendelse().medFødselsDato(fødselsdato, 1)
+            .medTerminbekreftelse(scenario.medSøknadHendelse().getTerminbekreftelseBuilder().medTermindato(fødselsdato));
+        scenario.medBekreftetHendelse().medFødselsDato(fødselsdato, 1)
+            .medTerminbekreftelse(scenario.medBekreftetHendelse().getTerminbekreftelseBuilder().medTermindato(fødselsdato));
+        var behandling = scenario.lagre(repositoryProvider);
+
+        var stp = skjæringstidspunktTjeneste.getSkjæringstidspunkter(behandling.getId());
+        assertThat(stp.getFørsteUttaksdato()).isEqualTo(skjæringstidspunkt);
+        assertThat(stp.getUtledetSkjæringstidspunkt()).isEqualTo(skjæringstidspunkt);
+        var ustp = stp.getUtledetSkjæringstidspunkt();
+        var intervall = new LocalDateInterval(ustp, stp.getUttaksintervall().map(LocalDateInterval::getTomDato).orElse(ustp));
+        assertThat(intervall).isEqualTo(new LocalDateInterval(skjæringstidspunkt, skjæringstidspunkt));
+    }
+
 
 
 }


### PR DESCRIPTION
Spesialtilfelle der søkt uttak begynner når barn er 3,5 år. Har gitt loggfeil sist uke pga minusDays(1).
Her er maxstønadsperiode = MaxUttakBarn3År - STP (første uttak). Pga minusDays(1) ble det 1 dag negativt intervall.
Saken, dvs uttaket, skal normalt avslås siden loven er eksplisitt her - men da må man få den opp i frontend uten feil. 

Man kan diskutere å bruke uttaksintervall tom siste søkte / overstyrte dato - uttaksintervall brukes tidligere i prosessen enn uttak (medlemskap, samme bosted). Normalt er det riktig å se bort fra søknadperioder som strekker seg forbi MaxDato.
Vi har en del MaxDato-logikk andre steder også - rundt saksavslutning. Hva tror du @palfi ? 

