### PR TITLE
TFP-6965 aksepter callback fra abakus selv om behandling avsluttet

### DIFF
--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/abakus/IAYRegisterdataCallbackRestTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/abakus/IAYRegisterdataCallbackRestTjeneste.java
@@ -51,7 +51,7 @@ public class IAYRegisterdataCallbackRestTjeneste {
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
     @Operation(description = "Callback når registerinnhenting av IAY har blitt fullført i Abakus", tags = "registerdata")
-    @BeskyttetRessurs(actionType = ActionType.UPDATE, resourceType = ResourceType.FAGSAK, sporingslogg = false)
+    @BeskyttetRessurs(actionType = ActionType.CREATE, resourceType = ResourceType.FAGSAK, sporingslogg = false)
     public Response callback(@Parameter(description = "callbackDto") @Valid @TilpassetAbacAttributt(supplierClass = AbacDataSupplier.class) CallbackDto dto) {
         // Ta lås
         var behandlingLås = låsRepository.taLås(dto.getAvsenderRef().getReferanse());


### PR DESCRIPTION
En gammel feil. UPDATE gir tilgangsnekt når behandlingen er avsluttet (henlagt ny søknad).
Denne endringen tillater callback - ingen feilende tasks i abakus og den som venter svar i fpsak går videre (skjer ingenting pga sjekker på at behandling er avsluttet i senere tasks)