### PR TITLE
Forvaltning: endreSaksrolle fjerner vilkår ved behov

### DIFF
--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/forvaltning/ForvaltningFagsakRestTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/forvaltning/ForvaltningFagsakRestTjeneste.java
@@ -5,6 +5,7 @@ import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
 import java.net.HttpURLConnection;
 import java.net.SocketTimeoutException;
 import java.util.List;
+import java.util.Set;
 import java.util.function.Function;
 
 import jakarta.enterprise.context.ApplicationScoped;
@@ -33,10 +34,14 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import no.nav.foreldrepenger.behandling.FagsakRelasjonTjeneste;
+import no.nav.foreldrepenger.behandlingslager.behandling.Behandlingsresultat;
+import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingsresultatRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.SpesialBehandling;
 import no.nav.foreldrepenger.behandlingslager.behandling.personopplysning.PersonopplysningRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepositoryProvider;
+import no.nav.foreldrepenger.behandlingslager.behandling.vilkår.VilkårResultat;
+import no.nav.foreldrepenger.behandlingslager.behandling.vilkår.VilkårType;
 import no.nav.foreldrepenger.behandlingslager.fagsak.Fagsak;
 import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakRelasjon;
 import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakRepository;
@@ -89,6 +94,7 @@ public class ForvaltningFagsakRestTjeneste {
     private NavBrukerTjeneste brukerTjeneste;
     private Persondata pdlKlient;
     private BehandlingRepository behandlingRepository;
+    private BehandlingsresultatRepository behandlingsresultatRepository;
     private InvaliderSakPersonCacheKlient invaliderSakPersonCacheKlient;
 
     public ForvaltningFagsakRestTjeneste() {
@@ -112,6 +118,7 @@ public class ForvaltningFagsakRestTjeneste {
         this.brukerTjeneste = brukerTjeneste;
         this.pdlKlient = pdlKlient;
         this.behandlingRepository = repositoryProvider.getBehandlingRepository();
+        this.behandlingsresultatRepository = repositoryProvider.getBehandlingsresultatRepository();
         this.invaliderSakPersonCacheKlient = invaliderSakPersonCacheKlient;
     }
 
@@ -268,6 +275,23 @@ public class ForvaltningFagsakRestTjeneste {
             responstekst = responstekst + " Åpen behandling - hopp tilbake til KOARB pga STP";
         }  else {
             responstekst = responstekst + " Opprett revurdering fra meny.";
+        }
+        if (!åpnebehandlinger.isEmpty()) {
+            var vilkårFjernes = nyRolle.erFarEllerMedMor() ? VilkårType.FØDSELSVILKÅRET_MOR : VilkårType.FØDSELSVILKÅRET_FAR_MEDMOR;
+            var behandlingerSomMåFjerneVilkår = åpnebehandlinger.stream()
+                .filter(b -> behandlingsresultatRepository.hentHvisEksisterer(b.getId())
+                    .map(Behandlingsresultat::getVilkårResultat)
+                    .map(VilkårResultat::getVilkårTyper).orElse(Set.of()).contains(vilkårFjernes))
+                .toList();
+            for (var b : behandlingerSomMåFjerneVilkår) {
+                // Bør virke pga (Orphanremoval + cascade/all). Ellers må lagre-metoden oppdateres
+                var lås = behandlingRepository.taSkriveLås(b.getId());
+                var br = behandlingsresultatRepository.hent(b.getId());
+                var vilkårBuilder = VilkårResultat.builderFraEksisterende(br.getVilkårResultat());
+                vilkårBuilder.fjernVilkår(vilkårFjernes);
+                var vilkårsResultat = vilkårBuilder.buildFor(b);
+                behandlingRepository.lagre(vilkårsResultat, lås);
+            }
         }
         fagsakRepository.oppdaterRelasjonsRolle(fagsak.getId(), nyRolle);
         LOG.info("Brukerrolle sak {} oppdatert til {}", saksnummer.getVerdi(), nyRolle);

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/forvaltning/ForvaltningUttrekkRestTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/forvaltning/ForvaltningUttrekkRestTjeneste.java
@@ -315,20 +315,4 @@ public class ForvaltningUttrekkRestTjeneste {
         return Response.ok(restanse).build();
     }
 
-    @POST
-    @Consumes(MediaType.APPLICATION_JSON)
-    @Produces(MediaType.APPLICATION_JSON)
-    @Operation(description = "Gir åpne aksjonspunkter med angitt kode", tags = "FORVALTNING-uttrekk")
-    @Path("/fikseGamleTekniskeAvvik")
-    @BeskyttetRessurs(actionType = ActionType.READ, resourceType = ResourceType.DRIFT, sporingslogg = false)
-    public Response fikseGamleTekniskeAvvik() {
-        entityManager.createNativeQuery("DELETE from VILKAR where vilkar_type = '-'").executeUpdate();
-        entityManager.createNativeQuery("DELETE from gr_familie_hendelse where soeknad_familie_hendelse_id in (select id from FH_FAMILIE_HENDELSE where familie_hendelse_type = '-')").executeUpdate();
-        entityManager.createNativeQuery("DELETE from FH_FAMILIE_HENDELSE where familie_hendelse_type = '-'").executeUpdate();
-        entityManager.createNativeQuery("UPDATE PO_PERSONOPPLYSNING set BRUKER_KJOENN = 'K' where id = 5016597").executeUpdate();
-        entityManager.createNativeQuery("UPDATE PO_PERSONSTATUS set PERSONSTATUS = 'BOSA' where id in (7168231,7306947)").executeUpdate();
-        entityManager.createNativeQuery("update PO_STATSBORGERSKAP set statsborgerskap = 'XUK' where statsborgerskap = '-'").executeUpdate();
-        return Response.ok().build();
-    }
-
 }


### PR DESCRIPTION
Tilfelle der saksrollekorrigering, som normalt er riktig, ikke er riktig - se etter "Brukerrolle sak"
Hvis denne koden virker så bør vi gjøre to ting: 
* KontrollerFakta-implementasjonene må fjerne uønskete vilkår
* SøknadOversetter kan potensielt beholde roller fra registrerte papirsøknader (elektronisk = Nei)
* Se også TFP-6246 - kan la folkeregisterrolle overstyre søknad og sette saksrolle.