### PR TITLE
TFP-6979 backendstøtte for mellomlagring papirsøknad

### DIFF
--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/registrerer/PapirsoknadEndringsøknadMellomlagreDto.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/registrerer/PapirsoknadEndringsøknadMellomlagreDto.java
@@ -1,0 +1,34 @@
+package no.nav.foreldrepenger.mottak.registrerer;
+
+import jakarta.validation.Valid;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.AksjonspunktKodeDefinisjon;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonTypeName(AksjonspunktKodeDefinisjon.REGISTRER_PAPIR_ENDRINGSØKNAD_FORELDREPENGER_KODE)
+public class PapirsoknadEndringsøknadMellomlagreDto extends PapirsoknadMellomlagreDto {
+
+    @Valid
+    private TidsromPermisjonFormValues tidsromPermisjon;
+
+    private Boolean annenForelderInformert;
+
+    public TidsromPermisjonFormValues getTidsromPermisjon() {
+        return tidsromPermisjon;
+    }
+
+    public void setTidsromPermisjon(TidsromPermisjonFormValues tidsromPermisjon) {
+        this.tidsromPermisjon = tidsromPermisjon;
+    }
+
+    public Boolean getAnnenForelderInformert() {
+        return annenForelderInformert;
+    }
+
+    public void setAnnenForelderInformert(Boolean annenForelderInformert) {
+        this.annenForelderInformert = annenForelderInformert;
+    }
+}

--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/registrerer/PapirsoknadEngangsstonadMellomlagreDto.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/registrerer/PapirsoknadEngangsstonadMellomlagreDto.java
@@ -1,0 +1,12 @@
+package no.nav.foreldrepenger.mottak.registrerer;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.AksjonspunktKodeDefinisjon;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonTypeName(AksjonspunktKodeDefinisjon.REGISTRER_PAPIRSØKNAD_ENGANGSSTØNAD_KODE)
+public class PapirsoknadEngangsstonadMellomlagreDto extends PapirsoknadMellomlagreDto {
+
+}

--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/registrerer/PapirsoknadForeldrepengerMellomlagreDto.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/registrerer/PapirsoknadForeldrepengerMellomlagreDto.java
@@ -1,0 +1,45 @@
+package no.nav.foreldrepenger.mottak.registrerer;
+
+import jakarta.validation.Valid;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.AksjonspunktKodeDefinisjon;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonTypeName(AksjonspunktKodeDefinisjon.REGISTRER_PAPIRSØKNAD_FORELDREPENGER_KODE)
+public class PapirsoknadForeldrepengerMellomlagreDto extends PapirsoknadMedInntektArbeidYtelseMellomlagreDto {
+
+    // Frontend lagrer dekningsgrad som string, f.eks. "100_PROSENT"
+    private String dekningsgrad;
+
+    @Valid
+    private TidsromPermisjonFormValues tidsromPermisjon;
+
+    private Boolean annenForelderInformert;
+
+    public String getDekningsgrad() {
+        return dekningsgrad;
+    }
+
+    public void setDekningsgrad(String dekningsgrad) {
+        this.dekningsgrad = dekningsgrad;
+    }
+
+    public TidsromPermisjonFormValues getTidsromPermisjon() {
+        return tidsromPermisjon;
+    }
+
+    public void setTidsromPermisjon(TidsromPermisjonFormValues tidsromPermisjon) {
+        this.tidsromPermisjon = tidsromPermisjon;
+    }
+
+    public Boolean getAnnenForelderInformert() {
+        return annenForelderInformert;
+    }
+
+    public void setAnnenForelderInformert(Boolean annenForelderInformert) {
+        this.annenForelderInformert = annenForelderInformert;
+    }
+}

--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/registrerer/PapirsoknadMedInntektArbeidYtelseMellomlagreDto.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/registrerer/PapirsoknadMedInntektArbeidYtelseMellomlagreDto.java
@@ -1,0 +1,96 @@
+package no.nav.foreldrepenger.mottak.registrerer;
+
+import java.time.LocalDate;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Size;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+/**
+ * Mellomlagring-variant av {@link no.nav.foreldrepenger.web.app.tjenester.registrering.dto.MedInntektArbeidYtelseRegistrering}.
+ * Feltnavnene speiler frontend-skjemaets form field names.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public abstract class PapirsoknadMedInntektArbeidYtelseMellomlagreDto extends PapirsoknadMellomlagreDto {
+
+    @Size(max = 50)
+    private List<@Valid ArbeidsforholdFormValues> arbeidsforhold;
+
+    @Valid
+    private AndreYtelserFormValues andreYtelser;
+
+    @Valid
+    private EgenVirksomhetFormValues egenVirksomhet;
+
+    @Valid
+    private FrilansFormValues frilans;
+
+    protected PapirsoknadMedInntektArbeidYtelseMellomlagreDto() {
+        // For Jackson
+    }
+
+    public List<ArbeidsforholdFormValues> getArbeidsforhold() {
+        return arbeidsforhold;
+    }
+
+    public void setArbeidsforhold(List<ArbeidsforholdFormValues> arbeidsforhold) {
+        this.arbeidsforhold = arbeidsforhold;
+    }
+
+    public AndreYtelserFormValues getAndreYtelser() {
+        return andreYtelser;
+    }
+
+    public void setAndreYtelser(AndreYtelserFormValues andreYtelser) {
+        this.andreYtelser = andreYtelser;
+    }
+
+    public EgenVirksomhetFormValues getEgenVirksomhet() {
+        return egenVirksomhet;
+    }
+
+    public void setEgenVirksomhet(EgenVirksomhetFormValues egenVirksomhet) {
+        this.egenVirksomhet = egenVirksomhet;
+    }
+
+    public FrilansFormValues getFrilans() {
+        return frilans;
+    }
+
+    public void setFrilans(FrilansFormValues frilans) {
+        this.frilans = frilans;
+    }
+
+    // --- Selvstendige form-value records ---
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record ArbeidsforholdFormValues(String arbeidsgiver, LocalDate periodeFom, LocalDate periodeTom, String land) { }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record AndreYtelserFormValues(List<String> andreYtelserTyper,
+                                         Map<String, List<YtelserPeriode>> andreYtelserPerioder) {
+        @JsonIgnoreProperties(ignoreUnknown = true)
+        public record YtelserPeriode(LocalDate periodeFom, LocalDate periodeTom) { }
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record EgenVirksomhetFormValues(Boolean harArbeidetIEgenVirksomhet, List<VirksomhetFormValues> virksomheter) {
+        @JsonIgnoreProperties(ignoreUnknown = true)
+        public record VirksomhetFormValues(String navn, String organisasjonsnummer, LocalDate fom, LocalDate tom) { }
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record FrilansFormValues(Boolean harSøkerPeriodeMedFrilans, Collection<FrilansPeriode> perioder,
+                                    Boolean erNyoppstartetFrilanser, Boolean harInntektFraFosterhjem,
+                                    Boolean harHattOppdragForFamilie, Collection<OppdragPeriode> oppdragPerioder) {
+        @JsonIgnoreProperties(ignoreUnknown = true)
+        public record FrilansPeriode(LocalDate periodeFom, LocalDate periodeTom) { }
+
+        @JsonIgnoreProperties(ignoreUnknown = true)
+        public record OppdragPeriode(String oppdragsgiver, LocalDate fomDato, LocalDate tomDato) { }
+    }
+}

--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/registrerer/PapirsoknadMellomlagreDto.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/registrerer/PapirsoknadMellomlagreDto.java
@@ -1,0 +1,299 @@
+package no.nav.foreldrepenger.mottak.registrerer;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.AksjonspunktKodeDefinisjon;
+import no.nav.foreldrepenger.behandlingslager.behandling.familiehendelse.FamilieHendelseType;
+import no.nav.foreldrepenger.behandlingslager.behandling.søknad.ForeldreType;
+import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakYtelseType;
+import no.nav.foreldrepenger.behandlingslager.geografisk.Språkkode;
+import no.nav.foreldrepenger.validering.ValidKodeverk;
+import no.nav.vedtak.util.InputValideringRegex;
+
+/**
+ * Mellomlagring av papirsøknad-utkast. Feltnavnene speiler frontend-skjemaets form field names (raw getValues()),
+ * ikke ManuellRegistreringDto sine transformerte feltnavn.
+ * <p>
+ * Brukes ikke direkte i REST-endepunktet (som tar opak String), men kan benyttes for å bygge
+ * forhåndsutfylte mellomlagringsobjekter fra annen input og serialisere via {@code DefaultJsonMapper.toJson(dto)}.
+ * Frontenden konsumerer via JSON.parse() og spreader inn i form defaultValues.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "@type")
+@JsonSubTypes({
+    @JsonSubTypes.Type(value = PapirsoknadEngangsstonadMellomlagreDto.class, name = AksjonspunktKodeDefinisjon.REGISTRER_PAPIRSØKNAD_ENGANGSSTØNAD_KODE),
+    @JsonSubTypes.Type(value = PapirsoknadForeldrepengerMellomlagreDto.class, name = AksjonspunktKodeDefinisjon.REGISTRER_PAPIRSØKNAD_FORELDREPENGER_KODE),
+    @JsonSubTypes.Type(value = PapirsoknadEndringsøknadMellomlagreDto.class, name = AksjonspunktKodeDefinisjon.REGISTRER_PAPIR_ENDRINGSØKNAD_FORELDREPENGER_KODE),
+    @JsonSubTypes.Type(value = PapirsoknadSvangerskapspengerMellomlagreDto.class, name = AksjonspunktKodeDefinisjon.REGISTRER_PAPIRSØKNAD_SVANGERSKAPSPENGER_KODE),
+})
+public abstract class PapirsoknadMellomlagreDto {
+
+    // Metadata — satt av frontend-wrapper (RegistrerPapirsoknadPanel), bruker ASCII-feltnavn
+    @ValidKodeverk
+    private FamilieHendelseType tema;
+
+    @ValidKodeverk
+    private FagsakYtelseType soknadstype;
+
+    @ValidKodeverk
+    private ForeldreType foreldretype;
+
+    // Mottatt dato
+    private LocalDate mottattDato;
+
+    // Opphold i Norge — form field names (NB: oppholdSisteTolvINorge = "har bodd i Norge siste 12 mnd", IKKE negert)
+    private Boolean oppholdINorge;
+    private Boolean oppholdSisteTolvINorge;
+    private Boolean oppholdNesteTolvINorge;
+
+    @Size(max = 1000)
+    private List<@Valid UtenlandsoppholdFormValues> tidligereOppholdUtenlands;
+
+    @Size(max = 1000)
+    private List<@Valid UtenlandsoppholdFormValues> fremtidigeOppholdUtenlands;
+
+    // Termin og fødsel
+    private Boolean erBarnetFødt;
+    private LocalDate termindato;
+    private LocalDate terminbekreftelseDato;
+
+    @Max(9)
+    private Integer antallBarnFraTerminbekreftelse;
+
+    @Max(9)
+    private Integer antallBarn;
+
+    private LocalDate fødselsdato;
+
+    // Rettigheter (enum-verdi som string, f.eks. "ANNEN_FORELDER_DOED")
+    private String rettigheter;
+
+    // Omsorg og adopsjon
+    @Valid
+    private OmsorgFormValues omsorg;
+
+    // Annen forelder
+    @Valid
+    private AnnenForelderFormValues annenForelder;
+
+    // Språk
+    @ValidKodeverk
+    private Språkkode språkkode;
+
+    // Lagre-panel
+    @Size(max = 4000)
+    @Pattern(regexp = InputValideringRegex.FRITEKST)
+    private String kommentarEndring;
+
+    private Boolean registrerVerge;
+    private Boolean ufullstendigSøknad;
+
+    protected PapirsoknadMellomlagreDto() {
+        // For Jackson
+    }
+
+    public FamilieHendelseType getTema() {
+        return tema;
+    }
+
+    public void setTema(FamilieHendelseType tema) {
+        this.tema = tema;
+    }
+
+    public FagsakYtelseType getSoknadstype() {
+        return soknadstype;
+    }
+
+    public void setSoknadstype(FagsakYtelseType soknadstype) {
+        this.soknadstype = soknadstype;
+    }
+
+    public ForeldreType getForeldretype() {
+        return foreldretype;
+    }
+
+    public void setForeldretype(ForeldreType foreldretype) {
+        this.foreldretype = foreldretype;
+    }
+
+    public LocalDate getMottattDato() {
+        return mottattDato;
+    }
+
+    public void setMottattDato(LocalDate mottattDato) {
+        this.mottattDato = mottattDato;
+    }
+
+    public Boolean getOppholdINorge() {
+        return oppholdINorge;
+    }
+
+    public void setOppholdINorge(Boolean oppholdINorge) {
+        this.oppholdINorge = oppholdINorge;
+    }
+
+    public Boolean getOppholdSisteTolvINorge() {
+        return oppholdSisteTolvINorge;
+    }
+
+    public void setOppholdSisteTolvINorge(Boolean oppholdSisteTolvINorge) {
+        this.oppholdSisteTolvINorge = oppholdSisteTolvINorge;
+    }
+
+    public Boolean getOppholdNesteTolvINorge() {
+        return oppholdNesteTolvINorge;
+    }
+
+    public void setOppholdNesteTolvINorge(Boolean oppholdNesteTolvINorge) {
+        this.oppholdNesteTolvINorge = oppholdNesteTolvINorge;
+    }
+
+    public List<UtenlandsoppholdFormValues> getTidligereOppholdUtenlands() {
+        return tidligereOppholdUtenlands;
+    }
+
+    public void setTidligereOppholdUtenlands(List<UtenlandsoppholdFormValues> tidligereOppholdUtenlands) {
+        this.tidligereOppholdUtenlands = tidligereOppholdUtenlands;
+    }
+
+    public List<UtenlandsoppholdFormValues> getFremtidigeOppholdUtenlands() {
+        return fremtidigeOppholdUtenlands;
+    }
+
+    public void setFremtidigeOppholdUtenlands(List<UtenlandsoppholdFormValues> fremtidigeOppholdUtenlands) {
+        this.fremtidigeOppholdUtenlands = fremtidigeOppholdUtenlands;
+    }
+
+    public Boolean getErBarnetFødt() {
+        return erBarnetFødt;
+    }
+
+    public void setErBarnetFødt(Boolean erBarnetFødt) {
+        this.erBarnetFødt = erBarnetFødt;
+    }
+
+    public LocalDate getTermindato() {
+        return termindato;
+    }
+
+    public void setTermindato(LocalDate termindato) {
+        this.termindato = termindato;
+    }
+
+    public LocalDate getTerminbekreftelseDato() {
+        return terminbekreftelseDato;
+    }
+
+    public void setTerminbekreftelseDato(LocalDate terminbekreftelseDato) {
+        this.terminbekreftelseDato = terminbekreftelseDato;
+    }
+
+    public Integer getAntallBarnFraTerminbekreftelse() {
+        return antallBarnFraTerminbekreftelse;
+    }
+
+    public void setAntallBarnFraTerminbekreftelse(Integer antallBarnFraTerminbekreftelse) {
+        this.antallBarnFraTerminbekreftelse = antallBarnFraTerminbekreftelse;
+    }
+
+    public Integer getAntallBarn() {
+        return antallBarn;
+    }
+
+    public void setAntallBarn(Integer antallBarn) {
+        this.antallBarn = antallBarn;
+    }
+
+    public LocalDate getFødselsdato() {
+        return fødselsdato;
+    }
+
+    public void setFødselsdato(LocalDate fødselsdato) {
+        this.fødselsdato = fødselsdato;
+    }
+
+    public String getRettigheter() {
+        return rettigheter;
+    }
+
+    public void setRettigheter(String rettigheter) {
+        this.rettigheter = rettigheter;
+    }
+
+    public OmsorgFormValues getOmsorg() {
+        return omsorg;
+    }
+
+    public void setOmsorg(OmsorgFormValues omsorg) {
+        this.omsorg = omsorg;
+    }
+
+    public AnnenForelderFormValues getAnnenForelder() {
+        return annenForelder;
+    }
+
+    public void setAnnenForelder(AnnenForelderFormValues annenForelder) {
+        this.annenForelder = annenForelder;
+    }
+
+    public Språkkode getSpråkkode() {
+        return språkkode;
+    }
+
+    public void setSpråkkode(Språkkode språkkode) {
+        this.språkkode = språkkode;
+    }
+
+    public String getKommentarEndring() {
+        return kommentarEndring;
+    }
+
+    public void setKommentarEndring(String kommentarEndring) {
+        this.kommentarEndring = kommentarEndring;
+    }
+
+    public Boolean getRegistrerVerge() {
+        return registrerVerge;
+    }
+
+    public void setRegistrerVerge(Boolean registrerVerge) {
+        this.registrerVerge = registrerVerge;
+    }
+
+    public Boolean getUfullstendigSøknad() {
+        return ufullstendigSøknad;
+    }
+
+    public void setUfullstendigSøknad(Boolean ufullstendigSøknad) {
+        this.ufullstendigSøknad = ufullstendigSøknad;
+    }
+
+    // --- Selvstendige form-value records (uavhengig av web-modulens DTOer) ---
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record UtenlandsoppholdFormValues(String land, LocalDate periodeFom, LocalDate periodeTom) { }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record OmsorgFormValues(Integer antallBarn, List<LocalDate> fødselsdato, LocalDate omsorgsovertakelsesdato,
+                                   LocalDate ankomstdato, Boolean erEktefellesBarn) { }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record AnnenForelderFormValues(String fødselsnummer, Boolean kanIkkeOppgiAnnenForelder,
+                                          KanIkkeOppgiBegrunnelseFormValues kanIkkeOppgiBegrunnelse,
+                                          Boolean søkerHarAleneomsorg, Boolean denAndreForelderenHarRettPåForeldrepenger,
+                                          Boolean annenForelderRettEØS, Boolean morMottarUføretrygd) { }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record KanIkkeOppgiBegrunnelseFormValues(String årsak, String utenlandskFødselsnummer, String land) { }
+}

--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/registrerer/PapirsoknadSvangerskapspengerMellomlagreDto.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/registrerer/PapirsoknadSvangerskapspengerMellomlagreDto.java
@@ -1,0 +1,32 @@
+package no.nav.foreldrepenger.mottak.registrerer;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import jakarta.validation.Valid;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.AksjonspunktKodeDefinisjon;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonTypeName(AksjonspunktKodeDefinisjon.REGISTRER_PAPIRSØKNAD_SVANGERSKAPSPENGER_KODE)
+public class PapirsoknadSvangerskapspengerMellomlagreDto extends PapirsoknadMedInntektArbeidYtelseMellomlagreDto {
+
+    private List<@Valid TilretteleggingFormValues> tilrettelegging;
+
+    public List<TilretteleggingFormValues> getTilrettelegging() {
+        return tilrettelegging;
+    }
+
+    public void setTilrettelegging(List<TilretteleggingFormValues> tilrettelegging) {
+        this.tilrettelegging = tilrettelegging;
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record TilretteleggingFormValues(LocalDate behovsdato, List<TilretteleggingDetaljer> tilrettelegginger) {
+        @JsonIgnoreProperties(ignoreUnknown = true)
+        public record TilretteleggingDetaljer(String type, LocalDate dato, Integer stillingsprosent) { }
+    }
+}

--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/registrerer/TidsromPermisjonFormValues.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/registrerer/TidsromPermisjonFormValues.java
@@ -1,0 +1,41 @@
+package no.nav.foreldrepenger.mottak.registrerer;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+/**
+ * Speiler frontend-skjemaets tidsromPermisjon form field structure.
+ * Inkluderer boolean-toggler (fulltUttak, skalUtsette, etc.) som kontrollerer hvilke paneler som vises,
+ * i tillegg til periodelistene.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record TidsromPermisjonFormValues(
+    Boolean fulltUttak,
+    List<PermisjonPeriode> permisjonsPerioder,
+    Boolean skalOvertaKvote,
+    List<OverforingPeriode> overføringsperioder,
+    Boolean skalUtsette,
+    List<UtsettelsPeriode> utsettelsePeriode,
+    Boolean skalGradere,
+    List<GraderingPeriode> graderingPeriode,
+    Boolean skalHaOpphold,
+    List<OppholdPeriode> oppholdPerioder
+) {
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record PermisjonPeriode(LocalDate periodeFom, LocalDate periodeTom, String periodeType, String morsAktivitet) { }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record OverforingPeriode(LocalDate periodeFom, LocalDate periodeTom, String overforingArsak) { }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record UtsettelsPeriode(LocalDate periodeFom, LocalDate periodeTom, String arsakForUtsettelse) { }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record GraderingPeriode(LocalDate periodeFom, LocalDate periodeTom, String periodeForGradering,
+                                   Integer prosentandelArbeid, String arbeidsgiverIdentifikator) { }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record OppholdPeriode(LocalDate periodeFom, LocalDate periodeTom, String årsak) { }
+}

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/dto/behandling/BehandlingDtoTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/dto/behandling/BehandlingDtoTjeneste.java
@@ -91,10 +91,10 @@ import no.nav.foreldrepenger.web.app.tjenester.behandling.verge.VergeRestTjenest
 import no.nav.foreldrepenger.web.app.tjenester.behandling.vilkår.VilkårDtoMapper;
 import no.nav.foreldrepenger.web.app.tjenester.behandling.ytelsefordeling.YtelsefordelingRestTjeneste;
 import no.nav.foreldrepenger.web.app.tjenester.brev.BrevRestTjeneste;
-import no.nav.foreldrepenger.web.app.tjenester.mellomlagring.MellomlagringRestTjeneste;
 import no.nav.foreldrepenger.web.app.tjenester.dokument.DokumentRestTjeneste;
 import no.nav.foreldrepenger.web.app.tjenester.fagsak.dto.SaksnummerDto;
 import no.nav.foreldrepenger.web.app.tjenester.familiehendelse.FamiliehendelseRestTjeneste;
+import no.nav.foreldrepenger.web.app.tjenester.mellomlagring.MellomlagringRestTjeneste;
 
 /**
  * Bygger et sammensatt resultat av BehandlingDto ved å samle data fra ulike tjenester, for å kunne levere dette ut på en REST tjeneste.
@@ -341,6 +341,8 @@ public class BehandlingDtoTjeneste {
         dto.leggTil(get(SøknadRestTjeneste.SØKNAD_PATH, "søknad", uuidDto));
 
         if (dto.isAktivPapirsøknad()) {
+            dto.leggTil(post(MellomlagringRestTjeneste.MELLOMLAGRING_PATH, "mellomlagring"));
+            dto.leggTil(post(MellomlagringRestTjeneste.HENT_MELLOMLAGRING_PATH, "hent-mellomlagring"));
             return dto;
         }
 

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/dto/behandling/BehandlingDtoTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/dto/behandling/BehandlingDtoTjeneste.java
@@ -339,10 +339,10 @@ public class BehandlingDtoTjeneste {
         var harSakenSøknad = søknadRepository.hentSøknadHvisEksisterer(behandling.getId()).isPresent();
         dto.setHarSøknad(harSakenSøknad);
         dto.leggTil(get(SøknadRestTjeneste.SØKNAD_PATH, "søknad", uuidDto));
+        dto.leggTil(post(MellomlagringRestTjeneste.MELLOMLAGRING_PATH, "mellomlagring"));
+        dto.leggTil(post(MellomlagringRestTjeneste.HENT_MELLOMLAGRING_PATH, "hent-mellomlagring"));
 
         if (dto.isAktivPapirsøknad()) {
-            dto.leggTil(post(MellomlagringRestTjeneste.MELLOMLAGRING_PATH, "mellomlagring"));
-            dto.leggTil(post(MellomlagringRestTjeneste.HENT_MELLOMLAGRING_PATH, "hent-mellomlagring"));
             return dto;
         }
 
@@ -352,8 +352,6 @@ public class BehandlingDtoTjeneste {
         }
 
         dto.leggTil(post(BrevRestTjeneste.BREV_HTML_PATH, "hent-brev-html"));
-        dto.leggTil(post(MellomlagringRestTjeneste.MELLOMLAGRING_PATH, "mellomlagring"));
-        dto.leggTil(post(MellomlagringRestTjeneste.HENT_MELLOMLAGRING_PATH, "hent-mellomlagring"));
 
         dto.leggTil(get(FamiliehendelseRestTjeneste.FAMILIEHENDELSE_V3_PATH, "familiehendelse-v3", uuidDto));
 

--- a/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/mellomlagring/MellomlagringRestTjenesteTest.java
+++ b/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/mellomlagring/MellomlagringRestTjenesteTest.java
@@ -1,6 +1,7 @@
 package no.nav.foreldrepenger.web.app.tjenester.mellomlagring;
 
 import static no.nav.foreldrepenger.behandlingslager.behandling.dokument.MellomlagringType.INNHENT_OPPLYSNINGER;
+import static no.nav.foreldrepenger.behandlingslager.behandling.dokument.MellomlagringType.PAPIRSØKNAD;
 import static no.nav.foreldrepenger.behandlingslager.behandling.dokument.MellomlagringType.VARSEL_REVURDERING;
 import static no.nav.foreldrepenger.behandlingslager.behandling.dokument.MellomlagringType.VEDTAKSBREV;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -175,5 +176,62 @@ class MellomlagringRestTjenesteTest {
 
         assertThat(mellomlagringRepository.hentMellomlagring(behandling.getId(), VARSEL_REVURDERING)).isPresent();
         assertThat(mellomlagringRepository.hentMellomlagring(behandling.getId(), INNHENT_OPPLYSNINGER)).isEmpty();
+    }
+
+    // --- Papirsøknad mellomlagring (via generisk endpoint med type PAPIRSØKNAD) ---
+
+    @Test
+    void lagre_og_hent_papirsoknad_engangsstonad() {
+        var payload = "{\"@type\":\"5012\",\"antallBarn\":2}";
+        var lagreDto = new MellomlagringRestTjeneste.MellomlagringDto(behandling.getUuid(), PAPIRSØKNAD, null, payload);
+
+        var lagreRespons = tjeneste.lagreMellomlagring(lagreDto);
+        assertThat(lagreRespons.getStatus()).isEqualTo(200);
+
+        var hentRespons = tjeneste.hentMellomlagring(new MellomlagringRestTjeneste.HentMellomlagringDto(behandling.getUuid(), PAPIRSØKNAD, null));
+        assertThat(hentRespons.getStatus()).isEqualTo(200);
+        var resultat = (MellomlagringRestTjeneste.MellomlagringResultatDto) hentRespons.getEntity();
+        assertThat(resultat.innhold()).isEqualTo(payload);
+    }
+
+    @Test
+    void lagre_og_hent_papirsoknad_med_vilkaarlige_felter() {
+        var payload = "{\"@type\":\"5040\",\"mottattDato\":\"2024-01-15\",\"customField\":\"custom\"}";
+        var lagreDto = new MellomlagringRestTjeneste.MellomlagringDto(behandling.getUuid(), PAPIRSØKNAD, null, payload);
+
+        tjeneste.lagreMellomlagring(lagreDto);
+
+        var hentRespons = tjeneste.hentMellomlagring(new MellomlagringRestTjeneste.HentMellomlagringDto(behandling.getUuid(), PAPIRSØKNAD, null));
+        assertThat(hentRespons.getStatus()).isEqualTo(200);
+        var resultat = (MellomlagringRestTjeneste.MellomlagringResultatDto) hentRespons.getEntity();
+        assertThat(resultat.innhold()).isEqualTo(payload);
+    }
+
+    @Test
+    void slett_papirsoknad_mellomlagring() {
+        tjeneste.lagreMellomlagring(new MellomlagringRestTjeneste.MellomlagringDto(behandling.getUuid(), PAPIRSØKNAD, null, "{\"@type\":\"5012\"}"));
+        assertThat(mellomlagringRepository.hentMellomlagring(behandling.getId(), PAPIRSØKNAD)).isPresent();
+
+        tjeneste.lagreMellomlagring(new MellomlagringRestTjeneste.MellomlagringDto(behandling.getUuid(), PAPIRSØKNAD, null, null));
+
+        assertThat(mellomlagringRepository.hentMellomlagring(behandling.getId(), PAPIRSØKNAD)).isEmpty();
+    }
+
+    @Test
+    void hent_papirsoknad_returnerer_204_naar_ingenting_lagret() {
+        var respons = tjeneste.hentMellomlagring(new MellomlagringRestTjeneste.HentMellomlagringDto(behandling.getUuid(), PAPIRSØKNAD, null));
+        assertThat(respons.getStatus()).isEqualTo(204);
+    }
+
+    @Test
+    void lagre_papirsoknad_oppdaterer_eksisterende() {
+        tjeneste.lagreMellomlagring(new MellomlagringRestTjeneste.MellomlagringDto(behandling.getUuid(), PAPIRSØKNAD, null, "{\"antallBarn\":1}"));
+
+        var oppdatertPayload = "{\"antallBarn\":3}";
+        tjeneste.lagreMellomlagring(new MellomlagringRestTjeneste.MellomlagringDto(behandling.getUuid(), PAPIRSØKNAD, null, oppdatertPayload));
+
+        var hentRespons = tjeneste.hentMellomlagring(new MellomlagringRestTjeneste.HentMellomlagringDto(behandling.getUuid(), PAPIRSØKNAD, null));
+        var resultat = (MellomlagringRestTjeneste.MellomlagringResultatDto) hentRespons.getEntity();
+        assertThat(resultat.innhold()).isEqualTo(oppdatertPayload);
     }
 }


### PR DESCRIPTION
Gjør det samme som for brev - lar frontend håndtere, dvs (de)serialisere innholdet, og lagrer/henter String
Dto-samlingen skal være en gjenskaping av frontend - slik at tilfelle digital papirsøknad skal mappes fra FyllUtSendInn-Json til FyllUtSendInn-Dto til MellomlagrePapirsøknadDto som så serialiseres og lagres. Slik at de plukkes av frontend når man åpner behandlingen for å registrere.