### PR TITLE
Chore: migreringsscript som setter unused på gamle fritekstfelter i v…

### DIFF
--- a/migreringer/src/main/resources/db/migration/defaultDS/4.1/V4.1_46__fjern-overstyrt-brev-fritekst-overskrift.sql
+++ b/migreringer/src/main/resources/db/migration/defaultDS/4.1/V4.1_46__fjern-overstyrt-brev-fritekst-overskrift.sql
@@ -1,0 +1,1 @@
+ALTER TABLE BEHANDLING_DOKUMENT SET UNUSED (overstyrt_brev_fritekst, overstyrt_brev_overskrift);


### PR DESCRIPTION
…edtak. Teksten ligger i produserte vedtaksbrev, og trengs dermed ikke i db