### PR TITLE
TFP-6942 Legg til @NotNull-validering på nye SVP-arbeidsforhold-felter

### DIFF
--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/svp/BekreftSvangerskapspengerOppdaterer.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/svp/BekreftSvangerskapspengerOppdaterer.java
@@ -258,7 +258,7 @@ public class BekreftSvangerskapspengerOppdaterer implements AksjonspunktOppdater
     private boolean tilretteleggingErEndret(BekreftTilrettelegging arbeidsforholdDto,
                                             List<SvpTilretteleggingEntitet> eksisterendeTilrettelegingerListe) {
 
-        if (arbeidsforholdDto.getArbeidsforholdErSplittet()) {
+        if (arbeidsforholdDto.getArbeidsforholdetErSplittet()) {
             var splittetArbeidsforholdEksisterer = eksisterendeTilrettelegingerListe.stream()
                 .anyMatch(ste -> Objects.equals(ste.getArbeidsgiver().map(Arbeidsgiver::getIdentifikator).orElse(null),
                     arbeidsforholdDto.getArbeidsgiverReferanse()) && ste.getArbeidsforholdErSplittet());
@@ -297,7 +297,7 @@ public class BekreftSvangerskapspengerOppdaterer implements AksjonspunktOppdater
     private SvpTilretteleggingEntitet mapTilrettelegging(BekreftTilrettelegging arbeidsforholdDto,
                                                          List<SvpTilretteleggingEntitet> eksisterendeTilrettelegingerListe) {
         SvpTilretteleggingEntitet eksisterendeTilrettelegging;
-        if (arbeidsforholdDto.getArbeidsforholdErSplittet() && arbeidsforholdDto.getTilretteleggingId() == null) {
+        if (arbeidsforholdDto.getArbeidsforholdetErSplittet() && arbeidsforholdDto.getTilretteleggingId() == null) {
             eksisterendeTilrettelegging = hentEksisterendeTilretteleggingForSplittetArbeidsforhold(eksisterendeTilrettelegingerListe,
                 arbeidsforholdDto.getArbeidsgiverReferanse());
         } else {
@@ -367,7 +367,7 @@ public class BekreftSvangerskapspengerOppdaterer implements AksjonspunktOppdater
             .medMottattTidspunkt(eksisterendeTilrettelegging.getMottattTidspunkt())
             .medInternArbeidsforholdRef(eksisterendeTilrettelegging.getInternArbeidsforholdRef().orElse(null))
             .medSkalBrukes(arbeidsforholdDto.getSkalBrukes())
-            .medErArbeidsforholdSplittet(arbeidsforholdDto.getArbeidsforholdErSplittet());
+            .medErArbeidsforholdSplittet(arbeidsforholdDto.getArbeidsforholdetErSplittet());
 
         // nye tilrettelegging-fra-datoer per arbeidsforhold
         for (var datoDto : arbeidsforholdDto.getTilretteleggingDatoer()) {

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/svp/BekreftTilrettelegging.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/svp/BekreftTilrettelegging.java
@@ -52,7 +52,7 @@ public class BekreftTilrettelegging {
     @Pattern(regexp = InputValideringRegex.FRITEKST)
     private String begrunnelse;
 
-    private boolean arbeidsforholdErSplittet = false;
+    private boolean arbeidsforholdetErSplittet = false;
 
     public LocalDate getTilretteleggingBehovFom() {
         return tilretteleggingBehovFom;
@@ -162,11 +162,11 @@ public class BekreftTilrettelegging {
         this.stillingsprosentStartTilrettelegging = stillingsprosentStartTilrettelegging;
     }
 
-    public boolean getArbeidsforholdErSplittet() {
-        return arbeidsforholdErSplittet;
+    public boolean getArbeidsforholdetErSplittet() {
+        return arbeidsforholdetErSplittet;
     }
 
-    public void setArbeidsforholdErSplittet(boolean arbeidsforholdErSplittet) {
-        this.arbeidsforholdErSplittet = arbeidsforholdErSplittet;
+    public void setArbeidsforholdetErSplittet(boolean arbeidsforholdetErSplittet) {
+        this.arbeidsforholdetErSplittet = arbeidsforholdetErSplittet;
     }
 }

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/svp/SvpArbeidsforholdDto.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/svp/SvpArbeidsforholdDto.java
@@ -49,8 +49,10 @@ public class SvpArbeidsforholdDto {
     @NotNull
     private List<@Valid SvpAvklartOppholdPeriodeDto> avklarteOppholdPerioder = new ArrayList<>();
 
+    @NotNull
     private boolean skalVurdereSplittAvArbeidsforholdet;
 
+    @NotNull
     private boolean arbeidsforholdetErSplittet = false;
 
     @Size(max = 4000)


### PR DESCRIPTION
## Endringer

- Legger til `@NotNull`-validering på nye boolean-felter i `SvpArbeidsforholdDto` (`skalVurdereSplittAvArbeidsforholdet`, `arbeidsforholdetErSplittet`)
- Renamer `arbeidsforholdErSplittet` → `arbeidsforholdetErSplittet` i `BekreftTilrettelegging` og oppdaterer alle referanser i `BekreftSvangerskapspengerOppdaterer`

Sikrer konsistent navngivning og at frontend alltid sender med påkrevde felter.

Oppfølging av #7861.

TFP-6942