### PR TITLE
Bugfix: mer robust utledning av STP for SVP

### DIFF
--- a/domenetjenester/skjaeringstidspunkt/src/main/java/no/nav/foreldrepenger/skjæringstidspunkt/svp/SkjæringstidspunktTjenesteImpl.java
+++ b/domenetjenester/skjaeringstidspunkt/src/main/java/no/nav/foreldrepenger/skjæringstidspunkt/svp/SkjæringstidspunktTjenesteImpl.java
@@ -153,6 +153,11 @@ public class SkjæringstidspunktTjenesteImpl implements SkjæringstidspunktTjene
             .flatMap(SkjæringstidspunktTjenesteImpl::tidligsteDatoFraTilrettelegginger)
             .or(() -> Optional.ofNullable(grunnlag.getOpprinneligeTilrettelegginger())
                 .flatMap(SkjæringstidspunktTjenesteImpl::tidligsteDatoFraTilrettelegginger))
+            // I tilfelle alle tilrettelegginger har skalBrukes = false av mystisk grunner (sett ved søknad på åpen manuell revurdering).
+            .or(() -> Optional.ofNullable(grunnlag.getOverstyrteTilrettelegginger())
+                .flatMap(SkjæringstidspunktTjenesteImpl::tidligsteDatoFraAlleTilrettelegginger))
+            .or(() -> Optional.ofNullable(grunnlag.getOpprinneligeTilrettelegginger())
+                .flatMap(SkjæringstidspunktTjenesteImpl::tidligsteDatoFraAlleTilrettelegginger))
             .orElseThrow(() -> new IllegalStateException("Klarte ikke finne skjæringstidspunkt for SVP"));
     }
 
@@ -160,6 +165,13 @@ public class SkjæringstidspunktTjenesteImpl implements SkjæringstidspunktTjene
         return Optional.ofNullable(tilrettelegginger)
             .map(SvpTilretteleggingerEntitet::getTilretteleggingListe).orElse(List.of()).stream()
             .filter(SvpTilretteleggingEntitet::getSkalBrukes)
+            .map(BeregnTilrettleggingsdato::beregnFraTilrettelegging)
+            .min(Comparator.naturalOrder());
+    }
+
+    private static Optional<LocalDate> tidligsteDatoFraAlleTilrettelegginger(SvpTilretteleggingerEntitet tilrettelegginger) {
+        return Optional.ofNullable(tilrettelegginger)
+            .map(SvpTilretteleggingerEntitet::getTilretteleggingListe).orElse(List.of()).stream()
             .map(BeregnTilrettleggingsdato::beregnFraTilrettelegging)
             .min(Comparator.naturalOrder());
     }


### PR DESCRIPTION
Håndterer et never-seen-before-tilfelle i prod - søknad kommer inn på manuell revurdering i rar tilstand.
Her er det helt OK å bruke behovFom fra gamle perioder fram til man evt får justert startdato i panelet.