### PR TITLE
Bugfix: Svangerskapspenger riktigere justering og sikre at nyopprettet skal brukes

### DIFF
--- a/behandlingsprosess/src/main/java/no/nav/foreldrepenger/behandling/steg/inngangsvilkår/svp/UtledTilretteleggingerMedArbeidsgiverTjeneste.java
+++ b/behandlingsprosess/src/main/java/no/nav/foreldrepenger/behandling/steg/inngangsvilkår/svp/UtledTilretteleggingerMedArbeidsgiverTjeneste.java
@@ -97,6 +97,13 @@ class UtledTilretteleggingerMedArbeidsgiverTjeneste {
             });
         }
 
+        // Kommentar ifm utbedring av finnTilretteleggingerSomMåVurderesPåNytt - bare de som "skalBrukes"
+        // måVurderesPåNytt er fjernet fra tilretteleggingerMedArbeidsforholdId men lagt til i
+        // tilretteleggingerUtenArbeidsforholdId - dvs brukes i for-loopen
+        // Problemet er da at man glemmer både "skalBrukes", lista av "tilretteleggingFom", osv.
+        // Det virker mer fornuftig å videreføre eksisterende tilrettelegginger og lage nye for tilkommet arb.forhold.
+        // Bør også se på om de 2 new SvpTilretteleggingEntitet.Builder skal ta med ".medSkalBrukes(true)"
+
         nyeTilrettelegginger.addAll(tilretteleggingerMedArbeidsforholdId);
 
         for (var tilrettelegging : tilretteleggingerUtenArbeidsforholdId) {
@@ -110,7 +117,7 @@ class UtledTilretteleggingerMedArbeidsgiverTjeneste {
                     .toList();
 
             if (skalKunOppretteEnTilretteleggingForArbeidsgiver(inntektsmeldingerForArbeidsgiver)) {
-                nyeTilrettelegginger.add(new SvpTilretteleggingEntitet.Builder(tilrettelegging).medInternArbeidsforholdRef(null).medSkalBrukes(true).build());
+                nyeTilrettelegginger.add(new SvpTilretteleggingEntitet.Builder(tilrettelegging).medInternArbeidsforholdRef(null).build());
             } else {
                 var tilrettelegginger = opprettTilretteleggingForHverYrkesaktivitet(relevanteYrkesaktiviteter, tilrettelegging, arbeidsgiver);
                 nyeTilrettelegginger.addAll(tilrettelegginger);
@@ -167,7 +174,6 @@ class UtledTilretteleggingerMedArbeidsgiverTjeneste {
                 .filter(yrkesaktivitet -> arbeidsgiver.equals(yrkesaktivitet.getArbeidsgiver()))
                 .map(yrkesaktivitet -> new SvpTilretteleggingEntitet.Builder(tilrettelegging)
                         .medInternArbeidsforholdRef(yrkesaktivitet.getArbeidsforholdRef())
-                        .medSkalBrukes(true)
                         .build())
                 .toList();
     }

--- a/behandlingsprosess/src/main/java/no/nav/foreldrepenger/behandling/steg/inngangsvilkår/svp/UtledTilretteleggingerMedArbeidsgiverTjeneste.java
+++ b/behandlingsprosess/src/main/java/no/nav/foreldrepenger/behandling/steg/inngangsvilkår/svp/UtledTilretteleggingerMedArbeidsgiverTjeneste.java
@@ -84,7 +84,13 @@ class UtledTilretteleggingerMedArbeidsgiverTjeneste {
 
             tilretteleggingerMedArbeidsforholdId.removeAll(måVurderesPåNytt);
             //Dersom det er allerede finnes tilrettelegging for samme arbeidsgiver skal den ikke legges til listen.
-            måVurderesPåNytt.forEach(tilr -> {
+            //Prioriterer arbeidsforhold som er i bruk - unngå at getSkalBrukes brukes videre
+            måVurderesPåNytt.stream().filter(SvpTilretteleggingEntitet::getSkalBrukes).forEach(tilr -> {
+                if (tilretteleggingerUtenArbeidsforholdId.stream().map(SvpTilretteleggingEntitet::getArbeidsgiver).noneMatch(a -> a.equals(tilr.getArbeidsgiver()))) {
+                    tilretteleggingerUtenArbeidsforholdId.add(tilr);
+                }
+            });
+            måVurderesPåNytt.stream().filter(t -> !t.getSkalBrukes()).forEach(tilr -> {
                 if (tilretteleggingerUtenArbeidsforholdId.stream().map(SvpTilretteleggingEntitet::getArbeidsgiver).noneMatch(a -> a.equals(tilr.getArbeidsgiver()))) {
                     tilretteleggingerUtenArbeidsforholdId.add(tilr);
                 }
@@ -104,7 +110,7 @@ class UtledTilretteleggingerMedArbeidsgiverTjeneste {
                     .toList();
 
             if (skalKunOppretteEnTilretteleggingForArbeidsgiver(inntektsmeldingerForArbeidsgiver)) {
-                nyeTilrettelegginger.add(new SvpTilretteleggingEntitet.Builder(tilrettelegging).medInternArbeidsforholdRef(null).build());
+                nyeTilrettelegginger.add(new SvpTilretteleggingEntitet.Builder(tilrettelegging).medInternArbeidsforholdRef(null).medSkalBrukes(true).build());
             } else {
                 var tilrettelegginger = opprettTilretteleggingForHverYrkesaktivitet(relevanteYrkesaktiviteter, tilrettelegging, arbeidsgiver);
                 nyeTilrettelegginger.addAll(tilrettelegginger);
@@ -126,10 +132,12 @@ class UtledTilretteleggingerMedArbeidsgiverTjeneste {
                 .toList();
             var arbeidsgiver = Arbeidsgiver.virksomhet(arbeidsgiverIdentifikator);
 
-            var alleIderHarMatchendeIm = tilretteleggingerForArbeidsgiver.stream().map(SvpTilretteleggingEntitet::getInternArbeidsforholdRef)
+            var alleTilretteleggingIderSomSkalBrukesHarMatchendeIm = tilretteleggingerForArbeidsgiver.stream()
+                .filter(SvpTilretteleggingEntitet::getSkalBrukes)
+                .map(SvpTilretteleggingEntitet::getInternArbeidsforholdRef)
                 .allMatch(internArbeidsforholdRef -> finnesIdIListenAvInntektsmeldingerForArbeidsgiver(arbeidsgiver, kobledeInntektsmeldinger, internArbeidsforholdRef.orElse(null)));
 
-            if (!alleIderHarMatchendeIm || inntektsmeldingerForArbeidsgiver.size() > tilretteleggingerForArbeidsgiver.size() ) {
+            if (!alleTilretteleggingIderSomSkalBrukesHarMatchendeIm || inntektsmeldingerForArbeidsgiver.size() > tilretteleggingerForArbeidsgiver.size() ) {
                 tilretteleggingerSomMåVurderesPåNytt.addAll(tilretteleggingerForArbeidsgiver);
             }
         });
@@ -159,6 +167,7 @@ class UtledTilretteleggingerMedArbeidsgiverTjeneste {
                 .filter(yrkesaktivitet -> arbeidsgiver.equals(yrkesaktivitet.getArbeidsgiver()))
                 .map(yrkesaktivitet -> new SvpTilretteleggingEntitet.Builder(tilrettelegging)
                         .medInternArbeidsforholdRef(yrkesaktivitet.getArbeidsforholdRef())
+                        .medSkalBrukes(true)
                         .build())
                 .toList();
     }

--- a/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/inngangsvilkår/svp/UtledTilretteleggingerMedArbeidsgiverTjenesteTest.java
+++ b/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/inngangsvilkår/svp/UtledTilretteleggingerMedArbeidsgiverTjenesteTest.java
@@ -5,6 +5,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.when;
 
+import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
@@ -16,6 +17,7 @@ import org.mockito.Mockito;
 import no.nav.foreldrepenger.behandling.Skjæringstidspunkt;
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
 import no.nav.foreldrepenger.behandlingslager.behandling.tilrettelegging.SvpTilretteleggingEntitet;
+import no.nav.foreldrepenger.behandlingslager.behandling.tilrettelegging.SvpTilretteleggingFomKilde;
 import no.nav.foreldrepenger.behandlingslager.testutilities.behandling.ScenarioMorSøkerSvangerskapspenger;
 import no.nav.foreldrepenger.behandlingslager.virksomhet.ArbeidType;
 import no.nav.foreldrepenger.behandlingslager.virksomhet.Arbeidsgiver;
@@ -120,6 +122,49 @@ class UtledTilretteleggingerMedArbeidsgiverTjenesteTest {
         var result = utledTilretteleggingerMedArbeidsgiverTjeneste.utled(behandling, skjæringstidspunkt, tilrettelegginger);
         // Assert
         assertThat(result).hasSize(2);
+        assertThat(result.stream().anyMatch(tilr-> tilr.getInternArbeidsforholdRef().equals(Optional.of(ref_1)))).isTrue();
+        assertThat(result.stream().anyMatch(tilr-> tilr.getInternArbeidsforholdRef().equals(Optional.of(ref_2)))).isTrue();
+        assertThat(result.stream().anyMatch(tilr-> tilr.getArbeidsgiver().equals(Optional.of(DEFAULT_VIRKSOMHET)))).isTrue();
+    }
+
+    @Test
+    void skal_lage_to_tilrettelegginger_for_virksomhet_med_to_yrkesaktiviteter_ene_med_IM_andre_ikke_bruk() {
+        var startdato = LocalDate.of(2026, 3, 9);
+
+        // Arrange
+        var ref_1 = InternArbeidsforholdRef.nyRef();
+        var ref_2 = InternArbeidsforholdRef.nyRef();
+        var tlrg1 = new SvpTilretteleggingEntitet.Builder()
+                .medArbeidType(ArbeidType.ORDINÆRT_ARBEIDSFORHOLD)
+                .medBehovForTilretteleggingFom(startdato)
+                .medDelvisTilrettelegging(startdato, BigDecimal.TEN, startdato, SvpTilretteleggingFomKilde.TIDLIGERE_VEDTAK)
+                .medDelvisTilrettelegging(LocalDate.of(2026, 5, 4), BigDecimal.valueOf(30), startdato, SvpTilretteleggingFomKilde.TIDLIGERE_VEDTAK)
+                .medArbeidsgiver(DEFAULT_VIRKSOMHET)
+                .medInternArbeidsforholdRef(ref_1).build();
+        var tlrg2 = new SvpTilretteleggingEntitet.Builder()
+                .medArbeidType(ArbeidType.ORDINÆRT_ARBEIDSFORHOLD)
+                .medArbeidsgiver(DEFAULT_VIRKSOMHET)
+                .medSkalBrukes(false)
+                .medBehovForTilretteleggingFom(startdato)
+                .medDelvisTilrettelegging(startdato, BigDecimal.TEN, startdato, SvpTilretteleggingFomKilde.TIDLIGERE_VEDTAK)
+                .medInternArbeidsforholdRef(ref_2).build();
+
+        var tilrettelegginger = List.of(tlrg2, tlrg1); // Tidlligere - feilet med denne rekkefølgen, 1 før 2 var OK.
+
+        when(iayTjeneste.hentGrunnlag(anyLong())).thenReturn(lagGrunnlag(behandling, List.of(
+            lagYrkesaktivitet(DEFAULT_VIRKSOMHET, ArbeidType.ORDINÆRT_ARBEIDSFORHOLD, ref_1, SKJÆRINGSTIDSPUNKT.minusYears(1), Tid.TIDENES_ENDE),
+            lagYrkesaktivitet(DEFAULT_VIRKSOMHET, ArbeidType.ORDINÆRT_ARBEIDSFORHOLD, ref_2, SKJÆRINGSTIDSPUNKT.minusYears(2), Tid.TIDENES_ENDE))));
+
+        when(inntektsmeldingTjeneste.hentInntektsmeldinger(any(), any())).thenReturn(List.of(
+            lagInntektsmelding(DEFAULT_VIRKSOMHET, ref_1)));
+
+        // Act
+        var result = utledTilretteleggingerMedArbeidsgiverTjeneste.utled(behandling, skjæringstidspunkt, tilrettelegginger);
+        // Assert
+        assertThat(result).hasSize(2);
+        var resultatLikinput = tilrettelegginger.stream().allMatch(tlre -> result.stream().anyMatch(tlre::erLik));
+        assertThat(resultatLikinput).isTrue();
+        assertThat(result.stream().filter(SvpTilretteleggingEntitet::getSkalBrukes).count()).isEqualTo(1);
         assertThat(result.stream().anyMatch(tilr-> tilr.getInternArbeidsforholdRef().equals(Optional.of(ref_1)))).isTrue();
         assertThat(result.stream().anyMatch(tilr-> tilr.getInternArbeidsforholdRef().equals(Optional.of(ref_2)))).isTrue();
         assertThat(result.stream().anyMatch(tilr-> tilr.getArbeidsgiver().equals(Optional.of(DEFAULT_VIRKSOMHET)))).isTrue();


### PR DESCRIPTION
Utgangspunktet var prodfeil med 1 arbgiver og 2 arbeidsforhold der bare det ene skal bruke og har inntektsmelding.
Feilen er at vi først ikke fant STP og så ser at perioder er justert feil i VurderSvangerskapspengerTilretteleggingSteg
Lagde først et enkelt testcase og fant 
* rekkefølgen til måVurderesPåNytt er signifikant - hvis skalBrukes = false kom først så ble den brukt til å opprette nye
* feil utledning av måVurderesPåNytt - ser nå ikke etter IMs for tilfelle som ikke skal brukes

Resultat: Færre justeringer og riktigere justering når det først skjer.

Men: Les og tenk grundig før approve.
