### PR TITLE
TFP-6942 Fjern feil @NotNull på tilretteleggingId i BekreftTilrettelegging

### DIFF
--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/svp/BekreftSvangerskapspengerOppdaterer.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/svp/BekreftSvangerskapspengerOppdaterer.java
@@ -301,6 +301,10 @@ public class BekreftSvangerskapspengerOppdaterer implements AksjonspunktOppdater
             eksisterendeTilrettelegging = hentEksisterendeTilretteleggingForSplittetArbeidsforhold(eksisterendeTilrettelegingerListe,
                 arbeidsforholdDto.getArbeidsgiverReferanse());
         } else {
+            if (arbeidsforholdDto.getTilretteleggingId() == null) {
+                throw new TekniskException("FP-572363",
+                    "Mangler tilretteleggingId for ikke-splittet arbeidsforhold på svangerskapspengergrunnlag");
+            }
             eksisterendeTilrettelegging = hentEksisterendeTilrettelegging(eksisterendeTilrettelegingerListe,
                 arbeidsforholdDto.getTilretteleggingId());
         }

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/svp/BekreftTilrettelegging.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/svp/BekreftTilrettelegging.java
@@ -21,7 +21,6 @@ import no.nav.vedtak.util.InputValideringRegex;
 
 public class BekreftTilrettelegging {
 
-    @NotNull
     @Min(0L)
     @Max(Long.MAX_VALUE)
     private Long tilretteleggingId;


### PR DESCRIPTION
Fjerner feil `@NotNull` på `tilretteleggingId` i `BekreftTilrettelegging`. Feltet kan være null ved ny tilrettelegging for splittede arbeidsforhold.

Legger i tillegg til en eksplisitt validering i `BekreftSvangerskapspengerOppdaterer` som kaster `TekniskException` dersom `tilretteleggingId` mangler i andre tilfeller (når arbeidsforholdet ikke er splittet), på samme vis som øvrige valideringer i klassen.