### PR TITLE
Bugfix: Fjerner ikke mellomlagret vedtaksbrev ved avsluttet behandling

### DIFF
--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/dokument/MellomlagringRepository.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/dokument/MellomlagringRepository.java
@@ -89,11 +89,12 @@ public class MellomlagringRepository {
         entityManager.flush();
     }
 
-    public void fjernAlleMellomlagringer(Long behandlingId) {
+    public void fjernMellomlagringer(Long behandlingId, MellomlagringType ikkeSlettType) {
         LOG.info("Alle mellomlagringer slettet");
         entityManager.createQuery(
-                "delete from BehandlingMellomlagring m where m.behandlingId = :behandlingId")
+                "delete from BehandlingMellomlagring m where m.behandlingId = :behandlingId and m.type <> :type")
             .setParameter("behandlingId", behandlingId)
+            .setParameter("type", ikkeSlettType)
             .executeUpdate();
         entityManager.flush();
     }

--- a/behandlingslager/domene/src/test/java/no/nav/foreldrepenger/behandlingslager/behandling/dokument/MellomlagringRepositoryTest.java
+++ b/behandlingslager/domene/src/test/java/no/nav/foreldrepenger/behandlingslager/behandling/dokument/MellomlagringRepositoryTest.java
@@ -81,11 +81,17 @@ class MellomlagringRepositoryTest extends EntityManagerAwareTest {
             .medType(MellomlagringType.INNHENT_OPPLYSNINGER)
             .medInnhold("<p>Innhent</p>")
             .build());
+        mellomlagringRepository.lagreOgFlush(MellomlagringEntitet.Builder.ny()
+            .medBehandlingId(behandling.getId())
+            .medType(MellomlagringType.VEDTAKSBREV)
+            .medInnhold("<p>Vedtak</p>")
+            .build());
 
-        mellomlagringRepository.fjernAlleMellomlagringer(behandling.getId());
+        mellomlagringRepository.fjernMellomlagringer(behandling.getId(), MellomlagringType.VEDTAKSBREV);
 
         assertThat(mellomlagringRepository.hentMellomlagring(behandling.getId(), MellomlagringType.VARSEL_REVURDERING)).isEmpty();
         assertThat(mellomlagringRepository.hentMellomlagring(behandling.getId(), MellomlagringType.INNHENT_OPPLYSNINGER)).isEmpty();
+        assertThat(mellomlagringRepository.hentMellomlagring(behandling.getId(), MellomlagringType.VEDTAKSBREV)).isPresent();
     }
 
     @Test

--- a/domenetjenester/vedtak/src/main/java/no/nav/foreldrepenger/domene/vedtak/intern/AvsluttBehandling.java
+++ b/domenetjenester/vedtak/src/main/java/no/nav/foreldrepenger/domene/vedtak/intern/AvsluttBehandling.java
@@ -9,12 +9,13 @@ import org.slf4j.LoggerFactory;
 import no.nav.foreldrepenger.behandling.BehandlingEventPubliserer;
 import no.nav.foreldrepenger.behandlingskontroll.BehandlingskontrollTjeneste;
 import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingStegType;
+import no.nav.foreldrepenger.behandlingslager.behandling.dokument.MellomlagringRepository;
+import no.nav.foreldrepenger.behandlingslager.behandling.dokument.MellomlagringType;
 import no.nav.foreldrepenger.behandlingslager.behandling.events.BehandlingVedtakEvent;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepositoryProvider;
 import no.nav.foreldrepenger.behandlingslager.behandling.vedtak.BehandlingVedtakRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.vedtak.IverksettingStatus;
-import no.nav.foreldrepenger.behandlingslager.behandling.dokument.MellomlagringRepository;
 import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakEgenskapRepository;
 import no.nav.foreldrepenger.behandlingslager.fagsak.egenskaper.FagsakMarkering;
 import no.nav.foreldrepenger.behandlingsprosess.prosessering.BehandlingProsesseringTjeneste;
@@ -65,7 +66,7 @@ public class AvsluttBehandling {
         var behandling = behandlingRepository.hentBehandling(behandlingId);
         var kontekst = behandlingskontrollTjeneste.initBehandlingskontroll(behandling, lås);
 
-        mellomlagringRepository.fjernAlleMellomlagringer(behandlingId);
+        mellomlagringRepository.fjernMellomlagringer(behandlingId, MellomlagringType.VEDTAKSBREV); //Ikke slett vedtaksbrev før brev er produsert
         oppdatereFagsakRelasjonVedVedtak.oppdaterRelasjonVedVedtattBehandling(behandling);
 
         var vedtak = behandlingVedtakRepository.hentForBehandling(behandling.getId());


### PR DESCRIPTION
Problemer der behandling avsluttes før fpformidling har hentet friteksten

Tenker dette som en start, slik at vi ikke mister flere brev. Får tenke på en mer permanent løsning, og etterpå rydde opp i tabellen