### PR TITLE
TFP-6942: Tilpasse kode til svp-uttak 2.4.7 og fpkalkulus-kontrakt 1.0.4

### DIFF
--- a/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/arbeidsforhold/svp/TilretteleggingArbeidsforhold.java
+++ b/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/arbeidsforhold/svp/TilretteleggingArbeidsforhold.java
@@ -12,12 +12,16 @@ public final class TilretteleggingArbeidsforhold {
     private Arbeidsgiver arbeidsgiver;
     private InternArbeidsforholdRef internArbeidsforholdRef;
     private UttakArbeidType uttakArbeidType;
+    private boolean arbeidsforholdetErSplittet;
 
-    public TilretteleggingArbeidsforhold(Arbeidsgiver arbeidsgiver, InternArbeidsforholdRef internArbeidsforholdRef,
-            UttakArbeidType uttakArbeidType) {
+    public TilretteleggingArbeidsforhold(Arbeidsgiver arbeidsgiver,
+                                         InternArbeidsforholdRef internArbeidsforholdRef,
+                                         UttakArbeidType uttakArbeidType,
+                                         boolean arbeidsforholdetErSplittet) {
         this.arbeidsgiver = arbeidsgiver;
         this.internArbeidsforholdRef = Objects.requireNonNull(internArbeidsforholdRef, "internArbeidsforholdRef");
         this.uttakArbeidType = uttakArbeidType;
+        this.arbeidsforholdetErSplittet = arbeidsforholdetErSplittet;
     }
 
     public Optional<Arbeidsgiver> getArbeidsgiver() {
@@ -32,6 +36,10 @@ public final class TilretteleggingArbeidsforhold {
         return uttakArbeidType;
     }
 
+    public boolean getArbeidsforholdetErSplittet() {
+        return arbeidsforholdetErSplittet;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -41,14 +49,13 @@ public final class TilretteleggingArbeidsforhold {
             return false;
         }
         var that = (TilretteleggingArbeidsforhold) o;
-        return Objects.equals(arbeidsgiver, that.arbeidsgiver) &&
-                Objects.equals(internArbeidsforholdRef, that.internArbeidsforholdRef) &&
-                Objects.equals(uttakArbeidType, that.uttakArbeidType);
+        return Objects.equals(arbeidsgiver, that.arbeidsgiver) && Objects.equals(internArbeidsforholdRef, that.internArbeidsforholdRef)
+            && Objects.equals(uttakArbeidType, that.uttakArbeidType) && Objects.equals(arbeidsforholdetErSplittet, that.arbeidsforholdetErSplittet);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(arbeidsgiver, internArbeidsforholdRef, uttakArbeidType);
+        return Objects.hash(arbeidsgiver, internArbeidsforholdRef, uttakArbeidType, arbeidsforholdetErSplittet);
     }
 
 }

--- a/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/arbeidsforhold/svp/UtbetalingsgradBeregner.java
+++ b/domenetjenester/arbeidsforhold/src/main/java/no/nav/foreldrepenger/domene/arbeidsforhold/svp/UtbetalingsgradBeregner.java
@@ -72,7 +72,8 @@ class UtbetalingsgradBeregner {
         var tilretteleggingArbeidsforhold = new TilretteleggingArbeidsforhold(
                 svpTilrettelegging.getArbeidsgiver().orElse(null),
                 svpTilrettelegging.getInternArbeidsforholdRef().orElse(InternArbeidsforholdRef.nullRef()),
-                finnUttakArbeidType(svpTilrettelegging.getArbeidType()));
+                finnUttakArbeidType(svpTilrettelegging.getArbeidType()),
+            svpTilrettelegging.getArbeidsforholdErSplittet());
 
         return new TilretteleggingMedUtbelingsgrad(tilretteleggingArbeidsforhold, periodeMedUtbetalingsgrad);
     }

--- a/domenetjenester/beregningsgrunnlag/src/main/java/no/nav/foreldrepenger/domene/mappers/til_kalkulus/MapTilrettelegginger.java
+++ b/domenetjenester/beregningsgrunnlag/src/main/java/no/nav/foreldrepenger/domene/mappers/til_kalkulus/MapTilrettelegginger.java
@@ -51,11 +51,10 @@ public class MapTilrettelegginger {
     }
 
     private static AktivitetDto mapTilretteleggingArbeidsforhold(TilretteleggingArbeidsforhold tilretteleggingArbeidsforhold) {
-        return new AktivitetDto(
-            mapTilAktør(tilretteleggingArbeidsforhold.getArbeidsgiver().orElse(null)),
+        return new AktivitetDto(mapTilAktør(tilretteleggingArbeidsforhold.getArbeidsgiver().orElse(null)),
             mapReferanse(tilretteleggingArbeidsforhold.getInternArbeidsforholdRef()),
-            KodeverkTilKalkulusMapper.mapUttakArbeidType(tilretteleggingArbeidsforhold.getUttakArbeidType())
-        );
+            KodeverkTilKalkulusMapper.mapUttakArbeidType(tilretteleggingArbeidsforhold.getUttakArbeidType()),
+            tilretteleggingArbeidsforhold.getArbeidsforholdetErSplittet());
     }
 
     private static Aktør mapTilAktør(Arbeidsgiver arbeidsgiver) {

--- a/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/svp/OppholdTjeneste.java
+++ b/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/svp/OppholdTjeneste.java
@@ -38,8 +38,7 @@ public class OppholdTjeneste {
         svpGrunnlag.getGrunnlagEntitet()
             .map(SvpGrunnlagEntitet::hentTilretteleggingerSomSkalBrukes)
             .orElse(Collections.emptyList()).forEach(tilrettelegging -> {
-            var aktivitetType = RegelmodellSøknaderMapper.mapTilAktivitetType(tilrettelegging.getArbeidType());
-            var arbeidsforhold =  RegelmodellSøknaderMapper.lagArbeidsforhold(tilrettelegging.getArbeidsgiver(), tilrettelegging.getInternArbeidsforholdRef(), aktivitetType);
+            var arbeidsforhold =  RegelmodellSøknaderMapper.lagArbeidsforhold(tilrettelegging);
 
             //henter ferie- eller sykepenger-opphold registrert av saksbehandler
             var oppholdListeFraTIlr = hentOppholdListeFraTilrettelegging(tilrettelegging);

--- a/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/svp/RegelmodellSøknaderMapper.java
+++ b/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/svp/RegelmodellSøknaderMapper.java
@@ -49,8 +49,7 @@ public class RegelmodellSøknaderMapper {
 
     private Søknad lagSøknad(UttakInput input, SvpTilretteleggingEntitet tilrettelegging, LocalDate termindato) {
         var tilrettelegginger = tilrettelegging.getTilretteleggingFOMListe().stream().map(this::mapTilrettelegging).toList();
-        var aktivitetType = mapTilAktivitetType(tilrettelegging.getArbeidType());
-        var arbeidsforhold = lagArbeidsforhold(tilrettelegging.getArbeidsgiver(), tilrettelegging.getInternArbeidsforholdRef(), aktivitetType);
+        var arbeidsforhold = lagArbeidsforhold(tilrettelegging);
         var stillingsprosent = finnStillingsprosent(input, tilrettelegging, arbeidsforhold);
         return new Søknad(arbeidsforhold, stillingsprosent, termindato, tilrettelegging.getBehovForTilretteleggingFom(), tilrettelegginger);
     }
@@ -93,21 +92,24 @@ public class RegelmodellSøknaderMapper {
         return BigDecimal.valueOf(100L); //Ellers 100% stilling
     }
 
-    public static Arbeidsforhold lagArbeidsforhold(Optional<Arbeidsgiver> arbeidsforhold,
-                                             Optional<InternArbeidsforholdRef> internArbeidsforholdRef,
-                                             AktivitetType aktivitetType) {
+    public static Arbeidsforhold lagArbeidsforhold(SvpTilretteleggingEntitet tilrettelegging) {
+
+        var aktivitetType = mapTilAktivitetType(tilrettelegging.getArbeidType());
+        var arbeidsforhold= tilrettelegging.getArbeidsgiver();
+        var internArbeidsforholdRef= tilrettelegging.getInternArbeidsforholdRef();
+
         if (arbeidsforhold.isEmpty()) {
             return Arbeidsforhold.annet(aktivitetType);
         }
         var arbeidsgiver = arbeidsforhold.get();
         if (internArbeidsforholdRef.isEmpty()) {
             if (arbeidsgiver.getErVirksomhet()) {
-                return Arbeidsforhold.virksomhet(aktivitetType, arbeidsgiver.getOrgnr(), null);
+                return Arbeidsforhold.virksomhet(aktivitetType, arbeidsgiver.getOrgnr(), null, tilrettelegging.getArbeidsforholdErSplittet());
             }
             return Arbeidsforhold.aktør(aktivitetType, arbeidsgiver.getAktørId().getId(), null);
         }
         if (arbeidsgiver.getErVirksomhet()) {
-            return Arbeidsforhold.virksomhet(aktivitetType, arbeidsgiver.getOrgnr(), internArbeidsforholdRef.get().getReferanse());
+            return Arbeidsforhold.virksomhet(aktivitetType, arbeidsgiver.getOrgnr(), internArbeidsforholdRef.get().getReferanse(),tilrettelegging.getArbeidsforholdErSplittet() );
         }
         return Arbeidsforhold.aktør(aktivitetType, arbeidsgiver.getAktørId().getId(), internArbeidsforholdRef.get().getReferanse());
     }

--- a/domenetjenester/uttak/src/test/java/no/nav/foreldrepenger/domene/uttak/svp/OppholdTjenesteTest.java
+++ b/domenetjenester/uttak/src/test/java/no/nav/foreldrepenger/domene/uttak/svp/OppholdTjenesteTest.java
@@ -75,7 +75,7 @@ class OppholdTjenesteTest {
         var oppholdFraSaksbehandlerOgInntektsmeldingMap = oppholdTjeneste.finnOppholdFraTilretteleggingOgInntektsmelding(lagBehandlingReferanse(),
             Skjæringstidspunkt.builder().medSkjæringstidspunktOpptjening(LocalDate.now().minusMonths(1)).build(), svangerskapspengerGrunnlag);
 
-        var arbeidsforhold = Arbeidsforhold.virksomhet(AktivitetType.ARBEID, "123456789", null );
+        var arbeidsforhold = Arbeidsforhold.virksomhet(AktivitetType.ARBEID, "123456789", null, false);
         var oppholdForventet = oppholdFraSaksbehandlerOgInntektsmeldingMap.get(arbeidsforhold);
 
 
@@ -108,7 +108,7 @@ class OppholdTjenesteTest {
         var oppholdFraSaksbehandlerOgInntektsmeldingMap = oppholdTjeneste.finnOppholdFraTilretteleggingOgInntektsmelding(lagBehandlingReferanse(),
             Skjæringstidspunkt.builder().medSkjæringstidspunktOpptjening(LocalDate.now().minusMonths(1)).build(), svangerskapspengerGrunnlag);
 
-        var arbeidsforhold1 = Arbeidsforhold.virksomhet(AktivitetType.ARBEID, "123456789", null );
+        var arbeidsforhold1 = Arbeidsforhold.virksomhet(AktivitetType.ARBEID, "123456789", null, false);
         var arbeidsforhold2 = Arbeidsforhold.annet(AktivitetType.FRILANS);
         var oppholdForventetArbeidsforhold1 = oppholdFraSaksbehandlerOgInntektsmeldingMap.get(arbeidsforhold1);
         var oppholdForventetArbeidsforhold2 = oppholdFraSaksbehandlerOgInntektsmeldingMap.get(arbeidsforhold2);
@@ -148,7 +148,7 @@ class OppholdTjenesteTest {
         var oppholdFraSaksbehandlerOgInntektsmeldingMap = oppholdTjeneste.finnOppholdFraTilretteleggingOgInntektsmelding(lagBehandlingReferanse(),
             Skjæringstidspunkt.builder().medSkjæringstidspunktOpptjening(LocalDate.now().minusMonths(1)).build(), svangerskapspengerGrunnlag);
 
-        var arbeidsforhold1 = Arbeidsforhold.virksomhet(AktivitetType.ARBEID, "123456789", null );
+        var arbeidsforhold1 = Arbeidsforhold.virksomhet(AktivitetType.ARBEID, "123456789", null, false);
         var arbeidsforhold2 = Arbeidsforhold.annet(AktivitetType.FRILANS);
         var oppholdForventetArbeidsforhold1 = oppholdFraSaksbehandlerOgInntektsmeldingMap.get(arbeidsforhold1);
         var oppholdForventetArbeidsforhold2 = oppholdFraSaksbehandlerOgInntektsmeldingMap.get(arbeidsforhold2);

--- a/pom.xml
+++ b/pom.xml
@@ -32,9 +32,9 @@
         <beregning.version>6.6.1</beregning.version>
         <fp-uttak.version>15.5.6</fp-uttak.version>
         <fp-stonadskonto.version>2.1.1</fp-stonadskonto.version>
-        <svp-uttak.version>2.4.6</svp-uttak.version>
+        <svp-uttak.version>2.4.7</svp-uttak.version>
         <fp-ytelse-beregn.version>1.0.4</fp-ytelse-beregn.version>
-        <fpkalkulus.kontrakt.version>1.0.3</fpkalkulus.kontrakt.version>
+        <fpkalkulus.kontrakt.version>1.0.4</fpkalkulus.kontrakt.version>
 
         <felles.version>7.8.2</felles.version>
         <prosesstask.version>5.2.6</prosesstask.version>


### PR DESCRIPTION
## Sammendrag
- Bumper svp-uttak fra 2.4.6 til 2.4.7
- Bumper fpkalkulus-kontrakt fra 1.0.3 til 1.0.4
- Tilpasser kall til `Arbeidsforhold.virksomhet()` som nå krever `arbeidsforholdErSplittet`-parameter
- Refaktorerer `lagArbeidsforhold` til å ta inn `SvpTilretteleggingEntitet` direkte

## Validering
- Kompilering OK (`mvn install -DskipTests`)
