### PR TITLE
Teknisk: Slett mellomlagring ved kvittering og bruk kun mellomlagring…

### DIFF
--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/dokument/MellomlagringType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/dokument/MellomlagringType.java
@@ -13,6 +13,9 @@ public enum MellomlagringType implements DatabaseKode {
         if (dokumentMalType == null) {
             return null;
         }
+        if (DokumentMalType.erVedtaksBrev(dokumentMalType)) {
+            return VEDTAKSBREV;
+        }
         return switch (dokumentMalType) {
             case VARSEL_OM_REVURDERING -> VARSEL_REVURDERING;
             case INNHENTE_OPPLYSNINGER -> INNHENT_OPPLYSNINGER;

--- a/domenetjenester/dokumentbestiller/src/main/java/no/nav/foreldrepenger/dokumentbestiller/formidling/BestillDokumentTask.java
+++ b/domenetjenester/dokumentbestiller/src/main/java/no/nav/foreldrepenger/dokumentbestiller/formidling/BestillDokumentTask.java
@@ -9,9 +9,6 @@ import java.util.UUID;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import no.nav.foreldrepenger.behandlingslager.behandling.RevurderingVarslingÅrsak;
 import no.nav.foreldrepenger.behandlingslager.behandling.dokument.BehandlingDokumentBestiltEntitet;
 import no.nav.foreldrepenger.behandlingslager.behandling.dokument.BehandlingDokumentRepository;
@@ -33,7 +30,6 @@ public class BestillDokumentTask implements ProsessTaskHandler {
 
     public static final String REVURDERING_ÅRSAK = "revurderingAarsak";
     public static final String BESTILLING_UUID = "bestillingUuid";
-    private static final Logger LOG = LoggerFactory.getLogger(BestillDokumentTask.class);
     private Dokument brev;
     private BehandlingDokumentRepository behandlingDokumentRepository;
     private MellomlagringRepository mellomlagringRepository;
@@ -62,9 +58,6 @@ public class BestillDokumentTask implements ProsessTaskHandler {
             .orElseThrow(() -> new IllegalStateException("Fant ikke bestilt dokument for bestillingUuid: " + bestillingUuid));
 
         var fritekst = hentFritekst(prosessTaskData, bestiltEntitet);
-        if (fritekst != null) {
-            LOG.info("Fritekst er satt på dokumentbestilling");
-        }
 
         var revurderingÅrsak = mapRevurderignÅrsak(
             Optional.ofNullable(prosessTaskData.getPropertyValue(REVURDERING_ÅRSAK)).map(RevurderingVarslingÅrsak::valueOf).orElse(null));

--- a/domenetjenester/dokumentbestiller/src/main/java/no/nav/foreldrepenger/dokumentbestiller/formidling/DokumentBestiller.java
+++ b/domenetjenester/dokumentbestiller/src/main/java/no/nav/foreldrepenger/dokumentbestiller/formidling/DokumentBestiller.java
@@ -2,11 +2,11 @@ package no.nav.foreldrepenger.dokumentbestiller.formidling;
 
 import java.util.Optional;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
 import no.nav.foreldrepenger.behandlingslager.behandling.dokument.DokumentMalType;
@@ -46,10 +46,9 @@ public class DokumentBestiller {
 
     public void bestillDokument(DokumentBestilling bestilling) {
         var behandling = behandlingRepository.hentBehandling(bestilling.behandlingUuid());
-        var resolved = resolveMellomlagring(behandling, bestilling);
-        dokumentBehandlingTjeneste.lagreDokumentBestilt(behandling, resolved);
-        opprettBestillBrevTask(behandling, resolved);
-        låsMellomlagringHvisHtmlBrev(behandling, resolved);
+        dokumentBehandlingTjeneste.lagreDokumentBestilt(behandling, bestilling);
+        opprettBestillBrevTask(behandling, bestilling);
+        låsMellomlagringHvisHtmlBrev(behandling, bestilling);
     }
 
     private void låsMellomlagringHvisHtmlBrev(Behandling behandling, DokumentBestilling bestilling) {
@@ -60,26 +59,6 @@ public class DokumentBestiller {
                 mellomlagringRepository.låsMellomlagring(behandling.getId(), mellomlagringType);
             }
         }
-    }
-
-    private DokumentBestilling resolveMellomlagring(Behandling behandling, DokumentBestilling bestilling) {
-        var mellomlagringType = MellomlagringType.fraDokumentMalType(bestilling.dokumentMal());
-        if (mellomlagringType == null) {
-            return bestilling;
-        }
-        var mellomlagring = mellomlagringRepository.hentMellomlagring(behandling.getId(), mellomlagringType);
-        if (mellomlagring.isEmpty()) {
-            return bestilling;
-        }
-
-        return DokumentBestilling.builder()
-            .medBehandlingUuid(bestilling.behandlingUuid())
-            .medSaksnummer(bestilling.saksnummer())
-            .medDokumentMal(DokumentMalType.FRITEKST_HTML)
-            .medJournalførSom(bestilling.dokumentMal())
-            .medRevurderingÅrsak(bestilling.revurderingÅrsak())
-            .medBestillingUuid(bestilling.bestillingUuid())
-            .build();
     }
 
     private void opprettBestillBrevTask(Behandling behandling, DokumentBestilling bestilling) {

--- a/domenetjenester/dokumentbestiller/src/test/java/no/nav/foreldrepenger/dokumentbestiller/DokumentBehandlingTjenesteTest.java
+++ b/domenetjenester/dokumentbestiller/src/test/java/no/nav/foreldrepenger/dokumentbestiller/DokumentBehandlingTjenesteTest.java
@@ -292,6 +292,44 @@ class DokumentBehandlingTjenesteTest {
         assertThat(behandlingDokument).isNotPresent();
     }
 
+    @Test
+    void kvittering_skal_slette_vedtaksbrev_mellomlagring() {
+        // Arrange
+        behandling = scenario.lagre(repositoryProvider);
+        mellomlagringRepository.lagreEllerOppdater(behandling.getId(), MellomlagringType.VEDTAKSBREV, "<p>redigert vedtaksbrev</p>");
+
+        var bestilling = lagBestilling(DokumentMalType.FRITEKST_HTML, DokumentMalType.FORELDREPENGER_INNVILGELSE);
+        dokumentBehandlingTjeneste.lagreDokumentBestilt(behandling, bestilling);
+        var bestiltDokument = behandlingDokumentRepository.hentHvisEksisterer(behandling.getId()).orElseThrow().getBestilteDokumenter().getFirst();
+
+        // Act
+        dokumentBehandlingTjeneste.kvitterSendtBrev(new DokumentKvittering(
+            behandling.getUuid(), bestiltDokument.getBestillingUuid(), "123456789", "dok1"));
+
+        // Assert - mellomlagring skal være slettet
+        assertThat(mellomlagringRepository.hentMellomlagring(behandling.getId(), MellomlagringType.VEDTAKSBREV)).isEmpty();
+    }
+
+    @Test
+    void kvittering_for_annet_brev_skal_ikke_slette_vedtaksbrev_mellomlagring() {
+        // Arrange
+        behandling = scenario.lagre(repositoryProvider);
+        mellomlagringRepository.lagreEllerOppdater(behandling.getId(), MellomlagringType.VEDTAKSBREV, "<p>redigert vedtaksbrev</p>");
+        mellomlagringRepository.lagreEllerOppdater(behandling.getId(), MellomlagringType.INNHENT_OPPLYSNINGER, "<p>redigert innhent</p>");
+
+        var bestilling = lagBestilling(DokumentMalType.FRITEKST_HTML, DokumentMalType.INNHENTE_OPPLYSNINGER);
+        dokumentBehandlingTjeneste.lagreDokumentBestilt(behandling, bestilling);
+        var bestiltDokument = behandlingDokumentRepository.hentHvisEksisterer(behandling.getId()).orElseThrow().getBestilteDokumenter().getFirst();
+
+        // Act
+        dokumentBehandlingTjeneste.kvitterSendtBrev(new DokumentKvittering(
+            behandling.getUuid(), bestiltDokument.getBestillingUuid(), "123456789", "dok1"));
+
+        // Assert - vedtaksbrev mellomlagring skal IKKE slettes, men innhent opplysninger skal
+        assertThat(mellomlagringRepository.hentMellomlagring(behandling.getId(), MellomlagringType.VEDTAKSBREV)).isPresent();
+        assertThat(mellomlagringRepository.hentMellomlagring(behandling.getId(), MellomlagringType.INNHENT_OPPLYSNINGER)).isEmpty();
+    }
+
     private DokumentBestilling lagBestilling(DokumentMalType dokumentMal, DokumentMalType journalførSomMal) {
         return DokumentBestilling.builder()
             .medBehandlingUuid(behandling.getUuid())

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/brev/BrevRestTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/brev/BrevRestTjeneste.java
@@ -118,13 +118,23 @@ public class BrevRestTjeneste {
         var behandling = behandlingRepository.hentBehandling(bestillBrevDto.behandlingUuid());
         LOG.info("Brev med brevmalkode={} bestilt på behandlingId={}", bestillBrevDto.brevmalkode(), behandling.getId());
 
-        var dokumentBestilling = DokumentBestilling.builder()
+        var brevmalkode = bestillBrevDto.brevmalkode();
+        var mellomlagringType = MellomlagringType.fraDokumentMalType(brevmalkode);
+        var harMellomlagring = mellomlagringType != null
+            && mellomlagringRepository.harMellomlagring(behandling.getId(), mellomlagringType);
+
+        var builder = DokumentBestilling.builder()
             .medBehandlingUuid(bestillBrevDto.behandlingUuid())
             .medSaksnummer(behandling.getSaksnummer())
-            .medDokumentMal(bestillBrevDto.brevmalkode())
-            .medRevurderingÅrsak(bestillBrevDto.årsakskode())
-            .medFritekst(bestillBrevDto.fritekst())
-            .build();
+            .medRevurderingÅrsak(bestillBrevDto.årsakskode());
+
+        if (harMellomlagring) {
+            builder.medDokumentMal(DokumentMalType.FRITEKST_HTML).medJournalførSom(brevmalkode);
+        } else {
+            builder.medDokumentMal(brevmalkode).medFritekst(bestillBrevDto.fritekst());
+        }
+
+        var dokumentBestilling = builder.build();
 
         if (DokumentMalType.ETTERLYS_INNTEKTSMELDING.equals(bestillBrevDto.brevmalkode())) {
             validerFinnesManglendeInntektsmelding(behandling);
@@ -214,7 +224,8 @@ public class BrevRestTjeneste {
             ? mellomlagringRepository.hentMellomlagring(behandling.getId(), mellomlagringType)
             : Optional.<MellomlagringEntitet>empty();
         var dokumentMal = mellomlagring.isPresent() ? DokumentMalType.FRITEKST_HTML : brevmalkode;
-        var fritekst = mellomlagring.map(MellomlagringEntitet::getInnhold).orElse(forhåndsvisDto.fritekst());
+        // Fritekst hentes utelukkende fra mellomlagring for maltyper som støtter html redigering
+        var fritekst = mellomlagring.map(MellomlagringEntitet::getInnhold).orElse(mellomlagringType != null ? null : forhåndsvisDto.fritekst());
 
         var bestilling = DokumentForhandsvisning.builder()
             .medBehandlingUuid(forhåndsvisDto.behandlingUuid())

--- a/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/brev/BrevRestTjenesteTest.java
+++ b/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/brev/BrevRestTjenesteTest.java
@@ -19,11 +19,14 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
+import no.nav.foreldrepenger.behandlingslager.behandling.dokument.DokumentMalType;
 import no.nav.foreldrepenger.behandlingslager.behandling.dokument.MellomlagringEntitet;
 import no.nav.foreldrepenger.behandlingslager.behandling.dokument.MellomlagringRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.historikk.HistorikkinnslagRepository;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepository;
 import no.nav.foreldrepenger.behandlingslager.testutilities.behandling.ScenarioMorSøkerForeldrepenger;
+import no.nav.foreldrepenger.dokumentbestiller.DokumentForhandsvisning;
+import no.nav.foreldrepenger.dokumentbestiller.dto.ForhåndsvisDokumentDto;
 import no.nav.foreldrepenger.dokumentarkiv.ArkivDokument;
 import no.nav.foreldrepenger.dokumentarkiv.ArkivJournalPost;
 import no.nav.foreldrepenger.dokumentarkiv.DokumentArkivTjeneste;
@@ -231,5 +234,54 @@ class BrevRestTjenesteTest {
         var respons = brevRestTjeneste.hentOverstyrtVedtaksbrev(new UuidDto(behandlingUuid));
 
         assertThat(respons.getStatus()).isEqualTo(404);
+    }
+
+    @Test
+    void forhåndsvis_varselOmRevurdering_med_mellomlagring_bruker_mellomlagret_fritekst() {
+        var behandlingUuid = UUID.randomUUID();
+        var mellomlagretHtml = "<html>redigert varsel</html>";
+        var behandling = mock(Behandling.class);
+        when(behandling.getId()).thenReturn(1L);
+        when(behandling.getSaksnummer()).thenReturn(new Saksnummer("1234"));
+        when(behandlingRepository.hentBehandling(behandlingUuid)).thenReturn(behandling);
+        var mellomlagringEntitet = MellomlagringEntitet.Builder.ny()
+            .medBehandlingId(1L)
+            .medType(VARSEL_REVURDERING)
+            .medInnhold(mellomlagretHtml)
+            .build();
+        when(mellomlagringRepositoryMock.hentMellomlagring(1L, VARSEL_REVURDERING)).thenReturn(Optional.of(mellomlagringEntitet));
+        var pdf = new byte[]{1, 2, 3};
+        var bestillingCaptor = ArgumentCaptor.forClass(DokumentForhandsvisning.class);
+        when(dokumentForhåndsvisningTjenesteMock.forhåndsvisDokument(eq(1L), bestillingCaptor.capture())).thenReturn(pdf);
+
+        var dto = new ForhåndsvisDokumentDto(behandlingUuid, VARSEL_OM_REVURDERING, null, false, null, null);
+        var respons = brevRestTjeneste.forhåndsvisDokument(dto);
+
+        assertThat(respons.getStatus()).isEqualTo(200);
+        var bestilling = bestillingCaptor.getValue();
+        assertThat(bestilling.dokumentMal()).isEqualTo(DokumentMalType.FRITEKST_HTML);
+        assertThat(bestilling.fritekst()).isEqualTo(mellomlagretHtml);
+    }
+
+    @Test
+    void forhåndsvis_varselOmRevurdering_uten_mellomlagring_ignorerer_fritekst_fra_dto() {
+        var behandlingUuid = UUID.randomUUID();
+        var behandling = mock(Behandling.class);
+        when(behandling.getId()).thenReturn(1L);
+        when(behandling.getSaksnummer()).thenReturn(new Saksnummer("1234"));
+        when(behandlingRepository.hentBehandling(behandlingUuid)).thenReturn(behandling);
+        when(mellomlagringRepositoryMock.hentMellomlagring(1L, VARSEL_REVURDERING)).thenReturn(Optional.empty());
+        var pdf = new byte[]{1, 2, 3};
+        var bestillingCaptor = ArgumentCaptor.forClass(DokumentForhandsvisning.class);
+        when(dokumentForhåndsvisningTjenesteMock.forhåndsvisDokument(eq(1L), bestillingCaptor.capture())).thenReturn(pdf);
+
+        // fritekst sendt fra DTO skal IKKE brukes for maltyper med mellomlagring
+        var dto = new ForhåndsvisDokumentDto(behandlingUuid, VARSEL_OM_REVURDERING, null, false, null, "fritekst fra dto");
+        var respons = brevRestTjeneste.forhåndsvisDokument(dto);
+
+        assertThat(respons.getStatus()).isEqualTo(200);
+        var bestilling = bestillingCaptor.getValue();
+        assertThat(bestilling.dokumentMal()).isEqualTo(VARSEL_OM_REVURDERING);
+        assertThat(bestilling.fritekst()).isNull();
     }
 }


### PR DESCRIPTION
… som kilde for redigert HTML

- Vedtaksbrev-mellomlagring slettes når kvittering mottas
- Forhåndsvisning henter fritekst kun fra mellomlagring for alle brevtyper med redigering (vedtaksbrev, VARREV, INNOPP)
- resolveMellomlagring flyttet fra DokumentBestiller til BrevRestTjeneste
- Fjernet unødvendig logging i BestillDokumentTask