### PR TITLE
Teknisk: nytt forsøk på rydding i brevbestilling. Fjerner også mellom…

### DIFF
--- a/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/dokument/MellomlagringType.java
+++ b/behandlingslager/domene/src/main/java/no/nav/foreldrepenger/behandlingslager/behandling/dokument/MellomlagringType.java
@@ -13,6 +13,9 @@ public enum MellomlagringType implements DatabaseKode {
         if (dokumentMalType == null) {
             return null;
         }
+        if (DokumentMalType.erVedtaksBrev(dokumentMalType)) {
+            return VEDTAKSBREV;
+        }
         return switch (dokumentMalType) {
             case VARSEL_OM_REVURDERING -> VARSEL_REVURDERING;
             case INNHENTE_OPPLYSNINGER -> INNHENT_OPPLYSNINGER;

--- a/domenetjenester/dokumentbestiller/src/main/java/no/nav/foreldrepenger/dokumentbestiller/DokumentForhandsvisning.java
+++ b/domenetjenester/dokumentbestiller/src/main/java/no/nav/foreldrepenger/dokumentbestiller/DokumentForhandsvisning.java
@@ -11,7 +11,6 @@ public record DokumentForhandsvisning(UUID behandlingUuid,
                                        Saksnummer saksnummer,
                                        DokumentMalType dokumentMal,
                                        String fritekst,
-                                       String tittel,
                                        RevurderingVarslingÅrsak revurderingÅrsak,
                                        DokumentType dokumentType) {
 
@@ -30,7 +29,6 @@ public record DokumentForhandsvisning(UUID behandlingUuid,
         private DokumentMalType dokumentMal;
         private RevurderingVarslingÅrsak revurderingÅrsak;
         private String fritekst;
-        private String tittel;
         private DokumentType dokumentType;
 
         public Builder medBehandlingUuid(UUID behandlingUuid) {
@@ -58,11 +56,6 @@ public record DokumentForhandsvisning(UUID behandlingUuid,
             return this;
         }
 
-        public Builder medTittel(String tittel) {
-            this.tittel = tittel;
-            return this;
-        }
-
         public Builder medDokumentType(DokumentType dokumentType) {
             this.dokumentType = dokumentType;
             return this;
@@ -70,7 +63,7 @@ public record DokumentForhandsvisning(UUID behandlingUuid,
 
         public DokumentForhandsvisning build() {
             valider();
-            return new DokumentForhandsvisning(behandlingUuid, saksnummer, dokumentMal, fritekst, tittel, revurderingÅrsak, dokumentType);
+            return new DokumentForhandsvisning(behandlingUuid, saksnummer, dokumentMal, fritekst, revurderingÅrsak, dokumentType);
         }
 
         private void valider() {

--- a/domenetjenester/dokumentbestiller/src/main/java/no/nav/foreldrepenger/dokumentbestiller/DokumentForhåndsvisningTjeneste.java
+++ b/domenetjenester/dokumentbestiller/src/main/java/no/nav/foreldrepenger/dokumentbestiller/DokumentForhåndsvisningTjeneste.java
@@ -60,14 +60,14 @@ public class DokumentForhåndsvisningTjeneste extends AbstractDokumentBestillerT
         this.brev = brev;
     }
 
-    public byte[] forhåndsvisDokument(Long behandlingId, DokumentForhandsvisning bestilling) {
-        var bestillingDokumentMal = maltypeFraBestillingEllersUtledFraBehandling(behandlingId, bestilling, bestilling.behandlingUuid());
+    public byte[] forhåndsvisDokument(DokumentForhandsvisning bestilling) {
+        var bestillingDokumentMal = maltypeFraBestillingEllersUtledFraBehandling(bestilling, bestilling.behandlingUuid());
         LOG.info("Forhåndsviser brev med mal {} for behandling {}", bestillingDokumentMal, bestilling.behandlingUuid());
         return brev.forhåndsvis(lagForhåndsvisningDto(bestilling, bestillingDokumentMal));
     }
 
     public String genererHtml(Behandling behandling) {
-        var dokumentMalType = utledDokumentmalTypeFraBehandling(behandling.getId(), behandling.getUuid(), DokumentForhandsvisning.DokumentType.AUTOMATISK);
+        var dokumentMalType = utledDokumentmalTypeFraBehandling(behandling.getUuid(), DokumentForhandsvisning.DokumentType.AUTOMATISK);
         if (DokumentMalType.FORELDREPENGER_INNVILGELSE.equals(dokumentMalType) && erUttakTomt(behandling)) {
             LOG.info("Genererer annuleringsbrev som utgangspunkt for overstyring av foreldrepenger som med tomt uttak: {}", behandling.getFagsak().getSaksnummer());
             dokumentMalType = DokumentMalType.FORELDREPENGER_ANNULLERT;
@@ -101,14 +101,14 @@ public class DokumentForhåndsvisningTjeneste extends AbstractDokumentBestillerT
             .noneMatch(periode -> periode.harUtbetaling() || periode.harTrekkdager());
     }
 
-    private DokumentMalType maltypeFraBestillingEllersUtledFraBehandling(Long behandlingId, DokumentForhandsvisning bestilling, UUID behandlingUuid) {
+    private DokumentMalType maltypeFraBestillingEllersUtledFraBehandling(DokumentForhandsvisning bestilling, UUID behandlingUuid) {
         if (bestilling.dokumentMal() != null) {
             return bestilling.dokumentMal();
         }
-        return utledDokumentmalTypeFraBehandling(behandlingId, behandlingUuid, bestilling.dokumentType());
+        return utledDokumentmalTypeFraBehandling(behandlingUuid, bestilling.dokumentType());
     }
 
-    private DokumentMalType utledDokumentmalTypeFraBehandling(Long behandlingId, UUID behandlingUuid, DokumentForhandsvisning.DokumentType brevType) {
+    private DokumentMalType utledDokumentmalTypeFraBehandling(UUID behandlingUuid, DokumentForhandsvisning.DokumentType brevType) {
         LOG.info("Utleder dokumentMal for {}", behandlingUuid);
 
         var behandling = behandlingRepository.hentBehandling(behandlingUuid);
@@ -146,7 +146,7 @@ public class DokumentForhåndsvisningTjeneste extends AbstractDokumentBestillerT
             new Saksnummer(bestilling.saksnummer().getVerdi()),
             mapDokumentMal(bestillingDokumentMal),
             mapRevurderignÅrsak(bestilling.revurderingÅrsak()),
-            bestilling.tittel(),
+            null,
             bestilling.fritekst()
         );
     }

--- a/domenetjenester/dokumentbestiller/src/main/java/no/nav/foreldrepenger/dokumentbestiller/dto/BestillDokumentDto.java
+++ b/domenetjenester/dokumentbestiller/src/main/java/no/nav/foreldrepenger/dokumentbestiller/dto/BestillDokumentDto.java
@@ -4,17 +4,13 @@ import java.util.UUID;
 
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Size;
 
-import no.nav.folketrygdloven.kalkulus.annoteringer.Fritekst;
 import no.nav.foreldrepenger.behandlingslager.behandling.RevurderingVarslingÅrsak;
 import no.nav.foreldrepenger.behandlingslager.behandling.dokument.DokumentMalType;
 import no.nav.foreldrepenger.validering.ValidKodeverk;
 
 public record BestillDokumentDto(@Valid UUID behandlingUuid,
                                  @ValidKodeverk @NotNull DokumentMalType brevmalkode,
-                                 @Valid @Fritekst @Size(max = 20_000) String fritekst,
-                                 @ValidKodeverk RevurderingVarslingÅrsak årsakskode
-                                 ) {
+                                 @ValidKodeverk RevurderingVarslingÅrsak årsakskode) {
 }
 

--- a/domenetjenester/dokumentbestiller/src/main/java/no/nav/foreldrepenger/dokumentbestiller/dto/ForhåndsvisDokumentDto.java
+++ b/domenetjenester/dokumentbestiller/src/main/java/no/nav/foreldrepenger/dokumentbestiller/dto/ForhåndsvisDokumentDto.java
@@ -15,6 +15,6 @@ public record ForhåndsvisDokumentDto(@Valid @NotNull UUID behandlingUuid,
                                      @ValidKodeverk DokumentMalType dokumentMal,
                                      @ValidKodeverk RevurderingVarslingÅrsak årsakskode,
                                      boolean automatiskVedtaksbrev,
-                                     @Valid @Fritekst @Size(max = 20_000) String fritekst) {
+                                     @Valid @Fritekst @Size(max = 100_000) String fritekst) {
 }
 

--- a/domenetjenester/dokumentbestiller/src/main/java/no/nav/foreldrepenger/dokumentbestiller/dto/ForhåndsvisDokumentDto.java
+++ b/domenetjenester/dokumentbestiller/src/main/java/no/nav/foreldrepenger/dokumentbestiller/dto/ForhåndsvisDokumentDto.java
@@ -4,20 +4,17 @@ import java.util.UUID;
 
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 
 import no.nav.folketrygdloven.kalkulus.annoteringer.Fritekst;
 import no.nav.foreldrepenger.behandlingslager.behandling.RevurderingVarslingÅrsak;
 import no.nav.foreldrepenger.behandlingslager.behandling.dokument.DokumentMalType;
 import no.nav.foreldrepenger.validering.ValidKodeverk;
-import no.nav.vedtak.util.InputValideringRegex;
 
 public record ForhåndsvisDokumentDto(@Valid @NotNull UUID behandlingUuid,
                                      @ValidKodeverk DokumentMalType dokumentMal,
                                      @ValidKodeverk RevurderingVarslingÅrsak årsakskode,
                                      boolean automatiskVedtaksbrev,
-                                     @Size(max = 200) @Pattern(regexp = InputValideringRegex.FRITEKST) String tittel,
-                                     @Valid @Fritekst @Size(max = 20_000) String fritekst) { // HTML eller rå tekst avhengig av maltype
+                                     @Valid @Fritekst @Size(max = 20_000) String fritekst) {
 }
 

--- a/domenetjenester/dokumentbestiller/src/main/java/no/nav/foreldrepenger/dokumentbestiller/formidling/BestillDokumentTask.java
+++ b/domenetjenester/dokumentbestiller/src/main/java/no/nav/foreldrepenger/dokumentbestiller/formidling/BestillDokumentTask.java
@@ -9,9 +9,6 @@ import java.util.UUID;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import no.nav.foreldrepenger.behandlingslager.behandling.RevurderingVarslingÅrsak;
 import no.nav.foreldrepenger.behandlingslager.behandling.dokument.BehandlingDokumentBestiltEntitet;
 import no.nav.foreldrepenger.behandlingslager.behandling.dokument.BehandlingDokumentRepository;
@@ -33,7 +30,6 @@ public class BestillDokumentTask implements ProsessTaskHandler {
 
     public static final String REVURDERING_ÅRSAK = "revurderingAarsak";
     public static final String BESTILLING_UUID = "bestillingUuid";
-    private static final Logger LOG = LoggerFactory.getLogger(BestillDokumentTask.class);
     private Dokument brev;
     private BehandlingDokumentRepository behandlingDokumentRepository;
     private MellomlagringRepository mellomlagringRepository;
@@ -62,9 +58,6 @@ public class BestillDokumentTask implements ProsessTaskHandler {
             .orElseThrow(() -> new IllegalStateException("Fant ikke bestilt dokument for bestillingUuid: " + bestillingUuid));
 
         var fritekst = hentFritekst(prosessTaskData, bestiltEntitet);
-        if (fritekst != null) {
-            LOG.info("Fritekst er satt på dokumentbestilling");
-        }
 
         var revurderingÅrsak = mapRevurderignÅrsak(
             Optional.ofNullable(prosessTaskData.getPropertyValue(REVURDERING_ÅRSAK)).map(RevurderingVarslingÅrsak::valueOf).orElse(null));

--- a/domenetjenester/dokumentbestiller/src/main/java/no/nav/foreldrepenger/dokumentbestiller/formidling/DokumentBestiller.java
+++ b/domenetjenester/dokumentbestiller/src/main/java/no/nav/foreldrepenger/dokumentbestiller/formidling/DokumentBestiller.java
@@ -2,11 +2,11 @@ package no.nav.foreldrepenger.dokumentbestiller.formidling;
 
 import java.util.Optional;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import no.nav.foreldrepenger.behandlingslager.behandling.Behandling;
 import no.nav.foreldrepenger.behandlingslager.behandling.dokument.DokumentMalType;
@@ -46,10 +46,9 @@ public class DokumentBestiller {
 
     public void bestillDokument(DokumentBestilling bestilling) {
         var behandling = behandlingRepository.hentBehandling(bestilling.behandlingUuid());
-        var resolved = resolveMellomlagring(behandling, bestilling);
-        dokumentBehandlingTjeneste.lagreDokumentBestilt(behandling, resolved);
-        opprettBestillBrevTask(behandling, resolved);
-        låsMellomlagringHvisHtmlBrev(behandling, resolved);
+        dokumentBehandlingTjeneste.lagreDokumentBestilt(behandling, bestilling);
+        opprettBestillBrevTask(behandling, bestilling);
+        låsMellomlagringHvisHtmlBrev(behandling, bestilling);
     }
 
     private void låsMellomlagringHvisHtmlBrev(Behandling behandling, DokumentBestilling bestilling) {
@@ -60,26 +59,6 @@ public class DokumentBestiller {
                 mellomlagringRepository.låsMellomlagring(behandling.getId(), mellomlagringType);
             }
         }
-    }
-
-    private DokumentBestilling resolveMellomlagring(Behandling behandling, DokumentBestilling bestilling) {
-        var mellomlagringType = MellomlagringType.fraDokumentMalType(bestilling.dokumentMal());
-        if (mellomlagringType == null) {
-            return bestilling;
-        }
-        var mellomlagring = mellomlagringRepository.hentMellomlagring(behandling.getId(), mellomlagringType);
-        if (mellomlagring.isEmpty()) {
-            return bestilling;
-        }
-
-        return DokumentBestilling.builder()
-            .medBehandlingUuid(bestilling.behandlingUuid())
-            .medSaksnummer(bestilling.saksnummer())
-            .medDokumentMal(DokumentMalType.FRITEKST_HTML)
-            .medJournalførSom(bestilling.dokumentMal())
-            .medRevurderingÅrsak(bestilling.revurderingÅrsak())
-            .medBestillingUuid(bestilling.bestillingUuid())
-            .build();
     }
 
     private void opprettBestillBrevTask(Behandling behandling, DokumentBestilling bestilling) {

--- a/domenetjenester/dokumentbestiller/src/test/java/no/nav/foreldrepenger/dokumentbestiller/BrevForhåndsvisningTest.java
+++ b/domenetjenester/dokumentbestiller/src/test/java/no/nav/foreldrepenger/dokumentbestiller/BrevForhåndsvisningTest.java
@@ -16,14 +16,12 @@ class BrevForhåndsvisningTest {
     void positiv() {
         var dokumentMal = DokumentMalType.FRITEKST_HTML;
         var fritekst = "fritekst";
-        var tittel = "tittel";
         var revurderingÅrsak = RevurderingVarslingÅrsak.ANNET;
         var brevType = DokumentForhandsvisning.DokumentType.AUTOMATISK;
-        var forhåndsvisning = new DokumentForhandsvisning(UUID.randomUUID(), new Saksnummer("9999"), dokumentMal, fritekst, tittel, revurderingÅrsak, brevType);
+        var forhåndsvisning = new DokumentForhandsvisning(UUID.randomUUID(), new Saksnummer("9999"), dokumentMal, fritekst, revurderingÅrsak, brevType);
         assertThat(forhåndsvisning.behandlingUuid()).isNotNull();
         assertThat(forhåndsvisning.dokumentMal()).isNotNull().isEqualTo(dokumentMal);
         assertThat(forhåndsvisning.fritekst()).isNotNull().isEqualTo(fritekst);
-        assertThat(forhåndsvisning.tittel()).isNotNull().isEqualTo(tittel);
         assertThat(forhåndsvisning.revurderingÅrsak()).isNotNull().isEqualTo(revurderingÅrsak);
         assertThat(forhåndsvisning.dokumentType()).isNotNull().isEqualTo(brevType);
     }
@@ -43,7 +41,6 @@ class BrevForhåndsvisningTest {
         assertThat(bestilling.behandlingUuid()).isNotNull().isEqualTo(behandlingUuid);
         assertThat(bestilling.dokumentMal()).isNotNull().isEqualTo(dokumentMal);
         assertThat(bestilling.fritekst()).isNull();
-        assertThat(bestilling.tittel()).isNull();
         assertThat(bestilling.revurderingÅrsak()).isNull();
     }
 
@@ -53,7 +50,6 @@ class BrevForhåndsvisningTest {
         var dokumentMal = DokumentMalType.FORELDREPENGER_INNVILGELSE;
 
         var fritekst = "fritekst";
-        var tittel = "tittel";
         var revurderingÅrsak = RevurderingVarslingÅrsak.ANNET;
         var brevType = DokumentForhandsvisning.DokumentType.OVERSTYRT;
         var bestilling = DokumentForhandsvisning.builder()
@@ -61,7 +57,6 @@ class BrevForhåndsvisningTest {
             .medSaksnummer(new Saksnummer("9999"))
             .medDokumentMal(dokumentMal)
             .medFritekst(fritekst)
-            .medTittel(tittel)
             .medRevurderingÅrsak(revurderingÅrsak)
             .medDokumentType(brevType)
             .build();
@@ -69,7 +64,6 @@ class BrevForhåndsvisningTest {
         assertThat(bestilling.behandlingUuid()).isNotNull().isEqualTo(behandlingUuid);
         assertThat(bestilling.dokumentMal()).isNotNull().isEqualTo(dokumentMal);
         assertThat(bestilling.fritekst()).isNotNull().isEqualTo(fritekst);
-        assertThat(bestilling.tittel()).isNotNull().isEqualTo(tittel);
         assertThat(bestilling.revurderingÅrsak()).isNotNull().isEqualTo(revurderingÅrsak);
         assertThat(bestilling.dokumentType()).isNotNull().isEqualTo(brevType);
     }

--- a/domenetjenester/dokumentbestiller/src/test/java/no/nav/foreldrepenger/dokumentbestiller/DokumentBehandlingTjenesteTest.java
+++ b/domenetjenester/dokumentbestiller/src/test/java/no/nav/foreldrepenger/dokumentbestiller/DokumentBehandlingTjenesteTest.java
@@ -292,6 +292,44 @@ class DokumentBehandlingTjenesteTest {
         assertThat(behandlingDokument).isNotPresent();
     }
 
+    @Test
+    void kvittering_skal_slette_vedtaksbrev_mellomlagring() {
+        // Arrange
+        behandling = scenario.lagre(repositoryProvider);
+        mellomlagringRepository.lagreEllerOppdater(behandling.getId(), MellomlagringType.VEDTAKSBREV, "<p>redigert vedtaksbrev</p>");
+
+        var bestilling = lagBestilling(DokumentMalType.FRITEKST_HTML, DokumentMalType.FORELDREPENGER_INNVILGELSE);
+        dokumentBehandlingTjeneste.lagreDokumentBestilt(behandling, bestilling);
+        var bestiltDokument = behandlingDokumentRepository.hentHvisEksisterer(behandling.getId()).orElseThrow().getBestilteDokumenter().getFirst();
+
+        // Act
+        dokumentBehandlingTjeneste.kvitterSendtBrev(new DokumentKvittering(
+            behandling.getUuid(), bestiltDokument.getBestillingUuid(), "123456789", "dok1"));
+
+        // Assert - mellomlagring skal være slettet
+        assertThat(mellomlagringRepository.hentMellomlagring(behandling.getId(), MellomlagringType.VEDTAKSBREV)).isEmpty();
+    }
+
+    @Test
+    void kvittering_for_annet_brev_skal_ikke_slette_vedtaksbrev_mellomlagring() {
+        // Arrange
+        behandling = scenario.lagre(repositoryProvider);
+        mellomlagringRepository.lagreEllerOppdater(behandling.getId(), MellomlagringType.VEDTAKSBREV, "<p>redigert vedtaksbrev</p>");
+        mellomlagringRepository.lagreEllerOppdater(behandling.getId(), MellomlagringType.INNHENT_OPPLYSNINGER, "<p>redigert innhent</p>");
+
+        var bestilling = lagBestilling(DokumentMalType.FRITEKST_HTML, DokumentMalType.INNHENTE_OPPLYSNINGER);
+        dokumentBehandlingTjeneste.lagreDokumentBestilt(behandling, bestilling);
+        var bestiltDokument = behandlingDokumentRepository.hentHvisEksisterer(behandling.getId()).orElseThrow().getBestilteDokumenter().getFirst();
+
+        // Act
+        dokumentBehandlingTjeneste.kvitterSendtBrev(new DokumentKvittering(
+            behandling.getUuid(), bestiltDokument.getBestillingUuid(), "123456789", "dok1"));
+
+        // Assert - vedtaksbrev mellomlagring skal IKKE slettes, men innhent opplysninger skal
+        assertThat(mellomlagringRepository.hentMellomlagring(behandling.getId(), MellomlagringType.VEDTAKSBREV)).isPresent();
+        assertThat(mellomlagringRepository.hentMellomlagring(behandling.getId(), MellomlagringType.INNHENT_OPPLYSNINGER)).isEmpty();
+    }
+
     private DokumentBestilling lagBestilling(DokumentMalType dokumentMal, DokumentMalType journalførSomMal) {
         return DokumentBestilling.builder()
             .medBehandlingUuid(behandling.getUuid())

--- a/domenetjenester/dokumentbestiller/src/test/java/no/nav/foreldrepenger/dokumentbestiller/DokumentForhandsvisningTest.java
+++ b/domenetjenester/dokumentbestiller/src/test/java/no/nav/foreldrepenger/dokumentbestiller/DokumentForhandsvisningTest.java
@@ -21,7 +21,6 @@ class DokumentForhandsvisningTest {
         var expectedBehandlignUuid = UUID.randomUUID();
         var expectedÅrsak = RevurderingVarslingÅrsak.BRUKER_REGISTRERT_UTVANDRET;
         var expectedSaksnummer = "123";
-        var expectedTittel = "tittel";
         var expectedDokumentType = DokumentForhandsvisning.DokumentType.AUTOMATISK;
 
         var dokumentForhandsvisning = DokumentForhandsvisning.builder()
@@ -30,7 +29,6 @@ class DokumentForhandsvisningTest {
                 .medFritekst(expectedFritekst)
                 .medRevurderingÅrsak(expectedÅrsak)
                 .medSaksnummer(new Saksnummer(expectedSaksnummer))
-                .medTittel(expectedTittel)
                 .medDokumentType(expectedDokumentType)
                 .build();
 
@@ -41,7 +39,6 @@ class DokumentForhandsvisningTest {
             softly.assertThat(dokumentForhandsvisning.fritekst()).isEqualTo(expectedFritekst);
             softly.assertThat(dokumentForhandsvisning.revurderingÅrsak()).isEqualTo(expectedÅrsak);
             softly.assertThat(dokumentForhandsvisning.saksnummer().getVerdi()).isEqualTo(expectedSaksnummer);
-            softly.assertThat(dokumentForhandsvisning.tittel()).isEqualTo(expectedTittel);
             softly.assertThat(dokumentForhandsvisning.dokumentType()).isEqualTo(expectedDokumentType);
         });
     }

--- a/domenetjenester/dokumentbestiller/src/test/java/no/nav/foreldrepenger/dokumentbestiller/DokumentForhåndsvisningTjenesteTest.java
+++ b/domenetjenester/dokumentbestiller/src/test/java/no/nav/foreldrepenger/dokumentbestiller/DokumentForhåndsvisningTjenesteTest.java
@@ -57,7 +57,7 @@ class DokumentForhåndsvisningTjenesteTest extends EntityManagerAwareTest {
             .medDokumentType(DokumentForhandsvisning.DokumentType.OVERSTYRT)
             .build();
 
-        tjeneste.forhåndsvisDokument(behandling.getId(), bestilling);
+        tjeneste.forhåndsvisDokument(bestilling);
 
         var bestillingCaptor = ArgumentCaptor.forClass(DokumentForhåndsvisDto.class);
 
@@ -82,7 +82,7 @@ class DokumentForhåndsvisningTjenesteTest extends EntityManagerAwareTest {
             .medDokumentType(DokumentForhandsvisning.DokumentType.OVERSTYRT)
             .build();
 
-        tjeneste.forhåndsvisDokument(behandling.getId(), bestilling);
+        tjeneste.forhåndsvisDokument(bestilling);
 
         var bestillingCaptor = ArgumentCaptor.forClass(DokumentForhåndsvisDto.class);
 
@@ -105,7 +105,7 @@ class DokumentForhåndsvisningTjenesteTest extends EntityManagerAwareTest {
             .medDokumentType(DokumentForhandsvisning.DokumentType.AUTOMATISK)
             .build();
 
-        tjeneste.forhåndsvisDokument(behandling.getId(), bestilling);
+        tjeneste.forhåndsvisDokument(bestilling);
 
         var bestillingCaptor = ArgumentCaptor.forClass(DokumentForhåndsvisDto.class);
 
@@ -128,7 +128,7 @@ class DokumentForhåndsvisningTjenesteTest extends EntityManagerAwareTest {
             .medDokumentType(DokumentForhandsvisning.DokumentType.OVERSTYRT)
             .build();
 
-        tjeneste.forhåndsvisDokument(behandling.getId(), bestilling);
+        tjeneste.forhåndsvisDokument(bestilling);
 
         var bestillingCaptor = ArgumentCaptor.forClass(DokumentForhåndsvisDto.class);
 

--- a/domenetjenester/dokumentbestiller/src/test/java/no/nav/foreldrepenger/dokumentbestiller/dto/BestillBrevDtoTest.java
+++ b/domenetjenester/dokumentbestiller/src/test/java/no/nav/foreldrepenger/dokumentbestiller/dto/BestillBrevDtoTest.java
@@ -19,7 +19,7 @@ class BestillBrevDtoTest {
         var dokumentMal = DokumentMalType.FRITEKSTBREV;
         var årsak = RevurderingVarslingÅrsak.BARN_IKKE_REGISTRERT_FOLKEREGISTER;
 
-        var brev = new BestillDokumentDto(behandlingUuid, dokumentMal, null, årsak);
+        var brev = new BestillDokumentDto(behandlingUuid, dokumentMal, årsak);
 
         var json = DefaultJsonMapper.toJson(brev);
 
@@ -29,8 +29,6 @@ class BestillBrevDtoTest {
         assertThat(dokumentMal).isEqualTo(brev.brevmalkode());
         assertThat(brev.årsakskode()).isEqualTo(etterRoundtrip.årsakskode());
         assertThat(årsak).isEqualTo(etterRoundtrip.årsakskode());
-        assertThat(brev.fritekst()).isEqualTo(etterRoundtrip.fritekst());
-        assertThat(etterRoundtrip.fritekst()).isNull();
         assertThat(brev.behandlingUuid()).isEqualTo(etterRoundtrip.behandlingUuid());
         assertThat(uuid).isEqualTo(etterRoundtrip.behandlingUuid().toString());
     }

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/brev/BrevRestTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/brev/BrevRestTjeneste.java
@@ -1,7 +1,6 @@
 package no.nav.foreldrepenger.web.app.tjenester.brev;
 
 import java.util.Objects;
-import java.util.Optional;
 import java.util.UUID;
 import java.util.function.Function;
 
@@ -118,13 +117,23 @@ public class BrevRestTjeneste {
         var behandling = behandlingRepository.hentBehandling(bestillBrevDto.behandlingUuid());
         LOG.info("Brev med brevmalkode={} bestilt på behandlingId={}", bestillBrevDto.brevmalkode(), behandling.getId());
 
-        var dokumentBestilling = DokumentBestilling.builder()
+        var brevmalkode = bestillBrevDto.brevmalkode();
+        var mellomlagringType = MellomlagringType.fraDokumentMalType(brevmalkode);
+        var harMellomlagring = mellomlagringType != null
+            && mellomlagringRepository.harMellomlagring(behandling.getId(), mellomlagringType);
+
+        var builder = DokumentBestilling.builder()
             .medBehandlingUuid(bestillBrevDto.behandlingUuid())
             .medSaksnummer(behandling.getSaksnummer())
-            .medDokumentMal(bestillBrevDto.brevmalkode())
-            .medRevurderingÅrsak(bestillBrevDto.årsakskode())
-            .medFritekst(bestillBrevDto.fritekst())
-            .build();
+            .medRevurderingÅrsak(bestillBrevDto.årsakskode());
+
+        if (harMellomlagring) {
+            builder.medDokumentMal(DokumentMalType.FRITEKST_HTML).medJournalførSom(brevmalkode);
+        } else {
+            builder.medDokumentMal(brevmalkode);
+        }
+
+        var dokumentBestilling = builder.build();
 
         if (DokumentMalType.ETTERLYS_INNTEKTSMELDING.equals(bestillBrevDto.brevmalkode())) {
             validerFinnesManglendeInntektsmelding(behandling);
@@ -208,13 +217,8 @@ public class BrevRestTjeneste {
     public Response forhåndsvisDokument(@Parameter(description = "Inneholder kode til brevmal og bestillingsdetaljer.") @TilpassetAbacAttributt(supplierClass = ForhåndsvisSupplier.class) @Valid ForhåndsvisDokumentDto forhåndsvisDto) { // NOSONAR
         var behandling = behandlingRepository.hentBehandling(forhåndsvisDto.behandlingUuid());
 
-        var brevmalkode = forhåndsvisDto.dokumentMal();
-        var mellomlagringType = MellomlagringType.fraDokumentMalType(brevmalkode);
-        var mellomlagring = mellomlagringType != null
-            ? mellomlagringRepository.hentMellomlagring(behandling.getId(), mellomlagringType)
-            : Optional.<MellomlagringEntitet>empty();
-        var dokumentMal = mellomlagring.isPresent() ? DokumentMalType.FRITEKST_HTML : brevmalkode;
-        var fritekst = mellomlagring.map(MellomlagringEntitet::getInnhold).orElse(forhåndsvisDto.fritekst());
+        var fritekst = forhåndsvisDto.fritekst();
+        var dokumentMal = forhåndsvisDto.fritekst() != null ? DokumentMalType.FRITEKST_HTML : forhåndsvisDto.dokumentMal();
 
         var bestilling = DokumentForhandsvisning.builder()
             .medBehandlingUuid(forhåndsvisDto.behandlingUuid())
@@ -222,7 +226,6 @@ public class BrevRestTjeneste {
             .medDokumentMal(dokumentMal)
             .medRevurderingÅrsak(forhåndsvisDto.årsakskode())
             .medFritekst(fritekst)
-            .medTittel(forhåndsvisDto.tittel())
             .medDokumentType(utledDokumentType(forhåndsvisDto.automatiskVedtaksbrev()))
             .build();
 
@@ -230,7 +233,7 @@ public class BrevRestTjeneste {
             validerFinnesManglendeInntektsmelding(behandling);
         }
 
-        var dokument = dokumentForhåndsvisningTjeneste.forhåndsvisDokument(behandling.getId(), bestilling);
+        var dokument = dokumentForhåndsvisningTjeneste.forhåndsvisDokument(bestilling);
         if (dokument != null && dokument.length != 0) {
             var responseBuilder = Response.ok(dokument);
             responseBuilder.type("application/pdf");
@@ -292,7 +295,7 @@ public class BrevRestTjeneste {
                 .medFritekst(mellomlagretHtml.get())
                 .medDokumentType(DokumentForhandsvisning.DokumentType.OVERSTYRT)
                 .build();
-            var pdf = dokumentForhåndsvisningTjeneste.forhåndsvisDokument(behandling.getId(), bestilling);
+            var pdf = dokumentForhåndsvisningTjeneste.forhåndsvisDokument(bestilling);
             if (pdf != null && pdf.length != 0) {
                 return Response.ok(pdf).type("application/pdf")
                     .header("Content-Disposition", "filename=vedtaksbrev.pdf").build();

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/mellomlagring/MellomlagringRestTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/mellomlagring/MellomlagringRestTjeneste.java
@@ -134,7 +134,7 @@ public class MellomlagringRestTjeneste {
         @Valid @NotNull UUID behandlingUuid,
         @Valid MellomlagringType type,
         @ValidKodeverk DokumentMalType dokumentMal,
-        @Fritekst @Size(max = 200_000) String innhold
+        @Fritekst @Size(max = 100_000) String innhold
     ) {}
 
     public record MellomlagringResultatDto(String innhold) {}

--- a/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/brev/BrevRestTjenesteTest.java
+++ b/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/brev/BrevRestTjenesteTest.java
@@ -6,7 +6,6 @@ import static no.nav.foreldrepenger.behandlingslager.behandling.dokument.Melloml
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -73,9 +72,8 @@ class BrevRestTjenesteTest {
         var behandlingMock = mock(Behandling.class);
         when(behandlingMock.getSaksnummer()).thenReturn(new Saksnummer("9999"));
         when(behandlingRepository.hentBehandling(behandlingUuid)).thenReturn(behandlingMock);
-        var fritekst = "Dette er en fritekst";
         var dokumentMal = INNHENTE_OPPLYSNINGER;
-        var bestillBrevDto = new BestillDokumentDto(behandlingUuid, dokumentMal, fritekst, null);
+        var bestillBrevDto = new BestillDokumentDto(behandlingUuid, dokumentMal, null);
 
         // Act
         brevRestTjeneste.bestillDokument(bestillBrevDto);
@@ -91,7 +89,7 @@ class BrevRestTjenesteTest {
         assertThat(bestilling.bestillingUuid()).isNotNull();
         assertThat(bestilling.behandlingUuid()).isEqualTo(behandlingUuid);
         assertThat(bestilling.dokumentMal()).isEqualTo(dokumentMal);
-        assertThat(bestilling.fritekst()).isEqualTo(fritekst);
+        assertThat(bestilling.fritekst()).isNull();
         assertThat(bestilling.revurderingÅrsak()).isNull();
         assertThat(bestilling.journalførSom()).isNull();
     }
@@ -186,7 +184,7 @@ class BrevRestTjenesteTest {
         when(behandling.getSaksnummer()).thenReturn(new Saksnummer("9999"));
         when(behandlingRepository.hentBehandling(behandlingUuid)).thenReturn(behandling);
         when(dokumentBehandlingTjenesteMock.hentMellomlagretOverstyring(behandling.getId())).thenReturn(Optional.of("<html>redigert</html>"));
-        when(dokumentForhåndsvisningTjenesteMock.forhåndsvisDokument(eq(behandling.getId()), any())).thenReturn(pdf);
+        when(dokumentForhåndsvisningTjenesteMock.forhåndsvisDokument(any())).thenReturn(pdf);
 
         var respons = brevRestTjeneste.hentOverstyrtVedtaksbrev(new UuidDto(behandlingUuid));
 


### PR DESCRIPTION
…lagret overstyring ved mottatt kvittering

Mellomlagring av vedtaksbrev slettes ved kvittering (pga vi utvider mapping i MellomlagringType)
Syncer antall tegn for mellomlagring og forhåndsvisning til 100 000