### PR TITLE
Bugfix: behold klagemal ved forhåndsvisning med fritekst

### DIFF
--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/brev/BrevRestTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/brev/BrevRestTjeneste.java
@@ -1,6 +1,7 @@
 package no.nav.foreldrepenger.web.app.tjenester.brev;
 
 import java.util.Objects;
+import java.util.Set;
 import java.util.UUID;
 import java.util.function.Function;
 
@@ -74,6 +75,8 @@ public class BrevRestTjeneste {
     public static final String BREV_HTML_PATH = BASE_PATH + BREV_HTML_PART_PATH;
     private static final String HENT_OVERSTYRT_VEDTAKSBREV_PART_PATH = "/hent-overstyrt-vedtaksbrev";
     public static final String HENT_OVERSTYRT_VEDTAKSBREV_PATH = BASE_PATH + HENT_OVERSTYRT_VEDTAKSBREV_PART_PATH;
+    private static final Set<DokumentMalType> BREV_SOM_FORHÅNDSVISES_MED_FRITEKST_UTEN_HTML_REDIGERING = Set.of(DokumentMalType.KLAGE_OVERSENDT,
+        DokumentMalType.KLAGE_OMGJORT);
 
     private DokumentForhåndsvisningTjeneste dokumentForhåndsvisningTjeneste;
     private DokumentBestillerTjeneste dokumentBestillerTjeneste;
@@ -217,15 +220,14 @@ public class BrevRestTjeneste {
     public Response forhåndsvisDokument(@Parameter(description = "Inneholder kode til brevmal og bestillingsdetaljer.") @TilpassetAbacAttributt(supplierClass = ForhåndsvisSupplier.class) @Valid ForhåndsvisDokumentDto forhåndsvisDto) { // NOSONAR
         var behandling = behandlingRepository.hentBehandling(forhåndsvisDto.behandlingUuid());
 
-        var fritekst = forhåndsvisDto.fritekst();
-        var dokumentMal = forhåndsvisDto.fritekst() != null ? DokumentMalType.FRITEKST_HTML : forhåndsvisDto.dokumentMal();
+        var dokumentMal = utledDokumentMapTypeForhåndsvisning(forhåndsvisDto);
 
         var bestilling = DokumentForhandsvisning.builder()
             .medBehandlingUuid(forhåndsvisDto.behandlingUuid())
             .medSaksnummer(behandling.getSaksnummer())
             .medDokumentMal(dokumentMal)
             .medRevurderingÅrsak(forhåndsvisDto.årsakskode())
-            .medFritekst(fritekst)
+            .medFritekst(forhåndsvisDto.fritekst())
             .medDokumentType(utledDokumentType(forhåndsvisDto.automatiskVedtaksbrev()))
             .build();
 
@@ -241,6 +243,14 @@ public class BrevRestTjeneste {
             return responseBuilder.build();
         }
         return Response.serverError().build();
+    }
+
+    private static DokumentMalType utledDokumentMapTypeForhåndsvisning(ForhåndsvisDokumentDto forhåndsvisDto) {
+        if (forhåndsvisDto.fritekst() != null) {
+            return BREV_SOM_FORHÅNDSVISES_MED_FRITEKST_UTEN_HTML_REDIGERING
+                .contains(forhåndsvisDto.dokumentMal()) ? forhåndsvisDto.dokumentMal() : DokumentMalType.FRITEKST_HTML;
+        }
+        return forhåndsvisDto.dokumentMal();
     }
 
     private DokumentForhandsvisning.DokumentType utledDokumentType(boolean gjelderAutomatiskBrev) {

--- a/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/brev/BrevRestTjenesteTest.java
+++ b/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/brev/BrevRestTjenesteTest.java
@@ -1,6 +1,7 @@
 package no.nav.foreldrepenger.web.app.tjenester.brev;
 
 import static no.nav.foreldrepenger.behandlingslager.behandling.dokument.DokumentMalType.INNHENTE_OPPLYSNINGER;
+import static no.nav.foreldrepenger.behandlingslager.behandling.dokument.DokumentMalType.KLAGE_OVERSENDT;
 import static no.nav.foreldrepenger.behandlingslager.behandling.dokument.DokumentMalType.VARSEL_OM_REVURDERING;
 import static no.nav.foreldrepenger.behandlingslager.behandling.dokument.MellomlagringType.VARSEL_REVURDERING;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -30,8 +31,10 @@ import no.nav.foreldrepenger.dokumentarkiv.DokumentRespons;
 import no.nav.foreldrepenger.dokumentbestiller.DokumentBehandlingTjeneste;
 import no.nav.foreldrepenger.dokumentbestiller.DokumentBestillerTjeneste;
 import no.nav.foreldrepenger.dokumentbestiller.DokumentBestilling;
+import no.nav.foreldrepenger.dokumentbestiller.DokumentForhandsvisning;
 import no.nav.foreldrepenger.dokumentbestiller.DokumentForhåndsvisningTjeneste;
 import no.nav.foreldrepenger.dokumentbestiller.dto.BestillDokumentDto;
+import no.nav.foreldrepenger.dokumentbestiller.dto.ForhåndsvisDokumentDto;
 import no.nav.foreldrepenger.domene.arbeidInntektsmelding.ArbeidsforholdInntektsmeldingMangelTjeneste;
 import no.nav.foreldrepenger.domene.typer.JournalpostId;
 import no.nav.foreldrepenger.domene.typer.Saksnummer;
@@ -172,6 +175,25 @@ class BrevRestTjenesteTest {
         var dto = (BrevRestTjeneste.OverstyrtDokumentDto) respons.getEntity();
         assertThat(dto.opprinneligHtml()).isEqualTo(brevProdusertAvFpdokgen);
         assertThat(dto.redigertHtml()).isNull();
+    }
+
+    @Test
+    void forhåndsvis_klage_oversendt_med_fritekst_bruker_ikke_fritekst_html_som_dokumentmal() {
+        var behandlingUuid = UUID.randomUUID();
+        var behandling = mock(Behandling.class);
+        var pdf = "pdf".getBytes();
+        when(behandling.getSaksnummer()).thenReturn(new Saksnummer("9999"));
+        when(behandlingRepository.hentBehandling(behandlingUuid)).thenReturn(behandling);
+        when(dokumentForhåndsvisningTjenesteMock.forhåndsvisDokument(any())).thenReturn(pdf);
+        var dto = new ForhåndsvisDokumentDto(behandlingUuid, KLAGE_OVERSENDT, null, false, "fritekst");
+
+        var respons = brevRestTjeneste.forhåndsvisDokument(dto);
+
+        var captor = ArgumentCaptor.forClass(DokumentForhandsvisning.class);
+        verify(dokumentForhåndsvisningTjenesteMock).forhåndsvisDokument(captor.capture());
+        assertThat(captor.getValue().dokumentMal()).isEqualTo(KLAGE_OVERSENDT);
+        assertThat(captor.getValue().fritekst()).isEqualTo("fritekst");
+        assertThat(respons.getStatus()).isEqualTo(200);
     }
 
     @Test


### PR DESCRIPTION
Klagebrev med fritekst (KLAGE_OVERSENDT/KLAGE_OMGJORT) skal ikke tvinges til FRITEKST_HTML ved forhåndsvisning.

Legger til regression-test for KLAGE_OVERSENDT med fritekst i BrevRestTjenesteTest.


Glemte disse. Er det flere?