### PR TITLE
Bugfix: håndter fritekst-beregning uten dokumentmal i forhåndsvisning

### DIFF
--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/brev/BrevRestTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/brev/BrevRestTjeneste.java
@@ -248,7 +248,7 @@ public class BrevRestTjeneste {
     }
 
     private static DokumentMalType utledDokumentMapTypeForhåndsvisning(ForhåndsvisDokumentDto forhåndsvisDto) {
-        if (forhåndsvisDto.fritekst() != null) {
+        if (forhåndsvisDto.fritekst() != null && forhåndsvisDto.dokumentMal() != null) { //Endring i beregning i vedtakspanelet har fritekst uten dokumentmal
             return BREV_SOM_FORHÅNDSVISES_MED_FRITEKST_UTEN_HTML_REDIGERING
                 .contains(forhåndsvisDto.dokumentMal()) ? forhåndsvisDto.dokumentMal() : DokumentMalType.FRITEKST_HTML;
         }

--- a/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/brev/BrevRestTjenesteTest.java
+++ b/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/brev/BrevRestTjenesteTest.java
@@ -197,6 +197,25 @@ class BrevRestTjenesteTest {
     }
 
     @Test
+    void forhåndsvis_med_fritekst_uten_dokumentmal_sender_null_dokumentmal_videre() {
+        var behandlingUuid = UUID.randomUUID();
+        var behandling = mock(Behandling.class);
+        var pdf = "pdf".getBytes();
+        when(behandling.getSaksnummer()).thenReturn(new Saksnummer("9999"));
+        when(behandlingRepository.hentBehandling(behandlingUuid)).thenReturn(behandling);
+        when(dokumentForhåndsvisningTjenesteMock.forhåndsvisDokument(any())).thenReturn(pdf);
+        var dto = new ForhåndsvisDokumentDto(behandlingUuid, null, null, false, "fritekst");
+
+        var respons = brevRestTjeneste.forhåndsvisDokument(dto);
+
+        var captor = ArgumentCaptor.forClass(DokumentForhandsvisning.class);
+        verify(dokumentForhåndsvisningTjenesteMock).forhåndsvisDokument(captor.capture());
+        assertThat(captor.getValue().dokumentMal()).isNull();
+        assertThat(captor.getValue().fritekst()).isEqualTo("fritekst");
+        assertThat(respons.getStatus()).isEqualTo(200);
+    }
+
+    @Test
     void hent_overstyrt_vedtaksbrev_returnerer_pdf_fra_mellomlagring() {
         var behandlingUuid = UUID.randomUUID();
         var pdf = "pdf".getBytes();


### PR DESCRIPTION
Forhåndsvisning kunne få fritekst uten dokumentmal fra vedtakspanelet. Legger inn null-sjekk i dokumentmal-utledning og regresjonstest som verifiserer at fritekst fortsatt sendes videre.

Glemte denne..