### PR TITLE
TFP-6942: legg til internArbeidsforholdId på VelferdspermisjonDto

### DIFF
--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/svp/SvangerskapspengerTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/svp/SvangerskapspengerTjeneste.java
@@ -399,7 +399,8 @@ public class SvangerskapspengerTjeneste {
     private VelferdspermisjonDto mapPermisjon(Permisjon p, Optional<YrkesaktivitetFilter> registerFilter, Optional<YrkesaktivitetFilter> saksbehandletFilter) {
         return new VelferdspermisjonDto(p.getFraOgMed(),
             p.getTilOgMed() == null || p.getTilOgMed().isEqual(Tid.TIDENES_ENDE) ? null : p.getTilOgMed(), p.getProsentsats().getVerdi(),
-            p.getPermisjonsbeskrivelseType(), erGyldig(p, registerFilter, saksbehandletFilter));
+            p.getPermisjonsbeskrivelseType(), erGyldig(p, registerFilter, saksbehandletFilter),
+            p.getYrkesaktivitet().getArbeidsforholdRef().getUUIDReferanse());
     }
 
     private Boolean erGyldig(Permisjon p, Optional<YrkesaktivitetFilter> yrkesfilter, Optional<YrkesaktivitetFilter> saksbehandletFilter) {

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/svp/VelferdspermisjonDto.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/svp/VelferdspermisjonDto.java
@@ -16,23 +16,20 @@ import no.nav.foreldrepenger.validering.ValidKodeverk;
 
 public class VelferdspermisjonDto {
 
-    @JsonProperty("permisjonFom") @NotNull
+    @NotNull
     private LocalDate permisjonFom;
-    @JsonProperty("permisjonTom")
     private LocalDate permisjonTom;
-    @JsonProperty("permisjonsprosent") @NotNull
+    @NotNull
     @DecimalMin("0.00")
     @DecimalMax("100.00")
     private BigDecimal permisjonsprosent;
     @ValidKodeverk
-    @JsonProperty("type") @NotNull
+    @NotNull
     private PermisjonsbeskrivelseType type;
-    @JsonProperty("erGyldig")
     private Boolean erGyldig;
-    @JsonProperty("internArbeidsforholdId")
     private UUID internArbeidsforholdId;
 
-    public VelferdspermisjonDto(){
+    public VelferdspermisjonDto() {
         // Jackson
     }
 

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/svp/VelferdspermisjonDto.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/svp/VelferdspermisjonDto.java
@@ -3,6 +3,7 @@ package no.nav.foreldrepenger.web.app.tjenester.behandling.svp;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.util.UUID;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
@@ -28,6 +29,8 @@ public class VelferdspermisjonDto {
     private PermisjonsbeskrivelseType type;
     @JsonProperty("erGyldig")
     private Boolean erGyldig;
+    @JsonProperty("internArbeidsforholdId")
+    private UUID internArbeidsforholdId;
 
     public VelferdspermisjonDto(){
         // Jackson
@@ -37,12 +40,14 @@ public class VelferdspermisjonDto {
                                 LocalDate permisjonTom,
                                 BigDecimal permisjonsprosent,
                                 PermisjonsbeskrivelseType type,
-                                Boolean erGyldig) {
+                                Boolean erGyldig,
+                                UUID internArbeidsforholdId) {
         this.permisjonFom = permisjonFom;
         this.permisjonTom = permisjonTom;
         this.permisjonsprosent = permisjonsprosent;
         this.type = type;
         this.erGyldig = erGyldig;
+        this.internArbeidsforholdId = internArbeidsforholdId;
     }
 
     public LocalDate getPermisjonFom() {
@@ -83,5 +88,13 @@ public class VelferdspermisjonDto {
 
     public void setErGyldig(Boolean erGyldig) {
         this.erGyldig = erGyldig;
+    }
+
+    public UUID getInternArbeidsforholdId() {
+        return internArbeidsforholdId;
+    }
+
+    public void setInternArbeidsforholdId(UUID internArbeidsforholdId) {
+        this.internArbeidsforholdId = internArbeidsforholdId;
     }
 }

--- a/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/svp/BekreftSvangerskapspengerOppdatererTest.java
+++ b/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/svp/BekreftSvangerskapspengerOppdatererTest.java
@@ -119,7 +119,7 @@ class BekreftSvangerskapspengerOppdatererTest {
         var dto = byggDto(BEHOV_FRA_DATO, TERMINDATO,
             svpGrunnlag.getOpprinneligeTilrettelegginger().getTilretteleggingListe().get(0).getId(),
             true,
-            new VelferdspermisjonDto(permisjonFom, permisjonTom, BigDecimal.valueOf(100), PermisjonsbeskrivelseType.VELFERDSPERMISJON, false),
+            new VelferdspermisjonDto(permisjonFom, permisjonTom, BigDecimal.valueOf(100), PermisjonsbeskrivelseType.VELFERDSPERMISJON, false, null),
             null,
             List.of(new SvpTilretteleggingDatoDto(BEHOV_FRA_DATO.plusWeeks(1), TilretteleggingType.INGEN_TILRETTELEGGING, null)),
             null);
@@ -135,10 +135,10 @@ class BekreftSvangerskapspengerOppdatererTest {
 
         assertThat(overstyringer).hasSize(1);
 
-        assertThat(overstyringer.get(0).getBekreftetPermisjon()).isPresent();
-        assertThat(overstyringer.get(0).getBekreftetPermisjon().get().getStatus()).isEqualTo(BekreftetPermisjonStatus.IKKE_BRUK_PERMISJON);
-        assertThat(overstyringer.get(0).getArbeidsgiver().getIdentifikator()).isEqualTo(ARBEIDSGIVER_IDENT);
-        assertThat(overstyringer.get(0).getArbeidsforholdRef()).isEqualTo(INTERN_ARBEIDSFORHOLD_REF);
+        assertThat(overstyringer.getFirst().getBekreftetPermisjon()).isPresent();
+        assertThat(overstyringer.getFirst().getBekreftetPermisjon().get().getStatus()).isEqualTo(BekreftetPermisjonStatus.IKKE_BRUK_PERMISJON);
+        assertThat(overstyringer.getFirst().getArbeidsgiver().getIdentifikator()).isEqualTo(ARBEIDSGIVER_IDENT);
+        assertThat(overstyringer.getFirst().getArbeidsforholdRef()).isEqualTo(INTERN_ARBEIDSFORHOLD_REF);
     }
 
     @Test
@@ -152,7 +152,7 @@ class BekreftSvangerskapspengerOppdatererTest {
         var svpGrunnlag = byggSøknadsgrunnlag(behandling, true, false);
         //endrer
         var dto = byggDto(BEHOV_FRA_DATO, TERMINDATO,
-            svpGrunnlag.getOpprinneligeTilrettelegginger().getTilretteleggingListe().get(0).getId(),
+            svpGrunnlag.getOpprinneligeTilrettelegginger().getTilretteleggingListe().getFirst().getId(),
             true, null, null,
             List.of(new SvpTilretteleggingDatoDto(TLR_FRA_2, TilretteleggingType.INGEN_TILRETTELEGGING, null, null, SvpTilretteleggingFomKilde.REGISTRERT_AV_SAKSBEHANDLER,
                     null),
@@ -177,7 +177,7 @@ class BekreftSvangerskapspengerOppdatererTest {
 
         var svpGrunnlag = byggSøknadsgrunnlag(behandling, true, false);
         var dto = byggDto(BEHOV_FRA_DATO, TERMINDATO,
-            svpGrunnlag.getOpprinneligeTilrettelegginger().getTilretteleggingListe().get(0).getId(),
+            svpGrunnlag.getOpprinneligeTilrettelegginger().getTilretteleggingListe().getFirst().getId(),
             false,
             null,
             INTERN_ARBEIDSFORHOLD_REF,
@@ -201,7 +201,7 @@ class BekreftSvangerskapspengerOppdatererTest {
 
         var svpGrunnlag = byggSøknadsgrunnlag(behandling, true, false);
         var dto = byggDto(BEHOV_FRA_DATO.minusDays(1), TERMINDATO,
-            svpGrunnlag.getOpprinneligeTilrettelegginger().getTilretteleggingListe().get(0).getId(),
+            svpGrunnlag.getOpprinneligeTilrettelegginger().getTilretteleggingListe().getFirst().getId(),
             true, null, null,
             List.of(new SvpTilretteleggingDatoDto(TLR_FRA_2, TilretteleggingType.INGEN_TILRETTELEGGING, null),
                 new SvpTilretteleggingDatoDto(BEHOV_FRA_DATO, TilretteleggingType.DELVIS_TILRETTELEGGING, BigDecimal.valueOf(50))),
@@ -224,7 +224,7 @@ class BekreftSvangerskapspengerOppdatererTest {
         var svpGrunnlag = byggSøknadsgrunnlag(behandling, true, false);
         //endrer
         var dto = byggDto(BEHOV_FRA_DATO, TERMINDATO,
-            svpGrunnlag.getOpprinneligeTilrettelegginger().getTilretteleggingListe().get(0).getId(),
+            svpGrunnlag.getOpprinneligeTilrettelegginger().getTilretteleggingListe().getFirst().getId(),
             true, null, null,
             List.of(new SvpTilretteleggingDatoDto(TLR_FRA_2, TilretteleggingType.INGEN_TILRETTELEGGING, null),
                 new SvpTilretteleggingDatoDto(BEHOV_FRA_DATO, TilretteleggingType.DELVIS_TILRETTELEGGING, BigDecimal.valueOf(50), null, SvpTilretteleggingFomKilde.SØKNAD,
@@ -248,7 +248,7 @@ class BekreftSvangerskapspengerOppdatererTest {
 
         var svpGrunnlag = byggSøknadsgrunnlag(behandling, true, true);
         var dto = byggDto(BEHOV_FRA_DATO, LocalDate.now().plusDays(40),
-            svpGrunnlag.getOpprinneligeTilrettelegginger().getTilretteleggingListe().get(0).getId(),
+            svpGrunnlag.getOpprinneligeTilrettelegginger().getTilretteleggingListe().getFirst().getId(),
             true, null, null,
             List.of(new SvpTilretteleggingDatoDto(TLR_FRA_2, TilretteleggingType.INGEN_TILRETTELEGGING, null),
             new SvpTilretteleggingDatoDto(BEHOV_FRA_DATO, TilretteleggingType.DELVIS_TILRETTELEGGING, BigDecimal.valueOf(50))),
@@ -270,7 +270,7 @@ class BekreftSvangerskapspengerOppdatererTest {
 
         var svpGrunnlag = byggSøknadsgrunnlag(behandling, true, false);
         var dto = byggDto(BEHOV_FRA_DATO, LocalDate.now().plusDays(40),
-            svpGrunnlag.getOpprinneligeTilrettelegginger().getTilretteleggingListe().get(0).getId(),
+            svpGrunnlag.getOpprinneligeTilrettelegginger().getTilretteleggingListe().getFirst().getId(),
             true, null, null,
             List.of(new SvpTilretteleggingDatoDto(TLR_FRA_2, TilretteleggingType.INGEN_TILRETTELEGGING, null),
                 new SvpTilretteleggingDatoDto(BEHOV_FRA_DATO, TilretteleggingType.DELVIS_TILRETTELEGGING, BigDecimal.valueOf(50))),
@@ -309,7 +309,7 @@ class BekreftSvangerskapspengerOppdatererTest {
 
         var svpGrunnlag = byggSøknadsgrunnlag(behandling, false, false);
         var dto = byggDto(BEHOV_FRA_DATO, TERMINDATO,
-            svpGrunnlag.getOpprinneligeTilrettelegginger().getTilretteleggingListe().get(0).getId(), false,
+            svpGrunnlag.getOpprinneligeTilrettelegginger().getTilretteleggingListe().getFirst().getId(), false,
             null, INTERN_ARBEIDSFORHOLD_REF,
             List.of(new SvpTilretteleggingDatoDto(BEHOV_FRA_DATO.plusWeeks(1), TilretteleggingType.DELVIS_TILRETTELEGGING, null)),
             null);


### PR DESCRIPTION
## Sammendrag

Legger til `internArbeidsforholdId` på `VelferdspermisjonDto` slik at frontend kan koble permisjoner til riktig arbeidsforhold ved splitting.

### Endringer

- Nytt felt `internArbeidsforholdId` (UUID) på `VelferdspermisjonDto`
- Mapper `arbeidsforholdRef.getUUIDReferanse()` fra `Yrkesaktivitet` i `SvangerskapspengerTjeneste`