### PR TITLE
Chore: flytter miljøuavhengige params til kode

### DIFF
--- a/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/registrersøknad/RegistrerSøknadStegTest.java
+++ b/behandlingsprosess/src/test/java/no/nav/foreldrepenger/behandling/steg/registrersøknad/RegistrerSøknadStegTest.java
@@ -6,7 +6,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.time.LocalDate;
-import java.time.Period;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -50,8 +49,7 @@ class RegistrerSøknadStegTest extends EntityManagerAwareTest {
         behandlingRepository = new BehandlingRepository(getEntityManager());
         fagsakRepository = new FagsakRepository(getEntityManager());
         mottatteDokumentRepository = new MottatteDokumentRepository(getEntityManager());
-        mottatteDokumentTjeneste = new MottatteDokumentTjeneste(Period.ofWeeks(6), null, mottatteDokumentRepository,
-                new BehandlingRepositoryProvider(getEntityManager()));
+        mottatteDokumentTjeneste = new MottatteDokumentTjeneste(null, mottatteDokumentRepository, new BehandlingRepositoryProvider(getEntityManager()));
         steg = new RegistrerSøknadSteg(behandlingRepository, mottatteDokumentTjeneste, mock(RegistrerFagsakEgenskaper.class),
             null, kompletthetsjekker, mock(FyllUtSendInnOversetter.class));
         when(kompletthetsjekker.vurderSøknadMottatt(any())).thenReturn(KompletthetResultat.oppfylt());

--- a/domenetjenester/behandling-revurdering/src/main/java/no/nav/foreldrepenger/behandling/revurdering/etterkontroll/tjeneste/EtterkontrollEventObserver.java
+++ b/domenetjenester/behandling-revurdering/src/main/java/no/nav/foreldrepenger/behandling/revurdering/etterkontroll/tjeneste/EtterkontrollEventObserver.java
@@ -27,32 +27,25 @@ import no.nav.foreldrepenger.behandlingslager.etterkontroll.Etterkontroll;
 import no.nav.foreldrepenger.behandlingslager.etterkontroll.EtterkontrollRepository;
 import no.nav.foreldrepenger.behandlingslager.etterkontroll.KontrollType;
 import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakYtelseType;
-import no.nav.foreldrepenger.konfig.KonfigVerdi;
 
 @ApplicationScoped
 public class EtterkontrollEventObserver {
 
     private static final Logger LOG = LoggerFactory.getLogger(EtterkontrollEventObserver.class);
 
+    private static final Period ETTERKONTROLL_DAGER_TILBAKE = Period.ofDays(60);
+
     private EtterkontrollRepository etterkontrollRepository;
     private FamilieHendelseRepository familieHendelseRepository;
-    private Period etterkontrollTidTilbake;
 
     public EtterkontrollEventObserver() {
         // Cool Devices Installed
     }
 
-    /**
-     * @param etterkontrollTidTilbake - Tid etter innvilgelsesdato før en fagsak
-     *                                vurderes for etterkontroll
-     */
     @Inject
-    public EtterkontrollEventObserver(EtterkontrollRepository etterkontrollRepository,
-            FamilieHendelseRepository familieHendelseRepository,
-            @KonfigVerdi(value = "etterkontroll.tid.tilbake", defaultVerdi = "P60D") Period etterkontrollTidTilbake) {
+    public EtterkontrollEventObserver(EtterkontrollRepository etterkontrollRepository, FamilieHendelseRepository familieHendelseRepository) {
         this.etterkontrollRepository = etterkontrollRepository;
         this.familieHendelseRepository = familieHendelseRepository;
-        this.etterkontrollTidTilbake = etterkontrollTidTilbake;
     }
 
     public void observerFamiliehendelseEvent(@Observes FamiliehendelseEvent event) {
@@ -87,7 +80,7 @@ public class EtterkontrollEventObserver {
 
     private void markerForEtterkontroll(Behandling behandling, FamilieHendelseGrunnlagEntitet grunnlag) {
         skalEtterkontrolleresMedDato(behandling, grunnlag).ifPresent(ekDato -> {
-            var ekTid = ekDato.plus(etterkontrollTidTilbake).atStartOfDay();
+            var ekTid = ekDato.plus(ETTERKONTROLL_DAGER_TILBAKE).atStartOfDay();
             var ekListe = etterkontrollRepository.finnEtterkontrollForFagsak(behandling.getFagsakId(), KontrollType.MANGLENDE_FØDSEL);
             if (ekListe.isEmpty()) {
                 var etterkontroll = new Etterkontroll.Builder(behandling.getFagsakId())

--- a/domenetjenester/behandling-revurdering/src/main/java/no/nav/foreldrepenger/behandling/revurdering/etterkontroll/tjeneste/es/EtterkontrollTjenesteImpl.java
+++ b/domenetjenester/behandling-revurdering/src/main/java/no/nav/foreldrepenger/behandling/revurdering/etterkontroll/tjeneste/es/EtterkontrollTjenesteImpl.java
@@ -23,13 +23,12 @@ import no.nav.foreldrepenger.behandlingslager.behandling.familiehendelse.Terminb
 import no.nav.foreldrepenger.behandlingslager.behandling.vedtak.BehandlingVedtakRepository;
 import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakYtelseType;
 import no.nav.foreldrepenger.behandlingsprosess.prosessering.BehandlingProsesseringTjeneste;
-import no.nav.foreldrepenger.konfig.KonfigVerdi;
 
 @ApplicationScoped
 @FagsakYtelseTypeRef(FagsakYtelseType.ENGANGSTØNAD)
 public class EtterkontrollTjenesteImpl implements EtterkontrollTjeneste {
 
-    private Period pdlRegistreringsTidsrom;
+    private static final Period PDL_TIDSROM = Period.ofWeeks(11); // Håndtere fødsler uke 26-29 spesielt
     private RevurderingTjeneste revurderingTjeneste;
 
     private BehandlingVedtakRepository behandlingVedtakRepository;
@@ -43,9 +42,7 @@ public class EtterkontrollTjenesteImpl implements EtterkontrollTjeneste {
     public EtterkontrollTjenesteImpl(BehandlingVedtakRepository vedtakRepository,
             EngangsstønadBeregningRepository esBeregningRepository,
             BehandlingProsesseringTjeneste behandlingProsesseringTjeneste,
-            @FagsakYtelseTypeRef(FagsakYtelseType.ENGANGSTØNAD) RevurderingTjeneste revurderingTjeneste,
-            @KonfigVerdi(value = "etterkontroll.pdlregistrering.periode", defaultVerdi = "P11W") Period pdlRegistreringsTidsrom) {
-        this.pdlRegistreringsTidsrom = pdlRegistreringsTidsrom;
+            @FagsakYtelseTypeRef(FagsakYtelseType.ENGANGSTØNAD) RevurderingTjeneste revurderingTjeneste) {
         this.behandlingVedtakRepository = vedtakRepository;
         this.revurderingTjeneste = revurderingTjeneste;
         this.esBeregningRepository = esBeregningRepository;
@@ -89,7 +86,7 @@ public class EtterkontrollTjenesteImpl implements EtterkontrollTjeneste {
 
         var termindato = grunnlag.getGjeldendeTerminbekreftelse().map(TerminbekreftelseEntitet::getTermindato);
         if (termindato.isPresent()) {
-            var tidligstePDLRegistreringsDato = termindato.get().minus(pdlRegistreringsTidsrom);
+            var tidligstePDLRegistreringsDato = termindato.get().minus(PDL_TIDSROM);
             var vedtak = behandlingVedtakRepository.hentForBehandling(behandling.getId());
             var vedtaksDato = vedtak.getVedtaksdato();
             if (vedtaksDato.isBefore(tidligstePDLRegistreringsDato)) {

--- a/domenetjenester/behandling-revurdering/src/test/java/no/nav/foreldrepenger/behandling/revurdering/etterkontroll/tjeneste/EtterkontrollEventObserverTest.java
+++ b/domenetjenester/behandling-revurdering/src/test/java/no/nav/foreldrepenger/behandling/revurdering/etterkontroll/tjeneste/EtterkontrollEventObserverTest.java
@@ -5,7 +5,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.Month;
-import java.time.Period;
 
 import jakarta.persistence.EntityManager;
 
@@ -54,8 +53,7 @@ class EtterkontrollEventObserverTest {
         repositoryProvider = new BehandlingRepositoryProvider(entityManager);
         etterkontrollRepository = new EtterkontrollRepository(entityManager);
         familieHendelseRepository = new FamilieHendelseRepository(entityManager);
-        etterkontrollEventObserver = new EtterkontrollEventObserver(etterkontrollRepository, familieHendelseRepository,
-                Period.parse("P60D"));
+        etterkontrollEventObserver = new EtterkontrollEventObserver(etterkontrollRepository, familieHendelseRepository);
     }
 
     @Test

--- a/domenetjenester/dokumentbestiller/src/main/java/no/nav/foreldrepenger/dokumentbestiller/VarselRevurderingTjeneste.java
+++ b/domenetjenester/dokumentbestiller/src/main/java/no/nav/foreldrepenger/dokumentbestiller/VarselRevurderingTjeneste.java
@@ -13,22 +13,19 @@ import no.nav.foreldrepenger.behandlingslager.behandling.aksjonspunkt.Venteårsa
 import no.nav.foreldrepenger.behandlingslager.behandling.dokument.DokumentMalType;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepository;
 import no.nav.foreldrepenger.behandlingsprosess.prosessering.BehandlingProsesseringTjeneste;
-import no.nav.foreldrepenger.konfig.KonfigVerdi;
 
 @ApplicationScoped
 public class VarselRevurderingTjeneste {
 
-    private Period defaultVenteFrist;
+    private static final Period VENTEFRIST = Period.ofWeeks(4);
     private BehandlingProsesseringTjeneste behandlingProsesseringTjeneste;
     private DokumentBestillerTjeneste dokumentBestillerTjeneste;
     private BehandlingRepository behandlingRepository;
 
     @Inject
-    public VarselRevurderingTjeneste(@KonfigVerdi(value = "behandling.default.ventefrist.periode", defaultVerdi = "P4W") Period defaultVenteFrist,
-                                     BehandlingProsesseringTjeneste behandlingProsesseringTjeneste,
+    public VarselRevurderingTjeneste(BehandlingProsesseringTjeneste behandlingProsesseringTjeneste,
                                      DokumentBestillerTjeneste dokumentBestillerTjeneste,
                                      BehandlingRepository behandlingRepository) {
-        this.defaultVenteFrist = defaultVenteFrist;
         this.behandlingProsesseringTjeneste = behandlingProsesseringTjeneste;
         this.dokumentBestillerTjeneste = dokumentBestillerTjeneste;
         this.behandlingRepository = behandlingRepository;
@@ -56,7 +53,7 @@ public class VarselRevurderingTjeneste {
     }
 
     private LocalDateTime bestemFristForBehandlingVent(LocalDate frist) {
-        return frist != null ? LocalDateTime.of(frist, LocalDateTime.now().toLocalTime()) : LocalDateTime.now().plus(defaultVenteFrist);
+        return frist != null ? LocalDateTime.of(frist, LocalDateTime.now().toLocalTime()) : LocalDateTime.now().plus(VENTEFRIST);
     }
 
     private Venteårsak fraDto(String kode) {

--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/dokumentmottak/MottatteDokumentTjeneste.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/dokumentmottak/MottatteDokumentTjeneste.java
@@ -21,7 +21,6 @@ import no.nav.foreldrepenger.behandlingslager.behandling.repository.MottatteDoku
 import no.nav.foreldrepenger.behandlingslager.behandling.vedtak.BehandlingVedtak;
 import no.nav.foreldrepenger.behandlingslager.behandling.vilkår.Avslagsårsak;
 import no.nav.foreldrepenger.behandlingslager.fagsak.Fagsak;
-import no.nav.foreldrepenger.konfig.KonfigVerdi;
 import no.nav.foreldrepenger.mottak.dokumentpersiterer.SøknadUtsettelseUttakDato;
 import no.nav.foreldrepenger.mottak.dokumentpersiterer.impl.MottattDokumentPersisterer;
 import no.nav.foreldrepenger.mottak.dokumentpersiterer.impl.søknad.v3.EndringUtsettelseUttak;
@@ -30,7 +29,7 @@ import no.nav.foreldrepenger.mottak.dokumentpersiterer.impl.søknad.v3.SøknadWr
 @ApplicationScoped
 public class MottatteDokumentTjeneste {
 
-    private Period fristForInnsendingAvDokumentasjon;
+    private static final Period FRIST_INNSENDING_ETTER_AVSLAG = Period.ofWeeks(6);
 
     private MottattDokumentPersisterer mottattDokumentPersisterer;
     private MottatteDokumentRepository mottatteDokumentRepository;
@@ -40,16 +39,10 @@ public class MottatteDokumentTjeneste {
         // for CDI proxy
     }
 
-    /**
-     *
-     * @param fristForInnsendingAvDokumentasjon - Frist i uker fom siste vedtaksdato
-     */
     @Inject
-    public MottatteDokumentTjeneste(@KonfigVerdi(value = "sak.frist.innsending.dok", defaultVerdi = "P6W") Period fristForInnsendingAvDokumentasjon,
-                                    MottattDokumentPersisterer mottattDokumentPersisterer,
+    public MottatteDokumentTjeneste(MottattDokumentPersisterer mottattDokumentPersisterer,
                                     MottatteDokumentRepository mottatteDokumentRepository,
                                     BehandlingRepositoryProvider behandlingRepositoryProvider) {
-        this.fristForInnsendingAvDokumentasjon = fristForInnsendingAvDokumentasjon;
         this.mottattDokumentPersisterer = mottattDokumentPersisterer;
         this.mottatteDokumentRepository = mottatteDokumentRepository;
         this.behandlingRepositoryProvider = behandlingRepositoryProvider;
@@ -122,7 +115,7 @@ public class MottatteDokumentTjeneste {
         var behandlingOptional = behandlingRepositoryProvider.getBehandlingRepository().finnSisteAvsluttedeIkkeHenlagteBehandling(sak.getId());
         return behandlingOptional.flatMap(b -> behandlingRepositoryProvider.getBehandlingVedtakRepository().hentForBehandlingHvisEksisterer(b.getId()))
             .map(BehandlingVedtak::getVedtaksdato)
-            .map(dato -> dato.isBefore(LocalDate.now().minus(fristForInnsendingAvDokumentasjon))).orElse(Boolean.FALSE);
+            .map(dato -> dato.isBefore(LocalDate.now().minus(FRIST_INNSENDING_ETTER_AVSLAG))).orElse(Boolean.FALSE);
     }
 
     private boolean erAvsluttetPgaManglendeDokumentasjon(Behandling behandling) {

--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/hendelser/es/FødselForretningshendelseHåndtererImpl.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/hendelser/es/FødselForretningshendelseHåndtererImpl.java
@@ -12,7 +12,6 @@ import no.nav.foreldrepenger.behandlingslager.behandling.BehandlingÅrsakType;
 import no.nav.foreldrepenger.behandlingslager.behandling.beregning.EngangsstønadBeregningRepository;
 import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakYtelseType;
 import no.nav.foreldrepenger.behandlingslager.hendelser.ForretningshendelseType;
-import no.nav.foreldrepenger.konfig.KonfigVerdi;
 import no.nav.foreldrepenger.mottak.hendelser.ForretningshendelseHåndterer;
 import no.nav.foreldrepenger.mottak.hendelser.ForretningshendelsestypeRef;
 import no.nav.foreldrepenger.mottak.hendelser.håndterer.ForretningshendelseHåndtererFelles;
@@ -23,22 +22,18 @@ import no.nav.foreldrepenger.skjæringstidspunkt.SkjæringstidspunktTjeneste;
 @FagsakYtelseTypeRef(FagsakYtelseType.ENGANGSTØNAD)
 public class FødselForretningshendelseHåndtererImpl implements ForretningshendelseHåndterer {
 
-    private ForretningshendelseHåndtererFelles forretningshendelseHåndtererFelles;
-    private SkjæringstidspunktTjeneste skjæringstidspunktTjeneste;
-    private Period pdlRegistreringsTidsrom;
-    private EngangsstønadBeregningRepository engangsstønadBeregningRepository;
+    private static final Period REGULERINGSVINDU = Period.ofDays(60); // Se etterkontrollvindu - EK vil fange opp øvrige tilfelle
+
+    private final ForretningshendelseHåndtererFelles forretningshendelseHåndtererFelles;
+    private final SkjæringstidspunktTjeneste skjæringstidspunktTjeneste;
+    private final EngangsstønadBeregningRepository engangsstønadBeregningRepository;
 
 
-    /**
-     * @param pdlRegistreringsTidsrom - Periode før termin hvor dødfødsel kan være registrert i PDL
-     */
     @Inject
     public FødselForretningshendelseHåndtererImpl(ForretningshendelseHåndtererFelles forretningshendelseHåndtererFelles,
-                                                  @KonfigVerdi(value = "etterkontroll.tid.tilbake", defaultVerdi = "P60D") Period pdlRegistreringsTidsrom,
                                                   SkjæringstidspunktTjeneste skjæringstidspunktTjeneste,
                                                   EngangsstønadBeregningRepository engangsstønadBeregningRepository) {
         this.forretningshendelseHåndtererFelles = forretningshendelseHåndtererFelles;
-        this.pdlRegistreringsTidsrom = pdlRegistreringsTidsrom;
         this.skjæringstidspunktTjeneste = skjæringstidspunktTjeneste;
         this.engangsstønadBeregningRepository = engangsstønadBeregningRepository;
     }
@@ -61,6 +56,6 @@ public class FødselForretningshendelseHåndtererImpl implements Forretningshend
         var stp = skjæringstidspunktTjeneste.getSkjæringstidspunkter(behandling.getId()).getUtledetSkjæringstidspunkt();
         var idag = LocalDate.now().minusDays(1);
         // Gjelder terminsøknader pluss intervall. Øvrige tilfelle fanges opp i etterkontroll.
-        return idag.isBefore(stp.plus(pdlRegistreringsTidsrom)) && engangsstønadBeregningRepository.skalReberegne(behandling.getId(), idag);
+        return idag.isBefore(stp.plus(REGULERINGSVINDU)) && engangsstønadBeregningRepository.skalReberegne(behandling.getId(), idag);
     }
 }

--- a/domenetjenester/mottak/src/test/java/no/nav/foreldrepenger/mottak/dokumentmottak/impl/HåndterMottattDokumentTaskTest.java
+++ b/domenetjenester/mottak/src/test/java/no/nav/foreldrepenger/mottak/dokumentmottak/impl/HåndterMottattDokumentTaskTest.java
@@ -6,7 +6,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
 import java.time.LocalDate;
-import java.time.Period;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -52,11 +51,9 @@ class HåndterMottattDokumentTaskTest extends EntityManagerAwareTest {
     public void before() {
         var entityManager = getEntityManager();
         var mottatteDokumentRepository = new MottatteDokumentRepository(entityManager);
-        var fristInnsendingPeriode = Period.ofWeeks(6);
         innhentDokumentTjeneste = mock(InnhentDokumentTjeneste.class);
         var repositoryProvider = new BehandlingRepositoryProvider(entityManager);
-        mottatteDokumentTjeneste = new MottatteDokumentTjeneste(fristInnsendingPeriode, mottattDokumentPersisterer,
-            mottatteDokumentRepository, repositoryProvider);
+        mottatteDokumentTjeneste = new MottatteDokumentTjeneste(mottattDokumentPersisterer, mottatteDokumentRepository, repositoryProvider);
         håndterMottattDokumentTask = new HåndterMottattDokumentTask(innhentDokumentTjeneste, mottattDokumentPersisterer,
             mottatteDokumentTjeneste, repositoryProvider);
         fagsakRepository = new FagsakRepository(entityManager);

--- a/domenetjenester/mottak/src/test/java/no/nav/foreldrepenger/mottak/hendelser/impl/håndterer/FødselForretningshendelseHåndtererESTest.java
+++ b/domenetjenester/mottak/src/test/java/no/nav/foreldrepenger/mottak/hendelser/impl/håndterer/FødselForretningshendelseHåndtererESTest.java
@@ -11,7 +11,6 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import java.time.LocalDate;
-import java.time.Period;
 import java.util.List;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -71,7 +70,7 @@ class FødselForretningshendelseHåndtererESTest {
     void setUp() {
         håndtererFelles = new ForretningshendelseHåndtererFelles(historikkinnslagTjeneste, kompletthetskontroller,
             behandlingProsesseringTjeneste, behandlingsoppretter, familieHendelseTjeneste, personinfoAdapter, køKontroller);
-        håndterer = new FødselForretningshendelseHåndtererImpl(håndtererFelles, Period.ofDays(60), skjæringstidspunktTjeneste, beregningRepository);
+        håndterer = new FødselForretningshendelseHåndtererImpl(håndtererFelles, skjæringstidspunktTjeneste, beregningRepository);
     }
 
     @Test
@@ -101,7 +100,7 @@ class FødselForretningshendelseHåndtererESTest {
 
         håndtererFelles = new ForretningshendelseHåndtererFelles(historikkinnslagTjeneste, kompletthetskontroller, behandlingProsesseringTjeneste, behandlingsoppretter,
             new FamilieHendelseTjeneste(null, scenario.mockBehandlingRepositoryProvider().getFamilieHendelseRepository()), personinfoAdapter, køKontroller);
-        håndterer = new FødselForretningshendelseHåndtererImpl(håndtererFelles, Period.ofDays(60), skjæringstidspunktTjeneste, beregningRepository);
+        håndterer = new FødselForretningshendelseHåndtererImpl(håndtererFelles, skjæringstidspunktTjeneste, beregningRepository);
 
         when(personinfoAdapter.innhentAlleFødteForBehandlingIntervaller(any(), any(), any())).thenReturn(List.of(lagBarn(fødselsdato).build(),lagBarn(fødselsdato).build()));
 

--- a/domenetjenester/mottak/src/test/java/no/nav/foreldrepenger/mottak/vurderfagsystem/impl/VurderFagsystemTjenesteImplForAvlsluttetFagsakOgAvslåttBehandlingTest.java
+++ b/domenetjenester/mottak/src/test/java/no/nav/foreldrepenger/mottak/vurderfagsystem/impl/VurderFagsystemTjenesteImplForAvlsluttetFagsakOgAvslåttBehandlingTest.java
@@ -58,9 +58,7 @@ class VurderFagsystemTjenesteImplForAvlsluttetFagsakOgAvslåttBehandlingTest ext
         var mottattDokumentPersisterer = new MottattDokumentPersisterer(BehandlingEventPubliserer.NULL_EVENT_PUB);
 
         behandlingRepositoryProvider = new BehandlingRepositoryProvider(getEntityManager());
-        var mottatteDokumentTjeneste = new MottatteDokumentTjeneste(FRIST_INNSENDING_PERIODE,
-            mottattDokumentPersisterer,
-                mottatteDokumentRepository, behandlingRepositoryProvider);
+        var mottatteDokumentTjeneste = new MottatteDokumentTjeneste(mottattDokumentPersisterer, mottatteDokumentRepository, behandlingRepositoryProvider);
 
         var familieTjeneste = new FamilieHendelseTjeneste(null, behandlingRepositoryProvider.getFamilieHendelseRepository());
         var fagsakRelasjonTjeneste = new FagsakRelasjonTjeneste(behandlingRepositoryProvider);

--- a/domenetjenester/registerinnhenting/src/main/java/no/nav/foreldrepenger/domene/registerinnhenting/RegisterdataEndringshåndterer.java
+++ b/domenetjenester/registerinnhenting/src/main/java/no/nav/foreldrepenger/domene/registerinnhenting/RegisterdataEndringshåndterer.java
@@ -3,7 +3,6 @@ package no.nav.foreldrepenger.domene.registerinnhenting;
 import java.time.Duration;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.temporal.TemporalAmount;
 import java.util.Optional;
 
 import jakarta.enterprise.context.ApplicationScoped;
@@ -26,7 +25,6 @@ import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakYtelseType;
 import no.nav.foreldrepenger.behandlingslager.hendelser.StartpunktType;
 import no.nav.foreldrepenger.domene.registerinnhenting.impl.Endringskontroller;
 import no.nav.foreldrepenger.familiehendelse.FamilieHendelseTjeneste;
-import no.nav.foreldrepenger.konfig.KonfigVerdi;
 
 /**
  * Oppdaterer registeropplysninger for engangsstønader og skrur behandlingsprosessen tilbake
@@ -36,8 +34,8 @@ import no.nav.foreldrepenger.konfig.KonfigVerdi;
 public class RegisterdataEndringshåndterer {
 
     private static final Logger LOG = LoggerFactory.getLogger(RegisterdataEndringshåndterer.class);
+    private static final Duration OPPDATER_ETTER_TID = Duration.ofHours(10);
 
-    private TemporalAmount oppdatereRegisterdataTidspunkt;
     private BehandlingRepository behandlingRepository;
     private BehandlingsresultatRepository behandlingsresultatRepository;
     private Endringskontroller endringskontroller;
@@ -47,7 +45,6 @@ public class RegisterdataEndringshåndterer {
 
     @Inject
     public RegisterdataEndringshåndterer( BehandlingRepositoryProvider repositoryProvider,
-                                          @KonfigVerdi(value = "oppdatere.registerdata.tidspunkt", defaultVerdi = "PT10H") String oppdaterRegisterdataEtterPeriode,
                                           Endringskontroller endringskontroller,
                                           EndringsresultatSjekker endringsresultatSjekker,
                                           FamilieHendelseTjeneste familieHendelseTjeneste,
@@ -59,9 +56,6 @@ public class RegisterdataEndringshåndterer {
         this.endringsresultatSjekker = endringsresultatSjekker;
         this.behandlingÅrsakTjeneste = behandlingÅrsakTjeneste;
         this.familieHendelseTjeneste = familieHendelseTjeneste;
-        if (oppdaterRegisterdataEtterPeriode != null) {
-            this.oppdatereRegisterdataTidspunkt = Duration.parse(oppdaterRegisterdataEtterPeriode);
-        }
     }
 
     RegisterdataEndringshåndterer() {
@@ -75,11 +69,7 @@ public class RegisterdataEndringshåndterer {
         }
         var midnatt = LocalDate.now().atStartOfDay();
         var opplysningerOppdatertTidspunkt = behandlingRepository.hentSistOppdatertTidspunkt(behandling.getId());
-        if (oppdatereRegisterdataTidspunkt == null) {
-            // konfig-verdien er ikke satt
-            return erOpplysningerOppdatertTidspunktFør(midnatt, opplysningerOppdatertTidspunkt);
-        }
-        var nårOppdatereRegisterdata = LocalDateTime.now().minus(oppdatereRegisterdataTidspunkt);
+        var nårOppdatereRegisterdata = LocalDateTime.now().minus(OPPDATER_ETTER_TID);
         if (nårOppdatereRegisterdata.isAfter(midnatt)) {
             // konfigverdien er etter midnatt, da skal midnatt gjelde
             return erOpplysningerOppdatertTidspunktFør(midnatt, opplysningerOppdatertTidspunkt);

--- a/domenetjenester/registerinnhenting/src/test/java/no/nav/foreldrepenger/domene/registerinnhenting/RegisterdataEndringshåndtererTest.java
+++ b/domenetjenester/registerinnhenting/src/test/java/no/nav/foreldrepenger/domene/registerinnhenting/RegisterdataEndringshåndtererTest.java
@@ -213,10 +213,8 @@ class RegisterdataEndringshåndtererTest extends EntityManagerAwareTest {
 
     private RegisterdataEndringshåndterer lagRegisterdataEndringshåndterer() {
 
-        var durationInstance = "PT10H";
         return new RegisterdataEndringshåndterer(
             repositoryProvider,
-            durationInstance,
             endringskontroller,
             endringsresultatSjekker,
             familieHendelseTjeneste,

--- a/domenetjenester/registerinnhenting/src/test/java/no/nav/foreldrepenger/domene/registerinnhenting/RegisterdataInnhenterTest.java
+++ b/domenetjenester/registerinnhenting/src/test/java/no/nav/foreldrepenger/domene/registerinnhenting/RegisterdataInnhenterTest.java
@@ -7,7 +7,6 @@ import static org.mockito.Mockito.when;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
 
@@ -20,8 +19,6 @@ import no.nav.foreldrepenger.domene.typer.AktørId;
 
 class RegisterdataInnhenterTest {
 
-    private final String durationInstance = "PT10H";
-
     @Test
     void skal_innhente_registeropplysninger_på_nytt_når_det_ble_hentet_inn_i_går() {
         // Arrange
@@ -31,7 +28,7 @@ class RegisterdataInnhenterTest {
         var behandling = scenario.lagMocked();
 
         // Act
-        var registerdataEndringshåndterer = lagRegisterdataInnhenter(scenario, durationInstance);
+        var registerdataEndringshåndterer = lagRegisterdataInnhenter(scenario);
         Boolean harHentetInn = registerdataEndringshåndterer.skalInnhenteRegisteropplysningerPåNytt(behandling);
 
         // Assert
@@ -47,7 +44,7 @@ class RegisterdataInnhenterTest {
         var behandling = scenario.lagMocked();
 
         // Act
-        var registerdataEndringshåndterer = lagRegisterdataInnhenter(scenario, durationInstance);
+        var registerdataEndringshåndterer = lagRegisterdataInnhenter(scenario);
         Boolean harHentetInn = registerdataEndringshåndterer.skalInnhenteRegisteropplysningerPåNytt(behandling);
 
         // Assert
@@ -63,62 +60,7 @@ class RegisterdataInnhenterTest {
         var behandling = scenario.lagMocked();
 
         // Act
-        var registerdataEndringshåndterer = lagRegisterdataInnhenter(scenario, durationInstance);
-        Boolean harHentetInn = registerdataEndringshåndterer.skalInnhenteRegisteropplysningerPåNytt(behandling);
-
-        // Assert
-        assertThat(harHentetInn).isFalse();
-    }
-
-    @Test
-    void skal_innhente_registeropplysninger_ut_ifra_midnatt_når_konfigurasjonsverdien_mangler() {
-        // Arrange
-        var midnatt = LocalDateTime.now().withHour(0).withMinute(0).withSecond(0).withNano(0);
-
-        var scenario = ScenarioMorSøkerEngangsstønad
-            .forFødsel()
-            .medOpplysningerOppdatertTidspunkt(midnatt.minusMinutes(1));
-        var behandling = scenario.lagMocked();
-        var registerdataEndringshåndterer = lagRegisterdataInnhenter(scenario, null);
-
-        // Act
-        Boolean harHentetInn = registerdataEndringshåndterer.skalInnhenteRegisteropplysningerPåNytt(behandling);
-
-        // Assert
-        assertThat(harHentetInn).isTrue();
-    }
-
-    @Test
-    void skal_innhente_registeropplysninger_mellom_midnatt_og_klokken_3_men_ikke_ellers_grunnet_konfigverdien() {
-        // Arrange
-        var midnatt = LocalDate.now().atStartOfDay();
-        var opplysningerOppdatertTidspunkt = midnatt.minusHours(1); // en time før midnatt
-
-        var scenario = ScenarioMorSøkerEngangsstønad
-            .forFødsel()
-            .medOpplysningerOppdatertTidspunkt(opplysningerOppdatertTidspunkt);
-
-        var registerdataOppdatererEngangsstønad = lagRegisterdataInnhenter(scenario, "PT3H");
-
-        // Act
-        Boolean skalInnhente = registerdataOppdatererEngangsstønad.erOpplysningerOppdatertTidspunktFør(midnatt,
-            Optional.of(opplysningerOppdatertTidspunkt));
-
-        // Assert
-        assertThat(skalInnhente).isTrue();
-    }
-
-    @Test
-    void skal_ikke_innhente_opplysninger_på_nytt_selvom_det_ble_hentet_inn_i_går_fordi_konfigverdien_er_mer_enn_midnatt() {
-        // Arrange
-        var scenario = ScenarioMorSøkerEngangsstønad
-            .forFødsel()
-            .medOpplysningerOppdatertTidspunkt(LocalDateTime.now().minusHours(20));
-        var behandling = scenario.lagMocked();
-
-        var registerdataEndringshåndterer = lagRegisterdataInnhenter(scenario, "PT30H");
-
-        // Act
+        var registerdataEndringshåndterer = lagRegisterdataInnhenter(scenario);
         Boolean harHentetInn = registerdataEndringshåndterer.skalInnhenteRegisteropplysningerPåNytt(behandling);
 
         // Assert
@@ -145,15 +87,14 @@ class RegisterdataInnhenterTest {
         assertThat(deser.innleggelsesPerioder().get(0).fom()).isEqualTo(LocalDate.of(2021,5,3));
     }
 
-    private RegisterdataEndringshåndterer lagRegisterdataInnhenter(AbstractTestScenario<?> scenario, String durationInstance) {
+    private RegisterdataEndringshåndterer lagRegisterdataInnhenter(AbstractTestScenario<?> scenario) {
         var repositoryProvider = scenario.mockBehandlingRepositoryProvider();
-        return lagRegisterdataOppdaterer(repositoryProvider, durationInstance);
+        return lagRegisterdataOppdaterer(repositoryProvider);
     }
 
-    private RegisterdataEndringshåndterer lagRegisterdataOppdaterer(BehandlingRepositoryProvider repositoryProvider,
-                                                                    String durationInstance) {
+    private RegisterdataEndringshåndterer lagRegisterdataOppdaterer(BehandlingRepositoryProvider repositoryProvider) {
         var endringskontroller = mock(Endringskontroller.class);
         when(endringskontroller.erRegisterinnhentingPassert(any())).thenReturn(Boolean.TRUE);
-        return new RegisterdataEndringshåndterer(repositoryProvider, durationInstance, endringskontroller, null, null, null);
+        return new RegisterdataEndringshåndterer(repositoryProvider, endringskontroller, null, null, null);
     }
 }

--- a/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/aksjonspunkt/BehandlingsutredningTjeneste.java
+++ b/web/src/main/java/no/nav/foreldrepenger/web/app/tjenester/behandling/aksjonspunkt/BehandlingsutredningTjeneste.java
@@ -19,7 +19,6 @@ import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRe
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepositoryProvider;
 import no.nav.foreldrepenger.behandlingsprosess.prosessering.BehandlingProsesseringTjeneste;
 import no.nav.foreldrepenger.domene.typer.Saksnummer;
-import no.nav.foreldrepenger.konfig.KonfigVerdi;
 import no.nav.foreldrepenger.produksjonsstyring.behandlingenhet.BehandlendeEnhetTjeneste;
 import no.nav.vedtak.exception.FunksjonellException;
 import no.nav.vedtak.sikkerhet.kontekst.KontekstHolder;
@@ -27,7 +26,7 @@ import no.nav.vedtak.sikkerhet.kontekst.KontekstHolder;
 @ApplicationScoped
 public class BehandlingsutredningTjeneste {
 
-    private Period defaultVenteFrist;
+    private static final Period VENTEFRIST = Period.ofWeeks(4);
     private BehandlingRepository behandlingRepository;
     private BehandlingProsesseringTjeneste behandlingProsesseringTjeneste;
     private BehandlendeEnhetTjeneste behandlendeEnhetTjeneste;
@@ -37,11 +36,9 @@ public class BehandlingsutredningTjeneste {
     }
 
     @Inject
-    public BehandlingsutredningTjeneste(@KonfigVerdi(value = "behandling.default.ventefrist.periode", defaultVerdi = "P4W") Period defaultVenteFrist,
-                                        BehandlingRepositoryProvider behandlingRepositoryProvider,
+    public BehandlingsutredningTjeneste(BehandlingRepositoryProvider behandlingRepositoryProvider,
                                         BehandlendeEnhetTjeneste behandlendeEnhetTjeneste,
                                         BehandlingProsesseringTjeneste behandlingProsesseringTjeneste) {
-        this.defaultVenteFrist = defaultVenteFrist;
         Objects.requireNonNull(behandlingRepositoryProvider, "behandlingRepositoryProvider");
         this.behandlingRepository = behandlingRepositoryProvider.getBehandlingRepository();
         this.behandlingProsesseringTjeneste = behandlingProsesseringTjeneste;
@@ -93,7 +90,7 @@ public class BehandlingsutredningTjeneste {
     private LocalDateTime bestemFristForBehandlingVent(LocalDate frist) {
         return frist != null
             ? LocalDateTime.of(frist, LocalDateTime.now().toLocalTime())
-            : LocalDateTime.now().plus(defaultVenteFrist);
+            : LocalDateTime.now().plus(VENTEFRIST);
     }
 
     public void byttBehandlendeEnhet(Long behandlingId, OrganisasjonsEnhet enhet, String begrunnelse, HistorikkAktør aktør) {

--- a/web/src/main/resources/application.properties
+++ b/web/src/main/resources/application.properties
@@ -35,25 +35,3 @@ fpsak.it.sv.sak.url=http://fp-infotrygd-svangerskapspenger/sak
 
 fpsak.it.fp.restanse.url=http://fp-infotrygd-foreldrepenger/restanse
 fpsak.it.sv.restanse.url=http://fp-infotrygd-svangerskapspenger/restanse
-
-# Default ventefrist for behandling
-behandling.default.ventefrist.periode = P4W
-
-# Dato for nye beregningsregler
-dato.for.nye.beregningsregler = 2019-01-01
-
-# Offset - for testing
-funksjonelt.tidsoffset.offset = P0D
-
-# Innsendingsfrist for inntekter for foregående måned
-inntekt.rapportering.frist.dato = 5
-
-# Dato for tidligst mulig request til inntekt
-inntektskomponent.tidligste.dato = 2015-07-01
-
-# Periode etter termindato hvor det skal etterkontrolleres barn er født
-etterkontroll.ettertermin.periode = P4W
-# Periode før søknadsdato hvor det skal etterkontrolleres barn er født
-etterkontroll.førsøknad.periode = P1W
-#  Periode før termin hvor dødfødsel kan være registrert i PDL
-etterkontroll.pdlregistrering.periode = P11W

--- a/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/aksjonspunkt/BehandlingsutredningTjenesteTest.java
+++ b/web/src/test/java/no/nav/foreldrepenger/web/app/tjenester/behandling/aksjonspunkt/BehandlingsutredningTjenesteTest.java
@@ -7,7 +7,6 @@ import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.verify;
 
 import java.time.LocalDate;
-import java.time.Period;
 
 import jakarta.inject.Inject;
 
@@ -59,7 +58,6 @@ class BehandlingsutredningTjenesteTest {
                 .thenReturn(new OrganisasjonsEnhet("1234", "Testlokasjon"));
 
         behandlingsutredningTjeneste = new BehandlingsutredningTjeneste(
-                Period.parse("P4W"),
                 repositoryProvider,
                 behandlendeEnhetTjeneste,
                 behandlingProsesseringTjeneste);


### PR DESCRIPTION
Disse parametrene varierer ikke med miljø - tar dem derfor inn i kode. Feriepengedager i egen commit.

Så kan vi tenke på om de hører hjemme i domenetjenester, i klasser i domenetjenester, eller i behandlingslager (under domene/params/OperasjonelleParametre)?
Tingen er at en del perioder/ints trengs i skjæringstidspunkt, selv om de er naturlige domeneting.

Jeg tenkte å ta en review av det som ligger i koden og se på felles-konstantklasse/domene-konstantklasse/klasselokalt