### PR TITLE
Chore: kaster ikke exception ved bestilling av html brev, og det ikke…

### DIFF
--- a/domenetjenester/dokumentbestiller/src/main/java/no/nav/foreldrepenger/dokumentbestiller/formidling/BestillDokumentTask.java
+++ b/domenetjenester/dokumentbestiller/src/main/java/no/nav/foreldrepenger/dokumentbestiller/formidling/BestillDokumentTask.java
@@ -78,7 +78,7 @@ public class BestillDokumentTask implements ProsessTaskHandler {
                 return mellomlagringRepository.hentMellomlagring(bestiltEntitet.getBehandlingDokument().getBehandlingId(),
                         mellomlagringType)
                     .map(MellomlagringEntitet::getInnhold)
-                    .orElseThrow(() -> new IllegalStateException("Fant ikke mellomlagring for FRITEKST_HTML bestilling"));
+                    .orElse(null); //TODO palfi, kast heller exception når alle med gammel overstyring (BEHANDLING_DOKUMENT) er bestilt
             }
         }
         return prosessTaskData.getPayloadAsString();


### PR DESCRIPTION
… finnes noe i mellomlagring. Ligger fortsatt noen behandlinger med mellomlagret vedtak i BEHANDLING_DOKUMENT

Kan sette null her, ettersom fp-formidling bruker fritekst fra callback