### PR TITLE
Chore: feriepengedager mer eksplisitt i koden.

### DIFF
--- a/domenetjenester/beregning-ytelse/src/main/java/no/nav/foreldrepenger/ytelse/beregning/Feriepengedager.java
+++ b/domenetjenester/beregning-ytelse/src/main/java/no/nav/foreldrepenger/ytelse/beregning/Feriepengedager.java
@@ -1,0 +1,22 @@
+package no.nav.foreldrepenger.ytelse.beregning;
+
+import java.util.Map;
+import java.util.Optional;
+
+import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakYtelseType;
+
+public class Feriepengedager {
+
+    // La stå.
+    private static final Map<FagsakYtelseType, Integer> YTELSE_DAGER = Map.of(
+        FagsakYtelseType.FORELDREPENGER, 60,
+        FagsakYtelseType.SVANGERSKAPSPENGER, 64
+    );
+
+    private Feriepengedager() {
+    }
+
+    public static int forYtelse(FagsakYtelseType ytelseType) {
+        return Optional.ofNullable(YTELSE_DAGER.get(ytelseType)).orElseThrow();
+    }
+}

--- a/domenetjenester/beregning-ytelse/src/main/java/no/nav/foreldrepenger/ytelse/beregning/fp/BeregnFeriepenger.java
+++ b/domenetjenester/beregning-ytelse/src/main/java/no/nav/foreldrepenger/ytelse/beregning/fp/BeregnFeriepenger.java
@@ -10,8 +10,8 @@ import no.nav.foreldrepenger.behandlingskontroll.FagsakYtelseTypeRef;
 import no.nav.foreldrepenger.behandlingslager.behandling.beregning.BeregningsresultatEntitet;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepositoryProvider;
 import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakYtelseType;
-import no.nav.foreldrepenger.konfig.KonfigVerdi;
 import no.nav.foreldrepenger.ytelse.beregning.BeregnFeriepengerTjeneste;
+import no.nav.foreldrepenger.ytelse.beregning.Feriepengedager;
 import no.nav.foreldrepenger.ytelse.beregning.adapter.MapInputFraVLTilRegelGrunnlag;
 
 @FagsakYtelseTypeRef(FagsakYtelseType.FORELDREPENGER)
@@ -22,16 +22,13 @@ public class BeregnFeriepenger extends BeregnFeriepengerTjeneste {
         //CDI
     }
 
-    /**
-     * @param antallDagerFeriepenger - Antall dager i feriepengerperioden for foreldrepenger ved 100% dekningsgrad
-     */
     @Inject
     public BeregnFeriepenger(BehandlingRepositoryProvider repositoryProvider,
                              MapInputFraVLTilRegelGrunnlag inputTjeneste,
                              FagsakRelasjonTjeneste fagsakRelasjonTjeneste,
-                             DekningsgradTjeneste dekningsgradTjeneste,
-                             @KonfigVerdi(value = "fp.antall.dager.feriepenger", defaultVerdi = "60") int antallDagerFeriepenger) {
-        super(repositoryProvider, inputTjeneste, fagsakRelasjonTjeneste, dekningsgradTjeneste, antallDagerFeriepenger);
+                             DekningsgradTjeneste dekningsgradTjeneste) {
+        super(repositoryProvider, inputTjeneste, fagsakRelasjonTjeneste, dekningsgradTjeneste,
+            Feriepengedager.forYtelse(FagsakYtelseType.FORELDREPENGER));
     }
 
     @Override

--- a/domenetjenester/beregning-ytelse/src/main/java/no/nav/foreldrepenger/ytelse/beregning/svp/BeregnFeriepenger.java
+++ b/domenetjenester/beregning-ytelse/src/main/java/no/nav/foreldrepenger/ytelse/beregning/svp/BeregnFeriepenger.java
@@ -10,8 +10,8 @@ import no.nav.foreldrepenger.behandlingskontroll.FagsakYtelseTypeRef;
 import no.nav.foreldrepenger.behandlingslager.behandling.beregning.BeregningsresultatEntitet;
 import no.nav.foreldrepenger.behandlingslager.behandling.repository.BehandlingRepositoryProvider;
 import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakYtelseType;
-import no.nav.foreldrepenger.konfig.KonfigVerdi;
 import no.nav.foreldrepenger.ytelse.beregning.BeregnFeriepengerTjeneste;
+import no.nav.foreldrepenger.ytelse.beregning.Feriepengedager;
 import no.nav.foreldrepenger.ytelse.beregning.adapter.MapInputFraVLTilRegelGrunnlag;
 
 @FagsakYtelseTypeRef(FagsakYtelseType.SVANGERSKAPSPENGER)
@@ -23,18 +23,14 @@ public class BeregnFeriepenger extends BeregnFeriepengerTjeneste {
         // CDI
     }
 
-    /**
-     *
-     * @param antallDagerFeriepenger - Antall dager i feriepengerperioden for svangerskapspenger
-     */
     @Inject
     public BeregnFeriepenger(BehandlingRepositoryProvider repositoryProvider,
                              MapInputFraVLTilRegelGrunnlag inputTjeneste,
                              FagsakRelasjonTjeneste fagsakRelasjonTjeneste,
                              DekningsgradTjeneste dekningsgradTjeneste,
-                             @KonfigVerdi(value = "svp.antall.dager.feriepenger", defaultVerdi = "64") int antallDagerFeriepenger,
                              SvangerskapspengerFeriekvoteTjeneste svangerskapspengerFeriekvoteTjeneste) {
-        super(repositoryProvider, inputTjeneste, fagsakRelasjonTjeneste, dekningsgradTjeneste, antallDagerFeriepenger);
+        super(repositoryProvider, inputTjeneste, fagsakRelasjonTjeneste, dekningsgradTjeneste,
+            Feriepengedager.forYtelse(FagsakYtelseType.SVANGERSKAPSPENGER));
         this.svangerskapspengerFeriekvoteTjeneste = svangerskapspengerFeriekvoteTjeneste;
     }
 

--- a/domenetjenester/beregning-ytelse/src/main/java/no/nav/foreldrepenger/ytelse/beregning/svp/SvangerskapFeriepengeKvoteBeregner.java
+++ b/domenetjenester/beregning-ytelse/src/main/java/no/nav/foreldrepenger/ytelse/beregning/svp/SvangerskapFeriepengeKvoteBeregner.java
@@ -4,49 +4,39 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 
-import jakarta.enterprise.context.ApplicationScoped;
-import jakarta.inject.Inject;
-
 import no.nav.foreldrepenger.behandlingslager.behandling.beregning.BehandlingBeregningsresultatEntitet;
 import no.nav.foreldrepenger.behandlingslager.behandling.beregning.BeregningsresultatAndel;
 import no.nav.foreldrepenger.behandlingslager.behandling.beregning.BeregningsresultatEntitet;
 import no.nav.foreldrepenger.behandlingslager.behandling.beregning.BeregningsresultatFeriepenger;
 import no.nav.foreldrepenger.behandlingslager.behandling.beregning.BeregningsresultatPeriode;
 import no.nav.foreldrepenger.behandlingslager.behandling.beregning.Inntektskategori;
-import no.nav.foreldrepenger.konfig.KonfigVerdi;
+import no.nav.foreldrepenger.behandlingslager.fagsak.FagsakYtelseType;
+import no.nav.foreldrepenger.ytelse.beregning.Feriepengedager;
 import no.nav.foreldrepenger.ytelse.beregning.Virkedager;
 import no.nav.fpsak.tidsserie.LocalDateInterval;
 import no.nav.vedtak.konfig.Tid;
 
-@ApplicationScoped
 public class SvangerskapFeriepengeKvoteBeregner {
-    private int svpFerieKvote;
+    private static final int SVP_FERIEDAGER = Feriepengedager.forYtelse(FagsakYtelseType.SVANGERSKAPSPENGER);
 
-    public SvangerskapFeriepengeKvoteBeregner() {
-        // CDI
+    private SvangerskapFeriepengeKvoteBeregner() {
     }
 
-    @Inject
-    public SvangerskapFeriepengeKvoteBeregner(@KonfigVerdi(value = "svp.antall.dager.feriepenger", defaultVerdi = "64") int antallDagerFeriepenger) {
-        this.svpFerieKvote = antallDagerFeriepenger;
-    }
-
-
-    public Optional<Integer> beregn(BeregningsresultatEntitet beregnetYtelse, List<BehandlingBeregningsresultatEntitet> annenTilkjentYtelsePåSammeSvangerskap) {
+    public static Optional<Integer> beregn(BeregningsresultatEntitet beregnetYtelse, List<BehandlingBeregningsresultatEntitet> annenTilkjentYtelsePåSammeSvangerskap) {
         var førsteDagMedFeriepengerOpt = finnFørsteDagSomGirFeriepenger(beregnetYtelse);
         if (førsteDagMedFeriepengerOpt.isEmpty()) {
             return Optional.empty();
         }
         var førsteDagMedFeriepenger = førsteDagMedFeriepengerOpt.get();
         var brukteFeriedager = annenTilkjentYtelsePåSammeSvangerskap.stream().mapToInt(ty -> finnBrukteFeriepengedager(ty, førsteDagMedFeriepenger)).sum();
-        if (brukteFeriedager > svpFerieKvote) {
+        if (brukteFeriedager > SVP_FERIEDAGER) {
             throw new IllegalStateException("Brukte feriedager overstiger kvote! Tidligere saker må revurderes først. Brukte feriedager var " + brukteFeriedager);
         }
-        return Optional.of(svpFerieKvote - brukteFeriedager);
+        return Optional.of(SVP_FERIEDAGER - brukteFeriedager);
     }
 
-    private Integer finnBrukteFeriepengedager(BehandlingBeregningsresultatEntitet tilkjentytelse, LocalDate førsteDagMedFeriepenger) {
-        var feriepengetidslinjeOpt = tilkjentytelse.getBeregningsresultatFeriepenger().flatMap(this::lagFeriepengeperiode);
+    private static Integer finnBrukteFeriepengedager(BehandlingBeregningsresultatEntitet tilkjentytelse, LocalDate førsteDagMedFeriepenger) {
+        var feriepengetidslinjeOpt = tilkjentytelse.getBeregningsresultatFeriepenger().flatMap(SvangerskapFeriepengeKvoteBeregner::lagFeriepengeperiode);
         if (feriepengetidslinjeOpt.isEmpty()) {
             return 0;
         }
@@ -63,33 +53,33 @@ public class SvangerskapFeriepengeKvoteBeregner {
         return perioderSomTrekkerFraFeriekvote.stream().mapToInt(p -> Virkedager.beregnAntallVirkedager(p.getFomDato(), p.getTomDato())).sum();
     }
 
-    private List<LocalDateInterval> lagTilkjentYtelseFerieTidslinje(List<BeregningsresultatPeriode> tilkjentytelse) {
+    private static List<LocalDateInterval> lagTilkjentYtelseFerieTidslinje(List<BeregningsresultatPeriode> tilkjentytelse) {
         return tilkjentytelse.stream()
             .filter(p -> finnesAndelMedKravPåFeriepengerOgUtbetaling(p.getBeregningsresultatAndelList()))
-            .map(this::lagIntervall)
+            .map(SvangerskapFeriepengeKvoteBeregner::lagIntervall)
             .toList();
     }
 
-    private Optional<LocalDateInterval> lagFeriepengeperiode(BeregningsresultatFeriepenger beregningsresultatFeriepenger) {
+    private static Optional<LocalDateInterval> lagFeriepengeperiode(BeregningsresultatFeriepenger beregningsresultatFeriepenger) {
         if (beregningsresultatFeriepenger.getFeriepengerPeriodeFom() == null || beregningsresultatFeriepenger.getFeriepengerPeriodeTom() == null) {
             return Optional.empty();
         }
         return Optional.of(new LocalDateInterval(beregningsresultatFeriepenger.getFeriepengerPeriodeFom(), beregningsresultatFeriepenger.getFeriepengerPeriodeTom()));
     }
 
-    private LocalDateInterval lagIntervall(BeregningsresultatPeriode p) {
+    private static LocalDateInterval lagIntervall(BeregningsresultatPeriode p) {
 
         return new LocalDateInterval(p.getBeregningsresultatPeriodeFom(), p.getBeregningsresultatPeriodeTom());
     }
 
-    private Optional<LocalDate> finnFørsteDagSomGirFeriepenger(BeregningsresultatEntitet beregnetYtelse) {
+    private static Optional<LocalDate> finnFørsteDagSomGirFeriepenger(BeregningsresultatEntitet beregnetYtelse) {
         return beregnetYtelse.getBeregningsresultatPerioder().stream()
             .filter(p -> finnesAndelMedKravPåFeriepengerOgUtbetaling(p.getBeregningsresultatAndelList()))
             .map(BeregningsresultatPeriode::getBeregningsresultatPeriodeFom)
             .min(LocalDate::compareTo);
     }
 
-    private boolean finnesAndelMedKravPåFeriepengerOgUtbetaling(List<BeregningsresultatAndel> andeler) {
+    private static boolean finnesAndelMedKravPåFeriepengerOgUtbetaling(List<BeregningsresultatAndel> andeler) {
         return andeler.stream().filter(andel -> Inntektskategori.girFeriepenger().contains(andel.getInntektskategori())).anyMatch(andel -> andel.getDagsats() > 0);
 
     }

--- a/domenetjenester/beregning-ytelse/src/main/java/no/nav/foreldrepenger/ytelse/beregning/svp/SvangerskapspengerFeriekvoteTjeneste.java
+++ b/domenetjenester/beregning-ytelse/src/main/java/no/nav/foreldrepenger/ytelse/beregning/svp/SvangerskapspengerFeriekvoteTjeneste.java
@@ -28,7 +28,6 @@ public class SvangerskapspengerFeriekvoteTjeneste {
     private BehandlingRepository behandlingRepository;
     private FamilieHendelseRepository familieHendelseRepository;
     private BeregningsresultatRepository beregningsresultatRepository;
-    private SvangerskapFeriepengeKvoteBeregner svangerskapFeriepengeKvoteBeregner;
 
     public SvangerskapspengerFeriekvoteTjeneste() {
         // CDI
@@ -38,12 +37,10 @@ public class SvangerskapspengerFeriekvoteTjeneste {
     public SvangerskapspengerFeriekvoteTjeneste(FagsakRepository fagsakRepository,
                                                 BehandlingRepository behandlingRepository,
                                                 FamilieHendelseRepository familieHendelseRepository,
-                                                SvangerskapFeriepengeKvoteBeregner svangerskapFeriepengeKvoteBeregner,
                                                 BeregningsresultatRepository beregningsresultatRepository) {
         this.fagsakRepository = fagsakRepository;
         this.behandlingRepository = behandlingRepository;
         this.familieHendelseRepository = familieHendelseRepository;
-        this.svangerskapFeriepengeKvoteBeregner = svangerskapFeriepengeKvoteBeregner;
         this.beregningsresultatRepository = beregningsresultatRepository;
     }
 
@@ -66,7 +63,7 @@ public class SvangerskapspengerFeriekvoteTjeneste {
             .map(b -> beregningsresultatRepository.hentBeregningsresultatAggregat(b.getId()))
             .flatMap(Optional::stream)
             .toList();
-        return svangerskapFeriepengeKvoteBeregner.beregn(beregnetYtelse, annenTilkjentYtelsePåSammeSvangerskap);
+        return SvangerskapFeriepengeKvoteBeregner.beregn(beregnetYtelse, annenTilkjentYtelsePåSammeSvangerskap);
     }
 
     private List<Behandling> finnBehandlingerSomGjelderSammeSvangerskap(List<Behandling> gjeldendeVedtakForSVP,
@@ -74,7 +71,7 @@ public class SvangerskapspengerFeriekvoteTjeneste {
         List<Behandling> behandlingerSomGjelderSammeSvangerskap = new ArrayList<>();
         gjeldendeVedtakForSVP.forEach(behandling -> {
             var termindatoOpt = finnTermindato(behandling.getId());
-            var gjelderSammeSvangerskap = termindatoOpt.map(td -> erInnenForTerskel(td, termindato)).orElse(false);
+            var gjelderSammeSvangerskap = termindatoOpt.filter(td -> erInnenForTerskel(td, termindato)).isPresent();
             if (gjelderSammeSvangerskap) {
                 behandlingerSomGjelderSammeSvangerskap.add(behandling);
             }

--- a/domenetjenester/beregning-ytelse/src/test/java/no/nav/foreldrepenger/ytelse/beregning/BeregnFeriepengerTjenesteTest.java
+++ b/domenetjenester/beregning-ytelse/src/test/java/no/nav/foreldrepenger/ytelse/beregning/BeregnFeriepengerTjenesteTest.java
@@ -65,7 +65,7 @@ class BeregnFeriepengerTjenesteTest {
         Mockito.when(inputTjeneste.arbeidstakerVedSkjæringstidspunkt(any())).thenReturn(true);
         fagsakRelasjonTjeneste = new FagsakRelasjonTjeneste(repositoryProvider);
         var dekningsgradTjeneste = new DekningsgradTjeneste(repositoryProvider.getYtelsesFordelingRepository());
-        tjeneste = new BeregnFeriepenger(repositoryProvider, inputTjeneste, fagsakRelasjonTjeneste, dekningsgradTjeneste, 60);
+        tjeneste = new BeregnFeriepenger(repositoryProvider, inputTjeneste, fagsakRelasjonTjeneste, dekningsgradTjeneste);
     }
 
     @Test

--- a/domenetjenester/beregning-ytelse/src/test/java/no/nav/foreldrepenger/ytelse/beregning/svp/SvangerskapFeriepengeKvoteBeregnerTest.java
+++ b/domenetjenester/beregning-ytelse/src/test/java/no/nav/foreldrepenger/ytelse/beregning/svp/SvangerskapFeriepengeKvoteBeregnerTest.java
@@ -22,7 +22,6 @@ import no.nav.foreldrepenger.behandlingslager.behandling.beregning.Inntektskateg
 
 class SvangerskapFeriepengeKvoteBeregnerTest {
     private static final LocalDate FØRSTE_UTTAK = LocalDate.of(2022,7,1);
-    private final SvangerskapFeriepengeKvoteBeregner beregner = new SvangerskapFeriepengeKvoteBeregner(64);
 
     @Test
     void skal_beregne_maks_kvote_når_ingen_dager_brukt() {
@@ -31,7 +30,7 @@ class SvangerskapFeriepengeKvoteBeregnerTest {
         lagTYPeriode(dagerEtter(0), dagerEtter(64), bgr, true);
 
         // Act
-        var resultat = beregner.beregn(bgr, Collections.emptyList());
+        var resultat = SvangerskapFeriepengeKvoteBeregner.beregn(bgr, Collections.emptyList());
 
         // Assert
         assertThat(resultat)
@@ -49,7 +48,7 @@ class SvangerskapFeriepengeKvoteBeregnerTest {
         lagTYPeriode(dagerFør(50), dagerFør(30), tidligereYtelse, false);
 
         // Act
-        var resultat = beregner.beregn(nyYtelse, List.of(lagBrR(tidligereYtelse)));
+        var resultat = SvangerskapFeriepengeKvoteBeregner.beregn(nyYtelse, List.of(lagBrR(tidligereYtelse)));
 
         // Assert
         assertThat(resultat)
@@ -68,7 +67,7 @@ class SvangerskapFeriepengeKvoteBeregnerTest {
         var ferie = lagFPPeriode(dagerEtter(50), dagerEtter(60));
 
         // Act
-        var resultat = beregner.beregn(nyYtelse, List.of(lagBrR(tidligereYtelse, ferie)));
+        var resultat = SvangerskapFeriepengeKvoteBeregner.beregn(nyYtelse, List.of(lagBrR(tidligereYtelse, ferie)));
 
         // Assert
         assertThat(resultat)
@@ -87,7 +86,7 @@ class SvangerskapFeriepengeKvoteBeregnerTest {
         var ferie = lagFPPeriode(dagerFør(50), dagerFør(40));
 
         // Act
-        var resultat = beregner.beregn(nyYtelse, List.of(lagBrR(tidligereYtelse, ferie)));
+        var resultat = SvangerskapFeriepengeKvoteBeregner.beregn(nyYtelse, List.of(lagBrR(tidligereYtelse, ferie)));
 
         // Assert
         assertThat(resultat)
@@ -109,7 +108,7 @@ class SvangerskapFeriepengeKvoteBeregnerTest {
         var ferie2 = lagFPPeriode(dagerFør(30), dagerFør(20));
 
         // Act
-        var resultat = beregner.beregn(nyYtelse, List.of(lagBrR(tidligereYtelse1, ferie1), lagBrR(tidligereYtelse2, ferie2)));
+        var resultat = SvangerskapFeriepengeKvoteBeregner.beregn(nyYtelse, List.of(lagBrR(tidligereYtelse1, ferie1), lagBrR(tidligereYtelse2, ferie2)));
 
         // Assert
         assertThat(resultat)
@@ -134,7 +133,7 @@ class SvangerskapFeriepengeKvoteBeregnerTest {
         var ferie3 = lagFPPeriode(dagerFør(15), dagerFør(10));
 
         // Act
-        var resultat = beregner.beregn(nyYtelse, List.of(lagBrR(tidligereYtelse1, ferie1), lagBrR(tidligereYtelse2, ferie2), lagBrR(tidligereYtelse3, ferie3)));
+        var resultat = SvangerskapFeriepengeKvoteBeregner.beregn(nyYtelse, List.of(lagBrR(tidligereYtelse1, ferie1), lagBrR(tidligereYtelse2, ferie2), lagBrR(tidligereYtelse3, ferie3)));
 
         // Assert
         assertThat(resultat)
@@ -153,7 +152,7 @@ class SvangerskapFeriepengeKvoteBeregnerTest {
         var ferie1 = lagFPPeriode(dagerFør(150), dagerFør(100));
 
         // Act
-        var resultat = beregner.beregn(nyYtelse, List.of(lagBrR(tidligereYtelse1, ferie1)));
+        var resultat = SvangerskapFeriepengeKvoteBeregner.beregn(nyYtelse, List.of(lagBrR(tidligereYtelse1, ferie1)));
 
         // Assert
         assertThat(resultat).isEmpty();
@@ -176,7 +175,7 @@ class SvangerskapFeriepengeKvoteBeregnerTest {
         var ferie3 = lagFPPeriode(dagerFør(15), dagerFør(10));
 
         // Act
-        var resultat = beregner.beregn(nyYtelse, List.of(lagBrR(tidligereYtelse1, ferie1), lagBrR(tidligereYtelse2, ferie2), lagBrR(tidligereYtelse3, ferie3)));
+        var resultat = SvangerskapFeriepengeKvoteBeregner.beregn(nyYtelse, List.of(lagBrR(tidligereYtelse1, ferie1), lagBrR(tidligereYtelse2, ferie2), lagBrR(tidligereYtelse3, ferie3)));
 
         // Assert
         assertThat(resultat)
@@ -196,7 +195,7 @@ class SvangerskapFeriepengeKvoteBeregnerTest {
         var ferie = lagFPPeriode(dagerFør(50), dagerFør(20)); // Ferieperiode dekker opphold i ytelsen
 
         // Act
-        var resultat = beregner.beregn(nyYtelse, List.of(lagBrR(tidligereYtelse, ferie)));
+        var resultat = SvangerskapFeriepengeKvoteBeregner.beregn(nyYtelse, List.of(lagBrR(tidligereYtelse, ferie)));
 
         // Assert
         assertThat(resultat)
@@ -224,7 +223,7 @@ class SvangerskapFeriepengeKvoteBeregnerTest {
 
         // Act
         Exception exception = assertThrows(IllegalStateException.class,
-            () -> beregner.beregn(nyYtelse, List.of(lagBrR(tidligereYtelse1, ferie1), lagBrR(tidligereYtelse2, ferie2))));
+            () -> SvangerskapFeriepengeKvoteBeregner.beregn(nyYtelse, List.of(lagBrR(tidligereYtelse1, ferie1), lagBrR(tidligereYtelse2, ferie2))));
 
         var forventetFeilmelding = "Brukte feriedager overstiger kvote! Tidligere saker må revurderes først. Brukte feriedager var 68";
 


### PR DESCRIPTION
Gjør antall feriepengedager mer statisk. Nå brukes defaultVerdiene i koden (variablene er ikke satt)
ikke behov for miljøavhengig konfig i overskuelig framtid. Ved endring må det lages en ikraftredelsemekanisme