### PR TITLE
fix: revert fp-tidsserie til 2.7.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
 
     <properties>
         <!-- regel-repositories -->
-        <fp-tidsserie.version>2.7.5</fp-tidsserie.version>
+        <fp-tidsserie.version>2.7.4</fp-tidsserie.version>
         <fp-nare.version>2.6.4</fp-nare.version>
         <fp-inngangsvilkar.version>1.1.4</fp-inngangsvilkar.version>
         <beregning.version>7.1.4</beregning.version>


### PR DESCRIPTION
fp-tidsserie 2.7.5 introduserte en bug i LocalDateTimeline.combine()/ intersection() (KnekkpunktIterator) der kombinering av to tidslinjer som begge har et segment åpent til LocalDate.MAX gir feil eller tomt resultat for JoinStyle INNER_JOIN, RIGHT_JOIN, CROSS_JOIN og LEFT_JOIN.

Reverter til siste kjente gode versjon inntil fikset er verifisert oppstrøms.