### PR TITLE
TFP-7093 mer robust deteksjon av første realendring.

### DIFF
--- a/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/dokumentpersiterer/SøknadDataFraTidligereVedtakTjeneste.java
+++ b/domenetjenester/mottak/src/main/java/no/nav/foreldrepenger/mottak/dokumentpersiterer/SøknadDataFraTidligereVedtakTjeneste.java
@@ -51,7 +51,7 @@ public class SøknadDataFraTidligereVedtakTjeneste {
             forrigeUttak.getGjeldendePerioder().getPerioder().stream()
                 .anyMatch(p -> p.getAktiviteter().stream().map(UttakResultatPeriodeAktivitetEntitet::getTrekkonto).anyMatch(UttakPeriodeType.FORELDREPENGER::equals));
         // Skal ikke legge inn fri utsettelse for å markere start på endring i søknaden for førstegangsbehandlinger eller BFHR
-        var beholdSenestePeriode = !behandling.erRevurdering() || foreldrepenger && !RelasjonsRolleType.MORA.equals(behandling.getRelasjonsRolleType());
+        var beholdSenestePeriode = !behandling.erRevurdering() || (foreldrepenger && !RelasjonsRolleType.MORA.equals(behandling.getRelasjonsRolleType()));
         return VedtaksperiodeFilter.filtrerVekkPerioderSomErLikeInnvilgetUttak(behandling.getId(), nysøknad, forrigeUttak, beholdSenestePeriode);
     }
 

--- a/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/uttaksgrunnlag/fp/VedtaksperiodeFilter.java
+++ b/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/uttaksgrunnlag/fp/VedtaksperiodeFilter.java
@@ -5,6 +5,9 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -14,6 +17,7 @@ import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.periode
 import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.periode.OppgittPeriodeBuilder;
 import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.periode.OppgittPeriodeEntitet;
 import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.periode.UttakPeriodeType;
+import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.årsak.OppholdÅrsak;
 import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.årsak.UtsettelseÅrsak;
 import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.årsak.Årsak;
 import no.nav.foreldrepenger.behandlingslager.uttak.fp.SamtidigUttaksprosent;
@@ -27,10 +31,13 @@ import no.nav.foreldrepenger.skjæringstidspunkt.overganger.UtsettelseCore2021;
 import no.nav.fpsak.tidsserie.LocalDateInterval;
 import no.nav.fpsak.tidsserie.LocalDateSegment;
 import no.nav.fpsak.tidsserie.LocalDateTimeline;
+import no.nav.fpsak.tidsserie.StandardCombinators;
 
 public final class VedtaksperiodeFilter {
 
     private static final Logger LOG = LoggerFactory.getLogger(VedtaksperiodeFilter.class);
+
+    private static final Set<UtsettelseÅrsak> UTS_14_11 = Set.of(UtsettelseÅrsak.SYKDOM, UtsettelseÅrsak.INSTITUSJON_BARN, UtsettelseÅrsak.INSTITUSJON_SØKER);
 
     private VedtaksperiodeFilter() {
     }
@@ -107,32 +114,56 @@ public final class VedtaksperiodeFilter {
     }
 
     private static LocalDate finnTidligsteUlikhetSøknadUttak(List<OppgittPeriodeEntitet> nysøknad, UttakResultatEntitet uttakResultatFraForrigeBehandling) {
-        // Tidslinje og tidligste/seneste dato fra ny søknad
-        var tidligsteFom = nysøknad.stream().map(OppgittPeriodeEntitet::getFom).min(Comparator.naturalOrder()).orElseThrow();
-        var segmenterSøknad = nysøknad.stream().map(VedtaksperiodeFilter::segmentForOppgittPeriode).toList();
-        var tidslinjeSammenlignSøknad =  new LocalDateTimeline<>(segmenterSøknad);
+        // Tidslinje fra ny søknad
+        var tidslinjeSøknad =  nysøknad.stream().map(VedtaksperiodeFilter::segmentForOppgittPeriode)
+            .collect(Collectors.collectingAndThen(Collectors.toList(), LocalDateTimeline::new));
+        var søknadPaddingPeriode = segmentForOppgittPeriode(lagFriUtsettelse(tidslinjeSøknad.getMinLocalDate(), tidslinjeSøknad.getMaxLocalDate()));
+        var paddingSøknad = new LocalDateTimeline<>(List.of(søknadPaddingPeriode));
+        var tidslinjeSøknadPadded = tidslinjeSøknad.combine(paddingSøknad, StandardCombinators::coalesceLeftHandSide, LocalDateTimeline.JoinStyle.CROSS_JOIN);
 
-        // Tidslinje for innvilgete peridoder fra forrige uttaksresultat - kun fom tidligstedato
-        var gjeldendeVedtaksperioder = opprettOppgittePerioderKunInnvilget(uttakResultatFraForrigeBehandling, tidligsteFom);
-        var segmenterVedtak = gjeldendeVedtaksperioder.stream().map(VedtaksperiodeFilter::segmentForOppgittPeriode).toList();
-        // Ser kun på perioder fom tidligsteFom fra søknad.
-        var tidslinjeSammenlignVedtak =  new LocalDateTimeline<>(segmenterVedtak).intersection(new LocalDateInterval(tidligsteFom, LocalDateInterval.TIDENES_ENDE));
+        // Tidslinje for innvilgete peridoder fra forrige uttaksresultat
+        var tidslinjeVedtak = opprettOppgittePerioderKunInnvilget(uttakResultatFraForrigeBehandling).stream().map(VedtaksperiodeFilter::segmentForOppgittPeriode)
+            .collect(Collectors.collectingAndThen(Collectors.toList(), LocalDateTimeline::new))
+            .intersection(søknadPaddingPeriode.getLocalDateInterval());
 
         // Finner segmenter der de to tidslinjene (søknad vs vedtakFomTidligsteDatoSøknad) er ulike
-        var ulike = tidslinjeSammenlignSøknad.combine(tidslinjeSammenlignVedtak, (i, l, r) -> new LocalDateSegment<>(i, !Objects.equals(l ,r)), LocalDateTimeline.JoinStyle.CROSS_JOIN)
-            .filterValue(v -> v);
+        var ulike = tidslinjeSøknadPadded.combine(tidslinjeVedtak, VedtaksperiodeFilter::ekvivalentSøknadVedtak, LocalDateTimeline.JoinStyle.CROSS_JOIN)
+            .filterValue(v -> !v);
 
         // Første segment med ulikhet
-        return ulike.getLocalDateIntervals().stream().map(LocalDateInterval::getFomDato).min(Comparator.naturalOrder()).orElse(null);
+        return ulike.getLocalDateIntervals().stream().map(LocalDateInterval::getFomDato).min(Comparator.naturalOrder()).orElse(null); // TODO vurder helgejustering til mandag
     }
 
-    private static List<OppgittPeriodeEntitet> opprettOppgittePerioderKunInnvilget(UttakResultatEntitet uttakResultatFraForrigeBehandling, LocalDate perioderFom) {
+    private static LocalDateSegment<Boolean> ekvivalentSøknadVedtak(LocalDateInterval i,
+                                                             LocalDateSegment<SammenligningPeriodeForOppgitt> søknad,
+                                                             LocalDateSegment<SammenligningPeriodeForOppgitt> vedtak) {
+        var søknadVerdi = Optional.ofNullable(søknad).map(LocalDateSegment::getValue).orElse(null);
+        var vedtakVerdi = Optional.ofNullable(vedtak).map(LocalDateSegment::getValue).orElse(null);
+        if (UtsettelseCore2021.kreverSammenhengendeUttak(i.getFomDato()) || !kanIgnorerePeriode(søknadVerdi) || !kanIgnorerePeriode(vedtakVerdi)) {
+            return new LocalDateSegment<>(i, Objects.equals(søknadVerdi, vedtakVerdi));
+        } else {
+            return new LocalDateSegment<>(i, true);
+        }
+    }
+
+    private static boolean kanIgnorerePeriode(SammenligningPeriodeForOppgitt periode) {
+        if (periode == null || periode.årsak() instanceof OppholdÅrsak) {
+            return true;
+        } else if (periode.årsak() instanceof UtsettelseÅrsak utsettelse) {
+            // TODO: gjennomgå logikk. Nå er det fokus på BFHR (morsaktivitet) og 3 årsaker (uansett første 6u eller senere)
+            // Selvbetjening bør tillate sykdom/institusjon kun for mor/6u og BFHR - ellers bare arbeid/ferie/fri
+            return !UTS_14_11.contains(utsettelse) && !MorsAktivitet.forventerDokumentasjon(periode.morsAktivitet());
+        } else {
+            return false;
+        }
+    }
+
+    private static List<OppgittPeriodeEntitet> opprettOppgittePerioderKunInnvilget(UttakResultatEntitet uttakResultatFraForrigeBehandling) {
         return uttakResultatFraForrigeBehandling.getGjeldendePerioder()
             .getPerioder()
             .stream()
-            .filter(UttakResultatPeriodeEntitet::isInnvilget)
-            .filter(p -> !p.getTom().isBefore(perioderFom))
-            .filter(p -> p.getPeriodeSøknad().isPresent()) // Tja - ta med evt utsettelse pleiepenger?
+            .filter(UttakResultatPeriodeEntitet::isInnvilget) // TODO vurder om avslått (utsettelse) bør med - hjelper på sykdom etter 6u.
+            .filter(p -> p.getPeriodeSøknad().isPresent()) // TODO vurder om disse bør med. Når mangler det periodeSøknad?
             .filter(p -> !p.getTidsperiode().erHelg())
             .map(VedtaksperioderHelper::konverter)
             .toList();

--- a/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/uttaksgrunnlag/fp/VedtaksperiodeFilter.java
+++ b/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/uttaksgrunnlag/fp/VedtaksperiodeFilter.java
@@ -31,7 +31,6 @@ import no.nav.foreldrepenger.skjæringstidspunkt.overganger.UtsettelseCore2021;
 import no.nav.fpsak.tidsserie.LocalDateInterval;
 import no.nav.fpsak.tidsserie.LocalDateSegment;
 import no.nav.fpsak.tidsserie.LocalDateTimeline;
-import no.nav.fpsak.tidsserie.StandardCombinators;
 
 public final class VedtaksperiodeFilter {
 
@@ -117,21 +116,20 @@ public final class VedtaksperiodeFilter {
         // Tidslinje fra ny søknad
         var tidslinjeSøknad =  nysøknad.stream().map(VedtaksperiodeFilter::segmentForOppgittPeriode)
             .collect(Collectors.collectingAndThen(Collectors.toList(), LocalDateTimeline::new));
-        var søknadPaddingPeriode = segmentForOppgittPeriode(lagFriUtsettelse(tidslinjeSøknad.getMinLocalDate(), tidslinjeSøknad.getMaxLocalDate()));
-        var paddingSøknad = new LocalDateTimeline<>(List.of(søknadPaddingPeriode));
-        var tidslinjeSøknadPadded = tidslinjeSøknad.combine(paddingSøknad, StandardCombinators::coalesceLeftHandSide, LocalDateTimeline.JoinStyle.CROSS_JOIN);
+        var søknadIntervall = new LocalDateInterval(tidslinjeSøknad.getMinLocalDate(), tidslinjeSøknad.getMaxLocalDate());
 
-        // Tidslinje for innvilgete peridoder fra forrige uttaksresultat
-        var tidslinjeVedtak = opprettOppgittePerioderKunInnvilget(uttakResultatFraForrigeBehandling).stream().map(VedtaksperiodeFilter::segmentForOppgittPeriode)
+        // Tidslinje for innvilgete peridoder fra forrige uttaksresultat - begrenset til søknadsintervallet.
+        var tidslinjeVedtak = opprettOppgittePerioderKunInnvilget(uttakResultatFraForrigeBehandling).stream()
+            .map(VedtaksperiodeFilter::segmentForOppgittPeriode)
             .collect(Collectors.collectingAndThen(Collectors.toList(), LocalDateTimeline::new))
-            .intersection(søknadPaddingPeriode.getLocalDateInterval());
+            .intersection(søknadIntervall);
 
         // Finner segmenter der de to tidslinjene (søknad vs vedtakFomTidligsteDatoSøknad) er ulike
-        var ulike = tidslinjeSøknadPadded.combine(tidslinjeVedtak, VedtaksperiodeFilter::ekvivalentSøknadVedtak, LocalDateTimeline.JoinStyle.CROSS_JOIN)
+        var ulike = tidslinjeSøknad.combine(tidslinjeVedtak, VedtaksperiodeFilter::ekvivalentSøknadVedtak, LocalDateTimeline.JoinStyle.CROSS_JOIN)
             .filterValue(v -> !v);
 
         // Første segment med ulikhet
-        return ulike.getLocalDateIntervals().stream().map(LocalDateInterval::getFomDato).min(Comparator.naturalOrder()).orElse(null); // TODO vurder helgejustering til mandag
+        return ulike.getLocalDateIntervals().stream().map(LocalDateInterval::getFomDato).min(Comparator.naturalOrder()).orElse(null);
     }
 
     private static LocalDateSegment<Boolean> ekvivalentSøknadVedtak(LocalDateInterval i,
@@ -162,7 +160,6 @@ public final class VedtaksperiodeFilter {
             .getPerioder()
             .stream()
             .filter(UttakResultatPeriodeEntitet::isInnvilget) // evt avslått utsettelse med dok må vurderes på nytt
-            .filter(p -> p.getPeriodeSøknad().isPresent()) // Tar ikke med manglende søkt - disse skal behandles
             .filter(p -> !p.getTidsperiode().erHelg())
             .map(VedtaksperioderHelper::konverter)
             .toList();

--- a/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/uttaksgrunnlag/fp/VedtaksperiodeFilter.java
+++ b/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/uttaksgrunnlag/fp/VedtaksperiodeFilter.java
@@ -139,22 +139,21 @@ public final class VedtaksperiodeFilter {
                                                              LocalDateSegment<SammenligningPeriodeForOppgitt> vedtak) {
         var søknadVerdi = Optional.ofNullable(søknad).map(LocalDateSegment::getValue).orElse(null);
         var vedtakVerdi = Optional.ofNullable(vedtak).map(LocalDateSegment::getValue).orElse(null);
-        if (UtsettelseCore2021.kreverSammenhengendeUttak(i.getFomDato()) || !kanIgnorerePeriode(søknadVerdi) || !kanIgnorerePeriode(vedtakVerdi)) {
+        if (UtsettelseCore2021.kreverSammenhengendeUttak(i.getFomDato()) || skalVurderePeriode(søknadVerdi) || skalVurderePeriode(vedtakVerdi)) {
             return new LocalDateSegment<>(i, Objects.equals(søknadVerdi, vedtakVerdi));
         } else {
             return new LocalDateSegment<>(i, true);
         }
     }
 
-    private static boolean kanIgnorerePeriode(SammenligningPeriodeForOppgitt periode) {
+    private static boolean skalVurderePeriode(SammenligningPeriodeForOppgitt periode) {
         if (periode == null || periode.årsak() instanceof OppholdÅrsak) {
-            return true;
-        } else if (periode.årsak() instanceof UtsettelseÅrsak utsettelse) {
-            // TODO: gjennomgå logikk. Nå er det fokus på BFHR (morsaktivitet) og 3 årsaker (uansett første 6u eller senere)
-            // Selvbetjening bør tillate sykdom/institusjon kun for mor/6u og BFHR - ellers bare arbeid/ferie/fri
-            return !UTS_14_11.contains(utsettelse) && !MorsAktivitet.forventerDokumentasjon(periode.morsAktivitet());
-        } else {
             return false;
+        } else if (periode.årsak() instanceof UtsettelseÅrsak utsettelse) {
+            // Mor første 6 uker og BFHR (morsaktivitet) skal behandles. Selvbetjening støtter dette.
+            return UTS_14_11.contains(utsettelse) || MorsAktivitet.forventerDokumentasjon(periode.morsAktivitet());
+        } else {
+            return true;
         }
     }
 

--- a/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/uttaksgrunnlag/fp/VedtaksperiodeFilter.java
+++ b/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/uttaksgrunnlag/fp/VedtaksperiodeFilter.java
@@ -162,8 +162,8 @@ public final class VedtaksperiodeFilter {
         return uttakResultatFraForrigeBehandling.getGjeldendePerioder()
             .getPerioder()
             .stream()
-            .filter(UttakResultatPeriodeEntitet::isInnvilget) // TODO vurder om avslått (utsettelse) bør med - hjelper på sykdom etter 6u.
-            .filter(p -> p.getPeriodeSøknad().isPresent()) // TODO vurder om disse bør med. Når mangler det periodeSøknad?
+            .filter(UttakResultatPeriodeEntitet::isInnvilget) // evt avslått utsettelse med dok må vurderes på nytt
+            .filter(p -> p.getPeriodeSøknad().isPresent()) // Tar ikke med manglende søkt - disse skal behandles
             .filter(p -> !p.getTidsperiode().erHelg())
             .map(VedtaksperioderHelper::konverter)
             .toList();

--- a/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/uttaksgrunnlag/fp/VedtaksperioderHelper.java
+++ b/domenetjenester/uttak/src/main/java/no/nav/foreldrepenger/domene/uttak/uttaksgrunnlag/fp/VedtaksperioderHelper.java
@@ -2,6 +2,7 @@ package no.nav.foreldrepenger.domene.uttak.uttaksgrunnlag.fp;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
@@ -73,7 +74,7 @@ public class VedtaksperioderHelper {
             .filter(p -> beholdAvslåttePerioderFrittUttak || UtsettelseCore2021.kreverSammenhengendeUttak(p) || !avslåttIngenTrekkdager(p))
             .filter(p -> !avslåttPgaAvTaptPeriodeTilAnnenpart(p))
             .filter(p -> filtrerFørsteSøknadsdato(p, førsteSøknadsdato))
-            .filter(VedtaksperioderHelper::erPeriodeFraSøknad)
+            .filter(p -> VedtaksperioderHelper.erPeriodeFraSøknad(p) || p.isInnvilget())
             .map(VedtaksperioderHelper::konverter)
             .flatMap(p -> klipp(p, fraDato, førsteSøknadsdato))
             .toList();
@@ -120,6 +121,7 @@ public class VedtaksperioderHelper {
 
     static OppgittPeriodeEntitet konverter(UttakResultatPeriodeEntitet up) {
         var samtidigUttaksprosent = finnSamtidigUttaksprosent(up).orElse(null);
+        var uttakOpprettet = Optional.ofNullable(up.getOpprettetTidspunkt()).map(LocalDateTime::toLocalDate).orElse(null);
         var builder = OppgittPeriodeBuilder.ny()
             .medPeriode(up.getTidsperiode().getFomDato(), up.getTidsperiode().getTomDato())
             .medPeriodeType(finnPeriodetype(up))
@@ -136,8 +138,8 @@ public class VedtaksperioderHelper {
         finnGradertArbeidsgiver(up).ifPresent(builder::medArbeidsgiver);
         finnOppholdsÅrsak(up).ifPresent(builder::medÅrsak);
         finnOverføringÅrsak(up).ifPresent(builder::medÅrsak);
-        builder.medMottattDato(up.getPeriodeSøknad().orElseThrow().getMottattDato());
-        builder.medTidligstMottattDato(up.getPeriodeSøknad().orElseThrow().getTidligstMottattDato().orElse(null));
+        builder.medMottattDato(up.getPeriodeSøknad().map(UttakResultatPeriodeSøknadEntitet::getMottattDato).orElse(uttakOpprettet));
+        builder.medTidligstMottattDato(up.getPeriodeSøknad().flatMap(UttakResultatPeriodeSøknadEntitet::getTidligstMottattDato).orElse(uttakOpprettet));
 
         return builder.build();
     }

--- a/domenetjenester/uttak/src/test/java/no/nav/foreldrepenger/domene/uttak/uttaksgrunnlag/fp/FastsettUttaksgrunnlagTjenesteTest.java
+++ b/domenetjenester/uttak/src/test/java/no/nav/foreldrepenger/domene/uttak/uttaksgrunnlag/fp/FastsettUttaksgrunnlagTjenesteTest.java
@@ -11,6 +11,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.Collections;
 import java.util.List;
@@ -28,8 +29,13 @@ import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.Oppgitt
 import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.periode.OppgittFordelingEntitet;
 import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.årsak.OppholdÅrsak;
 import no.nav.foreldrepenger.behandlingslager.uttak.PeriodeResultatType;
+import no.nav.foreldrepenger.behandlingslager.uttak.Utbetalingsgrad;
+import no.nav.foreldrepenger.behandlingslager.uttak.UttakArbeidType;
 import no.nav.foreldrepenger.behandlingslager.uttak.Uttaksperiodegrense;
 import no.nav.foreldrepenger.behandlingslager.uttak.fp.PeriodeResultatÅrsak;
+import no.nav.foreldrepenger.behandlingslager.uttak.fp.Trekkdager;
+import no.nav.foreldrepenger.behandlingslager.uttak.fp.UttakAktivitetEntitet;
+import no.nav.foreldrepenger.behandlingslager.uttak.fp.UttakResultatPeriodeAktivitetEntitet;
 import no.nav.foreldrepenger.behandlingslager.uttak.fp.UttakResultatPeriodeEntitet;
 import no.nav.foreldrepenger.behandlingslager.uttak.fp.UttakResultatPeriodeSøknadEntitet;
 import no.nav.foreldrepenger.behandlingslager.uttak.fp.UttakResultatPerioderEntitet;
@@ -45,6 +51,7 @@ import no.nav.foreldrepenger.domene.uttak.input.UttakInput;
 import no.nav.foreldrepenger.domene.uttak.testutilities.behandling.ScenarioFarSøkerForeldrepenger;
 import no.nav.foreldrepenger.domene.uttak.testutilities.behandling.ScenarioMorSøkerForeldrepenger;
 import no.nav.foreldrepenger.domene.uttak.testutilities.behandling.UttakRepositoryStubProvider;
+import no.nav.foreldrepenger.regler.uttak.fastsetteperiode.Virkedager;
 
 class FastsettUttaksgrunnlagTjenesteTest {
 
@@ -466,6 +473,13 @@ class FastsettUttaksgrunnlagTjenesteTest {
         var fordeling = new OppgittFordelingEntitet(List.of(mødrekvote1, mødrekvote2), true);
         var uttaksperiode = new UttakResultatPeriodeEntitet.Builder(mødrekvote1.getFom(), mødrekvote2.getTom())
             .medResultatType(PeriodeResultatType.INNVILGET, PeriodeResultatÅrsak.KVOTE_ELLER_OVERFØRT_KVOTE)
+            .build();
+        var uttakaktivitet =  new UttakAktivitetEntitet.Builder().medUttakArbeidType(UttakArbeidType.SELVSTENDIG_NÆRINGSDRIVENDE).build();
+        new UttakResultatPeriodeAktivitetEntitet.Builder(uttaksperiode, uttakaktivitet)
+            .medTrekkonto(MØDREKVOTE)
+            .medTrekkdager(new Trekkdager(Virkedager.beregnAntallVirkedager(uttaksperiode.getFom(), uttaksperiode.getTom())))
+            .medArbeidsprosent(BigDecimal.ZERO)
+            .medUtbetalingsgrad(Utbetalingsgrad.FULL)
             .build();
         var uttak = new UttakResultatPerioderEntitet().leggTilPeriode(uttaksperiode);
         var førstegangsbehandlingScenario = scenarioMorFødsel()

--- a/domenetjenester/uttak/src/test/java/no/nav/foreldrepenger/domene/uttak/uttaksgrunnlag/fp/VedtaksperiodeFilterFullPlanTest.java
+++ b/domenetjenester/uttak/src/test/java/no/nav/foreldrepenger/domene/uttak/uttaksgrunnlag/fp/VedtaksperiodeFilterFullPlanTest.java
@@ -1,0 +1,476 @@
+package no.nav.foreldrepenger.domene.uttak.uttaksgrunnlag.fp;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import no.nav.foreldrepenger.behandlingslager.behandling.Behandlingsresultat;
+import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.periode.FordelingPeriodeKilde;
+import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.periode.OppgittPeriodeBuilder;
+import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.periode.OppgittPeriodeEntitet;
+import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.periode.UttakPeriodeType;
+import no.nav.foreldrepenger.behandlingslager.behandling.ytelsefordeling.årsak.UtsettelseÅrsak;
+import no.nav.foreldrepenger.behandlingslager.uttak.PeriodeResultatType;
+import no.nav.foreldrepenger.behandlingslager.uttak.Utbetalingsgrad;
+import no.nav.foreldrepenger.behandlingslager.uttak.UttakArbeidType;
+import no.nav.foreldrepenger.behandlingslager.uttak.fp.PeriodeResultatÅrsak;
+import no.nav.foreldrepenger.behandlingslager.uttak.fp.SamtidigUttaksprosent;
+import no.nav.foreldrepenger.behandlingslager.uttak.fp.Trekkdager;
+import no.nav.foreldrepenger.behandlingslager.uttak.fp.UttakAktivitetEntitet;
+import no.nav.foreldrepenger.behandlingslager.uttak.fp.UttakResultatEntitet;
+import no.nav.foreldrepenger.behandlingslager.uttak.fp.UttakResultatPeriodeAktivitetEntitet;
+import no.nav.foreldrepenger.behandlingslager.uttak.fp.UttakResultatPeriodeEntitet;
+import no.nav.foreldrepenger.behandlingslager.uttak.fp.UttakResultatPeriodeSøknadEntitet;
+import no.nav.foreldrepenger.behandlingslager.uttak.fp.UttakResultatPerioderEntitet;
+import no.nav.foreldrepenger.behandlingslager.uttak.fp.UttakUtsettelseType;
+import no.nav.foreldrepenger.behandlingslager.virksomhet.Arbeidsgiver;
+import no.nav.foreldrepenger.behandlingslager.virksomhet.OrgNummer;
+import no.nav.foreldrepenger.domene.typer.InternArbeidsforholdRef;
+
+/**
+ * Probesuite for scenariet der endringssøknaden inneholder <em>hele</em> uttaksplanen, altså at
+ * frontend ikke lenger avkorter planen fra egen-detektert endringsdato, men overlater
+ * endringsdato-deteksjonen til {@link VedtaksperiodeFilter}.
+ * <p>
+ * Hver test asserterer <b>dagens</b> oppførsel. Der dagens oppførsel avviker fra ønsket oppførsel
+ * ved full plan, er målbildet dokumentert i en MÅLBILDE-kommentar rett over assert'en. Testene som
+ * da feiler ved en omlegging er nøyaktig de scenariene som endrer semantikk.
+ * <p>
+ * Forutsetninger som ligger til grunn for målbildet:
+ * <ul>
+ *   <li>Full plan rendres fra det <em>innvilgede</em> vedtaket. Avslåtte perioder blir hull i planen,
+ *       og et hull som gjensøkes er en reell endring (skal vurderes på nytt).</li>
+ *   <li>Fjerning av uttak uttrykkes med en utsettelse av type {@link UtsettelseÅrsak#FRI}, ikke med hull.</li>
+ * </ul>
+ */
+class VedtaksperiodeFilterFullPlanTest {
+
+    private static final long BEHANDLING_ID = 1L;
+
+    private static final LocalDate FØDSEL = LocalDate.of(2024, 1, 1); // mandag
+    private static final LocalDate FPFF_FOM = LocalDate.of(2023, 12, 11);
+    private static final LocalDate FPFF_TOM = LocalDate.of(2023, 12, 31);
+    private static final LocalDate MK_FOM = FØDSEL;
+    private static final LocalDate MK_TOM = LocalDate.of(2024, 3, 10);
+    private static final LocalDate FP_FOM = LocalDate.of(2024, 3, 11);
+    private static final LocalDate FP_TOM = LocalDate.of(2024, 6, 30);
+    private static final LocalDate HALE_FOM = FP_TOM.plusDays(3); // 2024-07-03, mandag
+
+    private static final UttakAktivitetEntitet AKTIVITET = new UttakAktivitetEntitet.Builder()
+        .medUttakArbeidType(UttakArbeidType.ORDINÆRT_ARBEID)
+        .medArbeidsforhold(Arbeidsgiver.virksomhet(OrgNummer.KUNSTIG_ORG), InternArbeidsforholdRef.nyRef())
+        .build();
+
+    /**
+     * Endringsdatoen slik den faller ut av filteret: tidligste fom blant periodene som beholdes.
+     * {@code null} betyr at hele planen ble filtrert bort, dvs. ingen endring.
+     */
+    private static LocalDate endringsdato(List<OppgittPeriodeEntitet> plan, UttakResultatEntitet vedtak, boolean beholdSenestePeriode) {
+        return VedtaksperiodeFilter.filtrerVekkPerioderSomErLikeInnvilgetUttak(BEHANDLING_ID, plan, vedtak, beholdSenestePeriode).stream()
+            .map(OppgittPeriodeEntitet::getFom)
+            .min(Comparator.naturalOrder())
+            .orElse(null);
+    }
+
+    private static List<OppgittPeriodeEntitet> filtrer(List<OppgittPeriodeEntitet> plan, UttakResultatEntitet vedtak, boolean beholdSeneste) {
+        return VedtaksperiodeFilter.filtrerVekkPerioderSomErLikeInnvilgetUttak(BEHANDLING_ID, plan, vedtak, beholdSeneste);
+    }
+
+    @Nested
+    class EndringerSomSkalDetekteres {
+
+        @Test
+        void ny_utsettelse_midt_i_plan_gir_endringsdato_fra_utsettelsen() {
+            var utsFom = LocalDate.of(2024, 5, 1);
+            var utsTom = LocalDate.of(2024, 5, 15);
+            var plan = List.of(
+                søkt(FPFF_FOM, FPFF_TOM, UttakPeriodeType.FORELDREPENGER_FØR_FØDSEL),
+                søkt(MK_FOM, MK_TOM, UttakPeriodeType.MØDREKVOTE),
+                søkt(FP_FOM, utsFom.minusDays(1), UttakPeriodeType.FELLESPERIODE),
+                søktUtsettelse(utsFom, utsTom, UtsettelseÅrsak.FERIE),
+                søkt(utsTom.plusDays(1), FP_TOM.plusWeeks(3), UttakPeriodeType.FELLESPERIODE));
+
+            assertThat(endringsdato(plan, uttak(normaltVedtak()), false)).isEqualTo(utsFom);
+        }
+
+        @Test
+        void plan_utvidet_bakover_foran_vedtaket_gir_endringsdato_fra_ny_start() {
+            List<OppgittPeriodeEntitet> plan = new ArrayList<>();
+            plan.add(søkt(FPFF_FOM.minusWeeks(2), FPFF_FOM.minusWeeks(2).plusDays(1), UttakPeriodeType.FELLESPERIODE));
+            plan.addAll(fullPlan());
+
+            assertThat(endringsdato(plan, uttak(normaltVedtak()), false)).isEqualTo(FPFF_FOM.minusWeeks(2));
+        }
+
+        @Test
+        void utsettelse_erstatter_vedtatt_uttak_midt_i_modrekvoten() {
+            var plan = List.of(
+                søkt(FPFF_FOM, FPFF_TOM, UttakPeriodeType.FORELDREPENGER_FØR_FØDSEL),
+                søkt(MK_FOM, LocalDate.of(2024, 2, 9), UttakPeriodeType.MØDREKVOTE),
+                søktUtsettelse(LocalDate.of(2024, 2, 12), LocalDate.of(2024, 3, 8), UtsettelseÅrsak.ARBEID),
+                søkt(LocalDate.of(2024, 3, 11), FP_TOM.plusWeeks(4), UttakPeriodeType.FELLESPERIODE));
+
+            assertThat(endringsdato(plan, uttak(normaltVedtak()), false)).isEqualTo(LocalDate.of(2024, 2, 12));
+        }
+
+        @Test
+        void fri_utsettelse_forst_i_plan_fjerner_forste_vedtatte_uttak() {
+            // Konvensjonen for å fjerne innvilget uttak: send FRI-utsettelse i stedet for hull
+            var plan = List.of(
+                søktUtsettelse(FPFF_FOM, LocalDate.of(2024, 1, 12), UtsettelseÅrsak.FRI),
+                søkt(LocalDate.of(2024, 1, 15), MK_TOM, UttakPeriodeType.MØDREKVOTE),
+                søkt(FP_FOM, FP_TOM, UttakPeriodeType.FELLESPERIODE));
+
+            assertThat(endringsdato(plan, uttak(normaltVedtak()), false)).isEqualTo(FPFF_FOM);
+        }
+
+        @Test
+        void avslatt_periode_i_vedtak_som_gjensokes_er_en_reell_endring() {
+            var avslagFom = LocalDate.of(2024, 2, 1);
+            var avslagTom = LocalDate.of(2024, 2, 15);
+            var vedtak = List.of(
+                vedtaksperiode(FPFF_FOM, FPFF_TOM, UttakPeriodeType.FORELDREPENGER_FØR_FØDSEL, PeriodeResultatType.INNVILGET, true),
+                vedtaksperiode(MK_FOM, avslagFom.minusDays(1), UttakPeriodeType.MØDREKVOTE, PeriodeResultatType.INNVILGET, true),
+                vedtaksperiode(avslagFom, avslagTom, UttakPeriodeType.MØDREKVOTE, PeriodeResultatType.AVSLÅTT, true),
+                vedtaksperiode(avslagTom.plusDays(1), MK_TOM, UttakPeriodeType.MØDREKVOTE, PeriodeResultatType.INNVILGET, true),
+                vedtaksperiode(FP_FOM, FP_TOM, UttakPeriodeType.FELLESPERIODE, PeriodeResultatType.INNVILGET, true));
+            var plan = planMedHale();
+
+            assertThat(endringsdato(plan, uttak(vedtak), false)).isEqualTo(avslagFom);
+        }
+
+        @Test
+        void avslag_med_null_trekkdager_pga_annenpart_som_gjensokes_er_en_reell_endring() {
+            var avslagFom = LocalDate.of(2024, 2, 1);
+            var avslagTom = LocalDate.of(2024, 2, 15);
+            var avslag = new UttakResultatPeriodeEntitet.Builder(avslagFom, avslagTom)
+                .medResultatType(PeriodeResultatType.AVSLÅTT,
+                    PeriodeResultatÅrsak.DEN_ANDRE_PART_OVERLAPPENDE_UTTAK_IKKE_SØKT_INNVILGET_SAMTIDIG_UTTAK)
+                .medPeriodeSoknad(new UttakResultatPeriodeSøknadEntitet.Builder().medUttakPeriodeType(UttakPeriodeType.MØDREKVOTE).build())
+                .build();
+            UttakResultatPeriodeAktivitetEntitet.builder(avslag, AKTIVITET)
+                .medTrekkdager(Trekkdager.ZERO)
+                .medTrekkonto(UttakPeriodeType.MØDREKVOTE)
+                .medUtbetalingsgrad(Utbetalingsgrad.ZERO)
+                .medArbeidsprosent(BigDecimal.ZERO)
+                .build();
+            var vedtak = List.of(
+                vedtaksperiode(FPFF_FOM, FPFF_TOM, UttakPeriodeType.FORELDREPENGER_FØR_FØDSEL, PeriodeResultatType.INNVILGET, true),
+                vedtaksperiode(MK_FOM, avslagFom.minusDays(1), UttakPeriodeType.MØDREKVOTE, PeriodeResultatType.INNVILGET, true),
+                avslag,
+                vedtaksperiode(avslagTom.plusDays(1), MK_TOM, UttakPeriodeType.MØDREKVOTE, PeriodeResultatType.INNVILGET, true),
+                vedtaksperiode(FP_FOM, FP_TOM, UttakPeriodeType.FELLESPERIODE, PeriodeResultatType.INNVILGET, true));
+
+            assertThat(endringsdato(planMedHale(), uttak(vedtak), false)).isEqualTo(avslagFom);
+        }
+    }
+
+    @Nested
+    class UendretPrefiksMedNyHale {
+
+        @Test
+        void ny_periode_bakerst_gir_endringsdato_fra_halen() {
+            assertThat(endringsdato(planMedHale(), uttak(normaltVedtak()), false)).isEqualTo(HALE_FOM);
+        }
+
+        @Test
+        void tidligere_innvilget_ferieutsettelse_gjentatt_i_planen_gir_ikke_endring() {
+            var utsFom = LocalDate.of(2024, 5, 1);
+            var utsTom = LocalDate.of(2024, 5, 15);
+            var vedtak = List.of(
+                vedtaksperiode(FPFF_FOM, FPFF_TOM, UttakPeriodeType.FORELDREPENGER_FØR_FØDSEL, PeriodeResultatType.INNVILGET, true),
+                vedtaksperiode(MK_FOM, MK_TOM, UttakPeriodeType.MØDREKVOTE, PeriodeResultatType.INNVILGET, true),
+                vedtaksperiode(FP_FOM, utsFom.minusDays(1), UttakPeriodeType.FELLESPERIODE, PeriodeResultatType.INNVILGET, true),
+                utsettelsesperiodeVedtak(utsFom, utsTom, UttakUtsettelseType.FERIE),
+                vedtaksperiode(utsTom.plusDays(1), FP_TOM, UttakPeriodeType.FELLESPERIODE, PeriodeResultatType.INNVILGET, true));
+            var plan = List.of(
+                søkt(FPFF_FOM, FPFF_TOM, UttakPeriodeType.FORELDREPENGER_FØR_FØDSEL),
+                søkt(MK_FOM, MK_TOM, UttakPeriodeType.MØDREKVOTE),
+                søkt(FP_FOM, utsFom.minusDays(1), UttakPeriodeType.FELLESPERIODE),
+                søktUtsettelse(utsFom, utsTom, UtsettelseÅrsak.FERIE),
+                søkt(utsTom.plusDays(1), FP_TOM, UttakPeriodeType.FELLESPERIODE),
+                søkt(HALE_FOM, FP_TOM.plusWeeks(3), UttakPeriodeType.FELLESPERIODE));
+
+            assertThat(endringsdato(plan, uttak(vedtak), false)).isEqualTo(HALE_FOM);
+        }
+
+        @Test
+        void plan_oppdelt_per_uke_uten_helg_gir_ikke_falsk_endring() {
+            List<OppgittPeriodeEntitet> plan = new ArrayList<>();
+            plan.add(søkt(FPFF_FOM, FPFF_TOM, UttakPeriodeType.FORELDREPENGER_FØR_FØDSEL));
+            for (var uke = MK_FOM; !uke.isAfter(MK_TOM.minusDays(2)); uke = uke.plusWeeks(1)) {
+                plan.add(søkt(uke, uke.plusDays(4), UttakPeriodeType.MØDREKVOTE));
+            }
+            plan.add(søkt(FP_FOM, FP_TOM, UttakPeriodeType.FELLESPERIODE));
+            plan.add(søkt(HALE_FOM, FP_TOM.plusWeeks(3), UttakPeriodeType.FELLESPERIODE));
+
+            assertThat(endringsdato(plan, uttak(normaltVedtak()), false)).isEqualTo(HALE_FOM);
+        }
+
+        @Test
+        void plan_som_hopper_over_avslatt_periode_gir_ikke_falsk_endring() {
+            var avslagFom = LocalDate.of(2024, 2, 1);
+            var avslagTom = LocalDate.of(2024, 2, 15);
+            var vedtak = List.of(
+                vedtaksperiode(FPFF_FOM, FPFF_TOM, UttakPeriodeType.FORELDREPENGER_FØR_FØDSEL, PeriodeResultatType.INNVILGET, true),
+                vedtaksperiode(MK_FOM, avslagFom.minusDays(1), UttakPeriodeType.MØDREKVOTE, PeriodeResultatType.INNVILGET, true),
+                vedtaksperiode(avslagFom, avslagTom, UttakPeriodeType.MØDREKVOTE, PeriodeResultatType.AVSLÅTT, true),
+                vedtaksperiode(avslagTom.plusDays(1), MK_TOM, UttakPeriodeType.MØDREKVOTE, PeriodeResultatType.INNVILGET, true),
+                vedtaksperiode(FP_FOM, FP_TOM, UttakPeriodeType.FELLESPERIODE, PeriodeResultatType.INNVILGET, true));
+            var plan = List.of(
+                søkt(FPFF_FOM, FPFF_TOM, UttakPeriodeType.FORELDREPENGER_FØR_FØDSEL),
+                søkt(MK_FOM, avslagFom.minusDays(1), UttakPeriodeType.MØDREKVOTE),
+                søkt(avslagTom.plusDays(1), MK_TOM, UttakPeriodeType.MØDREKVOTE),
+                søkt(FP_FOM, FP_TOM, UttakPeriodeType.FELLESPERIODE),
+                søkt(HALE_FOM, FP_TOM.plusWeeks(3), UttakPeriodeType.FELLESPERIODE));
+
+            assertThat(endringsdato(plan, uttak(vedtak), false)).isEqualTo(HALE_FOM);
+        }
+    }
+
+    /**
+     * Hull i planen tolkes i dag som fjerning av uttak. Ved full plan er hull normalt bare dager det
+     * ikke søkes uttak for, og fjerning uttrykkes med FRI-utsettelse. Alle testene her har derfor
+     * målbilde "ingen endring".
+     */
+    @Nested
+    class HullOgUendretPlanTolkesSomEndringIDag {
+
+        @Test
+        void plan_helt_lik_vedtak_gir_syntetisk_fri_etter_siste_vedtaksdag() {
+            // MÅLBILDE ved full plan: null (ingen endring)
+            assertThat(endringsdato(fullPlan(), uttak(normaltVedtak()), false)).isEqualTo(FP_TOM.plusDays(1));
+
+            var filtrert = filtrer(fullPlan(), uttak(normaltVedtak()), false);
+            assertThat(filtrert).hasSize(1);
+            assertThat(filtrert.getFirst().getÅrsak()).isEqualTo(UtsettelseÅrsak.FRI);
+        }
+
+        @Test
+        void plan_lik_vedtak_med_beholdSenestePeriode_beholder_siste_vedtaksperiode() {
+            // MÅLBILDE ved full plan: null (ingen endring)
+            assertThat(endringsdato(fullPlan(), uttak(normaltVedtak()), true)).isEqualTo(FP_FOM);
+        }
+
+        @Test
+        void plan_forkortet_bakerst_gir_fri_fra_forste_fjernede_dag() {
+            var plan = List.of(
+                søkt(FPFF_FOM, FPFF_TOM, UttakPeriodeType.FORELDREPENGER_FØR_FØDSEL),
+                søkt(MK_FOM, MK_TOM, UttakPeriodeType.MØDREKVOTE),
+                søkt(FP_FOM, LocalDate.of(2024, 5, 3), UttakPeriodeType.FELLESPERIODE));
+
+            // MÅLBILDE ved full plan: null - fjerning av halen må uttrykkes med FRI-utsettelse
+            assertThat(endringsdato(plan, uttak(normaltVedtak()), false)).isEqualTo(LocalDate.of(2024, 5, 6));
+        }
+
+        @Test
+        void hull_midt_i_plan_gir_endring_fra_hullets_start() {
+            var plan = List.of(
+                søkt(FPFF_FOM, FPFF_TOM, UttakPeriodeType.FORELDREPENGER_FØR_FØDSEL),
+                søkt(MK_FOM, MK_TOM, UttakPeriodeType.MØDREKVOTE),
+                søkt(FP_FOM, LocalDate.of(2024, 4, 30), UttakPeriodeType.FELLESPERIODE),
+                søkt(LocalDate.of(2024, 5, 16), FP_TOM, UttakPeriodeType.FELLESPERIODE));
+
+            // MÅLBILDE ved full plan: null - fjerning må uttrykkes med FRI-utsettelse
+            assertThat(endringsdato(plan, uttak(normaltVedtak()), false)).isEqualTo(LocalDate.of(2024, 5, 1));
+        }
+
+        @Test
+        void internt_hull_i_starten_av_modrekvoten_gir_endring_fra_hullets_start() {
+            var plan = List.of(
+                søkt(FPFF_FOM, FPFF_TOM, UttakPeriodeType.FORELDREPENGER_FØR_FØDSEL),
+                søkt(LocalDate.of(2024, 1, 15), MK_TOM, UttakPeriodeType.MØDREKVOTE),
+                søkt(FP_FOM, FP_TOM, UttakPeriodeType.FELLESPERIODE));
+
+            // MÅLBILDE ved full plan: null - fjerning må uttrykkes med FRI-utsettelse
+            assertThat(endringsdato(plan, uttak(normaltVedtak()), false)).isEqualTo(MK_FOM);
+        }
+
+        @Test
+        void plan_avkortet_i_starten_kan_ikke_skilles_fra_legacy_delsoknad() {
+            // Samme plan som testen over, men uten periodene før avkortingen. Dagens algoritme
+            // tolker den som en legacy delsøknad; målbildet er at begge tolkninger gir samme utfall.
+            var plan = List.of(
+                søkt(LocalDate.of(2024, 1, 15), MK_TOM, UttakPeriodeType.MØDREKVOTE),
+                søkt(FP_FOM, FP_TOM, UttakPeriodeType.FELLESPERIODE));
+
+            // MÅLBILDE ved full plan: null (ingen endring)
+            assertThat(endringsdato(plan, uttak(normaltVedtak()), false)).isEqualTo(FP_TOM.plusDays(1));
+        }
+    }
+
+    /**
+     * Vedtakssiden projiseres fra <em>resultatet</em> (trekkonto, innvilget samtidig uttak), ikke fra
+     * de søkte verdiene. Det er tilsiktet: {@link UttakResultatPeriodeEntitet} er det som gjelder og
+     * som presenteres for bruker, og den fulle planen rendres fra det. Sender søknaden tilbake den
+     * opprinnelig søkte verdien der regelen har overstyrt, er det en <em>reell</em> endring som skal
+     * behandles på nytt.
+     */
+    @Nested
+    class VedtakOverstyrerSøkteVerdier {
+
+        @Test
+        void plan_som_gjentar_sokt_konto_der_vedtaket_omfordelte_trekket_er_en_endring() {
+            var vedtak = List.of(
+                vedtaksperiode(FPFF_FOM, FPFF_TOM, UttakPeriodeType.FORELDREPENGER_FØR_FØDSEL, PeriodeResultatType.INNVILGET, true),
+                vedtaksperiode(MK_FOM, MK_TOM, UttakPeriodeType.MØDREKVOTE, PeriodeResultatType.INNVILGET, true),
+                vedtaksperiodeSøktAnnenKonto(FP_FOM, FP_TOM, UttakPeriodeType.FELLESPERIODE, UttakPeriodeType.MØDREKVOTE));
+
+            // Søkt FELLESPERIODE, innvilget med trekk fra MØDREKVOTE. Planen ber om FELLESPERIODE igjen,
+            // altså en omgjøring av det som er vedtatt og presentert for bruker.
+            assertThat(endringsdato(planMedHale(), uttak(vedtak), false)).isEqualTo(FP_FOM);
+        }
+
+        @Test
+        void plan_som_gjentar_sokt_samtidig_uttaksprosent_der_vedtaket_justerte_den_er_en_endring() {
+            var vedtakPeriode = new UttakResultatPeriodeEntitet.Builder(FP_FOM, FP_TOM)
+                .medResultatType(PeriodeResultatType.INNVILGET, PeriodeResultatÅrsak.UKJENT)
+                .medSamtidigUttak(true)
+                .medSamtidigUttaksprosent(new SamtidigUttaksprosent(50))
+                .medPeriodeSoknad(new UttakResultatPeriodeSøknadEntitet.Builder()
+                    .medUttakPeriodeType(UttakPeriodeType.FELLESPERIODE)
+                    .medSamtidigUttak(true)
+                    .medSamtidigUttaksprosent(new SamtidigUttaksprosent(40))
+                    .build())
+                .build();
+            UttakResultatPeriodeAktivitetEntitet.builder(vedtakPeriode, AKTIVITET)
+                .medTrekkdager(new Trekkdager(10))
+                .medTrekkonto(UttakPeriodeType.FELLESPERIODE)
+                .medUtbetalingsgrad(Utbetalingsgrad.HUNDRED)
+                .medArbeidsprosent(BigDecimal.ZERO)
+                .build();
+            var vedtak = List.of(
+                vedtaksperiode(FPFF_FOM, FPFF_TOM, UttakPeriodeType.FORELDREPENGER_FØR_FØDSEL, PeriodeResultatType.INNVILGET, true),
+                vedtaksperiode(MK_FOM, MK_TOM, UttakPeriodeType.MØDREKVOTE, PeriodeResultatType.INNVILGET, true),
+                vedtakPeriode);
+            var plan = List.of(
+                søkt(FPFF_FOM, FPFF_TOM, UttakPeriodeType.FORELDREPENGER_FØR_FØDSEL),
+                søkt(MK_FOM, MK_TOM, UttakPeriodeType.MØDREKVOTE),
+                OppgittPeriodeBuilder.ny()
+                    .medPeriodeKilde(FordelingPeriodeKilde.SØKNAD)
+                    .medPeriode(FP_FOM, FP_TOM)
+                    .medPeriodeType(UttakPeriodeType.FELLESPERIODE)
+                    .medSamtidigUttak(true)
+                    .medSamtidigUttaksprosent(new SamtidigUttaksprosent(40))
+                    .build(),
+                søkt(HALE_FOM, FP_TOM.plusWeeks(3), UttakPeriodeType.FELLESPERIODE));
+
+            // Søkt 40 %, innvilget 50 %. Planen ber om 40 % igjen - reell endring fra vedtatt uttak.
+            assertThat(endringsdato(plan, uttak(vedtak), false)).isEqualTo(FP_FOM);
+        }
+
+        @Test
+        void innvilget_vedtaksperiode_uten_periodesoknad_blir_et_hull_og_gir_falsk_endring() {
+            // Til forskjell fra de to over er dette en reell falsk positiv: perioden er innvilget og
+            // presenteres for bruker, men filtreres bort av opprettOppgittePerioderKunInnvilget fordi
+            // VedtaksperioderHelper.konverter krever periodeSøknad. Planen gjentar den uendret.
+            var systemFom = LocalDate.of(2024, 2, 1);
+            var systemTom = LocalDate.of(2024, 2, 15);
+            var vedtak = List.of(
+                vedtaksperiode(FPFF_FOM, FPFF_TOM, UttakPeriodeType.FORELDREPENGER_FØR_FØDSEL, PeriodeResultatType.INNVILGET, true),
+                vedtaksperiode(MK_FOM, systemFom.minusDays(1), UttakPeriodeType.MØDREKVOTE, PeriodeResultatType.INNVILGET, true),
+                vedtaksperiode(systemFom, systemTom, UttakPeriodeType.MØDREKVOTE, PeriodeResultatType.INNVILGET, false),
+                vedtaksperiode(systemTom.plusDays(1), MK_TOM, UttakPeriodeType.MØDREKVOTE, PeriodeResultatType.INNVILGET, true),
+                vedtaksperiode(FP_FOM, FP_TOM, UttakPeriodeType.FELLESPERIODE, PeriodeResultatType.INNVILGET, true));
+
+            // MÅLBILDE: HALE_FOM - krever at perioder uten periodeSøknad projiseres fra resultatet
+            assertThat(endringsdato(planMedHale(), uttak(vedtak), false)).isEqualTo(systemFom);
+        }
+    }
+
+    private static List<UttakResultatPeriodeEntitet> normaltVedtak() {
+        return List.of(
+            vedtaksperiode(FPFF_FOM, FPFF_TOM, UttakPeriodeType.FORELDREPENGER_FØR_FØDSEL, PeriodeResultatType.INNVILGET, true),
+            vedtaksperiode(MK_FOM, MK_TOM, UttakPeriodeType.MØDREKVOTE, PeriodeResultatType.INNVILGET, true),
+            vedtaksperiode(FP_FOM, FP_TOM, UttakPeriodeType.FELLESPERIODE, PeriodeResultatType.INNVILGET, true));
+    }
+
+    private static List<OppgittPeriodeEntitet> fullPlan() {
+        return List.of(
+            søkt(FPFF_FOM, FPFF_TOM, UttakPeriodeType.FORELDREPENGER_FØR_FØDSEL),
+            søkt(MK_FOM, MK_TOM, UttakPeriodeType.MØDREKVOTE),
+            søkt(FP_FOM, FP_TOM, UttakPeriodeType.FELLESPERIODE));
+    }
+
+    private static List<OppgittPeriodeEntitet> planMedHale() {
+        List<OppgittPeriodeEntitet> plan = new ArrayList<>(fullPlan());
+        plan.add(søkt(HALE_FOM, FP_TOM.plusWeeks(3), UttakPeriodeType.FELLESPERIODE));
+        return plan;
+    }
+
+    private static OppgittPeriodeEntitet søkt(LocalDate fom, LocalDate tom, UttakPeriodeType type) {
+        return OppgittPeriodeBuilder.ny()
+            .medPeriodeKilde(FordelingPeriodeKilde.SØKNAD)
+            .medPeriode(fom, tom)
+            .medPeriodeType(type)
+            .build();
+    }
+
+    private static OppgittPeriodeEntitet søktUtsettelse(LocalDate fom, LocalDate tom, UtsettelseÅrsak årsak) {
+        return OppgittPeriodeBuilder.ny()
+            .medPeriodeKilde(FordelingPeriodeKilde.SØKNAD)
+            .medPeriode(fom, tom)
+            .medPeriodeType(UttakPeriodeType.UDEFINERT)
+            .medÅrsak(årsak)
+            .build();
+    }
+
+    private static UttakResultatPeriodeEntitet vedtaksperiode(LocalDate fom, LocalDate tom, UttakPeriodeType konto,
+                                                             PeriodeResultatType resultat, boolean fraSøknad) {
+        var builder = new UttakResultatPeriodeEntitet.Builder(fom, tom).medResultatType(resultat, PeriodeResultatÅrsak.UKJENT);
+        if (fraSøknad) {
+            builder.medPeriodeSoknad(new UttakResultatPeriodeSøknadEntitet.Builder().medUttakPeriodeType(konto).build());
+        }
+        var periode = builder.build();
+        UttakResultatPeriodeAktivitetEntitet.builder(periode, AKTIVITET)
+            .medTrekkdager(new Trekkdager(10))
+            .medTrekkonto(konto)
+            .medUtbetalingsgrad(PeriodeResultatType.INNVILGET.equals(resultat) ? Utbetalingsgrad.HUNDRED : Utbetalingsgrad.ZERO)
+            .medArbeidsprosent(BigDecimal.ZERO)
+            .build();
+        return periode;
+    }
+
+    private static UttakResultatPeriodeEntitet vedtaksperiodeSøktAnnenKonto(LocalDate fom, LocalDate tom, UttakPeriodeType søkt,
+                                                                           UttakPeriodeType trukket) {
+        var periode = new UttakResultatPeriodeEntitet.Builder(fom, tom)
+            .medResultatType(PeriodeResultatType.INNVILGET, PeriodeResultatÅrsak.UKJENT)
+            .medPeriodeSoknad(new UttakResultatPeriodeSøknadEntitet.Builder().medUttakPeriodeType(søkt).build())
+            .build();
+        UttakResultatPeriodeAktivitetEntitet.builder(periode, AKTIVITET)
+            .medTrekkdager(new Trekkdager(10))
+            .medTrekkonto(trukket)
+            .medUtbetalingsgrad(Utbetalingsgrad.HUNDRED)
+            .medArbeidsprosent(BigDecimal.ZERO)
+            .build();
+        return periode;
+    }
+
+    private static UttakResultatPeriodeEntitet utsettelsesperiodeVedtak(LocalDate fom, LocalDate tom, UttakUtsettelseType type) {
+        var periode = new UttakResultatPeriodeEntitet.Builder(fom, tom)
+            .medResultatType(PeriodeResultatType.INNVILGET, PeriodeResultatÅrsak.UKJENT)
+            .medUtsettelseType(type)
+            .medPeriodeSoknad(new UttakResultatPeriodeSøknadEntitet.Builder().medUttakPeriodeType(UttakPeriodeType.UDEFINERT).build())
+            .build();
+        UttakResultatPeriodeAktivitetEntitet.builder(periode, AKTIVITET)
+            .medTrekkdager(Trekkdager.ZERO)
+            .medTrekkonto(UttakPeriodeType.UDEFINERT)
+            .medUtbetalingsgrad(Utbetalingsgrad.ZERO)
+            .medArbeidsprosent(BigDecimal.ZERO)
+            .build();
+        return periode;
+    }
+
+    private static UttakResultatEntitet uttak(List<UttakResultatPeriodeEntitet> perioder) {
+        var p = new UttakResultatPerioderEntitet();
+        perioder.forEach(p::leggTilPeriode);
+        return new UttakResultatEntitet.Builder(Behandlingsresultat.builder().build()).medOpprinneligPerioder(p).build();
+    }
+}

--- a/domenetjenester/uttak/src/test/java/no/nav/foreldrepenger/domene/uttak/uttaksgrunnlag/fp/VedtaksperiodeFilterFullPlanTest.java
+++ b/domenetjenester/uttak/src/test/java/no/nav/foreldrepenger/domene/uttak/uttaksgrunnlag/fp/VedtaksperiodeFilterFullPlanTest.java
@@ -367,10 +367,9 @@ class VedtaksperiodeFilterFullPlanTest {
         }
 
         @Test
-        void innvilget_vedtaksperiode_uten_periodesoknad_blir_et_hull_og_gir_falsk_endring() {
-            // Til forskjell fra de to over er dette en reell falsk positiv: perioden er innvilget og
-            // presenteres for bruker, men filtreres bort av opprettOppgittePerioderKunInnvilget fordi
-            // VedtaksperioderHelper.konverter krever periodeSøknad. Planen gjentar den uendret.
+        void innvilget_vedtaksperiode_uten_periodesoknad_tas_med_riktig_endring() {
+            // En periode er innvilget manuelt uten søknad (typisk manglende søkt).
+            // Planen gjentar den uendret og utvider med ekstra dager.
             var systemFom = LocalDate.of(2024, 2, 1);
             var systemTom = LocalDate.of(2024, 2, 15);
             var vedtak = List.of(
@@ -380,8 +379,7 @@ class VedtaksperiodeFilterFullPlanTest {
                 vedtaksperiode(systemTom.plusDays(1), MK_TOM, UttakPeriodeType.MØDREKVOTE, PeriodeResultatType.INNVILGET, true),
                 vedtaksperiode(FP_FOM, FP_TOM, UttakPeriodeType.FELLESPERIODE, PeriodeResultatType.INNVILGET, true));
 
-            // MÅLBILDE: HALE_FOM - krever at perioder uten periodeSøknad projiseres fra resultatet
-            assertThat(endringsdato(planMedHale(), uttak(vedtak), false)).isEqualTo(systemFom);
+            assertThat(endringsdato(planMedHale(), uttak(vedtak), false)).isEqualTo(HALE_FOM);
         }
     }
 

--- a/domenetjenester/uttak/src/test/java/no/nav/foreldrepenger/domene/uttak/uttaksgrunnlag/fp/VedtaksperioderHelperTest.java
+++ b/domenetjenester/uttak/src/test/java/no/nav/foreldrepenger/domene/uttak/uttaksgrunnlag/fp/VedtaksperioderHelperTest.java
@@ -26,7 +26,6 @@ import no.nav.foreldrepenger.behandlingslager.uttak.UttakArbeidType;
 import no.nav.foreldrepenger.behandlingslager.uttak.fp.MorsStillingsprosent;
 import no.nav.foreldrepenger.behandlingslager.uttak.fp.PeriodeResultatÅrsak;
 import no.nav.foreldrepenger.behandlingslager.uttak.fp.SamtidigUttaksprosent;
-import no.nav.foreldrepenger.behandlingslager.uttak.fp.StønadskontoType;
 import no.nav.foreldrepenger.behandlingslager.uttak.fp.Trekkdager;
 import no.nav.foreldrepenger.behandlingslager.uttak.fp.UttakAktivitetEntitet;
 import no.nav.foreldrepenger.behandlingslager.uttak.fp.UttakResultatDokRegelEntitet;
@@ -622,7 +621,7 @@ class VedtaksperioderHelperTest {
     }
 
     @Test
-    void skal_ikke_ta_med_uttak_periode_som_ikke_er_knyttet_til_søknadsperiode() {
+    void skal_ta_med_uttak_periode_som_ikke_er_knyttet_til_søknadsperiode() {
         var uttakResultatPerioderEntitet = new UttakResultatPerioderEntitet();
         uttakResultatPerioderEntitet.leggTilPeriode(
             nyPeriode(PeriodeResultatType.INNVILGET, fødselsdato.minusWeeks(3), fødselsdato.minusDays(1),
@@ -637,11 +636,11 @@ class VedtaksperioderHelperTest {
         var perioder = VedtaksperioderHelper.opprettOppgittePerioder(uttakResultatEntitet, List.of(),
             fødselsdato.minusWeeks(3), false);
 
-        assertThat(perioder).hasSize(1);
+        assertThat(perioder).hasSize(2);
 
-        assertThat(perioder.get(0).getPeriodeType()).isEqualTo(UttakPeriodeType.MØDREKVOTE);
-        assertThat(perioder.get(0).getFom()).isEqualTo(fødselsdato);
-        assertThat(perioder.get(0).getTom()).isEqualTo(fødselsdato.plusWeeks(6).minusDays(1));
+        assertThat(perioder.getLast().getPeriodeType()).isEqualTo(UttakPeriodeType.MØDREKVOTE);
+        assertThat(perioder.getLast().getFom()).isEqualTo(fødselsdato);
+        assertThat(perioder.getLast().getTom()).isEqualTo(fødselsdato.plusWeeks(6).minusDays(1));
     }
 
     @Test


### PR DESCRIPTION
Denne koden kalles fra koden som oversetter SøknadXml til YtelseFordeling (ForeldrepengerUttakOversetter via SøknadDataFraTidligereVedtakTjeneste). Allerede nå kommer det inn mye opphold og utsettelser utenom FRI og det vil føre til mange tidlige endringsdatoer dersom søknaden begynner sende hele planen.

Det som er endret er koden som skal ta en endringssøknad og finne første dato som er endret i forhold til eksisterende vedtak. Dette er basert på et nytt ekvivalensbegrep som likestiller null, opphold og utsettelser utenom sykdom/innleggelse. Unntak for bare far rett via morsAktivitet. 

Har også endret slik at vi tar med perioder som er innvilget men mangler periodeSøknad - dette er som hovedregel manglende søkt periode (avslått/manuelt) som er blitt innvilget (fx utbetaling første 6 uker).

Se beskrivelse i TFP-sak for bakgrunn. TFP-7095 tar opp filtrering av perioder som ikke trenger saksbehandling.